### PR TITLE
Add helm charts and dockerfile updates for packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,7 @@
-.git
-.yarn/cache
-.yarn/install-state.gz
+dist-types
 node_modules
-packages/*/src
+packages/*/dist
 packages/*/node_modules
-plugins
+plugins/*/dist
+plugins/*/node_modules
 *.local.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ dist-types
 # Temporary change files created by Vim
 *.swp
 
+# Helm packaged files
+*.tgz
+
 # MkDocs build output
 site
 

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -12,6 +12,8 @@ backend:
   # auth:
   #   keys:
   #     - secret: ${BACKEND_SECRET}
+  auth:
+    dangerouslyDisableDefaultAuthPolicy: true # TODO: Remove this when added auth properly
   baseUrl: http://localhost:7007
   listen:
     port: 7007
@@ -72,8 +74,8 @@ scaffolder:
   # see https://backstage.io/docs/features/software-templates/configuration for software template options
 
 openchoreo:
-  baseUrl: http://localhost:8080/api/v1
-  observabilityBaseUrl: http://localhost:9090
+  baseUrl: ${OPENCHOREO_API_URL}
+  observabilityBaseUrl: ${OPENCHOREO_OBS_URL}
   token: ${OPENCHOREO_TOKEN} # optional for now: for authentication
   schedule:
     frequency: 30 # seconds between runs (default: 30)

--- a/charts/backstage-openchoreo/Chart.lock
+++ b/charts/backstage-openchoreo/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: backstage
+  repository: https://backstage.github.io/charts
+  version: 2.6.0
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.10.0
+digest: sha256:402f96ef99b3e9ca6046ec40155b8ae1e7f9a20dbc58b865c1b9ce959103b3a1
+generated: "2025-07-28T17:48:57.113955+05:30"

--- a/charts/backstage-openchoreo/Chart.yaml
+++ b/charts/backstage-openchoreo/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: backstage-openchoreo
+description: A Helm chart for deploying Backstage with OpenChoreo plugins
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+home: https://github.com/wso2/backstage-plugins
+keywords:
+  - backstage
+  - openchoreo
+  - idp
+  - developer-portal
+maintainers:
+  - name: WSO2
+    url: https://wso2.com
+sources:
+  - https://github.com/wso2/backstage-plugins
+dependencies:
+  - name: backstage
+    version: "2.6.0"
+    repository: "https://backstage.github.io/charts"
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 2.10.0
+annotations:
+  category: Developer Tools

--- a/charts/backstage-openchoreo/templates/_helpers.tpl
+++ b/charts/backstage-openchoreo/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "backstage-openchoreo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "backstage-openchoreo.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "backstage-openchoreo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "backstage-openchoreo.labels" -}}
+helm.sh/chart: {{ include "backstage-openchoreo.chart" . }}
+{{ include "backstage-openchoreo.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "backstage-openchoreo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "backstage-openchoreo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "backstage-openchoreo.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "backstage-openchoreo.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/backstage-openchoreo/templates/backend-secret.yaml
+++ b/charts/backstage-openchoreo/templates/backend-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backstage-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backstage-openchoreo.labels" . | nindent 4 }}
+type: Opaque
+data:
+  backend-secret: {{ (.Values.backendSecret | default (randAlphaNum 32)) | b64enc | quote }}
+---

--- a/charts/backstage-openchoreo/values.yaml
+++ b/charts/backstage-openchoreo/values.yaml
@@ -1,0 +1,36 @@
+# Default values for backstage-openchoreo.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Backstage configuration (passed to backstage dependency)
+backstage:
+  backstage:
+    image:
+      registry: "ghcr.io"
+      repository: "openchoreo/backstage-plugins"
+      tag: "latest"
+      pullPolicy: IfNotPresent
+
+    # Resource limits and requests
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+
+    # Extra environment variables
+    extraEnvVars:
+      - name: OPENCHOREO_API_URL
+        value: "http://api-server.openchoreo-control-plane.svc.cluster.local:8080/api/v1"
+      - name: OPENCHOREO_OBS_URL
+        value: "http://openchoreo-observability:9090"
+      - name: BACKEND_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: backstage-secrets
+            key: backend-secret
+
+# Backend authentication secret (leave empty to auto-generate)
+# backendSecret: "your-custom-backend-secret"

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,18 +1,57 @@
-# This dockerfile builds an image for the backend package.
-# It should be executed with the root of the repo as docker context.
-#
-# Before building this image, be sure to have run the following commands in the repo root:
-#
-# yarn install --immutable
-# yarn tsc
-# yarn build:backend
-#
-# Once the commands have been run, you can build the image using `yarn build-image`
-#
-# Alternatively, there is also a multi-stage Dockerfile documented here:
-# https://backstage.io/docs/deployment/docker#multi-stage-build
+# Stage 1 - Create yarn install skeleton layer
+FROM node:22-bookworm-slim AS packages
 
-FROM node:20-bookworm-slim
+WORKDIR /app
+COPY backstage.json package.json yarn.lock ./
+COPY .yarn ./.yarn
+COPY .yarnrc.yml ./
+
+COPY packages packages
+
+# Comment this out if you don't have any internal plugins
+COPY plugins plugins
+
+RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
+
+# Stage 2 - Install dependencies and build packages
+FROM node:22-bookworm-slim AS build
+
+# Set Python interpreter for `node-gyp` to use
+ENV PYTHON=/usr/bin/python3
+
+# Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python3 g++ build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
+# in which case you should also move better-sqlite3 to "devDependencies" in package.json.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libsqlite3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+USER node
+WORKDIR /app
+
+COPY --from=packages --chown=node:node /app .
+
+RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
+    yarn install --immutable
+
+COPY --chown=node:node . .
+
+RUN yarn --cwd packages/backend build
+
+RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
+    && tar xzf packages/backend/dist/skeleton.tar.gz -C packages/backend/dist/skeleton \
+    && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
+
+# Stage 3 - Build the actual backend image and install production dependencies
+FROM node:22-bookworm-slim
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3
@@ -36,35 +75,38 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 USER node
 
 # This should create the app dir as `node`.
-# If it is instead created as `root` then the `tar` command below will fail: `can't create directory 'packages/': Permission denied`.
-# If this occurs, then ensure BuildKit is enabled (`DOCKER_BUILDKIT=1`) so the app dir is correctly created as `node`.
+# If it is instead created as `root` then the `tar` command below will
+# fail: `can't create directory 'packages/': Permission denied`.
+# If this occurs, then ensure BuildKit is enabled (`DOCKER_BUILDKIT=1`)
+# so the app dir is correctly created as `node`.
 WORKDIR /app
 
-# Copy files needed by Yarn
-COPY --chown=node:node .yarn ./.yarn
-COPY --chown=node:node .yarnrc.yml ./
-COPY --chown=node:node backstage.json ./
+# Copy the install dependencies from the build stage and context
+COPY --from=build --chown=node:node /app/.yarn ./.yarn
+COPY --from=build --chown=node:node /app/.yarnrc.yml  ./
+COPY --from=build --chown=node:node /app/backstage.json ./
+COPY --from=build --chown=node:node /app/yarn.lock /app/package.json /app/packages/backend/dist/skeleton/ ./
+
+# Note: The skeleton bundle only includes package.json files -- if your app has
+# plugins that define a `bin` export, the bin files need to be copied as well to
+# be linked in node_modules/.bin during yarn install.
+
+RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
+    yarn workspaces focus --all --production && rm -rf "$(yarn cache clean)"
+
+# Copy the built packages from the build stage
+COPY --from=build --chown=node:node /app/packages/backend/dist/bundle/ ./
+
+# Copy any other files that we need at runtime
+COPY --chown=node:node app-config*.yaml ./
+
+# This will include the examples, if you don't need these simply remove this line
+COPY --chown=node:node examples ./examples
 
 # This switches many Node.js dependencies to production mode.
 ENV NODE_ENV=production
 
 # This disables node snapshot for Node 20 to work with the Scaffolder
 ENV NODE_OPTIONS="--no-node-snapshot"
-
-# Copy repo skeleton first, to avoid unnecessary docker cache invalidation.
-# The skeleton contains the package.json of each package in the monorepo,
-# and along with yarn.lock and the root package.json, that's enough to run yarn install.
-COPY --chown=node:node yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
-RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
-
-RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
-    yarn workspaces focus --all --production && rm -rf "$(yarn cache clean)"
-
-# This will include the examples, if you don't need these simply remove this line
-COPY --chown=node:node examples ./examples
-
-# Then copy the rest of the backend bundle, along with any other files we might want.
-COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./
-RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 CMD ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.production.yaml"]

--- a/plugins/catalog-backend-module-openchoreo/package.json
+++ b/plugins/catalog-backend-module-openchoreo/package.json
@@ -37,7 +37,8 @@
     "@backstage/cli": "^0.32.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ],
   "configSchema": "config.d.ts"
 }


### PR DESCRIPTION
## Purpose

This adds initial deployment artifacts (Helm charts) on top of the existing backstage helm chart (https://github.com/backstage/charts/tree/main) to deploy backstage. 

This also updates the Dockerfile to do multi-stage docker build as mentioned in : https://backstage.io/docs/deployment/docker/#multi-stage-build