### PR TITLE
Add multiarch docker buildx command for linux/amd64 support

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,7 +13,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
-    "build-image": "docker build ../.. -f Dockerfile --tag backstage"
+    "build-image": "docker buildx build ../.. -f Dockerfile --platform linux/arm64,linux/amd64 --tag backstage "
   },
   "dependencies": {
     "@backstage/backend-defaults": "^0.9.0",


### PR DESCRIPTION
## Purpose

$title - The current image fails on x86 linux and WSL-based clusters.

## Goals

N/A

## Approach

Updated the existing docker build command to use docker buildx with platform flags.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

