### PR TITLE
Reduce logging noise by converting verbose INFO logs to DEBUG

### DIFF
--- a/plugins/catalog-backend-module-openchoreo-users/src/provider/ThunderUserGroupEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo-users/src/provider/ThunderUserGroupEntityProvider.ts
@@ -80,11 +80,11 @@ export class ThunderUserGroupEntityProvider implements EntityProvider {
 
       // Fetch all users
       const users = await this.fetchAllUsers();
-      this.logger.info(`Found ${users.length} users from Thunder IdP`);
+      this.logger.debug(`Found ${users.length} users from Thunder IdP`);
 
       // Fetch all groups
       const groups = await this.fetchAllGroups();
-      this.logger.info(`Found ${groups.length} groups from Thunder IdP`);
+      this.logger.debug(`Found ${groups.length} groups from Thunder IdP`);
 
       // Transform users to Backstage User entities
       const userEntities = users.map(user => this.transformUserToEntity(user));

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -72,7 +72,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
 
       // First, get all organizations
       const organizations = await this.client.getAllOrganizations();
-      this.logger.info(
+      this.logger.debug(
         `Found ${organizations.length} organizations from OpenChoreo`,
       );
 
@@ -88,7 +88,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       for (const org of organizations) {
         try {
           const environments = await this.client.getAllEnvironments(org.name);
-          this.logger.info(
+          this.logger.debug(
             `Found ${environments.length} environments in organization: ${org.name}`,
           );
 
@@ -107,7 +107,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       for (const org of organizations) {
         try {
           const dataplanes = await this.client.getAllDataplanes(org.name);
-          this.logger.info(
+          this.logger.debug(
             `Found ${dataplanes.length} dataplanes in organization: ${org.name}`,
           );
 
@@ -126,7 +126,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       for (const org of organizations) {
         try {
           const projects = await this.client.getAllProjects(org.name);
-          this.logger.info(
+          this.logger.debug(
             `Found ${projects.length} projects in organization: ${org.name}`,
           );
 
@@ -142,7 +142,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                 org.name,
                 project.name,
               );
-              this.logger.info(
+              this.logger.debug(
                 `Found ${components.length} components in project: ${project.name}`,
               );
 

--- a/plugins/openchoreo-backend/src/services/BuildService/BuildInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/BuildService/BuildInfoService.ts
@@ -29,7 +29,7 @@ export class BuildInfoService {
     projectName: string,
     componentName: string,
   ): Promise<ModelsBuild[]> {
-    this.logger.info(
+    this.logger.debug(
       `Fetching builds for component: ${componentName} in project: ${projectName}, organization: ${orgName}`,
     );
 
@@ -41,7 +41,7 @@ export class BuildInfoService {
         componentName,
       );
 
-      this.logger.info(
+      this.logger.debug(
         `Successfully fetched ${builds.length} builds for component: ${componentName}`,
       );
       return builds;
@@ -74,7 +74,7 @@ export class BuildInfoService {
         commit,
       );
 
-      this.logger.info(
+      this.logger.debug(
         `Successfully triggered build for component: ${componentName}, build name: ${build.name}`,
       );
       return build;
@@ -96,7 +96,7 @@ export class BuildInfoService {
     limit?: number,
     sortOrder?: 'asc' | 'desc',
   ): Promise<RuntimeLogsResponse> {
-    this.logger.info(
+    this.logger.debug(
       `Fetching build logs for component: ${componentName}, build: ${buildId}`,
     );
 
@@ -112,7 +112,7 @@ export class BuildInfoService {
         ...(sortOrder && { sortOrder }),
       };
 
-      this.logger.info(
+      this.logger.debug(
         `Sending build logs request for component ${componentName} with parameters: ${JSON.stringify(
           apiRequest,
         )}`,
@@ -135,7 +135,7 @@ export class BuildInfoService {
 
       const logsData = await response.json();
 
-      this.logger.info(
+      this.logger.debug(
         `Successfully fetched ${
           logsData.logs?.length || 0
         } build logs for component ${componentName}`,

--- a/plugins/openchoreo-backend/src/services/BuildTemplateService/BuildTemplateInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/BuildTemplateService/BuildTemplateInfoService.ts
@@ -14,13 +14,13 @@ export class BuildTemplateInfoService {
   }
 
   async fetchBuildTemplates(orgName: string): Promise<ModelsBuildTemplate[]> {
-    this.logger.info(`Fetching build templates for organization: ${orgName}`);
+    this.logger.debug(`Fetching build templates for organization: ${orgName}`);
 
     try {
       const client = new OpenChoreoApiClient(this.baseUrl, '', this.logger);
       const buildTemplates = await client.getAllBuildTemplates(orgName);
 
-      this.logger.info(
+      this.logger.debug(
         `Successfully fetched ${buildTemplates.length} build templates for org: ${orgName}`,
       );
       return buildTemplates;

--- a/plugins/openchoreo-backend/src/services/ComponentService/ComponentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/ComponentService/ComponentInfoService.ts
@@ -18,7 +18,7 @@ export class ComponentInfoService {
     projectName: string,
     componentName: string,
   ): Promise<ModelsCompleteComponent> {
-    this.logger.info(
+    this.logger.debug(
       `Fetching component details for: ${componentName} in project: ${projectName}, organization: ${orgName}`,
     );
 
@@ -30,7 +30,7 @@ export class ComponentInfoService {
         componentName,
       );
 
-      this.logger.info(
+      this.logger.debug(
         `Successfully fetched component details for: ${componentName}`,
       );
       return component;

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -51,7 +51,7 @@ export class EnvironmentInfoService implements EnvironmentService {
   }): Promise<Environment[]> {
     const startTime = Date.now();
     try {
-      this.logger.info(
+      this.logger.debug(
         `Starting environment fetch for component: ${request.componentName}`,
       );
 
@@ -115,10 +115,10 @@ export class EnvironmentInfoService implements EnvironmentService {
       const fetchEnd = Date.now();
 
       // Log individual timings
-      this.logger.info(
+      this.logger.debug(
         `API call timings - Environments: ${environmentsResult.duration}ms, Bindings: ${bindingsResult.duration}ms, Pipeline: ${pipelineResult.duration}ms`,
       );
-      this.logger.info(
+      this.logger.debug(
         `Total parallel API calls completed in ${fetchEnd - fetchStart}ms`,
       );
 
@@ -151,7 +151,7 @@ export class EnvironmentInfoService implements EnvironmentService {
       const transformEnd = Date.now();
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Environment fetch completed for ${request.componentName}: ` +
           `Individual API calls (Env: ${environmentsResult.duration}ms, Bind: ${bindingsResult.duration}ms, Pipeline: ${pipelineResult.duration}ms), ` +
           `Parallel execution: ${fetchEnd - fetchStart}ms, ` +
@@ -198,7 +198,7 @@ export class EnvironmentInfoService implements EnvironmentService {
 
     // If no pipeline data, use default ordering
     if (!deploymentPipeline || !deploymentPipeline.promotionPaths) {
-      this.logger.info('No deployment pipeline found, using default ordering');
+      this.logger.debug('No deployment pipeline found, using default ordering');
       return this.transformEnvironmentDataWithBindingsOnly(
         environmentData,
         bindingsByEnv,
@@ -572,7 +572,7 @@ export class EnvironmentInfoService implements EnvironmentService {
         request.targetEnvironment,
       );
 
-      this.logger.info(
+      this.logger.debug(
         `Promotion completed successfully. Received ${promotionResult.length} binding responses.`,
       );
 
@@ -584,7 +584,7 @@ export class EnvironmentInfoService implements EnvironmentService {
       });
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Component promotion completed for ${request.componentName}: Total: ${totalTime}ms`,
       );
 
@@ -634,7 +634,7 @@ export class EnvironmentInfoService implements EnvironmentService {
         request.releaseState,
       );
 
-      this.logger.info(
+      this.logger.debug(
         `Binding update completed successfully for ${request.bindingName}.`,
       );
 
@@ -646,7 +646,7 @@ export class EnvironmentInfoService implements EnvironmentService {
       });
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Component binding update completed for ${request.componentName}: Total: ${totalTime}ms`,
       );
 

--- a/plugins/platform-engineer-core-backend/src/services/PlatformEnvironmentService.ts
+++ b/plugins/platform-engineer-core-backend/src/services/PlatformEnvironmentService.ts
@@ -44,7 +44,7 @@ export class PlatformEnvironmentInfoService
   async fetchAllEnvironments(): Promise<Environment[]> {
     const startTime = Date.now();
     try {
-      this.logger.info('Starting platform-wide environment fetch');
+      this.logger.debug('Starting platform-wide environment fetch');
 
       // For now, we'll fetch environments from a default organization
       // In a real implementation, you might need to fetch from multiple organizations
@@ -68,7 +68,7 @@ export class PlatformEnvironmentInfoService
       const result = this.transformEnvironmentData(environments, 'default');
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Platform environment fetch completed: ${result.length} environments found (${totalTime}ms)`,
       );
 
@@ -91,7 +91,7 @@ export class PlatformEnvironmentInfoService
   ): Promise<Environment[]> {
     const startTime = Date.now();
     try {
-      this.logger.info(
+      this.logger.debug(
         `Starting environment fetch for organization: ${organizationName}`,
       );
 
@@ -121,7 +121,7 @@ export class PlatformEnvironmentInfoService
       );
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Environment fetch completed for ${organizationName}: ${result.length} environments found (${totalTime}ms)`,
       );
 
@@ -143,7 +143,7 @@ export class PlatformEnvironmentInfoService
   async fetchAllDataplanes(): Promise<DataPlane[]> {
     const startTime = Date.now();
     try {
-      this.logger.info('Starting platform-wide dataplane fetch');
+      this.logger.debug('Starting platform-wide dataplane fetch');
 
       // For now, we'll fetch dataplanes from a default organization
       // In a real implementation, you might need to fetch from multiple organizations
@@ -167,7 +167,7 @@ export class PlatformEnvironmentInfoService
       const result = this.transformDataPlaneData(dataplanes, 'default');
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Platform dataplane fetch completed: ${result.length} dataplanes found (${totalTime}ms)`,
       );
 
@@ -190,7 +190,7 @@ export class PlatformEnvironmentInfoService
   ): Promise<DataPlane[]> {
     const startTime = Date.now();
     try {
-      this.logger.info(
+      this.logger.debug(
         `Starting dataplane fetch for organization: ${organizationName}`,
       );
 
@@ -217,7 +217,7 @@ export class PlatformEnvironmentInfoService
       const result = this.transformDataPlaneData(dataplanes, organizationName);
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Dataplane fetch completed for ${organizationName}: ${result.length} dataplanes found (${totalTime}ms)`,
       );
 
@@ -240,7 +240,7 @@ export class PlatformEnvironmentInfoService
   > {
     const startTime = Date.now();
     try {
-      this.logger.info('Starting dataplanes with environments fetch');
+      this.logger.debug('Starting dataplanes with environments fetch');
 
       // Fetch both dataplanes and environments in parallel
       const [dataplanes, environments] = await Promise.all([
@@ -266,7 +266,7 @@ export class PlatformEnvironmentInfoService
         }));
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Dataplanes with environments fetch completed: ${dataplanesWithEnvironments.length} dataplanes with ${environments.length} total environments (${totalTime}ms)`,
       );
 
@@ -289,7 +289,7 @@ export class PlatformEnvironmentInfoService
   > {
     const startTime = Date.now();
     try {
-      this.logger.info(
+      this.logger.debug(
         'Starting dataplanes with environments and component counts fetch',
       );
 
@@ -313,7 +313,7 @@ export class PlatformEnvironmentInfoService
       }));
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Dataplanes with environments and component counts fetch completed: ${enrichedDataplanes.length} dataplanes (${totalTime}ms)`,
       );
 
@@ -342,7 +342,7 @@ export class PlatformEnvironmentInfoService
     const componentCountsByEnvironment = new Map<string, number>();
 
     try {
-      this.logger.info(
+      this.logger.debug(
         `Starting component counts fetch for ${components.length} components`,
       );
 
@@ -388,7 +388,7 @@ export class PlatformEnvironmentInfoService
       }
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Component counts fetch completed: Found deployments in ${componentCountsByEnvironment.size} environments (${totalTime}ms)`,
       );
 
@@ -417,7 +417,7 @@ export class PlatformEnvironmentInfoService
     const deployedComponents = new Set<string>();
 
     try {
-      this.logger.info(
+      this.logger.debug(
         `Starting distinct deployed components count for ${components.length} components`,
       );
 
@@ -461,7 +461,7 @@ export class PlatformEnvironmentInfoService
       }
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Distinct deployed components count completed: Found ${deployedComponents.size} deployed components (${totalTime}ms)`,
       );
 
@@ -491,7 +491,7 @@ export class PlatformEnvironmentInfoService
     let healthyWorkloadCount = 0;
 
     try {
-      this.logger.info(
+      this.logger.debug(
         `Starting healthy workload count for ${components.length} components`,
       );
 
@@ -540,7 +540,7 @@ export class PlatformEnvironmentInfoService
       }
 
       const totalTime = Date.now() - startTime;
-      this.logger.info(
+      this.logger.debug(
         `Healthy workload count completed: Found ${healthyWorkloadCount} healthy workloads (${totalTime}ms)`,
       );
 

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/component.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/component.ts
@@ -81,7 +81,7 @@ export const createComponentAction = (config: Config) => {
         }),
     },
     async handler(ctx) {
-      ctx.logger.info(
+      ctx.logger.debug(
         `Creating component with parameters: ${JSON.stringify(ctx.input)}`,
       );
 
@@ -100,10 +100,10 @@ export const createComponentAction = (config: Config) => {
       const orgName = extractOrgName(ctx.input.orgName);
       const projectName = extractProjectName(ctx.input.projectName);
 
-      ctx.logger.info(
+      ctx.logger.debug(
         `Extracted organization name: ${orgName} from ${ctx.input.orgName}`,
       );
-      ctx.logger.info(
+      ctx.logger.debug(
         `Extracted project name: ${projectName} from ${ctx.input.projectName}`,
       );
 
@@ -143,7 +143,7 @@ export const createComponentAction = (config: Config) => {
           buildTemplateRef: ctx.input.buildTemplateName,
           buildTemplateParams,
         };
-        ctx.logger.info(
+        ctx.logger.debug(
           `Build configuration created: ${JSON.stringify(buildConfig)}`,
         );
       }
@@ -157,7 +157,7 @@ export const createComponentAction = (config: Config) => {
           buildConfig,
         });
 
-        ctx.logger.info(
+        ctx.logger.debug(
           `Component created successfully: ${JSON.stringify(response)}`,
         );
 

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/project.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/project.ts
@@ -40,7 +40,7 @@ export const createProjectAction = (config: Config) => {
         }),
     },
     async handler(ctx) {
-      ctx.logger.info(
+      ctx.logger.debug(
         `Creating project with parameters: ${JSON.stringify(ctx.input)}`,
       );
 
@@ -51,7 +51,7 @@ export const createProjectAction = (config: Config) => {
       };
 
       const orgName = extractOrgName(ctx.input.orgName);
-      ctx.logger.info(
+      ctx.logger.debug(
         `Extracted organization name: ${orgName} from ${ctx.input.orgName}`,
       );
 
@@ -69,7 +69,7 @@ export const createProjectAction = (config: Config) => {
           deploymentPipeline: ctx.input.deploymentPipeline,
         });
 
-        ctx.logger.info(
+        ctx.logger.debug(
           `Project created successfully: ${JSON.stringify(response)}`,
         );
 


### PR DESCRIPTION
Changed ~60+ info logs to debug logs across providers, services, and scaffolder actions to reduce log noise in production. This change moves all intermediate operation details, loop iterations, timing metrics, and parameter dumps to DEBUG level while keeping high-level operation summaries at INFO.

Changes:
- Providers: Move iteration counts and "Found X items" logs to DEBUG
- Services: Move "Starting...", timing metrics, and completion details to DEBUG
- Scaffolder actions: Move parameter dumps and extraction logs to DEBUG