### PR TITLE
Optimize multi-platform builds - build on amd64, deploy to both platforms

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - Create yarn install skeleton layer
-FROM node:22-bookworm-slim AS packages
+FROM --platform=linux/amd64 node:22-bookworm-slim AS packages
 
 WORKDIR /app
 COPY backstage.json package.json yarn.lock ./
@@ -14,7 +14,7 @@ COPY plugins plugins
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
 
 # Stage 2 - Install dependencies and build packages
-FROM node:22-bookworm-slim AS build
+FROM --platform=linux/amd64 node:22-bookworm-slim AS build
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3


### PR DESCRIPTION
## Purpose
Fix multi-platform docker build after backstage migration

## Goals
Fixes: https://github.com/openchoreo/openchoreo/issues/791

## Approach

  IMPORTANT: Sending this immediate fix targeting milestone release, I am working on a more cleaner approach separately.
  
  This uses a **cross-compilation workaround** to support both `linux/amd64` and `linux/arm64`
   platforms while avoiding build issues with `@swc/core`.

  ### Why `--platform=linux/amd64` in Build Stages

  **Stages 1 & 2** (lines 2, 17) are locked to AMD64:
  ```dockerfile
  FROM --platform=linux/amd64 node:22-bookworm-slim AS packages
  FROM --platform=linux/amd64 node:22-bookworm-slim AS build
  ```

  Reason: @swc/core (used by @backstage/cli for TypeScript compilation) had ARM64 build issues. Building
  on AMD64 ensures consistent, reliable builds regardless of target platform.

  How ARM64 Runtime Works

  Stage 3 (line 54) has NO platform lock:
  FROM node:22-bookworm-slim

  When building for ARM64:
  1. Stage 3 runs natively on ARM64
  2. Line 95 performs a fresh production install on the target platform:
  yarn workspaces focus --all --production
  3. This installs only dependencies (skips devDependencies like @swc/core)
  4. Native modules (better-sqlite3, isolate-vm) compile/download for ARM64
  5. Only platform-independent JavaScript bundles are copied from the AMD64 build stage

  Result

  - ✅ Build stage avoids @swc/core ARM64 issues
  - ✅ Runtime stage gets correct platform-specific native dependencies
  - ✅ Final images work correctly on both AMD64 and ARM64
  - ✅ CI builds both platforms: platforms: linux/amd64,linux/arm64

  Current Versions

  - @swc/core: 1.13.20 (has ARM64 binaries, but kept AMD64 build for stability)
  - @backstage/cli: 0.34.3