### PR TITLE
Implement dynamic component type system with configuration support

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -114,6 +114,33 @@ openchoreo:
     frequency: 30 # seconds between runs (default: 30)
     timeout: 120 # seconds for timeout (default: 120)
 
+  # Component Type Mappings (optional - defaults provided)
+  # Maps OpenChoreo component types to Backstage page variants
+  # Custom mappings are evaluated before defaults
+  # componentTypes:
+  #   mappings:
+  #     # Example: All React-based components should use website page variant
+  #     - pattern: '^deployment/react-.*'
+  #       pageVariant: 'website'
+  #
+  #     # Example: Anything with 'api' should be a service page variant
+  #     - pattern: '^deployment/.*api.*'
+  #       pageVariant: 'service'
+  #
+  #     # Example: Python workers might be scheduled tasks
+  #     - pattern: '^deployment/python-worker.*'
+  #       pageVariant: 'scheduled-task'
+  #
+  # Default mappings (applied if no custom mapping matches):
+  # - deployment/.*web-app.*     -> website
+  # - deployment/.*webapp.*      -> website
+  # - deployment/.*frontend.*    -> website
+  # - cronjob/.*                 -> scheduled-task
+  # - job/.*                     -> scheduled-task
+  # - deployment/.*              -> service
+  # - statefulset/.*             -> service
+  # - (no match)                 -> default (uses defaultEntityPage)
+
 thunder:
   # Environment variables are injected by Helm chart (see https://github.com/openchoreo/openchoreo install/helm/openchoreo/templates/backstage/deployment.yaml)
   # For local Kind: set THUNDER_BASE_URL via https://github.com/openchoreo/openchoreo install/dev/openchoreo-values.yaml (defaults to internal service URL)

--- a/plugins/openchoreo-common/package.json
+++ b/plugins/openchoreo-common/package.json
@@ -28,6 +28,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
+    "@backstage/config": "^1.2.0",
     "@openchoreo/openchoreo-client-node": "workspace:^"
   },
   "devDependencies": {

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -1,6 +1,11 @@
 export { CHOREO_ANNOTATIONS, CHOREO_LABELS } from './constants';
 export { getRepositoryInfo, getRepositoryUrl } from './utils';
 export type { RepositoryInfo } from './utils';
+export {
+  ComponentTypeUtils,
+  type PageVariant,
+  type ComponentTypeMapping,
+} from './utils/componentTypeUtils';
 
 // Re-export types from the generated OpenAPI client for use in frontend plugins
 export type {

--- a/plugins/openchoreo-common/src/utils/componentTypeUtils.ts
+++ b/plugins/openchoreo-common/src/utils/componentTypeUtils.ts
@@ -1,0 +1,138 @@
+import { Config } from '@backstage/config';
+
+export type PageVariant = 'service' | 'website' | 'scheduled-task' | 'default';
+
+export interface ComponentTypeMapping {
+  pattern: string; // regex pattern
+  pageVariant: PageVariant;
+}
+
+/**
+ * Utilities for handling OpenChoreo component types and their mapping to Backstage page variants.
+ *
+ * Component types follow the format: {workloadType}/{componentTypeName}
+ * Examples: deployment/service, deployment/web-application, cronjob/scheduled-task
+ *
+ * This class maps component types to page variants which determine the UI features shown.
+ */
+export class ComponentTypeUtils {
+  private mappings: ComponentTypeMapping[];
+
+  private constructor(mappings: ComponentTypeMapping[]) {
+    this.mappings = mappings;
+  }
+
+  /**
+   * Creates ComponentTypeUtils from Backstage configuration.
+   * Reads optional custom mappings from openchoreo.componentTypes.mappings
+   * and combines them with default mappings (custom mappings take precedence).
+   */
+  static fromConfig(config: Config): ComponentTypeUtils {
+    const ctConfig = config.getOptionalConfig('openchoreo.componentTypes');
+    const customMappings = ctConfig?.getOptionalConfigArray('mappings') || [];
+
+    const mappings: ComponentTypeMapping[] = [
+      // Custom mappings from config (evaluated first)
+      ...customMappings.map(m => ({
+        pattern: m.getString('pattern'),
+        pageVariant: m.getString('pageVariant') as PageVariant,
+      })),
+      // Default mappings (fallback)
+      ...this.getDefaultMappings(),
+    ];
+
+    return new ComponentTypeUtils(mappings);
+  }
+
+  /**
+   * Creates ComponentTypeUtils with default mappings only.
+   * Useful for frontend routing where config might not be easily accessible.
+   */
+  static createDefault(): ComponentTypeUtils {
+    return new ComponentTypeUtils(this.getDefaultMappings());
+  }
+
+  /**
+   * Default mappings for component types to page variants.
+   * These patterns are evaluated in order until a match is found.
+   */
+  private static getDefaultMappings(): ComponentTypeMapping[] {
+    return [
+      // Web applications (no API tab)
+      { pattern: '^deployment/.*web-app.*', pageVariant: 'website' },
+      { pattern: '^deployment/.*webapp.*', pageVariant: 'website' },
+      { pattern: '^deployment/.*web-application.*', pageVariant: 'website' },
+      { pattern: '^deployment/.*frontend.*', pageVariant: 'website' },
+
+      // Scheduled tasks / jobs (future: different UI with executions, schedules)
+      { pattern: '^cronjob/.*', pageVariant: 'scheduled-task' },
+      { pattern: '^job/.*', pageVariant: 'scheduled-task' },
+
+      // Services (shows API tab, builds, deploy, metrics, etc.)
+      { pattern: '^deployment/.*', pageVariant: 'service' },
+      { pattern: '^statefulset/.*', pageVariant: 'service' },
+    ];
+  }
+
+  /**
+   * Determines the page variant for a given component type.
+   * The first matching pattern in the mappings list determines the variant.
+   *
+   * @param componentType - OpenChoreo component type (e.g., "deployment/service")
+   * @returns Page variant ('service', 'website', 'scheduled-task', or 'default')
+   */
+  getPageVariant(componentType: string): PageVariant {
+    for (const mapping of this.mappings) {
+      if (new RegExp(mapping.pattern).test(componentType)) {
+        return mapping.pageVariant;
+      }
+    }
+    // No pattern matched - use default page
+    return 'default';
+  }
+
+  /**
+   * Parses OpenChoreo component type format into workload type and type name.
+   *
+   * @param componentType - Format: "workloadType/componentTypeName"
+   * @returns Object with workloadType and typeName
+   *
+   * @example
+   * parseComponentType("deployment/service")
+   * // Returns: { workloadType: "deployment", typeName: "service" }
+   */
+  parseComponentType(componentType: string): {
+    workloadType: string;
+    typeName: string;
+  } {
+    const match = componentType.match(
+      /^(deployment|statefulset|cronjob|job)\/(.+)$/,
+    );
+    if (!match) {
+      return { workloadType: 'unknown', typeName: componentType };
+    }
+    return { workloadType: match[1], typeName: match[2] };
+  }
+
+  /**
+   * Generates Backstage tags for a component type.
+   * Tags include: openchoreo, component, workload type, type name, and full type.
+   *
+   * @param componentType - OpenChoreo component type
+   * @returns Array of tags for the component
+   *
+   * @example
+   * generateTags("deployment/service")
+   * // Returns: ["openchoreo", "component", "deployment", "service", "deployment-service"]
+   */
+  generateTags(componentType: string): string[] {
+    const { workloadType, typeName } = this.parseComponentType(componentType);
+    return [
+      'openchoreo',
+      'component',
+      workloadType !== 'unknown' ? workloadType : undefined,
+      typeName !== componentType ? typeName : undefined,
+      componentType.replace('/', '-'),
+    ].filter(Boolean) as string[];
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,6 +2378,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config@npm:^1.2.0":
+  version: 1.3.6
+  resolution: "@backstage/config@npm:1.3.6"
+  dependencies:
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.2"
+    ms: "npm:^2.1.3"
+  checksum: 10c0/e6f99f9077145bf103a98b2533c506ee3104af4345c4ace0b7e4714352f0374091f7c1d43b14715f9a3046464782d3bbe5e3821ae423c7a5e56dc921edc5bc59
+  languageName: node
+  linkType: hard
+
 "@backstage/config@npm:^1.3.0, @backstage/config@npm:^1.3.5":
   version: 1.3.5
   resolution: "@backstage/config@npm:1.3.5"
@@ -9228,6 +9239,7 @@ __metadata:
   resolution: "@openchoreo/backstage-plugin-common@workspace:plugins/openchoreo-common"
   dependencies:
     "@backstage/cli": "npm:^0.34.3"
+    "@backstage/config": "npm:^1.2.0"
     "@openchoreo/openchoreo-client-node": "workspace:^"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
  Replace hardcoded component type mappings with a flexible, configuration-driven
  system that properly handles OpenChoreo's dynamic component types.

  Changes:
  - Add ComponentTypeUtils class with factory pattern in openchoreo-common
    - Supports config-driven mappings via openchoreo.componentTypes in app-config
    - Default pattern matching for deployment/*, cronjob/*, statefulset/* types
    - Proper 'default' variant for unknown types instead of 'service' fallback

  - Update OpenChoreoEntityProvider to use actual component types
    - Store OpenChoreo types directly in spec.type (e.g., "deployment/service")
    - Remove hardcoded WebApplication→website mapping
    - Use ComponentTypeUtils for consistent tag generation

  - Update EntityPage.tsx with smart routing
    - Replace isComponentType() with custom condition functions
    - Map component types to page variants (service, website, scheduled-task, default)
    - Unknown types properly use defaultEntityPage

  - Add openchoreo.componentTypes configuration section
    - Platform engineers can customize mappings via app-config.yaml
    - Pattern-based regex matching with precedence over defaults
    - Documented with examples

  Benefits:
  - Catalog Type filter shows actual OpenChoreo component types
  - No code changes needed to support new component types
  - Isomorphic package works in both frontend and backend
  - Clean separation: mappings define variant, page defines features

  Breaking Changes:
  - Component entities now have OpenChoreo types in spec.type instead of Backstage-inferred types (e.g., "deployment/service" vs "service")
  - Legacy format support (Service, WebApplication) removed

Fixes: https://github.com/openchoreo/openchoreo/issues/901
