### PR TITLE
Improve ENV card height consistency and refresh UX

### DIFF
--- a/plugins/openchoreo/src/components/Environments/Workload/Workload.tsx
+++ b/plugins/openchoreo/src/components/Environments/Workload/Workload.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   useTheme,
   IconButton,
-  CircularProgress,
 } from '@material-ui/core';
 import { useEffect, useState } from 'react';
 import { WorkloadEditor } from './WorkloadEditor';
@@ -23,7 +22,7 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import { useApi } from '@backstage/core-plugin-api';
 import { discoveryApiRef } from '@backstage/core-plugin-api';
 import { identityApiRef } from '@backstage/core-plugin-api';
-import { Alert } from '@material-ui/lab';
+import { Alert, Skeleton } from '@material-ui/lab';
 import { WorkloadProvider } from './WorkloadContext';
 import { isFromSourceComponent } from '../../../utils/componentUtils';
 
@@ -154,9 +153,6 @@ export function Workload({
     if (isFromSource && !hasBuilds) {
       return 'Build your application first to generate a container image.';
     }
-    if (workloadSpec) {
-      return 'Loading workload configuration...';
-    }
     return 'Configure your workload to enable deployment.';
   };
 
@@ -166,30 +162,32 @@ export function Workload({
         display="flex"
         justifyContent="space-between"
         flexDirection="column"
-        gridGap={8}
+        gridGap={16}
+        mt="auto"
       >
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          alignItems="center"
-          p={2}
-        >
-          {isLoading && !error && <CircularProgress />}
-        </Box>
-        {!enableDeploy && (
-          <Alert severity={isFromSource && !hasBuilds ? 'warning' : 'info'}>
-            {getAlertMessage()}
-          </Alert>
+        {isLoading && !error ? (
+          <Box p={2}>
+            <Skeleton variant="rect" width="100%" height={40} />
+          </Box>
+        ) : (
+          <>
+            {!enableDeploy && (
+              <Alert severity={isFromSource && !hasBuilds ? 'warning' : 'info'}>
+                {getAlertMessage()}
+              </Alert>
+            )}
+            <Button
+              onClick={toggleDrawer}
+              disabled={!enableDeploy || isDeploying || isLoading || isWorking}
+              variant="contained"
+              color="primary"
+              size="small"
+              style={{ alignSelf: 'flex-end' }}
+            >
+              Configure & Deploy
+            </Button>
+          </>
         )}
-        <Button
-          onClick={toggleDrawer}
-          disabled={!enableDeploy || isDeploying || isLoading || isWorking}
-          variant="contained"
-          color="primary"
-          size="small"
-        >
-          Configure & Deploy
-        </Button>
       </Box>
 
       <Drawer open={open} onClose={toggleDrawer} anchor="right">

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentData.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentData.ts
@@ -1,0 +1,58 @@
+import { Entity } from '@backstage/catalog-model';
+import {
+  discoveryApiRef,
+  identityApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import { useAsyncRetry } from 'react-use';
+import { fetchEnvironmentInfo } from '../../../api/environments';
+
+interface EndpointInfo {
+  name: string;
+  type: string;
+  url: string;
+  visibility: 'project' | 'organization' | 'public';
+}
+
+export interface Environment {
+  uid?: string;
+  name: string;
+  resourceName?: string;
+  bindingName?: string;
+  hasComponentTypeOverrides?: boolean;
+  deployment: {
+    status: 'success' | 'failed' | 'pending' | 'not-deployed' | 'suspended';
+    lastDeployed?: string;
+    image?: string;
+    statusMessage?: string;
+    releaseName?: string;
+  };
+  endpoints: EndpointInfo[];
+  promotionTargets?: {
+    name: string;
+    requiresApproval?: boolean;
+    isManualApprovalRequired?: boolean;
+  }[];
+}
+
+export function useEnvironmentData(entity: Entity) {
+  const discovery = useApi(discoveryApiRef);
+  const identityApi = useApi(identityApiRef);
+
+  const {
+    loading,
+    value: environments,
+    error,
+    retry,
+  } = useAsyncRetry(async () => {
+    const data = await fetchEnvironmentInfo(entity, discovery, identityApi);
+    return data as Environment[];
+  }, [entity, discovery, identityApi]);
+
+  return {
+    environments: environments ?? [],
+    loading,
+    error,
+    refetch: retry,
+  };
+}


### PR DESCRIPTION
  
<img width="1501" height="539" alt="image" src="https://github.com/user-attachments/assets/8a890406-9e9c-4f7e-a5d8-442e09727086" />
  
  Fixed environment card height inconsistencies and implemented proper
  stale-while-revalidate pattern for per-environment refresh.

  Changes:
  - Add useEnvironmentData hook using useAsyncRetry for data fetching
  - Implement per-environment refresh state tracking with Set<string>
  - Add stale data caching to prevent content flashing during refresh
  - Set consistent card minHeight (380px) across all environment cards
  - Fix skeleton loader from expanding card height (fixed 280px with overflow hidden)
  - Add spinning refresh icon animation during refresh
  - Add 300ms minimum delay to ensure loading state visibility
  - Only show skeleton loader on the specific card being refreshed
  - Keep other environment cards interactive during refresh

  Benefits:
  - Consistent visual height across all card states (deployed, undeployed, pending, skeleton)
  - Better UX with cached data visible during refresh (true SWR pattern)
  - Granular refresh control - refreshing one card doesn't affect others
  - No layout shifts when switching between content and skeleton states
  - Reduced empty whitespace in cards with minimal content
