### PR TITLE
Fix cell diagram filtering for dynamic component types

### DIFF
--- a/plugins/openchoreo-backend/package.json
+++ b/plugins/openchoreo-backend/package.json
@@ -41,6 +41,7 @@
     "@backstage/plugin-kubernetes-backend": "^0.20.2",
     "@backstage/plugin-kubernetes-node": "^0.3.4",
     "@backstage/plugin-permission-common": "^0.9.1",
+    "@openchoreo/backstage-plugin-common": "workspace:^",
     "@openchoreo/openchoreo-client-node": "workspace:^",
     "@wso2/cell-diagram": "0.2.0",
     "express": "^4.17.1",

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -52,6 +52,7 @@ export const choreoPlugin = createBackendPlugin({
         const cellDiagramInfoService = new CellDiagramInfoService(
           logger,
           openchoreoConfig.get('baseUrl'),
+          config,
         );
 
         const buildTemplateInfoService = new BuildTemplateInfoService(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9191,6 +9191,7 @@ __metadata:
     "@backstage/plugin-kubernetes-backend": "npm:^0.20.2"
     "@backstage/plugin-kubernetes-node": "npm:^0.3.4"
     "@backstage/plugin-permission-common": "npm:^0.9.1"
+    "@openchoreo/backstage-plugin-common": "workspace:^"
     "@openchoreo/openchoreo-client-node": "workspace:^"
     "@types/express": "npm:^4.17.6"
     "@types/supertest": "npm:^2.0.12"


### PR DESCRIPTION
  Update CellDiagramInfoService to use ComponentTypeUtils instead of hardcoded
  type checks ('Service', 'WebApplication'). Now properly handles new dynamic
  component type format (e.g., 'deployment/http-service').

  - Add openchoreo-common dependency to openchoreo-backend
  - Pass config to CellDiagramInfoService constructor
  - Replace hardcoded type filters with page variant-based filtering
  - Support all service and website component types via pattern matching

  Fixes cell diagram returning empty components after component type system changes.