### PR TITLE
Add summary cards to component overview page

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -13,7 +13,6 @@ import {
   EntityDependsOnResourcesCard,
   EntityHasComponentsCard,
   EntityHasResourcesCard,
-  EntityHasSubcomponentsCard,
   EntityHasSystemsCard,
   EntityLayout,
   EntityLinksCard,
@@ -66,6 +65,9 @@ import {
   CellDiagram,
   RuntimeLogs,
   Workflows,
+  WorkflowsOverviewCard,
+  ProductionOverviewCard,
+  RuntimeHealthCard,
 } from '@openchoreo/backstage-plugin';
 
 import { ObservabilityMetrics } from '@openchoreo/backstage-plugin-openchoreo-observability';
@@ -140,18 +142,23 @@ const entityWarningContent = (
 const overviewContent = (
   <Grid container spacing={3} alignItems="stretch">
     {entityWarningContent}
+
+    {/* OpenChoreo Summary Cards */}
+    <Grid item md={4} xs={12}>
+      <WorkflowsOverviewCard />
+    </Grid>
+    <Grid item md={4} xs={12}>
+      <ProductionOverviewCard />
+    </Grid>
+    <Grid item md={4} xs={12}>
+      <RuntimeHealthCard />
+    </Grid>
+
     <Grid item md={6}>
       <EntityAboutCard variant="gridItem" />
     </Grid>
     <Grid item md={6} xs={12}>
       <EntityCatalogGraphCard variant="gridItem" height={400} />
-    </Grid>
-
-    <Grid item md={4} xs={12}>
-      <EntityLinksCard />
-    </Grid>
-    <Grid item md={8} xs={12}>
-      <EntityHasSubcomponentsCard variant="gridItem" />
     </Grid>
   </Grid>
 );

--- a/plugins/openchoreo/src/components/Environments/OverviewCard/ProductionOverviewCard.tsx
+++ b/plugins/openchoreo/src/components/Environments/OverviewCard/ProductionOverviewCard.tsx
@@ -1,0 +1,213 @@
+import {
+  Box,
+  Button,
+  Typography,
+  IconButton,
+  CircularProgress,
+  Tooltip,
+} from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+import { Link } from '@backstage/core-components';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import CloudOffIcon from '@material-ui/icons/CloudOff';
+import LinkIcon from '@material-ui/icons/Link';
+import { Card, StatusBadge } from '@openchoreo/backstage-design-system';
+import { formatRelativeTime } from '@openchoreo/backstage-plugin-react';
+import { useProductionStatus } from './useProductionStatus';
+import { useOverviewCardStyles } from './styles';
+
+/**
+ * Maps deployment status to StatusBadge status type
+ */
+function getStatusBadgeStatus(
+  deploymentStatus?: 'Ready' | 'NotReady' | 'Failed',
+): 'active' | 'pending' | 'failed' | 'not-deployed' {
+  switch (deploymentStatus) {
+    case 'Ready':
+      return 'active';
+    case 'NotReady':
+      return 'pending';
+    case 'Failed':
+      return 'failed';
+    default:
+      return 'not-deployed';
+  }
+}
+
+export const ProductionOverviewCard = () => {
+  const classes = useOverviewCardStyles();
+  const {
+    productionEnv,
+    isDeployed,
+    deploymentStatus,
+    loading,
+    error,
+    refreshing,
+    refresh,
+  } = useProductionStatus();
+
+  // Loading state
+  if (loading) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Skeleton variant="text" width={100} height={28} />
+        </Box>
+        <Box className={classes.content}>
+          <Skeleton variant="rect" height={60} />
+        </Box>
+      </Card>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Typography className={classes.cardTitle}>Production</Typography>
+        </Box>
+        <Box className={classes.disabledState}>
+          <Typography variant="body2" color="error">
+            Failed to load deployment data
+          </Typography>
+        </Box>
+      </Card>
+    );
+  }
+
+  // No production environment configured
+  if (!productionEnv) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Typography className={classes.cardTitle}>Production</Typography>
+          <Link to="environments" className={classes.viewLink}>
+            View All <ArrowForwardIcon fontSize="small" />
+          </Link>
+        </Box>
+        <Box className={classes.disabledState}>
+          <CloudOffIcon className={classes.disabledIcon} />
+          <Typography variant="body2">
+            No production environment configured
+          </Typography>
+          <Typography variant="caption" color="textSecondary">
+            Set up a production environment from the Deploy tab
+          </Typography>
+        </Box>
+        <Box className={classes.actions}>
+          <Link to="environments" style={{ textDecoration: 'none' }}>
+            <Button variant="outlined" color="primary" size="small">
+              Go to Deploy
+            </Button>
+          </Link>
+        </Box>
+      </Card>
+    );
+  }
+
+  // Not deployed state
+  if (!isDeployed) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Typography className={classes.cardTitle}>Production</Typography>
+          <Link to="environments" className={classes.viewLink}>
+            View All <ArrowForwardIcon fontSize="small" />
+          </Link>
+        </Box>
+        <Box className={classes.content}>
+          <Box className={classes.statusRow}>
+            <StatusBadge status="not-deployed" label="Not Deployed" />
+          </Box>
+          <Typography variant="body2" color="textSecondary">
+            Deploy to production from the Deploy tab
+          </Typography>
+        </Box>
+        <Box className={classes.actions}>
+          <Link to="environments" style={{ textDecoration: 'none' }}>
+            <Button variant="outlined" color="primary" size="small">
+              Go to Deploy
+            </Button>
+          </Link>
+        </Box>
+      </Card>
+    );
+  }
+
+  // Deployed state
+  const { deployment, endpoints } = productionEnv;
+  const endpointCount = endpoints?.length || 0;
+
+  // Truncate image for display
+  const getDisplayImage = () => {
+    if (!deployment?.image) return null;
+    if (deployment.image.length > 40) {
+      return `...${deployment.image.slice(-37)}`;
+    }
+    return deployment.image;
+  };
+  const displayImage = getDisplayImage();
+
+  return (
+    <Card padding={16} className={classes.card}>
+      <Box className={classes.cardHeader}>
+        <Typography className={classes.cardTitle}>Production</Typography>
+        <Link to="environments" className={classes.viewLink}>
+          View All <ArrowForwardIcon fontSize="small" />
+        </Link>
+      </Box>
+
+      <Box className={classes.content}>
+        <Box className={classes.statusRow}>
+          <StatusBadge
+            status={getStatusBadgeStatus(deploymentStatus)}
+            label={deploymentStatus}
+          />
+          {deployment?.lastDeployed && (
+            <Box className={classes.metaItem}>
+              <AccessTimeIcon className={classes.metaIcon} />
+              <Typography variant="caption" color="textSecondary">
+                {formatRelativeTime(deployment.lastDeployed)}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
+        {displayImage && (
+          <Tooltip title={deployment?.image || ''} placement="top">
+            <Box className={classes.imageContainer}>{displayImage}</Box>
+          </Tooltip>
+        )}
+
+        {deploymentStatus === 'Ready' && endpointCount > 0 && (
+          <Box className={classes.endpointCount}>
+            <LinkIcon className={classes.metaIcon} />
+            <span>
+              {endpointCount} endpoint{endpointCount !== 1 ? 's' : ''} available
+            </span>
+          </Box>
+        )}
+      </Box>
+
+      <Box className={classes.actions}>
+        <Tooltip title="Refresh status">
+          <IconButton
+            size="small"
+            onClick={refresh}
+            disabled={refreshing}
+            aria-label="refresh"
+          >
+            {refreshing ? (
+              <CircularProgress size={18} />
+            ) : (
+              <RefreshIcon fontSize="small" />
+            )}
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </Card>
+  );
+};

--- a/plugins/openchoreo/src/components/Environments/OverviewCard/index.ts
+++ b/plugins/openchoreo/src/components/Environments/OverviewCard/index.ts
@@ -1,0 +1,1 @@
+export { ProductionOverviewCard } from './ProductionOverviewCard';

--- a/plugins/openchoreo/src/components/Environments/OverviewCard/styles.ts
+++ b/plugins/openchoreo/src/components/Environments/OverviewCard/styles.ts
@@ -1,0 +1,110 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { alpha } from '@material-ui/core/styles/colorManipulator';
+
+export const useOverviewCardStyles = makeStyles(theme => ({
+  card: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  cardHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+  },
+  cardTitle: {
+    fontWeight: 600,
+    fontSize: theme.typography.h6.fontSize,
+    color: theme.palette.text.primary,
+  },
+  viewLink: {
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.primary.main,
+    textDecoration: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+  content: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  },
+  statusRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    flexWrap: 'wrap',
+  },
+  metaRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    flexWrap: 'wrap',
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize,
+  },
+  metaItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  },
+  metaIcon: {
+    fontSize: '1rem',
+  },
+  imageContainer: {
+    fontFamily: 'monospace',
+    backgroundColor: alpha(
+      theme.palette.type === 'dark'
+        ? theme.palette.common.white
+        : theme.palette.common.black,
+      0.05,
+    ),
+    padding: theme.spacing(0.75, 1),
+    borderRadius: theme.spacing(0.5),
+    fontSize: '0.75rem',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    color: theme.palette.text.secondary,
+  },
+  actions: {
+    marginTop: 'auto',
+    paddingTop: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  disabledState: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: theme.spacing(2),
+    color: theme.palette.text.secondary,
+    flex: 1,
+  },
+  disabledIcon: {
+    fontSize: '2.5rem',
+    color: theme.palette.action.disabled,
+    marginBottom: theme.spacing(1),
+  },
+  sectionLabel: {
+    fontSize: theme.typography.caption.fontSize,
+    color: theme.palette.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+    fontWeight: 600,
+  },
+  endpointCount: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize,
+  },
+}));

--- a/plugins/openchoreo/src/components/Environments/OverviewCard/useProductionStatus.ts
+++ b/plugins/openchoreo/src/components/Environments/OverviewCard/useProductionStatus.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useApi,
+  discoveryApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { fetchEnvironmentInfo } from '../../../api/environments';
+import type { Environment } from '../hooks/useEnvironmentData';
+
+interface ProductionStatusState {
+  productionEnv: Environment | null;
+  loading: boolean;
+  error: Error | null;
+  refreshing: boolean;
+}
+
+/**
+ * Hook for fetching production environment status for the overview card.
+ * Filters environments to find production (matches "prod" or "production").
+ */
+export function useProductionStatus() {
+  const { entity } = useEntity();
+  const discovery = useApi(discoveryApiRef);
+  const identityApi = useApi(identityApiRef);
+
+  const [state, setState] = useState<ProductionStatusState>({
+    productionEnv: null,
+    loading: true,
+    error: null,
+    refreshing: false,
+  });
+
+  const fetchData = useCallback(async () => {
+    try {
+      const environments = (await fetchEnvironmentInfo(
+        entity,
+        discovery,
+        identityApi,
+      )) as Environment[];
+
+      // Find production environment (matches "prod" or "production", case-insensitive)
+      const productionEnv = environments.find(env => {
+        const name = env.name.toLowerCase();
+        return name === 'prod' || name === 'production';
+      });
+
+      setState(prev => ({
+        ...prev,
+        productionEnv: productionEnv || null,
+        loading: false,
+        error: null,
+      }));
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        error: err as Error,
+      }));
+    }
+  }, [entity, discovery, identityApi]);
+
+  const refresh = useCallback(async () => {
+    setState(prev => ({ ...prev, refreshing: true }));
+    try {
+      await fetchData();
+    } finally {
+      setState(prev => ({ ...prev, refreshing: false }));
+    }
+  }, [fetchData]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Poll if deployment is pending (NotReady)
+  useEffect(() => {
+    const status = state.productionEnv?.deployment?.status;
+    if (status !== 'NotReady') return undefined;
+
+    const intervalId = setInterval(() => {
+      fetchData();
+    }, 10000);
+
+    return () => clearInterval(intervalId);
+  }, [state.productionEnv, fetchData]);
+
+  // Determine deployment status
+  const isDeployed = Boolean(state.productionEnv?.deployment?.status);
+  const deploymentStatus = state.productionEnv?.deployment?.status;
+
+  return {
+    productionEnv: state.productionEnv,
+    isDeployed,
+    deploymentStatus,
+    loading: state.loading,
+    error: state.error,
+    refreshing: state.refreshing,
+    refresh,
+  };
+}

--- a/plugins/openchoreo/src/components/Environments/index.ts
+++ b/plugins/openchoreo/src/components/Environments/index.ts
@@ -1,1 +1,2 @@
 export { Environments } from './Environments';
+export { ProductionOverviewCard } from './OverviewCard';

--- a/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/RuntimeHealthCard.tsx
+++ b/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/RuntimeHealthCard.tsx
@@ -1,0 +1,161 @@
+import {
+  Box,
+  Typography,
+  IconButton,
+  CircularProgress,
+  Tooltip,
+} from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+import { Link } from '@backstage/core-components';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import ErrorIcon from '@material-ui/icons/Error';
+import WarningIcon from '@material-ui/icons/Warning';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import { Card } from '@openchoreo/backstage-design-system';
+import { formatRelativeTime } from '@openchoreo/backstage-plugin-react';
+import { useLogsSummary } from './useLogsSummary';
+import { useOverviewCardStyles } from './styles';
+
+export const RuntimeHealthCard = () => {
+  const classes = useOverviewCardStyles();
+  const {
+    errorCount,
+    warningCount,
+    lastActivityTime,
+    loading,
+    error,
+    observabilityDisabled,
+    refreshing,
+    refresh,
+  } = useLogsSummary();
+
+  // Loading state
+  if (loading) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Skeleton variant="text" width={120} height={28} />
+        </Box>
+        <Box className={classes.content}>
+          <Skeleton variant="rect" height={60} />
+        </Box>
+      </Card>
+    );
+  }
+
+  // Observability disabled state
+  if (observabilityDisabled) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Typography className={classes.cardTitle}>Runtime Health</Typography>
+        </Box>
+        <Box className={classes.disabledState}>
+          <VisibilityOffIcon className={classes.disabledIcon} />
+          <Typography variant="body2">Observability not enabled</Typography>
+          <Typography variant="caption" color="textSecondary">
+            Enable observability to view runtime logs and health metrics
+          </Typography>
+        </Box>
+      </Card>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Typography className={classes.cardTitle}>Runtime Health</Typography>
+        </Box>
+        <Box className={classes.disabledState}>
+          <Typography variant="body2" color="error">
+            Failed to load health data
+          </Typography>
+        </Box>
+      </Card>
+    );
+  }
+
+  // Healthy state (no errors or warnings)
+  const isHealthy = errorCount === 0 && warningCount === 0;
+
+  return (
+    <Card padding={16} className={classes.card}>
+      <Box className={classes.cardHeader}>
+        <Typography className={classes.cardTitle}>Runtime Health</Typography>
+        <Link to="runtime-logs" className={classes.viewLink}>
+          View Logs <ArrowForwardIcon fontSize="small" />
+        </Link>
+      </Box>
+
+      <Box className={classes.content}>
+        <Typography className={classes.timeRangeLabel}>Last 1 hour</Typography>
+
+        {isHealthy ? (
+          <Box className={classes.healthyState}>
+            <CheckCircleIcon className={classes.healthyIcon} />
+            <Typography variant="body2">No errors or warnings</Typography>
+          </Box>
+        ) : (
+          <Box className={classes.countsRow}>
+            {errorCount > 0 && (
+              <Box className={classes.countItem}>
+                <ErrorIcon className={classes.errorCount} fontSize="small" />
+                <span className={`${classes.countValue} ${classes.errorCount}`}>
+                  {errorCount}
+                </span>
+                <span className={classes.countLabel}>
+                  Error{errorCount !== 1 ? 's' : ''}
+                </span>
+              </Box>
+            )}
+            {warningCount > 0 && (
+              <Box className={classes.countItem}>
+                <WarningIcon
+                  className={classes.warningCount}
+                  fontSize="small"
+                />
+                <span
+                  className={`${classes.countValue} ${classes.warningCount}`}
+                >
+                  {warningCount}
+                </span>
+                <span className={classes.countLabel}>
+                  Warning{warningCount !== 1 ? 's' : ''}
+                </span>
+              </Box>
+            )}
+          </Box>
+        )}
+
+        {lastActivityTime && (
+          <Box className={classes.lastActivityRow}>
+            <AccessTimeIcon className={classes.metaIcon} />
+            <span>Last activity: {formatRelativeTime(lastActivityTime)}</span>
+          </Box>
+        )}
+      </Box>
+
+      <Box className={classes.actions}>
+        <Tooltip title="Refresh">
+          <IconButton
+            size="small"
+            onClick={refresh}
+            disabled={refreshing}
+            aria-label="refresh"
+          >
+            {refreshing ? (
+              <CircularProgress size={18} />
+            ) : (
+              <RefreshIcon fontSize="small" />
+            )}
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </Card>
+  );
+};

--- a/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/index.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/index.ts
@@ -1,0 +1,1 @@
+export { RuntimeHealthCard } from './RuntimeHealthCard';

--- a/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/styles.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/styles.ts
@@ -1,0 +1,106 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useOverviewCardStyles = makeStyles(theme => ({
+  card: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  cardHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+  },
+  cardTitle: {
+    fontWeight: 600,
+    fontSize: theme.typography.h6.fontSize,
+    color: theme.palette.text.primary,
+  },
+  viewLink: {
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.primary.main,
+    textDecoration: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+  content: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  },
+  timeRangeLabel: {
+    fontSize: theme.typography.caption.fontSize,
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(0.5),
+  },
+  countsRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(3),
+    flexWrap: 'wrap',
+  },
+  countItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+  },
+  countValue: {
+    fontWeight: 600,
+    fontSize: theme.typography.h6.fontSize,
+  },
+  countLabel: {
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.secondary,
+  },
+  errorCount: {
+    color: theme.palette.error.main,
+  },
+  warningCount: {
+    color: theme.palette.warning.dark,
+  },
+  healthyState: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    color: theme.palette.success.main,
+  },
+  healthyIcon: {
+    color: theme.palette.success.main,
+  },
+  lastActivityRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize,
+  },
+  metaIcon: {
+    fontSize: '1rem',
+  },
+  actions: {
+    marginTop: 'auto',
+    paddingTop: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  disabledState: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: theme.spacing(2),
+    color: theme.palette.text.secondary,
+    flex: 1,
+  },
+  disabledIcon: {
+    fontSize: '2.5rem',
+    color: theme.palette.action.disabled,
+    marginBottom: theme.spacing(1),
+  },
+}));

--- a/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useApi,
+  discoveryApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import {
+  getRuntimeLogs,
+  getEnvironments,
+  getComponentDetails,
+  calculateTimeRange,
+} from '../../../api/runtimeLogs';
+import type { LogEntry, Environment } from '../types';
+
+interface LogsSummaryState {
+  errorCount: number;
+  warningCount: number;
+  lastActivityTime: string | null;
+  loading: boolean;
+  error: Error | null;
+  observabilityDisabled: boolean;
+  refreshing: boolean;
+}
+
+/**
+ * Hook for fetching log summary (error/warning counts) for the overview card.
+ * Fetches logs from the last 1 hour and counts by level.
+ */
+export function useLogsSummary() {
+  const { entity } = useEntity();
+  const discovery = useApi(discoveryApiRef);
+  const identity = useApi(identityApiRef);
+
+  const [state, setState] = useState<LogsSummaryState>({
+    errorCount: 0,
+    warningCount: 0,
+    lastActivityTime: null,
+    loading: true,
+    error: null,
+    observabilityDisabled: false,
+    refreshing: false,
+  });
+
+  const fetchData = useCallback(async () => {
+    try {
+      // Get component ID first
+      const componentDetails = await getComponentDetails(
+        entity,
+        discovery,
+        identity,
+      );
+      const componentId = componentDetails.uid;
+
+      if (!componentId) {
+        throw new Error('Component ID not found');
+      }
+
+      // Get environments
+      const environments: Environment[] = await getEnvironments(
+        entity,
+        discovery,
+        identity,
+      );
+
+      if (environments.length === 0) {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: null,
+        }));
+        return;
+      }
+
+      // Use first environment (usually the default/primary)
+      const selectedEnv = environments[0];
+      const componentName =
+        entity.metadata.annotations?.[CHOREO_ANNOTATIONS.COMPONENT];
+
+      if (!componentName) {
+        throw new Error('Component name not found in annotations');
+      }
+
+      const { startTime, endTime } = calculateTimeRange('1h');
+
+      // Fetch logs to get counts
+      const response = await getRuntimeLogs(entity, discovery, identity, {
+        componentId,
+        componentName,
+        environmentId: selectedEnv.id,
+        environmentName: selectedEnv.name,
+        logLevels: [], // Get all levels
+        startTime,
+        endTime,
+        limit: 100, // Limit for performance, we just need counts
+        offset: 0,
+      });
+
+      // Count errors and warnings
+      const logs: LogEntry[] = response.logs || [];
+      const errorCount = logs.filter(log => log.logLevel === 'ERROR').length;
+      const warningCount = logs.filter(log => log.logLevel === 'WARN').length;
+
+      // Get last activity time (most recent log)
+      const lastActivityTime = logs.length > 0 ? logs[0].timestamp : null;
+
+      setState(prev => ({
+        ...prev,
+        errorCount,
+        warningCount,
+        lastActivityTime,
+        loading: false,
+        error: null,
+        observabilityDisabled: false,
+      }));
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to fetch logs';
+
+      // Check if observability is disabled
+      if (errorMessage.includes('Observability is not enabled')) {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: null,
+          observabilityDisabled: true,
+        }));
+      } else {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: err as Error,
+        }));
+      }
+    }
+  }, [entity, discovery, identity]);
+
+  const refresh = useCallback(async () => {
+    setState(prev => ({ ...prev, refreshing: true }));
+    try {
+      await fetchData();
+    } finally {
+      setState(prev => ({ ...prev, refreshing: false }));
+    }
+  }, [fetchData]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Determine health status based on error/warning counts
+  const getHealthStatus = (): 'healthy' | 'warning' | 'error' => {
+    if (state.errorCount > 0) return 'error';
+    if (state.warningCount > 0) return 'warning';
+    return 'healthy';
+  };
+
+  return {
+    errorCount: state.errorCount,
+    warningCount: state.warningCount,
+    lastActivityTime: state.lastActivityTime,
+    healthStatus: getHealthStatus(),
+    loading: state.loading,
+    error: state.error,
+    observabilityDisabled: state.observabilityDisabled,
+    refreshing: state.refreshing,
+    refresh,
+  };
+}

--- a/plugins/openchoreo/src/components/RuntimeLogs/index.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/index.ts
@@ -2,5 +2,6 @@ export { RuntimeLogs } from './RuntimeLogs';
 export { LogsFilter } from './LogsFilter';
 export { LogsTable } from './LogsTable';
 export { LogEntry } from './LogEntry';
+export { RuntimeHealthCard } from './OverviewCard';
 export * from './types';
 export * from './hooks';

--- a/plugins/openchoreo/src/components/Workflows/OverviewCard/WorkflowsOverviewCard.tsx
+++ b/plugins/openchoreo/src/components/Workflows/OverviewCard/WorkflowsOverviewCard.tsx
@@ -1,0 +1,173 @@
+import { Box, Button, Typography, CircularProgress } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+import { Link } from '@backstage/core-components';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import CodeIcon from '@material-ui/icons/Code';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import BuildIcon from '@material-ui/icons/Build';
+import BlockIcon from '@material-ui/icons/Block';
+import { Card } from '@openchoreo/backstage-design-system';
+import { formatRelativeTime } from '@openchoreo/backstage-plugin-react';
+import { BuildStatusChip } from '../BuildStatusChip';
+import { useWorkflowsSummary } from './useWorkflowsSummary';
+import { useOverviewCardStyles } from './styles';
+
+export const WorkflowsOverviewCard = () => {
+  const classes = useOverviewCardStyles();
+  const {
+    latestBuild,
+    hasWorkflows,
+    loading,
+    error,
+    triggeringBuild,
+    triggerBuild,
+  } = useWorkflowsSummary();
+
+  // Loading state
+  if (loading) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Skeleton variant="text" width={100} height={28} />
+        </Box>
+        <Box className={classes.content}>
+          <Skeleton variant="rect" height={60} />
+        </Box>
+      </Card>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Typography className={classes.cardTitle}>Workflows</Typography>
+        </Box>
+        <Box className={classes.disabledState}>
+          <Typography variant="body2" color="error">
+            Failed to load workflow data
+          </Typography>
+        </Box>
+      </Card>
+    );
+  }
+
+  // Workflows not enabled state
+  if (!hasWorkflows) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Typography className={classes.cardTitle}>Workflows</Typography>
+        </Box>
+        <Box className={classes.disabledState}>
+          <BlockIcon className={classes.disabledIcon} />
+          <Typography variant="body2">
+            Workflows not enabled for this component
+          </Typography>
+        </Box>
+      </Card>
+    );
+  }
+
+  // No builds yet state
+  if (!latestBuild) {
+    return (
+      <Card padding={16} className={classes.card}>
+        <Box className={classes.cardHeader}>
+          <Typography className={classes.cardTitle}>Workflows</Typography>
+          <Link to="workflows" className={classes.viewLink}>
+            View All <ArrowForwardIcon fontSize="small" />
+          </Link>
+        </Box>
+        <Box className={classes.emptyState}>
+          <BuildIcon className={classes.disabledIcon} />
+          <Typography variant="body2">No builds yet</Typography>
+          <Typography variant="caption" color="textSecondary">
+            Trigger your first build to get started
+          </Typography>
+        </Box>
+        <Box className={classes.actions}>
+          <Button
+            variant="outlined"
+            color="primary"
+            size="small"
+            onClick={triggerBuild}
+            disabled={triggeringBuild}
+            startIcon={
+              triggeringBuild ? (
+                <CircularProgress size={14} />
+              ) : (
+                <BuildIcon fontSize="small" />
+              )
+            }
+          >
+            {triggeringBuild ? 'Building...' : 'Build Now'}
+          </Button>
+        </Box>
+      </Card>
+    );
+  }
+
+  // Normal state with latest build
+  const commitHash = latestBuild.commit
+    ? latestBuild.commit.substring(0, 8)
+    : null;
+
+  return (
+    <Card padding={16} className={classes.card}>
+      <Box className={classes.cardHeader}>
+        <Typography className={classes.cardTitle}>Workflows</Typography>
+        <Link to="workflows" className={classes.viewLink}>
+          View All <ArrowForwardIcon fontSize="small" />
+        </Link>
+      </Box>
+
+      <Box className={classes.content}>
+        <Typography className={classes.sectionLabel}>Latest Build</Typography>
+        <Box className={classes.buildInfo}>
+          <Box className={classes.buildHeader}>
+            <BuildStatusChip status={latestBuild.status} />
+            <Typography className={classes.buildName} title={latestBuild.name}>
+              {latestBuild.name}
+            </Typography>
+          </Box>
+
+          <Box className={classes.metaRow}>
+            {latestBuild.createdAt && (
+              <Box className={classes.metaItem}>
+                <AccessTimeIcon className={classes.metaIcon} />
+                <span>{formatRelativeTime(latestBuild.createdAt)}</span>
+              </Box>
+            )}
+            {commitHash && (
+              <Box className={classes.metaItem}>
+                <CodeIcon className={classes.metaIcon} />
+                <span className={classes.commitHash}>{commitHash}</span>
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </Box>
+
+      <Box className={classes.actions}>
+        <Button
+          variant="outlined"
+          color="primary"
+          size="small"
+          onClick={triggerBuild}
+          disabled={triggeringBuild}
+          startIcon={
+            triggeringBuild ? (
+              <CircularProgress size={14} />
+            ) : (
+              <BuildIcon fontSize="small" />
+            )
+          }
+        >
+          {triggeringBuild ? 'Building...' : 'Build Now'}
+        </Button>
+      </Box>
+    </Card>
+  );
+};

--- a/plugins/openchoreo/src/components/Workflows/OverviewCard/index.ts
+++ b/plugins/openchoreo/src/components/Workflows/OverviewCard/index.ts
@@ -1,0 +1,1 @@
+export { WorkflowsOverviewCard } from './WorkflowsOverviewCard';

--- a/plugins/openchoreo/src/components/Workflows/OverviewCard/styles.ts
+++ b/plugins/openchoreo/src/components/Workflows/OverviewCard/styles.ts
@@ -1,0 +1,124 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { alpha } from '@material-ui/core/styles/colorManipulator';
+
+export const useOverviewCardStyles = makeStyles(theme => ({
+  card: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  cardHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+  },
+  cardTitle: {
+    fontWeight: 600,
+    fontSize: theme.typography.h6.fontSize,
+    color: theme.palette.text.primary,
+  },
+  viewLink: {
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.primary.main,
+    textDecoration: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+  content: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  },
+  buildInfo: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+  buildHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    flexWrap: 'wrap',
+  },
+  buildName: {
+    fontWeight: 500,
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.primary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: '150px',
+  },
+  metaRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    flexWrap: 'wrap',
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize,
+  },
+  metaItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  },
+  metaIcon: {
+    fontSize: '1rem',
+  },
+  commitHash: {
+    fontFamily: 'monospace',
+    backgroundColor: alpha(
+      theme.palette.type === 'dark'
+        ? theme.palette.common.white
+        : theme.palette.common.black,
+      0.05,
+    ),
+    padding: theme.spacing(0.25, 0.75),
+    borderRadius: theme.spacing(0.5),
+    fontSize: '0.75rem',
+  },
+  actions: {
+    marginTop: 'auto',
+    paddingTop: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  disabledState: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: theme.spacing(2),
+    color: theme.palette.text.secondary,
+    flex: 1,
+  },
+  disabledIcon: {
+    fontSize: '2.5rem',
+    color: theme.palette.action.disabled,
+    marginBottom: theme.spacing(1),
+  },
+  emptyState: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: theme.spacing(2),
+    color: theme.palette.text.secondary,
+    flex: 1,
+  },
+  sectionLabel: {
+    fontSize: theme.typography.caption.fontSize,
+    color: theme.palette.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+    fontWeight: 600,
+    marginBottom: theme.spacing(0.5),
+  },
+}));

--- a/plugins/openchoreo/src/components/Workflows/OverviewCard/useWorkflowsSummary.ts
+++ b/plugins/openchoreo/src/components/Workflows/OverviewCard/useWorkflowsSummary.ts
@@ -1,0 +1,174 @@
+import { useState, useCallback, useEffect } from 'react';
+import {
+  useApi,
+  discoveryApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { useComponentEntityDetails } from '@openchoreo/backstage-plugin-react';
+import type {
+  ModelsBuild,
+  ModelsCompleteComponent,
+} from '@openchoreo/backstage-plugin-common';
+
+interface WorkflowsSummaryState {
+  latestBuild: ModelsBuild | null;
+  componentDetails: ModelsCompleteComponent | null;
+  loading: boolean;
+  error: Error | null;
+  triggeringBuild: boolean;
+}
+
+/**
+ * Simplified hook for fetching workflow summary data for the overview card.
+ * Fetches component details and latest build only.
+ */
+export function useWorkflowsSummary() {
+  const discoveryApi = useApi(discoveryApiRef);
+  const identityApi = useApi(identityApiRef);
+  const { getEntityDetails } = useComponentEntityDetails();
+
+  const [state, setState] = useState<WorkflowsSummaryState>({
+    latestBuild: null,
+    componentDetails: null,
+    loading: true,
+    error: null,
+    triggeringBuild: false,
+  });
+
+  const fetchData = useCallback(async () => {
+    try {
+      const { componentName, projectName, organizationName } =
+        await getEntityDetails();
+
+      const { token } = await identityApi.getCredentials();
+      const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
+
+      // Fetch component details and builds in parallel
+      const [componentResponse, buildsResponse] = await Promise.all([
+        fetch(
+          `${baseUrl}/component?componentName=${encodeURIComponent(
+            componentName,
+          )}&projectName=${encodeURIComponent(
+            projectName,
+          )}&organizationName=${encodeURIComponent(organizationName)}`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        ),
+        fetch(
+          `${baseUrl}/builds?componentName=${encodeURIComponent(
+            componentName,
+          )}&projectName=${encodeURIComponent(
+            projectName,
+          )}&organizationName=${encodeURIComponent(organizationName)}`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        ),
+      ]);
+
+      if (!componentResponse.ok) {
+        throw new Error(
+          `HTTP ${componentResponse.status}: ${componentResponse.statusText}`,
+        );
+      }
+
+      const componentData = await componentResponse.json();
+      let latestBuild: ModelsBuild | null = null;
+
+      if (buildsResponse.ok) {
+        const buildsData: ModelsBuild[] = await buildsResponse.json();
+        // Get the latest build (first in array, sorted by createdAt desc)
+        latestBuild = buildsData.length > 0 ? buildsData[0] : null;
+      }
+
+      setState(prev => ({
+        ...prev,
+        componentDetails: componentData,
+        latestBuild,
+        loading: false,
+        error: null,
+      }));
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        error: err as Error,
+      }));
+    }
+  }, [discoveryApi, identityApi, getEntityDetails]);
+
+  const triggerBuild = useCallback(async () => {
+    setState(prev => ({ ...prev, triggeringBuild: true }));
+    try {
+      const { componentName, projectName, organizationName } =
+        await getEntityDetails();
+
+      const { token } = await identityApi.getCredentials();
+      const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
+
+      const response = await fetch(`${baseUrl}/builds`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          componentName,
+          projectName,
+          organizationName,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      // Refresh data after triggering build
+      await fetchData();
+    } catch (err) {
+      setState(prev => ({ ...prev, error: err as Error }));
+    } finally {
+      setState(prev => ({ ...prev, triggeringBuild: false }));
+    }
+  }, [discoveryApi, identityApi, getEntityDetails, fetchData]);
+
+  const refresh = useCallback(async () => {
+    setState(prev => ({ ...prev, loading: true }));
+    await fetchData();
+  }, [fetchData]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Poll if latest build is active
+  useEffect(() => {
+    if (!state.latestBuild) return undefined;
+
+    const status = state.latestBuild.status?.toLowerCase() || '';
+    const isActive =
+      status.includes('pending') ||
+      status.includes('running') ||
+      status.includes('progress');
+
+    if (!isActive) return undefined;
+
+    const intervalId = setInterval(() => {
+      fetchData();
+    }, 5000);
+
+    return () => clearInterval(intervalId);
+  }, [state.latestBuild, fetchData]);
+
+  // Check if workflows are enabled for this component
+  const hasWorkflows = Boolean(state.componentDetails?.workflow?.name);
+
+  return {
+    latestBuild: state.latestBuild,
+    componentDetails: state.componentDetails,
+    hasWorkflows,
+    loading: state.loading,
+    error: state.error,
+    triggeringBuild: state.triggeringBuild,
+    triggerBuild,
+    refresh,
+  };
+}

--- a/plugins/openchoreo/src/components/Workflows/index.ts
+++ b/plugins/openchoreo/src/components/Workflows/index.ts
@@ -1,1 +1,2 @@
 export { Workflows } from './Workflows';
+export { WorkflowsOverviewCard } from './OverviewCard';

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -2,6 +2,12 @@ export { choreoPlugin } from './plugin';
 export { Environments } from './components/Environments/Environments';
 export { CellDiagram } from './components/CellDiagram/CellDiagram';
 export { Builds } from './components/Builds/Builds';
-export { RuntimeLogs, Workflows } from './plugin';
+export {
+  RuntimeLogs,
+  Workflows,
+  WorkflowsOverviewCard,
+  ProductionOverviewCard,
+  RuntimeHealthCard,
+} from './plugin';
 export * from './components/HomePage/MyProjectsWidget';
 export * from './components/HomePage/QuickActionsSection';

--- a/plugins/openchoreo/src/plugin.ts
+++ b/plugins/openchoreo/src/plugin.ts
@@ -1,6 +1,7 @@
 import {
   createPlugin,
   createRoutableExtension,
+  createComponentExtension,
 } from '@backstage/core-plugin-api';
 import {
   rootCatalogEnvironmentRouteRef,
@@ -48,5 +49,36 @@ export const Workflows = choreoPlugin.provide(
     name: 'ChoreoWorkflows',
     component: () => import('./components/Workflows').then(m => m.Workflows),
     mountPoint: rootCatalogWorkflowsRouteRef,
+  }),
+);
+
+// Overview cards (non-routable components for entity overview page)
+export const WorkflowsOverviewCard = choreoPlugin.provide(
+  createComponentExtension({
+    name: 'WorkflowsOverviewCard',
+    component: {
+      lazy: () =>
+        import('./components/Workflows').then(m => m.WorkflowsOverviewCard),
+    },
+  }),
+);
+
+export const ProductionOverviewCard = choreoPlugin.provide(
+  createComponentExtension({
+    name: 'ProductionOverviewCard',
+    component: {
+      lazy: () =>
+        import('./components/Environments').then(m => m.ProductionOverviewCard),
+    },
+  }),
+);
+
+export const RuntimeHealthCard = choreoPlugin.provide(
+  createComponentExtension({
+    name: 'RuntimeHealthCard',
+    component: {
+      lazy: () =>
+        import('./components/RuntimeLogs').then(m => m.RuntimeHealthCard),
+    },
   }),
 );


### PR DESCRIPTION
<img width="1715" height="872" alt="image" src="https://github.com/user-attachments/assets/27102e8c-890c-4777-864b-2f847bbe9ba2" />
<img width="1715" height="872" alt="image" src="https://github.com/user-attachments/assets/de93be71-e2d1-4606-b5b7-22113f0099c8" />
  
  
  Add three new overview cards that provide at-a-glance insights for
  components without navigating to individual tabs:

  - WorkflowsOverviewCard: Shows latest build status, commit info, and "Build Now" action. Displays disabled state for non-workflow components.

  - ProductionOverviewCard: Shows production environment deployment status, last deployed time, image, and endpoint count with refresh action.

  - RuntimeHealthCard: Shows error/warning counts from the last hour with last activity timestamp. Handles observability disabled state.

  Cards are positioned at the top of the overview page for immediate
  visibility. Each card links to its respective full tab for details.

Related to : https://github.com/openchoreo/openchoreo/issues/595
