### PR TITLE
Add security hardening for npm lifecycle scripts and npx commands

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Security: Disable automatic lifecycle script execution
+# Only enable scripts for trusted, vetted packages when absolutely necessary
+# See: https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts
+ignore-scripts=true

--- a/packages/openapi-client-generator-node/scripts/generate-client.sh
+++ b/packages/openapi-client-generator-node/scripts/generate-client.sh
@@ -181,14 +181,14 @@ for ((i=0; i<$SPECS_COUNT; i++)); do
 
   # Generate TypeScript types
   echo -e "   Generating types..."
-  npx openapi-typescript "$SPEC_INPUT" -o "$SPEC_OUTPUT_DIR/types.ts"
+  npx openapi-typescript@7.4.4 "$SPEC_INPUT" -o "$SPEC_OUTPUT_DIR/types.ts"
 
   if [ $? -eq 0 ]; then
     echo -e "${GREEN}✓ Types generated successfully${NC}"
 
     # Format with Prettier
     echo -e "   Formatting with Prettier..."
-    npx prettier --write "$SPEC_OUTPUT_DIR/types.ts" > /dev/null 2>&1
+    npx prettier@2.3.2 --write "$SPEC_OUTPUT_DIR/types.ts" > /dev/null 2>&1
     if [ $? -eq 0 ]; then
       echo -e "${GREEN}✓ Types formatted with Prettier${NC}"
     else

--- a/plugins/thunder-idp-client-node/scripts/generate-clients.sh
+++ b/plugins/thunder-idp-client-node/scripts/generate-clients.sh
@@ -117,7 +117,7 @@ echo -e "${YELLOW}🔨 Generating TypeScript types from OpenAPI specs...${NC}"
 
 # Generate User API types
 echo -e "   Generating User API types..."
-npx openapi-typescript "$OPENAPI_DIR/user.yaml" -o "$GENERATED_DIR/user/types.ts"
+npx openapi-typescript@7.4.4 "$OPENAPI_DIR/user.yaml" -o "$GENERATED_DIR/user/types.ts"
 
 if [ $? -eq 0 ]; then
   echo -e "${GREEN}✓ User API types generated successfully${NC}"
@@ -128,7 +128,7 @@ fi
 
 # Generate Group API types
 echo -e "   Generating Group API types..."
-npx openapi-typescript "$OPENAPI_DIR/group.yaml" -o "$GENERATED_DIR/group/types.ts"
+npx openapi-typescript@7.4.4 "$OPENAPI_DIR/group.yaml" -o "$GENERATED_DIR/group/types.ts"
 
 if [ $? -eq 0 ]; then
   echo -e "${GREEN}✓ Group API types generated successfully${NC}"


### PR DESCRIPTION
  - Pin npx command versions to prevent supply chain attacks:
    - openapi-typescript@7.4.4 in generate-client.sh scripts
    - prettier@2.3.2 in generate-client.sh
  - Add .npmrc with ignore-scripts=true to disable automatic lifecycle script execution in CI/CD environments
