### PR TITLE
Fix Secret Ref List DropDown selection issue in Env Vars

### DIFF
--- a/packages/design-system/src/components/SecretSelector/SecretSelector.tsx
+++ b/packages/design-system/src/components/SecretSelector/SecretSelector.tsx
@@ -70,10 +70,8 @@ export const SecretSelector: FC<SecretSelectorProps> = ({
   const handleNameChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     const newName = event.target.value as string;
     onSecretNameChange(newName);
-    // Auto-clear key when name changes
-    if (newName !== secretName) {
-      onSecretKeyChange('');
-    }
+    // Note: Key clearing is handled by the parent component (e.g., EnvVarEditor.handleSecretNameChange)
+    // to avoid race conditions with React state updates
   };
 
   const handleKeyChange = (event: React.ChangeEvent<{ value: unknown }>) => {


### PR DESCRIPTION
Fixes: https://github.com/openchoreo/openchoreo/issues/1197

 The Issue:
  When you select a secret name, SecretSelector calls two callbacks in sequence:
  1. onSecretNameChange(newName) - correctly updates the buffer with the new name
  2. onSecretKeyChange('') - tries to clear the key, but reads stale props and overwrites the
   name with an empty string

  The Fix:
  Remove the onSecretKeyChange('') call from SecretSelector.tsx:74-76 since
  EnvVarEditor.handleSecretNameChange already clears the key when setting { secretRef: { 
  name, key: '' } }.

https://github.com/user-attachments/assets/73a0ae74-7ec3-4ef9-9590-72c7b885b965

