### PR TITLE
Sync openchoreo auth config between base and production

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -80,7 +80,18 @@ openchoreo:
   # Environment variables are injected by Helm chart (see https://github.com/openchoreo/openchoreo install/helm/openchoreo/templates/backstage/deployment.yaml)
   # OPENCHOREO_API_URL: defaults to internal K8s service URL or set via backstage.openchoreoApi.url
   baseUrl: ${OPENCHOREO_API_URL}
-  token: ${OPENCHOREO_TOKEN} # optional for now: for authentication
+
+  # Authentication configuration
+  # User-initiated requests: Token forwarded from frontend (IDP access token via x-openchoreo-token header)
+  # Background tasks (Catalog Provider): Uses client credentials below
+  auth:
+    # OAuth2 Client Credentials for background tasks (Catalog Entity Provider)
+    # Required for the Catalog Provider to fetch organizations, projects, and components
+    clientId: ${OPENCHOREO_AUTH_CLIENT_ID}
+    clientSecret: ${OPENCHOREO_AUTH_CLIENT_SECRET}
+    tokenUrl: ${OPENCHOREO_AUTH_TOKEN_URL}
+    # scopes: ['openid'] # Optional: uncomment to specify scopes
+
   defaultOwner: 'platformengineer' # Default owner for catalog entities
   schedule:
     frequency: 30 # seconds between runs (default: 30)


### PR DESCRIPTION
  Replace deprecated token field with OAuth2 client credentials
  section in app-config.production.yaml to match app-config.yaml.
  This ensures production uses the same authentication approach
  for background tasks (Catalog Entity Provider)
