### PR TITLE
Update JWT payload to handle new groups array field

### DIFF
--- a/plugins/auth-backend-module-openchoreo-default/src/auth.ts
+++ b/plugins/auth-backend-module-openchoreo-default/src/auth.ts
@@ -260,8 +260,8 @@ export const OpenChoreoDefaultAuthModule = createBackendModule({
               let groups: string[] = [];
               if (accessToken) {
                 const payload = decodeJwtUnsafe(accessToken);
-                if (payload?.group) {
-                  groups = [payload.group];
+                if (payload?.groups && Array.isArray(payload.groups)) {
+                  groups = payload.groups;
                 } else if (!payload) {
                   logger.warn(
                     'Failed to decode access token for group extraction',

--- a/plugins/auth-backend-module-openchoreo-default/src/jwtUtils.ts
+++ b/plugins/auth-backend-module-openchoreo-default/src/jwtUtils.ts
@@ -9,7 +9,13 @@ export interface OpenChoreoTokenPayload {
   username: string;
   given_name?: string;
   family_name?: string;
-  group?: string;
+  groups?: string[];
+  ouHandle?: string;
+  ouId?: string;
+  ouName?: string;
+  userType?: string;
+  client_id?: string;
+  grant_type?: string;
   aud: string;
   exp: number;
   iat: number;


### PR DESCRIPTION
  - Change OpenChoreoTokenPayload interface from singular `group` string to plural `groups` array to match updated Thunder IdP JWT format
  - Add new JWT fields: ouHandle, ouId, ouName, userType, client_id, grant_type
  - Update signInResolver to use groups array directly instead of wrapping single group value

Fixes: https://github.com/openchoreo/openchoreo/issues/1210
