### PR TITLE
Bind fetch method in OpenChoreoFetchApi to preserve 'this' context for callback usage

### DIFF
--- a/packages/app/src/apis/OpenChoreoFetchApi.ts
+++ b/packages/app/src/apis/OpenChoreoFetchApi.ts
@@ -32,6 +32,9 @@ export class OpenChoreoFetchApi implements FetchApi {
   ) {
     this.authEnabled =
       configApi.getOptionalBoolean('openchoreo.features.auth.enabled') ?? true;
+
+    // Bind fetch method to preserve 'this' context when used as callback
+    this.fetch = this.fetch.bind(this);
   }
 
   async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {


### PR DESCRIPTION
## Purpose

This pull request makes a small but important change to the `OpenChoreoFetchApi` class to ensure correct context binding when the `fetch` method is used as a callback.

- Ensured that the `fetch` method is always called with the correct `this` context by explicitly binding it in the constructor of `OpenChoreoFetchApi` (`packages/app/src/apis/OpenChoreoFetchApi.ts`).

