### PR TITLE
Use fetchApiRef for all API calls to ensure x-openchoreo-token header

### DIFF
--- a/plugins/openchoreo-observability/src/hooks/useMetrics.ts
+++ b/plugins/openchoreo-observability/src/hooks/useMetrics.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
   fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { observabilityApiRef } from '../api/ObservabilityApi';
@@ -14,10 +13,8 @@ import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 async function getComponentDetails(
   entity: Entity,
   discovery: any,
-  identity: any,
   fetchApi: any,
 ): Promise<{ uid?: string }> {
-  const { token } = await identity.getCredentials();
   const component = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.COMPONENT];
   const project = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT];
   const organization =
@@ -41,11 +38,7 @@ async function getComponentDetails(
 
   backendUrl.search = params.toString();
 
-  const response = await fetchApi.fetch(backendUrl.toString(), {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  const response = await fetchApi.fetch(backendUrl.toString());
 
   if (!response.ok) {
     throw new Error(
@@ -60,10 +53,8 @@ async function getComponentDetails(
 async function getProjectDetails(
   entity: Entity,
   discovery: any,
-  identity: any,
   fetchApi: any,
 ): Promise<{ uid?: string }> {
-  const { token } = await identity.getCredentials();
   const project = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT];
   const organization =
     entity.metadata.annotations?.[CHOREO_ANNOTATIONS.ORGANIZATION];
@@ -85,11 +76,7 @@ async function getProjectDetails(
 
   backendUrl.search = params.toString();
 
-  const response = await fetchApi.fetch(backendUrl.toString(), {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  const response = await fetchApi.fetch(backendUrl.toString());
 
   if (!response.ok) {
     throw new Error(
@@ -109,7 +96,6 @@ export function useMetrics(
 ) {
   const observabilityApi = useApi(observabilityApiRef);
   const discovery = useApi(discoveryApiRef);
-  const identity = useApi(identityApiRef);
   const fetchApi = useApi(fetchApiRef);
   const [metrics, setMetrics] = useState<Metrics | null>(null);
   const [loading, setLoading] = useState(false);
@@ -122,8 +108,8 @@ export function useMetrics(
     const fetchIds = async () => {
       try {
         const [componentDetails, projectDetails] = await Promise.all([
-          getComponentDetails(entity, discovery, identity, fetchApi),
-          getProjectDetails(entity, discovery, identity, fetchApi),
+          getComponentDetails(entity, discovery, fetchApi),
+          getProjectDetails(entity, discovery, fetchApi),
         ]);
         setComponentId(componentDetails.uid || null);
         setProjectId(projectDetails.uid || null);
@@ -137,7 +123,7 @@ export function useMetrics(
     };
 
     fetchIds();
-  }, [entity, discovery, identity, fetchApi]);
+  }, [entity, discovery, fetchApi]);
 
   const fetchMetrics = useCallback(
     async (reset: boolean = false) => {

--- a/plugins/openchoreo-observability/src/hooks/useTraces.ts
+++ b/plugins/openchoreo-observability/src/hooks/useTraces.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState, useMemo } from 'react';
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
   fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { observabilityApiRef } from '../api/ObservabilityApi';
@@ -13,10 +12,8 @@ import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 async function getProjectDetails(
   entity: Entity,
   discovery: any,
-  identity: any,
   fetchApi: any,
 ): Promise<{ uid?: string }> {
-  const { token } = await identity.getCredentials();
   const project = entity.metadata.name as string;
   const organization =
     entity.metadata.annotations?.[CHOREO_ANNOTATIONS.ORGANIZATION];
@@ -38,11 +35,7 @@ async function getProjectDetails(
 
   backendUrl.search = params.toString();
 
-  const response = await fetchApi.fetch(backendUrl.toString(), {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  const response = await fetchApi.fetch(backendUrl.toString());
 
   if (!response.ok) {
     throw new Error(
@@ -57,7 +50,6 @@ async function getProjectDetails(
 export function useTraces(filters: Filters, entity: Entity) {
   const observabilityApi = useApi(observabilityApiRef);
   const discovery = useApi(discoveryApiRef);
-  const identity = useApi(identityApiRef);
   const fetchApi = useApi(fetchApiRef);
   const [traces, setTraces] = useState<Trace[]>([]);
   const [loading, setLoading] = useState(false);
@@ -148,7 +140,6 @@ export function useTraces(filters: Filters, entity: Entity) {
         const projectDetails = await getProjectDetails(
           entity,
           discovery,
-          identity,
           fetchApi,
         );
         setProjectId(projectDetails.uid || null);
@@ -160,7 +151,7 @@ export function useTraces(filters: Filters, entity: Entity) {
     };
 
     fetchIds();
-  }, [entity, discovery, identity, fetchApi]);
+  }, [entity, discovery, fetchApi]);
 
   // Auto-fetch traces when filters change
   useEffect(() => {

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -1,8 +1,4 @@
-import {
-  DiscoveryApi,
-  FetchApi,
-  IdentityApi,
-} from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import {
   CHOREO_ANNOTATIONS,
@@ -120,7 +116,6 @@ type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
 export class OpenChoreoClient implements OpenChoreoClientApi {
   constructor(
     private readonly discovery: DiscoveryApi,
-    private readonly identity: IdentityApi,
     private readonly fetchApi: FetchApi,
   ) {}
 
@@ -136,7 +131,6 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
       params?: Record<string, string>;
     },
   ): Promise<T> {
-    const { token } = await this.identity.getCredentials();
     const baseUrl = await this.discovery.getBaseUrl('openchoreo');
     const url = new URL(`${baseUrl}${endpoint}`);
 
@@ -144,9 +138,7 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
       url.search = new URLSearchParams(options.params).toString();
     }
 
-    const headers: HeadersInit = {
-      Authorization: `Bearer ${token}`,
-    };
+    const headers: HeadersInit = {};
 
     if (options?.body !== undefined) {
       headers['Content-Type'] = 'application/json';
@@ -154,7 +146,7 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
 
     const response = await this.fetchApi.fetch(url.toString(), {
       method: options?.method || 'GET',
-      headers,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
       body:
         options?.body !== undefined ? JSON.stringify(options.body) : undefined,
     });
@@ -175,7 +167,6 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
       params?: Record<string, string>;
     },
   ): Promise<Response> {
-    const { token } = await this.identity.getCredentials();
     const baseUrl = await this.discovery.getBaseUrl('openchoreo');
     const url = new URL(`${baseUrl}${endpoint}`);
 
@@ -183,9 +174,7 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
       url.search = new URLSearchParams(options.params).toString();
     }
 
-    const headers: HeadersInit = {
-      Authorization: `Bearer ${token}`,
-    };
+    const headers: HeadersInit = {};
 
     if (options?.body !== undefined) {
       headers['Content-Type'] = 'application/json';
@@ -193,7 +182,7 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
 
     return this.fetchApi.fetch(url.toString(), {
       method: options?.method || 'GET',
-      headers,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
       body:
         options?.body !== undefined ? JSON.stringify(options.body) : undefined,
     });

--- a/plugins/openchoreo/src/components/Builds/Builds.tsx
+++ b/plugins/openchoreo/src/components/Builds/Builds.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import {
   Progress,
@@ -54,7 +54,7 @@ const columns: TableColumn<ModelsBuild>[] = [
 
 export const Builds = () => {
   const discoveryApi = useApi(discoveryApiRef);
-  const identityApi = useApi(identityApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const { getEntityDetails } = useComponentEntityDetails();
 
   const {
@@ -66,7 +66,7 @@ export const Builds = () => {
     refreshing,
     triggerBuild,
     refreshBuilds,
-  } = useBuildsData(discoveryApi, identityApi, getEntityDetails);
+  } = useBuildsData(discoveryApi, fetchApi, getEntityDetails);
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedBuild, setSelectedBuild] = useState<ModelsBuild | null>(null);

--- a/plugins/openchoreo/src/components/Builds/useBuildsData.ts
+++ b/plugins/openchoreo/src/components/Builds/useBuildsData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import type {
   ModelsBuild,
   ModelsCompleteComponent,
@@ -27,7 +27,7 @@ interface UseBuildsDataReturn {
  */
 export function useBuildsData(
   discoveryApi: DiscoveryApi,
-  identityApi: IdentityApi,
+  fetchApi: FetchApi,
   getEntityDetails: () => Promise<EntityDetails>,
 ): UseBuildsDataReturn {
   const [builds, setBuilds] = useState<ModelsBuild[]>([]);
@@ -43,18 +43,14 @@ export function useBuildsData(
       const { componentName, projectName, organizationName } =
         await getEntityDetails();
 
-      const { token } = await identityApi.getCredentials();
       const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-      const response = await fetch(
+      const response = await fetchApi.fetch(
         `${baseUrl}/component?componentName=${encodeURIComponent(
           componentName,
         )}&projectName=${encodeURIComponent(
           projectName,
         )}&organizationName=${encodeURIComponent(organizationName)}`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        },
       );
 
       if (!response.ok) {
@@ -66,25 +62,21 @@ export function useBuildsData(
     } catch (err) {
       setError(err as Error);
     }
-  }, [discoveryApi, identityApi, getEntityDetails]);
+  }, [discoveryApi, fetchApi, getEntityDetails]);
 
   const fetchBuilds = useCallback(async () => {
     try {
       const { componentName, projectName, organizationName } =
         await getEntityDetails();
 
-      const { token } = await identityApi.getCredentials();
       const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-      const response = await fetch(
+      const response = await fetchApi.fetch(
         `${baseUrl}/builds?componentName=${encodeURIComponent(
           componentName,
         )}&projectName=${encodeURIComponent(
           projectName,
         )}&organizationName=${encodeURIComponent(organizationName)}`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        },
       );
 
       if (!response.ok) {
@@ -98,7 +90,7 @@ export function useBuildsData(
     } finally {
       setLoading(false);
     }
-  }, [discoveryApi, identityApi, getEntityDetails]);
+  }, [discoveryApi, fetchApi, getEntityDetails]);
 
   const triggerBuild = useCallback(async () => {
     setTriggeringBuild(true);
@@ -106,14 +98,12 @@ export function useBuildsData(
       const { componentName, projectName, organizationName } =
         await getEntityDetails();
 
-      const { token } = await identityApi.getCredentials();
       const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-      const response = await fetch(`${baseUrl}/builds`, {
+      const response = await fetchApi.fetch(`${baseUrl}/builds`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           componentName,
@@ -132,7 +122,7 @@ export function useBuildsData(
     } finally {
       setTriggeringBuild(false);
     }
-  }, [discoveryApi, identityApi, getEntityDetails, fetchBuilds]);
+  }, [discoveryApi, fetchApi, getEntityDetails, fetchBuilds]);
 
   const refreshBuilds = useCallback(async () => {
     setRefreshing(true);

--- a/plugins/openchoreo/src/components/Environments/Workload/WorkloadButton.tsx
+++ b/plugins/openchoreo/src/components/Environments/Workload/WorkloadButton.tsx
@@ -4,7 +4,7 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { Alert, Skeleton } from '@material-ui/lab';
 import { ModelsBuild } from '@openchoreo/backstage-plugin-common';
@@ -25,7 +25,7 @@ export const WorkloadButton = ({
   isWorking = false,
 }: WorkloadButtonProps) => {
   const discovery = useApi(discoveryApiRef);
-  const identity = useApi(identityApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const client = useApi(openChoreoClientApiRef);
   const { entity } = useEntity();
 
@@ -57,21 +57,15 @@ export const WorkloadButton = ({
         const organizationName =
           entity.metadata.annotations?.['openchoreo.io/organization'];
 
-        const { token } = await identity.getCredentials();
         const baseUrl = await discovery.getBaseUrl('openchoreo');
 
         if (projectName && organizationName && componentName) {
-          const response = await fetch(
+          const response = await fetchApi.fetch(
             `${baseUrl}/builds?componentName=${encodeURIComponent(
               componentName,
             )}&projectName=${encodeURIComponent(
               projectName,
             )}&organizationName=${encodeURIComponent(organizationName)}`,
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-              },
-            },
           );
 
           if (!response.ok) {
@@ -86,7 +80,7 @@ export const WorkloadButton = ({
       }
     };
     fetchBuilds();
-  }, [entity.metadata.name, entity.metadata.annotations, identity, discovery]);
+  }, [entity.metadata.name, entity.metadata.annotations, fetchApi, discovery]);
 
   const isFromSource = isFromSourceComponent(entity);
   const hasBuilds = builds.length > 0;

--- a/plugins/openchoreo/src/components/Environments/Workload/WorkloadConfigPage.tsx
+++ b/plugins/openchoreo/src/components/Environments/Workload/WorkloadConfigPage.tsx
@@ -6,7 +6,7 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import {
   ModelsWorkload,
@@ -61,7 +61,7 @@ export const WorkloadConfigPage = ({
 }: WorkloadConfigPageProps) => {
   const classes = useStyles();
   const discovery = useApi(discoveryApiRef);
-  const identity = useApi(identityApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const client = useApi(openChoreoClientApiRef);
   const { entity } = useEntity();
 
@@ -114,21 +114,15 @@ export const WorkloadConfigPage = ({
         const organizationName =
           entity.metadata.annotations?.['openchoreo.io/organization'];
 
-        const { token } = await identity.getCredentials();
         const baseUrl = await discovery.getBaseUrl('openchoreo');
 
         if (projectName && organizationName && componentName) {
-          const response = await fetch(
+          const response = await fetchApi.fetch(
             `${baseUrl}/builds?componentName=${encodeURIComponent(
               componentName,
             )}&projectName=${encodeURIComponent(
               projectName,
             )}&organizationName=${encodeURIComponent(organizationName)}`,
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-              },
-            },
           );
 
           if (!response.ok) {
@@ -143,7 +137,7 @@ export const WorkloadConfigPage = ({
       }
     };
     fetchBuilds();
-  }, [entity.metadata.name, entity.metadata.annotations, identity, discovery]);
+  }, [entity.metadata.name, entity.metadata.annotations, fetchApi, discovery]);
 
   const handleNext = async () => {
     if (!workloadSpec) {

--- a/plugins/openchoreo/src/components/Traits/AddTraitDialog.tsx
+++ b/plugins/openchoreo/src/components/Traits/AddTraitDialog.tsx
@@ -17,7 +17,7 @@ import {
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import Form from '@rjsf/material-ui';
@@ -120,7 +120,7 @@ export const AddTraitDialog: React.FC<AddTraitDialogProps> = ({
   const classes = useTraitsStyles();
   const { entity } = useEntity();
   const discoveryApi = useApi(discoveryApiRef);
-  const identityApi = useApi(identityApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [availableTraits, setAvailableTraits] = useState<TraitListItem[]>([]);
   const [selectedTrait, setSelectedTrait] = useState<string>('');
@@ -152,18 +152,12 @@ export const AddTraitDialog: React.FC<AddTraitDialogProps> = ({
       setError(null);
 
       try {
-        const { token } = await identityApi.getCredentials();
         const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-        const response = await fetch(
+        const response = await fetchApi.fetch(
           `${baseUrl}/traits?organizationName=${encodeURIComponent(
             metadata.organization,
           )}&page=1&pageSize=100`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          },
         );
 
         if (!response.ok) {
@@ -191,7 +185,7 @@ export const AddTraitDialog: React.FC<AddTraitDialogProps> = ({
     return () => {
       ignore = true;
     };
-  }, [open, metadata.organization, discoveryApi, identityApi]);
+  }, [open, metadata.organization, discoveryApi, fetchApi]);
 
   // Fetch schema when trait is selected
   useEffect(() => {
@@ -210,18 +204,12 @@ export const AddTraitDialog: React.FC<AddTraitDialogProps> = ({
       setError(null);
 
       try {
-        const { token } = await identityApi.getCredentials();
         const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-        const response = await fetch(
+        const response = await fetchApi.fetch(
           `${baseUrl}/trait-schema?organizationName=${encodeURIComponent(
             metadata.organization,
           )}&traitName=${encodeURIComponent(selectedTrait)}`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          },
         );
 
         if (!response.ok) {
@@ -258,7 +246,7 @@ export const AddTraitDialog: React.FC<AddTraitDialogProps> = ({
     return () => {
       ignore = true;
     };
-  }, [selectedTrait, metadata.organization, discoveryApi, identityApi]);
+  }, [selectedTrait, metadata.organization, discoveryApi, fetchApi]);
 
   // Validate instance name
   useEffect(() => {

--- a/plugins/openchoreo/src/components/Traits/EditTraitDialog.tsx
+++ b/plugins/openchoreo/src/components/Traits/EditTraitDialog.tsx
@@ -13,7 +13,7 @@ import {
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import Form from '@rjsf/material-ui';
@@ -113,7 +113,7 @@ export const EditTraitDialog: React.FC<EditTraitDialogProps> = ({
   const classes = useTraitsStyles();
   const { entity } = useEntity();
   const discoveryApi = useApi(discoveryApiRef);
-  const identityApi = useApi(identityApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [instanceName, setInstanceName] = useState<string>('');
   const [parameters, setParameters] = useState<Record<string, any>>({});
@@ -155,18 +155,12 @@ export const EditTraitDialog: React.FC<EditTraitDialogProps> = ({
       setError(null);
 
       try {
-        const { token } = await identityApi.getCredentials();
         const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-        const response = await fetch(
+        const response = await fetchApi.fetch(
           `${baseUrl}/trait-schema?organizationName=${encodeURIComponent(
             metadata.organization,
           )}&traitName=${encodeURIComponent(trait.name)}`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          },
         );
 
         if (!response.ok) {
@@ -198,7 +192,7 @@ export const EditTraitDialog: React.FC<EditTraitDialogProps> = ({
     return () => {
       ignore = true;
     };
-  }, [trait, open, metadata.organization, discoveryApi, identityApi]);
+  }, [trait, open, metadata.organization, discoveryApi, fetchApi]);
 
   // Validate instance name
   useEffect(() => {

--- a/plugins/openchoreo/src/components/Workflows/Workflows.tsx
+++ b/plugins/openchoreo/src/components/Workflows/Workflows.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo } from 'react';
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import {
   Progress,
@@ -63,7 +63,7 @@ const useStyles = makeStyles(theme => ({
 export const Workflows = () => {
   const classes = useStyles();
   const discoveryApi = useApi(discoveryApiRef);
-  const identityApi = useApi(identityApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const { getEntityDetails } = useComponentEntityDetails();
 
   // URL-based routing
@@ -99,14 +99,12 @@ export const Workflows = () => {
       async (commit?: string) => {
         const { componentName, projectName, organizationName } =
           await getEntityDetails();
-        const { token } = await identityApi.getCredentials();
         const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-        const response = await fetch(`${baseUrl}/builds`, {
+        const response = await fetchApi.fetch(`${baseUrl}/builds`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({
             componentName,
@@ -122,7 +120,7 @@ export const Workflows = () => {
 
         await workflowData.fetchBuilds();
       },
-      [discoveryApi, identityApi, getEntityDetails, workflowData],
+      [discoveryApi, fetchApi, getEntityDetails, workflowData],
     ),
   );
 

--- a/plugins/openchoreo/src/components/Workflows/hooks/useWorkflowData.ts
+++ b/plugins/openchoreo/src/components/Workflows/hooks/useWorkflowData.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import {
   useApi,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { useComponentEntityDetails } from '@openchoreo/backstage-plugin-react';
 import type {
@@ -23,7 +23,7 @@ interface WorkflowDataState {
  */
 export function useWorkflowData() {
   const discoveryApi = useApi(discoveryApiRef);
-  const identityApi = useApi(identityApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const { getEntityDetails } = useComponentEntityDetails();
 
   const [state, setState] = useState<WorkflowDataState>({
@@ -38,20 +38,14 @@ export function useWorkflowData() {
       const { componentName, projectName, organizationName } =
         await getEntityDetails();
 
-      const { token } = await identityApi.getCredentials();
       const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-      const response = await fetch(
+      const response = await fetchApi.fetch(
         `${baseUrl}/component?componentName=${encodeURIComponent(
           componentName,
         )}&projectName=${encodeURIComponent(
           projectName,
         )}&organizationName=${encodeURIComponent(organizationName)}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        },
       );
 
       if (!response.ok) {
@@ -63,27 +57,21 @@ export function useWorkflowData() {
     } catch (err) {
       setState(prev => ({ ...prev, error: err as Error }));
     }
-  }, [discoveryApi, identityApi, getEntityDetails]);
+  }, [discoveryApi, fetchApi, getEntityDetails]);
 
   const fetchBuilds = useCallback(async () => {
     try {
       const { componentName, projectName, organizationName } =
         await getEntityDetails();
 
-      const { token } = await identityApi.getCredentials();
       const baseUrl = await discoveryApi.getBaseUrl('openchoreo');
 
-      const response = await fetch(
+      const response = await fetchApi.fetch(
         `${baseUrl}/builds?componentName=${encodeURIComponent(
           componentName,
         )}&projectName=${encodeURIComponent(
           projectName,
         )}&organizationName=${encodeURIComponent(organizationName)}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        },
       );
 
       if (!response.ok) {
@@ -95,7 +83,7 @@ export function useWorkflowData() {
     } catch (err) {
       setState(prev => ({ ...prev, error: err as Error }));
     }
-  }, [discoveryApi, identityApi, getEntityDetails]);
+  }, [discoveryApi, fetchApi, getEntityDetails]);
 
   // Initial data fetch
   useEffect(() => {

--- a/plugins/openchoreo/src/plugin.ts
+++ b/plugins/openchoreo/src/plugin.ts
@@ -5,7 +5,6 @@ import {
   createApiFactory,
   discoveryApiRef,
   fetchApiRef,
-  identityApiRef,
 } from '@backstage/core-plugin-api';
 import { openChoreoClientApiRef } from './api/OpenChoreoClientApi';
 import { OpenChoreoClient } from './api/OpenChoreoClient';
@@ -24,10 +23,9 @@ export const choreoPlugin = createPlugin({
       deps: {
         discoveryApi: discoveryApiRef,
         fetchApi: fetchApiRef,
-        identityApi: identityApiRef,
       },
-      factory: ({ discoveryApi, fetchApi, identityApi }) =>
-        new OpenChoreoClient(discoveryApi, identityApi, fetchApi),
+      factory: ({ discoveryApi, fetchApi }) =>
+        new OpenChoreoClient(discoveryApi, fetchApi),
     }),
   ],
 });


### PR DESCRIPTION
  Migrate all frontend hooks and API clients from manual Authorization header
  construction to using fetchApiRef, which automatically injects both the
  Backstage token and the x-openchoreo-token via OpenChoreoFetchApi wrapper.

  This fixes 401 Unauthorized errors from the OpenChoreo API caused by missing
  x-openchoreo-token headers when using native fetch() with only the
  Authorization header.

  Files migrated:
  - useTraces.ts, useMetrics.ts (observability hooks)
  - useSecretReferences.ts (openchoreo-react)
  - useWorkflowData.ts, useWorkflowsSummary.ts, Workflows.tsx
  - useBuildsData.ts, Builds.tsx
  - AddTraitDialog.tsx, EditTraitDialog.tsx
  - WorkloadButton.tsx, WorkloadConfigPage.tsx
  - OpenChoreoClient.ts (central API client)
  - plugin.ts (removed identityApi dependency)

Related to https://github.com/openchoreo/openchoreo/issues/1170