### PR TITLE
Add Service Token authentication for Scaffolder API calls

### DIFF
--- a/plugins/scaffolder-backend-module-openchoreo/package.json
+++ b/plugins/scaffolder-backend-module-openchoreo/package.json
@@ -37,6 +37,7 @@
     "@backstage/plugin-scaffolder-node": "0.11.1",
     "@openchoreo/backstage-plugin-catalog-backend-module": "workspace:^",
     "@openchoreo/backstage-plugin-common": "workspace:^",
+    "@openchoreo/openchoreo-auth": "workspace:^",
     "@openchoreo/openchoreo-client-node": "workspace:^",
     "zod": "3.25.76"
   },

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/component.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/component.ts
@@ -16,6 +16,7 @@ import {
   translateComponentToEntity,
 } from '@openchoreo/backstage-plugin-catalog-backend-module';
 import type { DiscoveryService } from '@backstage/backend-plugin-api';
+import type { OpenChoreoTokenService } from '@openchoreo/openchoreo-auth';
 
 type ModelsComponent = OpenChoreoComponents['schemas']['ComponentResponse'];
 
@@ -28,6 +29,7 @@ export const createComponentAction = (
   config: Config,
   discovery: DiscoveryService,
   immediateCatalog: ImmediateCatalogService,
+  tokenService: OpenChoreoTokenService,
 ) => {
   return createTemplateAction({
     id: 'openchoreo:component:create',
@@ -229,8 +231,21 @@ export const createComponentAction = (
 
         // Create the API client using the auto-generated client
         const baseUrl = config.getString('openchoreo.baseUrl');
+
+        // Get service token for authentication
+        let token: string | undefined;
+        if (tokenService.hasServiceCredentials()) {
+          try {
+            token = await tokenService.getServiceToken();
+            ctx.logger.debug('Using service token for OpenChoreo API');
+          } catch (error) {
+            ctx.logger.warn(`Failed to get service token: ${error}`);
+          }
+        }
+
         const client = createOpenChoreoApiClient({
           baseUrl,
+          token,
           logger: ctx.logger,
         });
 

--- a/plugins/scaffolder-backend-module-openchoreo/src/module.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/module.ts
@@ -4,6 +4,7 @@ import { coreServices } from '@backstage/backend-plugin-api';
 import { createProjectAction } from './actions/project';
 import { createComponentAction } from './actions/component';
 import { immediateCatalogServiceRef } from '@openchoreo/backstage-plugin-catalog-backend-module';
+import { openChoreoTokenServiceRef } from '@openchoreo/openchoreo-auth';
 
 /**
  * A backend module that registers the actions into the scaffolder
@@ -18,11 +19,23 @@ export const scaffolderModule = createBackendModule({
         config: coreServices.rootConfig,
         discovery: coreServices.discovery,
         immediateCatalog: immediateCatalogServiceRef,
+        openChoreoToken: openChoreoTokenServiceRef,
       },
-      async init({ scaffolderActions, config, discovery, immediateCatalog }) {
+      async init({
+        scaffolderActions,
+        config,
+        discovery,
+        immediateCatalog,
+        openChoreoToken,
+      }) {
         scaffolderActions.addActions(
-          createProjectAction(config),
-          createComponentAction(config, discovery, immediateCatalog),
+          createProjectAction(config, openChoreoToken),
+          createComponentAction(
+            config,
+            discovery,
+            immediateCatalog,
+            openChoreoToken,
+          ),
         );
       },
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9398,6 +9398,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node-test-utils": "npm:0.3.3"
     "@openchoreo/backstage-plugin-catalog-backend-module": "workspace:^"
     "@openchoreo/backstage-plugin-common": "workspace:^"
+    "@openchoreo/openchoreo-auth": "workspace:^"
     "@openchoreo/openchoreo-client-node": "workspace:^"
     zod: "npm:3.25.76"
   languageName: unknown


### PR DESCRIPTION
  The scaffolder backend module was creating OpenChoreo API clients without
  authentication tokens, causing 401 Unauthorized errors when calling
  endpoints like /apply.

  Changes:
  - Add openChoreoTokenServiceRef dependency to scaffolder module
  - Update createProjectAction to obtain and use service token
  - Update createComponentAction to obtain and use service token
  - Add @openchoreo/openchoreo-auth package dependency

  The scaffolder now uses OAuth2 client credentials (configured in
  app-config.yaml) to authenticate with the OpenChoreo API, matching
  the pattern used by the catalog provider.

Related to: https://github.com/openchoreo/openchoreo/issues/1170
