### PR TITLE
Update invoke URL construction to use port 19080 instead of 9080

### DIFF
--- a/plugins/openchoreo/src/components/Environments/utils/invokeUrlUtils.ts
+++ b/plugins/openchoreo/src/components/Environments/utils/invokeUrlUtils.ts
@@ -4,10 +4,6 @@ import { ReleaseData } from '../ReleaseDataRenderer/types';
  * Extracts the invoke URL from release data by finding HTTPRoute resources
  * and constructing the URL from hostname and path prefix.
  *
- * Based on the pattern:
- * HOSTNAME=$(kubectl get httproute -A -l openchoreo.dev/component=greeting-service -o jsonpath='{.items[0].spec.hostnames[0]}')
- * PATH_PREFIX=$(kubectl get httproute -A -l openchoreo.dev/component=greeting-service -o jsonpath='{.items[0].spec.rules[0].matches[0].path.value}')
- * curl "http://${HOSTNAME}:9080${PATH_PREFIX}/greeter/greet"
  */
 export function extractInvokeUrl(
   releaseData: ReleaseData | null,
@@ -43,10 +39,10 @@ export function extractInvokeUrl(
     }
 
     // Construct the invoke URL
-    // Format: http://{hostname}:9080{path} or just http://{hostname}:9080 if no path
+    // Format: http://{hostname}:19080{path} or just http://{hostname}:19080 if no path
     const url = pathValue
-      ? `http://${hostname}:9080${pathValue}`
-      : `http://${hostname}:9080`;
+      ? `http://${hostname}:19080${pathValue}`
+      : `http://${hostname}:19080`;
     return url;
   } catch (error) {
     // If there's any error parsing the structure, return null


### PR DESCRIPTION
## Purpose

With the OC 0.8.0 release the gateway port has been changed. This PR adds a temporary fix to change the port during invoke URL construction
However we need to properly fix this to get the gateway port at runtime, which will be provided in 0.9.0 release

