### PR TITLE
Display OpenChoreo IDP in Settings -> Authentication Providers

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -54,6 +54,7 @@ import { AccessControlPage } from '@openchoreo/backstage-plugin';
 import { UnifiedThemeProvider } from '@backstage/theme';
 import { VisitListener } from '@backstage/plugin-home';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { OpenChoreoProviderSettings } from './components/settings/OpenChoreoProviderSettings';
 
 /**
  * Dynamic SignInPage that switches between OAuth and Guest mode
@@ -195,7 +196,12 @@ const routes = (
     <Route path="/search" element={<SearchPage />}>
       {searchPage}
     </Route>
-    <Route path="/settings" element={<UserSettingsPage />} />
+    <Route
+      path="/settings"
+      element={
+        <UserSettingsPage providerSettings={<OpenChoreoProviderSettings />} />
+      }
+    />
     <Route path="/catalog-graph" element={<CatalogGraphPage />} />
     <Route path="/admin/access-control" element={<AccessControlPage />} />
   </FlatRoutes>

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -16,6 +16,8 @@ import {
   fetchApiRef,
   storageApiRef,
   OAuthApi,
+  ProfileInfoApi,
+  SessionApi,
 } from '@backstage/core-plugin-api';
 import { OAuth2 } from '@backstage/core-app-api';
 import { VisitsWebStorageApi, visitsApiRef } from '@backstage/plugin-home';
@@ -25,7 +27,9 @@ import { OpenChoreoFetchApi } from './apis/OpenChoreoFetchApi';
 import { OpenChoreoPermissionApi } from './apis/OpenChoreoPermissionApi';
 
 // API reference for default-idp OIDC provider
-export const defaultIdpAuthApiRef: ApiRef<OAuthApi> = createApiRef({
+export const defaultIdpAuthApiRef: ApiRef<
+  OAuthApi & ProfileInfoApi & SessionApi
+> = createApiRef({
   id: 'auth.default-idp',
 });
 

--- a/packages/app/src/components/settings/OpenChoreoProviderSettings.tsx
+++ b/packages/app/src/components/settings/OpenChoreoProviderSettings.tsx
@@ -1,0 +1,17 @@
+import List from '@material-ui/core/List';
+import { ProviderSettingsItem } from '@backstage/plugin-user-settings';
+import { defaultIdpAuthApiRef } from '../../apis';
+import { OpenChoreoIcon } from '@openchoreo/backstage-design-system';
+
+export const OpenChoreoProviderSettings = () => {
+  return (
+    <List>
+      <ProviderSettingsItem
+        title="OpenChoreo IDP"
+        description="Sign in with Thunder Identity Provider"
+        icon={OpenChoreoIcon}
+        apiRef={defaultIdpAuthApiRef}
+      />
+    </List>
+  );
+};


### PR DESCRIPTION

<img width="1630" height="435" alt="Screenshot 2025-12-20 at 15 24 50" src="https://github.com/user-attachments/assets/5c319cce-5a04-4943-b27f-986de0144b66" />



  Custom OAuth providers like Thunder IDP were not appearing in the
  Settings page because Backstage's DefaultProviderSettings only renders
  built-in providers (Google, GitHub, etc.).

  - Create OpenChoreoProviderSettings component using ProviderSettingsItem
  - Pass custom providerSettings to UserSettingsPage
  - Extend defaultIdpAuthApiRef type to include ProfileInfoApi & SessionApi
