### PR TITLE
Update user-types API endpoint and schema

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -1464,24 +1464,36 @@ components:
             type: string
           description: List of actions to assign to the role
 
-    EntitlementClaimInfo:
+    EntitlementConfig:
       type: object
       required:
-        - name
+        - claim
         - display_name
       properties:
-        name:
+        claim:
           type: string
         display_name:
           type: string
 
-    UserTypeInfo:
+    AuthMechanismConfig:
+      type: object
+      required:
+        - type
+        - entitlement
+      properties:
+        type:
+          type: string
+          description: Authentication mechanism type (e.g., "jwt", "oauth2", "api_key")
+        entitlement:
+          $ref: '#/components/schemas/EntitlementConfig'
+
+    UserTypeConfig:
       type: object
       required:
         - type
         - display_name
         - priority
-        - entitlement
+        - auth_mechanisms
       properties:
         type:
           $ref: '#/components/schemas/SubjectType'
@@ -1489,8 +1501,10 @@ components:
           type: string
         priority:
           type: integer
-        entitlement:
-          $ref: '#/components/schemas/EntitlementClaimInfo'
+        auth_mechanisms:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuthMechanismConfig'
 
     Subject:
       type: object
@@ -3731,12 +3745,12 @@ paths:
                         items:
                           type: string
 
-  /authz/user-types:
+  /user-types:
     get:
       summary: List all configured user types
       operationId: listUserTypes
       tags:
-        - Authorization
+        - Configuration
       responses:
         '200':
           description: Successful response
@@ -3750,7 +3764,7 @@ paths:
                       data:
                         type: array
                         items:
-                          $ref: '#/components/schemas/UserTypeInfo'
+                          $ref: '#/components/schemas/UserTypeConfig'
 
   /authz/evaluate:
     post:

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -834,7 +834,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/authz/user-types': {
+  '/user-types': {
     parameters: {
       query?: never;
       header?: never;
@@ -1543,15 +1543,20 @@ export interface components {
       /** @description List of actions to assign to the role */
       actions: string[];
     };
-    EntitlementClaimInfo: {
-      name: string;
+    EntitlementConfig: {
+      claim: string;
       display_name: string;
     };
-    UserTypeInfo: {
+    AuthMechanismConfig: {
+      /** @description Authentication mechanism type (e.g., "jwt", "oauth2", "api_key") */
+      type: string;
+      entitlement: components['schemas']['EntitlementConfig'];
+    };
+    UserTypeConfig: {
       type: components['schemas']['SubjectType'];
       display_name: string;
       priority: number;
-      entitlement: components['schemas']['EntitlementClaimInfo'];
+      auth_mechanisms: components['schemas']['AuthMechanismConfig'][];
     };
     Subject: {
       jwt_token: string;
@@ -3488,7 +3493,7 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['APIResponse'] & {
-            data?: components['schemas']['UserTypeInfo'][];
+            data?: components['schemas']['UserTypeConfig'][];
           };
         };
       };

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -1014,7 +1014,7 @@ export async function createRouter({
   });
 
   // User Types
-  router.get('/authz/user-types', async (req, res) => {
+  router.get('/user-types', async (req, res) => {
     const userToken = getUserTokenFromRequest(req);
     res.json(await authzService.listUserTypes(userToken));
   });

--- a/plugins/openchoreo-backend/src/services/AuthzService/AuthzService.ts
+++ b/plugins/openchoreo-backend/src/services/AuthzService/AuthzService.ts
@@ -11,7 +11,7 @@ export type ResourceHierarchy =
   OpenChoreoComponents['schemas']['AuthzResourceHierarchy'];
 export type RoleEntitlementMapping =
   OpenChoreoComponents['schemas']['RoleEntitlementMapping'];
-export type UserTypeInfo = OpenChoreoComponents['schemas']['UserTypeInfo'];
+export type UserTypeConfig = OpenChoreoComponents['schemas']['UserTypeConfig'];
 export type PolicyEffect = OpenChoreoComponents['schemas']['PolicyEffectType'];
 
 // Response types
@@ -37,7 +37,7 @@ type ActionsListResponse = OpenChoreoComponents['schemas']['APIResponse'] & {
 };
 
 type UserTypesListResponse = OpenChoreoComponents['schemas']['APIResponse'] & {
-  data?: UserTypeInfo[];
+  data?: UserTypeConfig[];
 };
 
 // Helper to extract error message from API response
@@ -381,12 +381,12 @@ export class AuthzService {
   }
 
   // User Types
-  async listUserTypes(userToken?: string): Promise<{ data: UserTypeInfo[] }> {
+  async listUserTypes(userToken?: string): Promise<{ data: UserTypeConfig[] }> {
     this.logger.debug('Fetching all user types');
 
     try {
       const client = this.createClient(userToken);
-      const { data, error, response } = await client.GET('/authz/user-types');
+      const { data, error, response } = await client.GET('/user-types');
 
       if (error || !response.ok) {
         const errorMsg = extractErrorMessage(

--- a/plugins/openchoreo-backend/src/services/AuthzService/index.ts
+++ b/plugins/openchoreo-backend/src/services/AuthzService/index.ts
@@ -4,5 +4,5 @@ export type {
   Entitlement,
   ResourceHierarchy,
   RoleEntitlementMapping,
-  UserTypeInfo,
+  UserTypeConfig,
 } from './AuthzService';

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -19,7 +19,7 @@ import type {
   AuthzRole,
   RoleEntitlementMapping,
   RoleMappingFilters,
-  UserTypeInfo,
+  UserTypeConfig,
   OrganizationSummary,
   ProjectSummary,
   ComponentSummary,
@@ -61,7 +61,8 @@ const API_ENDPOINTS = {
   AUTHZ_ROLES: '/authz/roles',
   AUTHZ_ROLE_MAPPINGS: '/authz/role-mappings',
   AUTHZ_ACTIONS: '/authz/actions',
-  AUTHZ_USER_TYPES: '/authz/user-types',
+  // Configuration endpoints
+  USER_TYPES: '/user-types',
   // Hierarchy data endpoints
   ORGANIZATIONS: '/orgs',
   PROJECTS: '/projects', // GET /orgs/{orgName}/projects
@@ -819,9 +820,9 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
     return response.data || [];
   }
 
-  async listUserTypes(): Promise<UserTypeInfo[]> {
-    const response = await this.apiFetch<{ data: UserTypeInfo[] }>(
-      API_ENDPOINTS.AUTHZ_USER_TYPES,
+  async listUserTypes(): Promise<UserTypeConfig[]> {
+    const response = await this.apiFetch<{ data: UserTypeConfig[] }>(
+      API_ENDPOINTS.USER_TYPES,
     );
     return response.data || [];
   }

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -134,18 +134,23 @@ export interface RoleMappingFilters {
   value?: string;
 }
 
-export interface EntitlementClaimInfo {
-  name: string;
+export interface EntitlementConfig {
+  claim: string;
   display_name: string;
+}
+
+export interface AuthMechanismConfig {
+  type: string;
+  entitlement: EntitlementConfig;
 }
 
 export type SubjectType = 'user' | 'service_account';
 
-export interface UserTypeInfo {
+export interface UserTypeConfig {
   type: SubjectType;
   display_name: string;
   priority: number;
-  entitlement: EntitlementClaimInfo;
+  auth_mechanisms: AuthMechanismConfig[];
 }
 
 /** Organization summary for listing */
@@ -380,7 +385,7 @@ export interface OpenChoreoClientApi {
   listActions(): Promise<string[]>;
 
   /** List all user types */
-  listUserTypes(): Promise<UserTypeInfo[]>;
+  listUserTypes(): Promise<UserTypeConfig[]>;
 
   // === Hierarchy Data Operations ===
 

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/MappingDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/MappingDialog.tsx
@@ -9,7 +9,12 @@ import {
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import { makeStyles } from '@material-ui/core/styles';
-import { useUserTypes, Role, RoleEntitlementMapping } from '../hooks';
+import {
+  useUserTypes,
+  getEntitlementClaim,
+  Role,
+  RoleEntitlementMapping,
+} from '../hooks';
 import {
   WizardState,
   WizardStepId,
@@ -86,7 +91,7 @@ export const MappingDialog = ({
       if (editingMapping) {
         // Populate from editing mapping
         const matchingUserType = userTypes.find(
-          ut => ut.entitlement.name === editingMapping.entitlement.claim,
+          ut => getEntitlementClaim(ut) === editingMapping.entitlement.claim,
         );
 
         setWizardState({
@@ -148,7 +153,7 @@ export const MappingDialog = ({
     const selectedUserTypeInfo = userTypes.find(
       ut => ut.type === wizardState.subjectType,
     );
-    const entitlementClaim = selectedUserTypeInfo?.entitlement.name || '';
+    const entitlementClaim = getEntitlementClaim(selectedUserTypeInfo);
 
     if (!entitlementClaim) {
       setError('Invalid subject type selected');

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/ReviewStep.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/ReviewStep.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import BlockIcon from '@material-ui/icons/Block';
 import { WizardStepProps } from './types';
+import { getEntitlementClaim } from '../../hooks';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -73,7 +74,7 @@ export const ReviewStep = ({ state, userTypes }: WizardStepProps) => {
   const selectedUserTypeInfo = userTypes.find(
     ut => ut.type === state.subjectType,
   );
-  const entitlementClaim = selectedUserTypeInfo?.entitlement.name || '';
+  const entitlementClaim = getEntitlementClaim(selectedUserTypeInfo);
 
   const getScopePath = (): string => {
     if (state.scopeType === 'global') {

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/SubjectStep.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/SubjectStep.tsx
@@ -11,6 +11,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import PersonIcon from '@material-ui/icons/Person';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { WizardStepProps } from './types';
+import { getEntitlementClaim } from '../../hooks';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -120,7 +121,7 @@ export const SubjectStep = ({
   const selectedUserTypeInfo = userTypes.find(
     ut => ut.type === state.subjectType,
   );
-  const entitlementClaim = selectedUserTypeInfo?.entitlement.name || '';
+  const entitlementClaim = getEntitlementClaim(selectedUserTypeInfo);
 
   const handleTypeChange = (type: string) => {
     onChange({ subjectType: type });

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/types.ts
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/types.ts
@@ -1,4 +1,4 @@
-import { Role, PolicyEffect, UserTypeInfo } from '../../hooks';
+import { Role, PolicyEffect, UserTypeConfig } from '../../hooks';
 
 /**
  * Wizard state representing all form data across steps
@@ -48,14 +48,14 @@ export interface WizardStepProps {
   state: WizardState;
   onChange: (updates: Partial<WizardState>) => void;
   availableRoles: Role[];
-  userTypes: UserTypeInfo[];
+  userTypes: UserTypeConfig[];
 }
 
 /**
  * Initial state factory
  */
 export function createInitialWizardState(
-  userTypes: UserTypeInfo[],
+  userTypes: UserTypeConfig[],
 ): WizardState {
   return {
     selectedRole: '',

--- a/plugins/openchoreo/src/components/AccessControl/hooks/index.ts
+++ b/plugins/openchoreo/src/components/AccessControl/hooks/index.ts
@@ -9,11 +9,16 @@ export type {
   PolicyEffect,
 } from './useMappings';
 export { useActions } from './useActions';
-export { useUserTypes } from './useUserTypes';
+export {
+  useUserTypes,
+  getEntitlementClaim,
+  getEntitlementDisplayName,
+} from './useUserTypes';
 export type {
-  UserTypeInfo,
+  UserTypeConfig,
   SubjectType,
-  EntitlementClaimInfo,
+  EntitlementConfig,
+  AuthMechanismConfig,
 } from './useUserTypes';
 export {
   useOrganizations,

--- a/plugins/openchoreo/src/components/AccessControl/hooks/useUserTypes.ts
+++ b/plugins/openchoreo/src/components/AccessControl/hooks/useUserTypes.ts
@@ -2,22 +2,50 @@ import { useState, useCallback, useEffect } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import {
   openChoreoClientApiRef,
-  UserTypeInfo,
+  UserTypeConfig,
   SubjectType,
-  EntitlementClaimInfo,
+  EntitlementConfig,
+  AuthMechanismConfig,
 } from '../../../api/OpenChoreoClientApi';
 
-export type { UserTypeInfo, SubjectType, EntitlementClaimInfo };
+export type {
+  UserTypeConfig,
+  SubjectType,
+  EntitlementConfig,
+  AuthMechanismConfig,
+};
+
+/**
+ * Extracts the entitlement claim from a UserTypeConfig.
+ *
+ * TODO: Currently uses the first auth mechanism. Future options:
+ * - Filter by specific type (e.g., type === 'jwt')
+ * - Support multiple auth mechanisms in UI
+ */
+export function getEntitlementClaim(
+  userType: UserTypeConfig | undefined,
+): string {
+  if (!userType || !userType.auth_mechanisms?.length) return '';
+  // Currently uses first auth mechanism - see TODO above for future enhancements
+  return userType.auth_mechanisms[0].entitlement.claim;
+}
+
+export function getEntitlementDisplayName(
+  userType: UserTypeConfig | undefined,
+): string {
+  if (!userType || !userType.auth_mechanisms?.length) return '';
+  return userType.auth_mechanisms[0].entitlement.display_name;
+}
 
 interface UseUserTypesResult {
-  userTypes: UserTypeInfo[];
+  userTypes: UserTypeConfig[];
   loading: boolean;
   error: Error | null;
   fetchUserTypes: () => Promise<void>;
 }
 
 export function useUserTypes(): UseUserTypesResult {
-  const [userTypes, setUserTypes] = useState<UserTypeInfo[]>([]);
+  const [userTypes, setUserTypes] = useState<UserTypeConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 


### PR DESCRIPTION
 Align with backend changes from openchoreo/openchoreo#1188 that moved
  user type detection from authorization layer to authentication layer.

  Changes:
  - Update endpoint path from /authz/user-types to /user-types
  - Update response schema: UserTypeInfo → UserTypeConfig
  - Replace single 'entitlement' field with 'auth_mechanisms' array
  - Add helper functions getEntitlementClaim() and getEntitlementDisplayName() to extract claim from first auth mechanism (JWT only for now)

  Backend PR: https://github.com/openchoreo/openchoreo/pull/1188
