### PR TITLE
Fix user-types API field name mismatch

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -1467,41 +1467,41 @@ components:
     EntitlementConfig:
       type: object
       required:
-        - claim
-        - display_name
+        - Claim
+        - DisplayName
       properties:
-        claim:
+        Claim:
           type: string
-        display_name:
+        DisplayName:
           type: string
 
     AuthMechanismConfig:
       type: object
       required:
-        - type
-        - entitlement
+        - Type
+        - Entitlement
       properties:
-        type:
+        Type:
           type: string
           description: Authentication mechanism type (e.g., "jwt", "oauth2", "api_key")
-        entitlement:
+        Entitlement:
           $ref: '#/components/schemas/EntitlementConfig'
 
     UserTypeConfig:
       type: object
       required:
-        - type
-        - display_name
-        - priority
-        - auth_mechanisms
+        - Type
+        - DisplayName
+        - Priority
+        - AuthMechanisms
       properties:
-        type:
+        Type:
           $ref: '#/components/schemas/SubjectType'
-        display_name:
+        DisplayName:
           type: string
-        priority:
+        Priority:
           type: integer
-        auth_mechanisms:
+        AuthMechanisms:
           type: array
           items:
             $ref: '#/components/schemas/AuthMechanismConfig'

--- a/packages/openchoreo-client-node/src/generated/observability/types.ts
+++ b/packages/openchoreo-client-node/src/generated/observability/types.ts
@@ -411,7 +411,6 @@ export interface components {
        *     - Prefix match: `63d7c3065ab2537*`
        *     - Suffix match: `*135a77db`
        *     - Single char wildcard: `63d7c3065ab2537?e6c5d6bb135a77db`
-       *
        * @example 63d7c3065ab25375*
        */
       traceId?: string;
@@ -511,7 +510,8 @@ export interface components {
        */
       tookMs?: number;
     };
-    /** @example {
+    /**
+     * @example {
      *       "traces": [
      *         {
      *           "traceId": "f3a7b9e1c4d2f5a8b6e3c9f1d4a7e2b8",
@@ -530,7 +530,8 @@ export interface components {
      *         }
      *       ],
      *       "tookMs": 15
-     *     } */
+     *     }
+     */
     TraceResponse: {
       /** @description Array of traces with their spans */
       traces?: components['schemas']['Trace'][];
@@ -610,7 +611,8 @@ export interface components {
        */
       value?: number;
     };
-    /** @example {
+    /**
+     * @example {
      *       "cpuUsage": [
      *         {
      *           "time": "2025-01-10T12:00:00Z",
@@ -671,7 +673,8 @@ export interface components {
      *           "value": 2147483648
      *         }
      *       ]
-     *     } */
+     *     }
+     */
     ResourceMetricsTimeSeries: {
       /** @description CPU usage time series (in cores) */
       cpuUsage?: components['schemas']['TimeValuePoint'][];
@@ -686,7 +689,8 @@ export interface components {
       /** @description Memory limits time series (in bytes) */
       memoryLimits?: components['schemas']['TimeValuePoint'][];
     };
-    /** @example {
+    /**
+     * @example {
      *       "requestCount": [
      *         {
      *           "time": "2025-01-10T12:00:00Z",
@@ -757,7 +761,8 @@ export interface components {
      *           "value": 0.52
      *         }
      *       ]
-     *     } */
+     *     }
+     */
     HTTPMetricsTimeSeries: {
       /** @description Total HTTP request count time series (requests per second) */
       requestCount?: components['schemas']['TimeValuePoint'][];

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -1313,13 +1313,14 @@ export interface components {
     ObserverUrlData: {
       observerUrl?: string;
     };
-    /** @description Immutable snapshot of component configuration.
+    /**
+     * @description Immutable snapshot of component configuration.
      *     Note: The following fields are immutable after creation and cannot be modified:
      *     - componentType
      *     - traits
      *     - componentProfile
      *     - workload
-     *      */
+     */
     ComponentReleaseResponse: {
       name: string;
       componentName: string;
@@ -1544,19 +1545,19 @@ export interface components {
       actions: string[];
     };
     EntitlementConfig: {
-      claim: string;
-      display_name: string;
+      Claim: string;
+      DisplayName: string;
     };
     AuthMechanismConfig: {
       /** @description Authentication mechanism type (e.g., "jwt", "oauth2", "api_key") */
-      type: string;
-      entitlement: components['schemas']['EntitlementConfig'];
+      Type: string;
+      Entitlement: components['schemas']['EntitlementConfig'];
     };
     UserTypeConfig: {
-      type: components['schemas']['SubjectType'];
-      display_name: string;
-      priority: number;
-      auth_mechanisms: components['schemas']['AuthMechanismConfig'][];
+      Type: components['schemas']['SubjectType'];
+      DisplayName: string;
+      Priority: number;
+      AuthMechanisms: components['schemas']['AuthMechanismConfig'][];
     };
     Subject: {
       jwt_token: string;

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -135,22 +135,22 @@ export interface RoleMappingFilters {
 }
 
 export interface EntitlementConfig {
-  claim: string;
-  display_name: string;
+  Claim: string;
+  DisplayName: string;
 }
 
 export interface AuthMechanismConfig {
-  type: string;
-  entitlement: EntitlementConfig;
+  Type: string;
+  Entitlement: EntitlementConfig;
 }
 
 export type SubjectType = 'user' | 'service_account';
 
 export interface UserTypeConfig {
-  type: SubjectType;
-  display_name: string;
-  priority: number;
-  auth_mechanisms: AuthMechanismConfig[];
+  Type: SubjectType;
+  DisplayName: string;
+  Priority: number;
+  AuthMechanisms: AuthMechanismConfig[];
 }
 
 /** Organization summary for listing */

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/MappingDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/MappingDialog.tsx
@@ -96,7 +96,7 @@ export const MappingDialog = ({
 
         setWizardState({
           selectedRole: editingMapping.role_name,
-          subjectType: matchingUserType?.type || userTypes[0]?.type || '',
+          subjectType: matchingUserType?.Type || userTypes[0]?.Type || '',
           entitlementValue: editingMapping.entitlement.value,
           scopeType:
             editingMapping.hierarchy.organization ||
@@ -151,7 +151,7 @@ export const MappingDialog = ({
 
     // Get entitlement claim from user type
     const selectedUserTypeInfo = userTypes.find(
-      ut => ut.type === wizardState.subjectType,
+      ut => ut.Type === wizardState.subjectType,
     );
     const entitlementClaim = getEntitlementClaim(selectedUserTypeInfo);
 

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/ReviewStep.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/ReviewStep.tsx
@@ -72,7 +72,7 @@ export const ReviewStep = ({ state, userTypes }: WizardStepProps) => {
   const classes = useStyles();
 
   const selectedUserTypeInfo = userTypes.find(
-    ut => ut.type === state.subjectType,
+    ut => ut.Type === state.subjectType,
   );
   const entitlementClaim = getEntitlementClaim(selectedUserTypeInfo);
 
@@ -94,7 +94,7 @@ export const ReviewStep = ({ state, userTypes }: WizardStepProps) => {
   };
 
   const getSubjectDescription = (): string => {
-    const typeName = selectedUserTypeInfo?.display_name || state.subjectType;
+    const typeName = selectedUserTypeInfo?.DisplayName || state.subjectType;
     return `${typeName} (${entitlementClaim} = "${state.entitlementValue}")`;
   };
 

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/SubjectStep.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/SubjectStep.tsx
@@ -119,7 +119,7 @@ export const SubjectStep = ({
   const classes = useStyles();
 
   const selectedUserTypeInfo = userTypes.find(
-    ut => ut.type === state.subjectType,
+    ut => ut.Type === state.subjectType,
   );
   const entitlementClaim = getEntitlementClaim(selectedUserTypeInfo);
 
@@ -144,7 +144,7 @@ export const SubjectStep = ({
 
   const getValueLabel = () => {
     if (selectedUserTypeInfo) {
-      return `${selectedUserTypeInfo.display_name} Identifier`;
+      return `${selectedUserTypeInfo.DisplayName} Identifier`;
     }
     return 'Identifier';
   };
@@ -170,29 +170,29 @@ export const SubjectStep = ({
         <Box className={classes.typeCards}>
           {userTypes.map(userType => (
             <Paper
-              key={userType.type}
+              key={userType.Type}
               variant="outlined"
               className={`${classes.typeCard} ${
-                state.subjectType === userType.type
+                state.subjectType === userType.Type
                   ? classes.typeCardSelected
                   : ''
               }`}
-              onClick={() => handleTypeChange(userType.type)}
+              onClick={() => handleTypeChange(userType.Type)}
             >
               <Box className={classes.typeIcon}>
-                {getTypeIcon(userType.type)}
+                {getTypeIcon(userType.Type)}
               </Box>
               <Box className={classes.typeContent}>
                 <FormControlLabel
-                  value={userType.type}
+                  value={userType.Type}
                   control={<Radio color="primary" size="small" />}
                   label={
                     <Box>
                       <Typography className={classes.typeName}>
-                        {userType.display_name}
+                        {userType.DisplayName}
                       </Typography>
                       <Typography className={classes.typeDescription}>
-                        {getTypeDescription(userType.type)}
+                        {getTypeDescription(userType.Type)}
                       </Typography>
                     </Box>
                   }

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/types.ts
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/types.ts
@@ -59,7 +59,7 @@ export function createInitialWizardState(
 ): WizardState {
   return {
     selectedRole: '',
-    subjectType: userTypes[0]?.type || '',
+    subjectType: userTypes[0]?.Type || '',
     entitlementValue: '',
     scopeType: 'global',
     organization: '',

--- a/plugins/openchoreo/src/components/AccessControl/hooks/useUserTypes.ts
+++ b/plugins/openchoreo/src/components/AccessControl/hooks/useUserTypes.ts
@@ -19,22 +19,22 @@ export type {
  * Extracts the entitlement claim from a UserTypeConfig.
  *
  * TODO: Currently uses the first auth mechanism. Future options:
- * - Filter by specific type (e.g., type === 'jwt')
+ * - Filter by specific type (e.g., Type === 'jwt')
  * - Support multiple auth mechanisms in UI
  */
 export function getEntitlementClaim(
   userType: UserTypeConfig | undefined,
 ): string {
-  if (!userType || !userType.auth_mechanisms?.length) return '';
+  if (!userType || !userType.AuthMechanisms?.length) return '';
   // Currently uses first auth mechanism - see TODO above for future enhancements
-  return userType.auth_mechanisms[0].entitlement.claim;
+  return userType.AuthMechanisms[0].Entitlement.Claim;
 }
 
 export function getEntitlementDisplayName(
   userType: UserTypeConfig | undefined,
 ): string {
-  if (!userType || !userType.auth_mechanisms?.length) return '';
-  return userType.auth_mechanisms[0].entitlement.display_name;
+  if (!userType || !userType.AuthMechanisms?.length) return '';
+  return userType.AuthMechanisms[0].Entitlement.DisplayName;
 }
 
 interface UseUserTypesResult {


### PR DESCRIPTION
  The Go backend serializes UserTypeConfig without json tags, resulting
  in PascalCase field names (Type, DisplayName, AuthMechanisms, etc.).
  Updated frontend types and components to match the actual API response.
