### PR TITLE
Fix permission denied for component build/deploy operations

### DIFF
--- a/plugins/openchoreo-common/src/permissions.ts
+++ b/plugins/openchoreo-common/src/permissions.ts
@@ -148,7 +148,7 @@ export const OPENCHOREO_PERMISSION_TO_ACTION: Record<string, string> = {
   'openchoreo.component.create': 'component:create',
   'openchoreo.component.read': 'component:view',
   'openchoreo.component.update': 'component:update',
-  'openchoreo.component.build': 'componentworkflow:trigger',
+  'openchoreo.component.build': 'componentworkflow:create',
   'openchoreo.component.deploy': 'component:deploy',
   'openchoreo.project.create': 'project:create',
   'openchoreo.project.read': 'project:view',


### PR DESCRIPTION
- Change componentworkflow action mapping from 'trigger' to 'create' The 'componentworkflow:trigger' action doesn't exist in OpenChoreo, use 'componentworkflow:create' instead

- Fix catalog entity lookup in permission resource resolution Use getEntitiesByRefs with proper service credentials as required by the new Backstage backend API

- Allow service-to-service catalog reads in permission policy Internal calls for permission resolution need to read catalog entities without user context
