### PR TITLE
Add JSON syntax highlighting to ReleaseDataRenderer

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -25,12 +25,14 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.34.3",
-    "@testing-library/jest-dom": "6.9.1"
+    "@testing-library/jest-dom": "6.9.1",
+    "@types/react-syntax-highlighter": "^15.5.13"
   },
   "dependencies": {
     "@backstage/theme": "0.6.8",
     "@material-ui/core": "4.12.4",
-    "@material-ui/icons": "^4.11.3"
+    "@material-ui/icons": "^4.11.3",
+    "react-syntax-highlighter": "^15.6.1"
   },
   "peerDependencies": {
     "react": "^18.0.0"

--- a/packages/design-system/src/components/JsonViewer/JsonViewer.tsx
+++ b/packages/design-system/src/components/JsonViewer/JsonViewer.tsx
@@ -1,0 +1,125 @@
+import React, { useMemo } from 'react';
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import json from 'react-syntax-highlighter/dist/cjs/languages/prism/json';
+import oneDark from 'react-syntax-highlighter/dist/cjs/styles/prism/one-dark';
+import oneLight from 'react-syntax-highlighter/dist/cjs/styles/prism/one-light';
+import { useTheme } from '@material-ui/core/styles';
+import { Box } from '@material-ui/core';
+
+SyntaxHighlighter.registerLanguage('json', json);
+
+export interface JsonViewerProps {
+  /**
+   * The value to display. Can be any JSON-serializable value.
+   * Will be stringified with 2-space indentation.
+   */
+  value: unknown;
+  /**
+   * Whether to show line numbers
+   * @default false
+   */
+  showLineNumbers?: boolean;
+  /**
+   * Maximum height of the container. Content will scroll if exceeded.
+   * Accepts any valid CSS height value (e.g., '200px', '50vh', 'auto')
+   * @default 'auto'
+   */
+  maxHeight?: string | number;
+  /**
+   * Custom indentation spaces for JSON.stringify
+   * @default 2
+   */
+  indent?: number;
+  /**
+   * Whether to wrap long lines
+   * @default true
+   */
+  wrapLongLines?: boolean;
+  /**
+   * Additional CSS class name for the container
+   */
+  className?: string;
+  /**
+   * Custom inline styles for the container
+   */
+  style?: React.CSSProperties;
+}
+
+/**
+ * A component for displaying JSON data with syntax highlighting.
+ * Automatically adapts to light/dark theme based on Material-UI theme.
+ *
+ * @example
+ * // Basic usage
+ * <JsonViewer value={{ key: 'value', nested: { data: true } }} />
+ *
+ * @example
+ * // With options
+ * <JsonViewer
+ *   value={data}
+ *   showLineNumbers
+ *   maxHeight="300px"
+ *   wrapLongLines={false}
+ * />
+ */
+export const JsonViewer: React.FC<JsonViewerProps> = ({
+  value,
+  showLineNumbers = false,
+  maxHeight = 'auto',
+  indent = 2,
+  wrapLongLines = true,
+  className,
+  style,
+}) => {
+  const theme = useTheme();
+  const isDarkMode = theme.palette.type === 'dark';
+
+  // Memoize the JSON string to avoid re-stringify on every render
+  const jsonString = useMemo(() => {
+    try {
+      return JSON.stringify(value, null, indent);
+    } catch {
+      return String(value);
+    }
+  }, [value, indent]);
+
+  // Select theme based on Material-UI palette type
+  const syntaxTheme = isDarkMode ? oneDark : oneLight;
+
+  // Custom style overrides to integrate with Material-UI theme
+  const customStyle: React.CSSProperties = {
+    margin: 0,
+    padding: theme.spacing(1.5),
+    borderRadius: theme.shape.borderRadius,
+    fontSize: '0.75rem',
+    backgroundColor: isDarkMode
+      ? 'rgba(255, 255, 255, 0.05)'
+      : 'rgba(0, 0, 0, 0.03)',
+    ...(maxHeight !== 'auto' && {
+      maxHeight,
+      overflowY: 'auto',
+    }),
+  };
+
+  return (
+    <Box className={className} style={style}>
+      <SyntaxHighlighter
+        language="json"
+        style={syntaxTheme}
+        showLineNumbers={showLineNumbers}
+        wrapLongLines={wrapLongLines}
+        customStyle={customStyle}
+        codeTagProps={{
+          style: {
+            fontFamily:
+              'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+          },
+        }}
+      >
+        {jsonString}
+      </SyntaxHighlighter>
+    </Box>
+  );
+};
+
+JsonViewer.displayName = 'JsonViewer';

--- a/packages/design-system/src/components/JsonViewer/index.ts
+++ b/packages/design-system/src/components/JsonViewer/index.ts
@@ -1,0 +1,2 @@
+export { JsonViewer } from './JsonViewer';
+export type { JsonViewerProps } from './JsonViewer';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -19,3 +19,5 @@ export type {
   SecretSelectorProps,
   SecretOption,
 } from './components/SecretSelector';
+export { JsonViewer } from './components/JsonViewer';
+export type { JsonViewerProps } from './components/JsonViewer';

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceCard.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceCard.tsx
@@ -9,6 +9,7 @@ import {
   AccordionDetails,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { JsonViewer } from '@openchoreo/backstage-design-system';
 import { ReleaseResource } from './types';
 import { ReleaseInfoStyleClasses } from './styles';
 import { formatTimestamp, getHealthChipClass } from './utils';
@@ -78,17 +79,7 @@ export const ResourceCard: FC<ResourceCardProps> = ({ resource, classes }) => (
             </Typography>
           </AccordionSummary>
           <AccordionDetails>
-            <pre
-              style={{
-                margin: 0,
-                fontSize: '0.75rem',
-                overflowX: 'auto',
-                whiteSpace: 'pre-wrap',
-                wordBreak: 'break-word',
-              }}
-            >
-              {JSON.stringify(resource.status, null, 2)}
-            </pre>
+            <JsonViewer value={resource.status} maxHeight="400px" />
           </AccordionDetails>
         </Accordion>
       </Box>

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceGroupTab.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceGroupTab.tsx
@@ -7,6 +7,7 @@ import {
   AccordionDetails,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { JsonViewer } from '@openchoreo/backstage-design-system';
 import { ResourceGroup } from './useResourceGroups';
 import { ReleaseInfoStyleClasses } from './styles';
 import { ResourceCard } from './ResourceCard';
@@ -54,17 +55,7 @@ export const ResourceGroupTab: FC<ResourceGroupTabProps> = ({
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <pre
-                style={{
-                  margin: 0,
-                  fontSize: '0.75rem',
-                  overflowX: 'auto',
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-word',
-                }}
-              >
-                {JSON.stringify(def.object, null, 2)}
-              </pre>
+              <JsonViewer value={def.object} maxHeight="500px" />
             </AccordionDetails>
           </Accordion>
         ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9599,6 +9599,8 @@ __metadata:
     "@material-ui/core": "npm:4.12.4"
     "@material-ui/icons": "npm:^4.11.3"
     "@testing-library/jest-dom": "npm:6.9.1"
+    "@types/react-syntax-highlighter": "npm:^15.5.13"
+    react-syntax-highlighter: "npm:^15.6.1"
   peerDependencies:
     react: ^18.0.0
   languageName: unknown
@@ -15812,6 +15814,15 @@ __metadata:
   dependencies:
     "@types/react": "npm:*"
   checksum: 10c0/acb0937ebc06019921ec5254fb125356f206038f5e2f244663eb849c692b6f6413f75ce3ee84be91d8c659ae43c8f743dd5c4397cdea65749cd601a495491242
+  languageName: node
+  linkType: hard
+
+"@types/react-syntax-highlighter@npm:^15.5.13":
+  version: 15.5.13
+  resolution: "@types/react-syntax-highlighter@npm:15.5.13"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10c0/e3bca325b27519fb063d3370de20d311c188ec16ffc01e5bc77bdf2d7320756725ee3d0246922cd5d38b75c5065a1bc43d0194e92ecf6556818714b4ffb0967a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
  Create a reusable JsonViewer component in the design system using
  react-syntax-highlighter with Prism. The component auto-detects
  dark/light theme from Material-UI and applies appropriate syntax
  highlighting.

  - Add react-syntax-highlighter dependency to design-system
  - Create JsonViewer component with PrismLight for smaller bundle
  - Export JsonViewer from @openchoreo/backstage-design-system
  - Update ResourceCard.tsx to use JsonViewer for status details
  - Update ResourceGroupTab.tsx to use JsonViewer for resource definitions
  
  

https://github.com/user-attachments/assets/ae07b226-09d2-4d8b-9fc8-de81f6fd6402



Fixes: https://github.com/openchoreo/openchoreo/issues/1342
