### PR TITLE
Remove redundant header and fix canvas layout in CellDiagram

### DIFF
--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -1,12 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
-import {
-  Content,
-  Header,
-  HeaderLabel,
-  Page,
-  Progress,
-} from '@backstage/core-components';
-
+import { Progress } from '@backstage/core-components';
+import Box from '@material-ui/core/Box';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useApi } from '@backstage/core-plugin-api';
 import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
@@ -37,14 +31,16 @@ export const CellDiagram = () => {
   }, [entity, client]);
 
   return (
-    <Page themeId="tool">
-      <Header title="Architecture Diagram" type="tool">
-        <HeaderLabel label="Project" value={entity.metadata.name} />
-      </Header>
-      <Content>
+    <Box
+      sx={{
+        height: 'calc(100vh - 146px)',
+        width: 'calc(100% + 48px)',
+        margin: '-24px -24px -24px -24px',
+      }}
+    >
+      <Suspense fallback={<Progress />}>
         <CellView project={cellDiagramData} />
-        <Suspense fallback={<Progress />} />
-      </Content>
-    </Page>
+      </Suspense>
+    </Box>
   );
 };


### PR DESCRIPTION
  - Remove Backstage Page/Header/Content wrapper that created duplicate "Architecture Diagram" header
  - Apply negative margins to eliminate gray border padding from EntityLayout
  - Adjust height to fill available viewport space
  
<img width="1725" height="869" alt="Screenshot 2025-12-23 at 09 59 15" src="https://github.com/user-attachments/assets/98ddbd4c-dd59-4311-864e-060e1793cb50" />
