### PR TITLE
 Make thunder IDP configuration optional

### DIFF
--- a/plugins/catalog-backend-module-openchoreo-users/src/module.ts
+++ b/plugins/catalog-backend-module-openchoreo-users/src/module.ts
@@ -17,6 +17,15 @@ export const catalogModuleOpenchoreoUsers = createBackendModule({
         scheduler: coreServices.scheduler,
       },
       async init({ catalog, config, logger, scheduler }) {
+        // Check if thunder is configured - skip if using a different IDP
+        const thunderBaseUrl = config.getOptionalString('thunder.baseUrl');
+        if (!thunderBaseUrl) {
+          logger.info(
+            'Thunder IDP not configured (thunder.baseUrl missing) - skipping user/group sync',
+          );
+          return;
+        }
+
         // Read schedule configuration from app-config.yaml
         const thunderConfig = config.getOptionalConfig('thunder');
         const frequency =


### PR DESCRIPTION
  Skip user/group sync gracefully when thunder.baseUrl is not configured,
  allowing the backend to start when using alternative identity providers.
