### PR TITLE
Fix runtime logs environment name regression

### DIFF
--- a/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
@@ -72,7 +72,7 @@ export function useLogsSummary() {
         componentId,
         componentName,
         environmentId: selectedEnv.id,
-        environmentName: selectedEnv.name,
+        environmentName: selectedEnv.resourceName,
         logLevels: [], // Get all levels
         startTime,
         endTime,

--- a/plugins/openchoreo/src/components/RuntimeLogs/hooks.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/hooks.ts
@@ -111,7 +111,7 @@ export function useRuntimeLogs(
           componentId,
           componentName,
           environmentId: filters.environmentId,
-          environmentName: selectedEnvironment.name,
+          environmentName: selectedEnvironment.resourceName,
           logLevels: filters.logLevel,
           startTime,
           endTime,


### PR DESCRIPTION
  The refactoring commit 9e3f2ab accidentally reverted the PR #123 fix,
  causing runtime logs to send displayName ("Development") instead of
  resourceName ("dev") to the backend API
