### PR TITLE
Format links and timestamps in RCA Report UI

### DIFF
--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -648,6 +648,9 @@ export class OpenChoreoEntityProvider implements EntityProvider {
           'backstage.io/managed-by-origin-location': `provider:${this.getProviderName()}`,
           [CHOREO_ANNOTATIONS.ENVIRONMENT]: environment.name,
           [CHOREO_ANNOTATIONS.ORGANIZATION]: orgName,
+          ...(environment.uid && {
+            [CHOREO_ANNOTATIONS.ENVIRONMENT_UID]: environment.uid,
+          }),
           ...(environment.namespace && {
             [CHOREO_ANNOTATIONS.NAMESPACE]: environment.namespace,
           }),

--- a/plugins/openchoreo-common/src/constants.ts
+++ b/plugins/openchoreo-common/src/constants.ts
@@ -4,6 +4,7 @@ export const CHOREO_ANNOTATIONS = {
   DEPLOYMENT: 'openchoreo.io/deployment',
   ENDPOINT: 'openchoreo.io/endpoint',
   ENVIRONMENT: 'openchoreo.io/environment',
+  ENVIRONMENT_UID: 'openchoreo.io/environment-uid',
   COMPONENT: 'openchoreo.io/component',
   COMPONENT_UID: 'openchoreo.io/component-uid',
   BRANCH: 'openchoreo.io/branch',

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/EntityLinkContext.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/EntityLinkContext.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+import type { EntityMap } from '../../../hooks/useEntitiesByUids';
+
+export const EntityLinkContext = createContext<{
+  entityMap: EntityMap;
+  loading: boolean;
+}>({
+  entityMap: new Map(),
+  loading: false,
+});
+
+export const useEntityLinkContext = () => useContext(EntityLinkContext);

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/FormattedText.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/FormattedText.tsx
@@ -1,0 +1,80 @@
+import { Fragment } from 'react';
+import { Link } from '@backstage/core-components';
+import { useEntityLinkContext } from './EntityLinkContext';
+
+interface FormattedTextProps {
+  text: string;
+  /** When true, renders entities as bold text instead of clickable links */
+  disableLinks?: boolean;
+}
+
+// Single pattern to match any {{tag:value}} format
+const TAG_PATTERN = /\{\{(\w+):([^}]+)\}\}/;
+
+function formatTimestamp(isoString: string): string {
+  try {
+    const date = new Date(isoString);
+    return date.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  } catch {
+    return isoString;
+  }
+}
+
+/**
+ * Component that renders text with:
+ * - {{comp|env|proj:uuid}} patterns replaced by entity links
+ * - {{ts:ISO_TIMESTAMP}} patterns replaced by formatted timestamps
+ */
+export const FormattedText = ({
+  text,
+  disableLinks = false,
+}: FormattedTextProps) => {
+  const { entityMap, loading } = useEntityLinkContext();
+
+  // Split by any {{tag:value}} pattern, keeping delimiters
+  const parts = text.split(/(\{\{\w+:[^}]+\}\})/g);
+
+  return (
+    <>
+      {parts.map((part, index) => {
+        const match = part.match(TAG_PATTERN);
+        if (!match) {
+          return <Fragment key={index}>{part}</Fragment>;
+        }
+
+        const [, tag, value] = match;
+
+        switch (tag.toLowerCase()) {
+          case 'comp':
+          case 'env':
+          case 'proj': {
+            const entityInfo = entityMap.get(value);
+            if (loading) {
+              return <Fragment key={index}>...</Fragment>;
+            }
+            const displayText = entityInfo
+              ? entityInfo.title || entityInfo.name
+              : value;
+            if (disableLinks || !entityInfo) {
+              return <strong key={index}>{displayText}</strong>;
+            }
+            return (
+              <Link key={index} to={entityInfo.path}>
+                <strong>{displayText}</strong>
+              </Link>
+            );
+          }
+          case 'ts':
+            return <strong key={index}>{formatTimestamp(value)}</strong>;
+          default:
+            return <Fragment key={index}>{part}</Fragment>;
+        }
+      })}
+    </>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/ExcludedCausesSection.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/ExcludedCausesSection.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import { List, ListItem, ListItemText, Divider } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { FormattedText } from '../FormattedText';
 import type { ObservabilityComponents } from '@openchoreo/backstage-plugin-common';
 
 type ExcludedCause = ObservabilityComponents['schemas']['ExcludedCause'];
@@ -19,7 +20,7 @@ const useStyles = makeStyles(theme => ({
   },
   primary: {
     fontWeight: 600,
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: theme.typography.body1.fontSize,
     color: theme.palette.text.primary,
   },
   secondary: {
@@ -42,8 +43,10 @@ export const ExcludedCausesSection = ({
         <Fragment key={idx}>
           <ListItem className={classes.listItem} disableGutters>
             <ListItemText
-              primary={cause.description}
-              secondary={cause.reason}
+              primary={<FormattedText text={cause.description || ''} />}
+              secondary={
+                cause.reason ? <FormattedText text={cause.reason} /> : undefined
+              }
               classes={{
                 primary: classes.primary,
                 secondary: classes.secondary,

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/InvestigationPathSection.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/InvestigationPathSection.tsx
@@ -19,6 +19,7 @@ import Filter8Icon from '@material-ui/icons/Filter8';
 import Filter9Icon from '@material-ui/icons/Filter9';
 import Filter9PlusIcon from '@material-ui/icons/Filter9Plus';
 import { useRCAReportStyles } from '../styles';
+import { FormattedText } from '../FormattedText';
 import type { ObservabilityComponents } from '@openchoreo/backstage-plugin-common';
 
 const numberIcons = [
@@ -75,16 +76,18 @@ export const InvestigationPathSection = ({
               <Box className={classes.timelineHeaderRow}>
                 {getNumberIcon(idx + 1)}
                 <Typography variant="body2" style={{ fontWeight: 600 }}>
-                  {step.action}
+                  <FormattedText text={step.action || ''} />
                 </Typography>
               </Box>
               {step.rationale && (
                 <Typography className={classes.stepRationale}>
-                  {step.rationale}
+                  <FormattedText text={step.rationale} />
                 </Typography>
               )}
               <Box className={classes.stepOutcomeBox}>
-                <Typography variant="body2">{step.outcome}</Typography>
+                <Typography variant="body2">
+                  <FormattedText text={step.outcome || ''} />
+                </Typography>
               </Box>
             </TimelineContent>
           </TimelineItem>

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RecommendationsSection.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RecommendationsSection.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import { List, ListItem, ListItemText, Divider } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { FormattedText } from '../FormattedText';
 import type { ObservabilityComponents } from '@openchoreo/backstage-plugin-common';
 
 type Action = ObservabilityComponents['schemas']['Action'];
@@ -19,7 +20,7 @@ const useStyles = makeStyles(theme => ({
   },
   primary: {
     fontWeight: 600,
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: theme.typography.body1.fontSize,
     color: theme.palette.text.primary,
   },
   secondary: {
@@ -42,8 +43,12 @@ export const RecommendationsSection = ({
         <Fragment key={idx}>
           <ListItem className={classes.listItem} disableGutters>
             <ListItemText
-              primary={action.description}
-              secondary={action.rationale}
+              primary={<FormattedText text={action.description || ''} />}
+              secondary={
+                action.rationale ? (
+                  <FormattedText text={action.rationale} />
+                ) : undefined
+              }
               classes={{
                 primary: classes.primary,
                 secondary: classes.secondary,

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RootCausesSection.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RootCausesSection.tsx
@@ -4,6 +4,7 @@ import { alpha, makeStyles } from '@material-ui/core/styles';
 import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
+import { FormattedText } from '../FormattedText';
 import type { ObservabilityComponents } from '@openchoreo/backstage-plugin-common';
 
 type RootCause = ObservabilityComponents['schemas']['RootCause'];
@@ -41,8 +42,8 @@ const useStyles = makeStyles(theme => ({
     paddingLeft: theme.spacing(2),
   },
   rootCauseTitle: {
-    fontSize: theme.typography.body1.fontSize,
-    fontWeight: 600,
+    fontSize: theme.typography.body2.fontSize,
+    fontWeight: 500,
     color: theme.palette.text.primary,
     flex: 1,
     lineHeight: 1.4,
@@ -373,7 +374,9 @@ const LogEvidence = ({
       >
         {evidence.log_level}
       </span>
-      <span className={classes.componentName}>{evidence.component_uid}</span>
+      <span className={classes.componentName}>
+        <FormattedText text={`{{comp:${evidence.component_uid}}}`} /> component
+      </span>
     </Box>
     <Box className={classes.logLine}>
       <span className={classes.logMessageText}>{evidence.log_message}</span>
@@ -405,12 +408,16 @@ const MetricEvidence = ({
           classes,
         )}`}
       >
-        {evidence.value} {evidence.metric_name}
+        <FormattedText text={`${evidence.value} ${evidence.metric_name}`} />
       </span>
-      <span className={classes.componentName}>{evidence.component_uid}</span>
+      <span className={classes.componentName}>
+        <FormattedText text={`{{comp:${evidence.component_uid}}}`} /> component
+      </span>
     </Box>
     <Box className={classes.metricLine}>
-      <span className={classes.metricDescription}>{evidence.description}</span>
+      <span className={classes.metricDescription}>
+        <FormattedText text={evidence.description} />
+      </span>
     </Box>
     <Box className={classes.evidenceFooter}>
       <span className={classes.metricTimestamp}>
@@ -471,7 +478,10 @@ const TraceEvidence = ({
         <span className={classes.traceDuration}>
           {evidence.total_duration_ms}ms
         </span>
-        <span className={classes.componentName}>{evidence.component_uid}</span>
+        <span className={classes.componentName}>
+          <FormattedText text={`{{comp:${evidence.component_uid}}}`} />{' '}
+          component
+        </span>
       </Box>
       <Box className={classes.traceTreeView}>
         <Box className={classes.spanTreeRoot}>
@@ -513,7 +523,7 @@ const RootCauseItem = ({
   <>
     <Box className={classes.rootCauseHeader}>
       <Typography className={classes.rootCauseTitle}>
-        {rootCause.description}
+        <FormattedText text={rootCause.description} />
       </Typography>
       <span className={getConfidenceBadgeClass(rootCause.confidence, classes)}>
         {rootCause.confidence}
@@ -522,11 +532,11 @@ const RootCauseItem = ({
     <Box className={classes.rootCauseContent}>
       {rootCause.analysis && (
         <Typography
-          variant="body2"
+          variant="body1"
           color="textSecondary"
           className={classes.analysis}
         >
-          {rootCause.analysis}
+          <FormattedText text={rootCause.analysis} />
         </Typography>
       )}
 

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/SystemTimelineSection.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/SystemTimelineSection.tsx
@@ -12,6 +12,7 @@ import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import { useRCAReportStyles } from '../styles';
+import { FormattedText } from '../FormattedText';
 import type { ObservabilityComponents } from '@openchoreo/backstage-plugin-common';
 
 type TimelineEvent = ObservabilityComponents['schemas']['TimelineEvent'];
@@ -86,7 +87,7 @@ export const SystemTimelineSection = ({
                 </Typography>
               </Box>
               <Typography variant="body2" className={classes.timelineEventText}>
-                {event.description}
+                <FormattedText text={event.description || ''} />
                 {event.aggregated_count && event.aggregated_count > 1 && (
                   <> ({event.aggregated_count}x)</>
                 )}

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/VisibilityImprovementsSection.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/VisibilityImprovementsSection.tsx
@@ -1,5 +1,6 @@
 import { Box, Divider, List, ListItem, ListItemText } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { FormattedText } from '../FormattedText';
 
 interface VisibilityImprovementsSectionProps {
   improvements?: string[];
@@ -15,7 +16,7 @@ const useStyles = makeStyles(theme => ({
   },
   primary: {
     fontWeight: 600,
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: theme.typography.body1.fontSize,
     color: theme.palette.text.primary,
   },
 }));
@@ -35,7 +36,7 @@ export const VisibilityImprovementsSection = ({
         <Box key={idx}>
           <ListItem className={classes.listItem}>
             <ListItemText
-              primary={improvement}
+              primary={<FormattedText text={improvement} />}
               classes={{ primary: classes.primary }}
             />
           </ListItem>

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/styles.ts
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/styles.ts
@@ -8,7 +8,6 @@ export const useRCAReportStyles = makeStyles(theme => ({
     justifyContent: 'space-between',
     padding: theme.spacing(2, 0),
     borderBottom: `1px solid ${theme.palette.divider}`,
-    flexShrink: 0,
   },
   headerLeft: {
     display: 'flex',
@@ -32,8 +31,6 @@ export const useRCAReportStyles = makeStyles(theme => ({
     gap: theme.spacing(1),
   },
   content: {
-    flex: 1,
-    overflowY: 'auto',
     paddingTop: theme.spacing(2),
   },
   cardTitle: {
@@ -84,7 +81,11 @@ export const useRCAReportStyles = makeStyles(theme => ({
   },
   summaryLabel: {
     color: theme.palette.text.secondary,
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: theme.typography.caption.fontSize,
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+    fontWeight: 500,
+    marginBottom: theme.spacing(0.5),
   },
   summaryValue: {
     color: theme.palette.text.primary,
@@ -95,5 +96,9 @@ export const useRCAReportStyles = makeStyles(theme => ({
     whiteSpace: 'nowrap',
     maxWidth: '60%',
     textAlign: 'right',
+  },
+  overviewMetaValue: {
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.primary,
   },
 }));

--- a/plugins/openchoreo-observability/src/components/RCA/RCATable.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCATable.tsx
@@ -11,6 +11,7 @@ import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import { StatusBadge, StatusType } from '@openchoreo/backstage-design-system';
 import { RCAReportSummary } from '../../types';
+import { FormattedText } from './RCAReport/FormattedText';
 
 const useStyles = makeStyles({
   truncateSingleLine: {
@@ -76,42 +77,43 @@ export const RCATable = ({ reports, loading = false }: RCATableProps) => {
       },
     },
     {
-      title: 'Report ID',
-      field: 'reportId',
-      width: '10%',
-      render: (row: any) => {
-        const report = row as RCAReportSummary;
-        const reportId = report.reportId || 'N/A';
-        const truncatedId =
-          reportId.length > 30 ? `${reportId.substring(0, 30)}...` : reportId;
-        return (
-          <Typography variant="body2" className={classes.truncateSingleLine}>
-            {truncatedId}
-          </Typography>
-        );
-      },
-    },
-    {
       title: 'Summary',
       field: 'summary',
-      width: '60%',
+      width: '66%',
       highlight: true,
       render: (row: any) => {
         const report = row as RCAReportSummary;
+        if (report.status === 'pending') {
+          return (
+            <Typography variant="body2">Generating RCA report...</Typography>
+          );
+        }
         return (
           <Typography variant="body2" className={classes.truncateTwoLines}>
-            {report.summary || 'No summary available'}
+            {report.summary ? (
+              <FormattedText text={report.summary} disableLinks />
+            ) : (
+              'No summary available'
+            )}
           </Typography>
         );
       },
     },
     {
-      title: 'Status',
+      title: 'Report Status',
       field: 'status',
-      width: '10%',
+      width: '14%',
       render: (row: any) => {
         const report = row as RCAReportSummary;
-        return <StatusBadge status={mapStatusToStatusType(report.status)} />;
+        const status = mapStatusToStatusType(report.status);
+        const labelMap: Record<string, string> = {
+          success: 'Available',
+          pending: 'Pending',
+          failed: 'Failed',
+        };
+        return (
+          <StatusBadge status={status} label={labelMap[status] || status} />
+        );
       },
     },
     {

--- a/plugins/openchoreo-observability/src/hooks/index.ts
+++ b/plugins/openchoreo-observability/src/hooks/index.ts
@@ -7,3 +7,10 @@ export { useTraces } from './useTraces';
 export { useGetComponentsByProject } from './useGetComponentsByProject';
 export { useRCAReportByAlert } from './useRCAReportByAlert';
 export { useRCAReports } from './useRCAReports';
+export {
+  useEntitiesByUids,
+  extractEntityUids,
+  type EntityInfo,
+  type EntityMap,
+  type EntityRef,
+} from './useEntitiesByUids';

--- a/plugins/openchoreo-observability/src/hooks/useEntitiesByUids.ts
+++ b/plugins/openchoreo-observability/src/hooks/useEntitiesByUids.ts
@@ -1,0 +1,120 @@
+import { useEffect, useState, useMemo } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+
+export interface EntityInfo {
+  name: string;
+  title?: string;
+  path: string;
+}
+
+export type EntityMap = Map<string, EntityInfo>;
+
+export interface EntityRef {
+  type: 'comp' | 'env' | 'proj';
+  uid: string;
+}
+
+const ENTITY_PATTERN = /\{\{(comp|env|proj):([a-f0-9-]{36})\}\}/gi;
+
+const TYPE_CONFIG: Record<
+  EntityRef['type'],
+  { kind: string; annotation: string }
+> = {
+  comp: { kind: 'Component', annotation: CHOREO_ANNOTATIONS.COMPONENT_UID },
+  env: { kind: 'Environment', annotation: CHOREO_ANNOTATIONS.ENVIRONMENT_UID },
+  proj: { kind: 'System', annotation: CHOREO_ANNOTATIONS.PROJECT_UID },
+};
+
+const KIND_TO_ANNOTATION = Object.fromEntries(
+  Object.entries(TYPE_CONFIG).map(([_, { kind, annotation }]) => [
+    kind,
+    annotation,
+  ]),
+) as Record<string, string>;
+
+/**
+ * Extracts all entity references from text containing {{type:uuid}} patterns.
+ */
+export function extractEntityUids(text: string): EntityRef[] {
+  const matches = text.matchAll(ENTITY_PATTERN);
+  const seen = new Set<string>();
+  const result: EntityRef[] = [];
+  for (const m of matches) {
+    if (!seen.has(m[2])) {
+      seen.add(m[2]);
+      result.push({ type: m[1].toLowerCase() as EntityRef['type'], uid: m[2] });
+    }
+  }
+  return result;
+}
+
+/**
+ * Hook to batch-fetch entities from the catalog by their OpenChoreo UIDs.
+ */
+export function useEntitiesByUids(refs: EntityRef[]): {
+  entityMap: EntityMap;
+  loading: boolean;
+  error: Error | undefined;
+} {
+  const catalogApi = useApi(catalogApiRef);
+  const [entityMap, setEntityMap] = useState<EntityMap>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>();
+
+  const uniqueRefs = useMemo(() => {
+    const seen = new Set<string>();
+    return refs.filter(ref => {
+      if (!ref.uid || seen.has(ref.uid)) return false;
+      seen.add(ref.uid);
+      return true;
+    });
+  }, [refs]);
+
+  useEffect(() => {
+    if (uniqueRefs.length === 0) {
+      setEntityMap(new Map());
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(undefined);
+
+    const filters = uniqueRefs.map(({ type, uid }) => ({
+      kind: TYPE_CONFIG[type].kind,
+      [`metadata.annotations.${TYPE_CONFIG[type].annotation}`]: uid,
+    }));
+
+    catalogApi
+      .getEntities({ filter: filters })
+      .then(response => {
+        const map = new Map<string, EntityInfo>();
+        for (const entity of response.items) {
+          const annotations = entity.metadata.annotations || {};
+          const uid = annotations[KIND_TO_ANNOTATION[entity.kind]];
+
+          if (uid) {
+            const namespace = entity.metadata.namespace || 'default';
+            const kind = entity.kind.toLowerCase();
+            const name = entity.metadata.name;
+            map.set(uid, {
+              name,
+              title: entity.metadata.title,
+              path: `/catalog/${namespace}/${kind}/${name}`,
+            });
+          }
+        }
+        setEntityMap(map);
+      })
+      .catch(err => {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [uniqueRefs, catalogApi]);
+
+  return { entityMap, loading, error };
+}


### PR DESCRIPTION
- In RCA reports, now we get appropriate links to different entities(eg: project, env etc) wherever mentioned.
- More readable timestamps
- UI refinements

<img width="1510" height="858" alt="image" src="https://github.com/user-attachments/assets/1a4ddf13-54a0-47a0-a0db-ca0668c21ea4" />
<img width="1510" height="858" alt="image" src="https://github.com/user-attachments/assets/2233fec7-834e-40f2-a074-c9774d1b693a" />
