### PR TITLE
Add permission configuration in app-config.production.yaml

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -131,3 +131,8 @@ thunder:
   schedule:
     frequency: 600 # seconds between runs (default: 600 = 10 minutes)
     timeout: 300 # seconds for timeout (default: 300 = 5 minutes)
+
+# see https://backstage.io/docs/permissions/getting-started for more on the permission framework
+permission:
+  # setting this to `false` will disable permissions
+  enabled: ${OPENCHOREO_FEATURES_AUTHZ_ENABLED}


### PR DESCRIPTION
## Purpose

This PR adds permission configuration in app-config.production.yaml , so that permission checks will be properly enabled in production, in authz is enabled in the OC setup.
Previously this was not working properly, since this config was there in the production backstage config.

