### PR TITLE
Add flexible database configuration support

### DIFF
--- a/app-config.local.yaml.example
+++ b/app-config.local.yaml.example
@@ -26,6 +26,11 @@ backend:
     methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
     credentials: true
 
+  # Database configuration (in-memory SQLite for local development)
+  database:
+    client: better-sqlite3
+    connection: ':memory:'
+
 # OpenChoreo API configuration (Kind cluster)
 openchoreo:
   baseUrl: http://api.openchoreo.localhost:8080/api/v1

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -31,11 +31,28 @@ backend:
     origin: ${BACKSTAGE_BASE_URL}
     methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
     credentials: true
-  # This is for local development only, it is not recommended to use this in production
-  # The production database configuration is stored in app-config.production.yaml
+  # Database configuration
+  # Supports both SQLite (default) and PostgreSQL via environment variables
+  # Set by Helm chart based on backstage.database.type (sqlite or postgresql)
+  #
+  # For SQLite (default):
+  #   DATABASE_CLIENT=better-sqlite3
+  #   SQLITE_STORAGE_DIR=/app/.config/backstage (mounted directory)
+  #
+  # For PostgreSQL:
+  #   DATABASE_CLIENT=pg
+  #   POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
   database:
-    client: better-sqlite3
-    connection: ':memory:'
+    client: ${DATABASE_CLIENT}
+    connection:
+      # SQLite settings (used when DATABASE_CLIENT=better-sqlite3)
+      filename: ${SQLITE_STORAGE_DIR}/backstage.db
+      # PostgreSQL settings (used when DATABASE_CLIENT=pg)
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
+      password: ${POSTGRES_PASSWORD}
+      database: ${POSTGRES_DB}
   # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration


### PR DESCRIPTION
## Purpose

This PR updates the Backstage production configuration to support flexible database backends, allowing deployments to choose between lightweight SQLite storage and production-grade PostgreSQL databases based on their operational requirements.

The configuration now reads all database settings from environment variables, enabling operators to switch between database backends without modifying configuration files. This is essential for containerized deployments where the same image needs to work across different environments—development setups can use SQLite for simplicity, while production deployments can connect to managed PostgreSQL services.

SQLite mode uses `better-sqlite3` client with a configurable storage directory, making it suitable for single-replica deployments, development environments, and scenarios where simplicity outweighs horizontal scalability. PostgreSQL mode uses the standard `pg` client with environment variables following the common PostgreSQL naming conventions (POSTGRES_HOST, POSTGRES_PORT, etc.), ensuring compatibility with any PostgreSQL-compatible database including managed services like AWS RDS, Google Cloud SQL, Azure Database for PostgreSQL, or self-hosted instances.

## Environment Variables

**For SQLite (default):**
- `DATABASE_CLIENT=better-sqlite3`
- `SQLITE_STORAGE_DIR=/app/.config/backstage`

**For PostgreSQL:**
- `DATABASE_CLIENT=pg`
- `POSTGRES_HOST`
- `POSTGRES_PORT`
- `POSTGRES_USER`
- `POSTGRES_PASSWORD`
- `POSTGRES_DB`

## Related PRs
- https://github.com/openchoreo/openchoreo/pull/1443 (Helm chart changes)