### PR TITLE
Fix API entity generation for Service components in catalog sync

### DIFF
--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -292,8 +292,11 @@ export class OpenChoreoEntityProvider implements EntityProvider {
               );
 
               for (const component of components) {
-                // If the component is a Service, fetch complete details and create both component and API entities
-                if (component.type === '') {
+                // If the component is a Service (has endpoints), fetch complete details and create both component and API entities
+                const pageVariant = this.componentTypeUtils.getPageVariant(
+                  component.type || '',
+                );
+                if (pageVariant === 'service') {
                   try {
                     const {
                       data: detailData,
@@ -307,6 +310,9 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                             orgName: org.name!,
                             projectName: project.name!,
                             componentName: component.name!,
+                          },
+                          query: {
+                            include: 'workload',
                           },
                         },
                       },


### PR DESCRIPTION
  The OpenChoreoEntityProvider was not generating API entities for Service
  components due to two issues:

  1. Missing `include=workload` query parameter when fetching component details, causing the API to return components without workload data (including endpoints)

  2. Incorrect Service detection logic using `component.type === ''` which never matched since component types have values like 'deployment/service'