### PR TITLE
Fix database configuration defaults and structure

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -35,9 +35,9 @@ backend:
   # Supports both SQLite (default) and PostgreSQL via environment variables
   # Set by Helm chart based on backstage.database.type (sqlite or postgresql)
   #
-  # For SQLite (default):
+  # For SQLite:
   #   DATABASE_CLIENT=better-sqlite3
-  #   SQLITE_STORAGE_DIR=/app/.config/backstage (mounted directory)
+  #   SQLITE_STORAGE_DIR=/app/.config/backstage (directory for per-plugin db files)
   #
   # For PostgreSQL:
   #   DATABASE_CLIENT=pg
@@ -46,7 +46,8 @@ backend:
     client: ${DATABASE_CLIENT}
     connection:
       # SQLite settings (used when DATABASE_CLIENT=better-sqlite3)
-      filename: ${SQLITE_STORAGE_DIR}/backstage.db
+      # Uses directory for per-plugin database files
+      directory: ${SQLITE_STORAGE_DIR}
       # PostgreSQL settings (used when DATABASE_CLIENT=pg)
       host: ${POSTGRES_HOST}
       port: ${POSTGRES_PORT}


### PR DESCRIPTION
## Purpose

This PR fixes the database configuration in `app-config.production.yaml` to use the correct Backstage SQLite configuration structure.

**Issue:** Backstage's SQLite connector requires `connection.directory` (a directory path where per-plugin database files are created), not `connection.filename`.

**Before (broken):**
```yaml
database:
  client: ${DATABASE_CLIENT}
  connection:
    filename: ${SQLITE_STORAGE_DIR}/backstage.db  # Wrong - SQLite connector doesn't support this
```

**After (fixed):**
```yaml
database:
  client: ${DATABASE_CLIENT}
  connection:
    directory: ${SQLITE_STORAGE_DIR}  # Correct - directory for per-plugin db files
```

## Related PRs
- https://github.com/openchoreo/openchoreo/pull/1443 (Helm chart changes - must be merged together)
- https://github.com/openchoreo/backstage-plugins/pull/186 (Original database config PR)