### PR TITLE
Update changeset config with correct package names

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,9 +7,17 @@
     [
       "@openchoreo/backstage-plugin",
       "@openchoreo/backstage-plugin-backend",
-      "@openchoreo/backstage-plugin-api",
       "@openchoreo/backstage-plugin-catalog-backend-module",
-      "@openchoreo/backstage-plugin-scaffolder-backend-module"
+      "@openchoreo/backstage-plugin-scaffolder-backend-module",
+      "@openchoreo/backstage-plugin-common",
+      "@openchoreo/backstage-plugin-react",
+      "@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy",
+      "@openchoreo/backstage-plugin-platform-engineer-core",
+      "@openchoreo/backstage-plugin-platform-engineer-core-backend",
+      "@openchoreo/backstage-design-system",
+      "@openchoreo/openapi-client-generator-node",
+      "@openchoreo/openchoreo-auth",
+      "@openchoreo/openchoreo-client-node"
     ]
   ],
   "access": "restricted",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -2,7 +2,6 @@
   "name": "@openchoreo/backstage-design-system",
   "version": "0.1.0",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/openapi-client-generator-node/package.json
+++ b/packages/openapi-client-generator-node/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "Generic OpenAPI client generator for Backstage plugins",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/openchoreo-auth/package.json
+++ b/packages/openchoreo-auth/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "Authentication service for OpenChoreo API integration",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/openchoreo-client-node/package.json
+++ b/packages/openchoreo-client-node/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "OpenChoreo API client with auto-generated TypeScript types",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {


### PR DESCRIPTION
  Remove non-existent @openchoreo/backstage-plugin-api from linked array
  and add all 13 publishable packages. Remove private: true from packages
  that should be published to GitHub Packages registry.