### PR TITLE
Fix namespace extraction from qualified domain ref

### DIFF
--- a/plugins/openchoreo-ci/src/hooks/useWorkflowData.ts
+++ b/plugins/openchoreo-ci/src/hooks/useWorkflowData.ts
@@ -55,7 +55,9 @@ export function useWorkflowData() {
       const componentData = await response.json();
       setState(prev => ({ ...prev, componentDetails: componentData }));
     } catch (err) {
-      setState(prev => ({ ...prev, error: err as Error }));
+      // Don't set error state — let componentDetails remain null so the UI
+      // shows "Workflows Not Available" instead of a raw HTTP error.
+      setState(prev => ({ ...prev, componentDetails: null }));
     }
   }, [discoveryApi, fetchApi, getEntityDetails]);
 


### PR DESCRIPTION
  useComponentEntityDetails now parses the qualified spec.domain ref
  (e.g. "default/team-alpha") using parseEntityRef to extract just the
  domain name, instead of passing the full ref as the namespace name to
  OpenChoreo API calls.

  useWorkflowData no longer sets error state when fetchComponentDetails
  fails, allowing the Workflows page to fall through to the "Workflows
  Not Available" empty state instead of showing a raw HTTP error