### PR TITLE
Scope component queries by namespace to prevent cross-namespace leakage

### DIFF
--- a/plugins/openchoreo/src/components/EnvironmentOverview/hooks/useEnvironmentDeployedComponents.ts
+++ b/plugins/openchoreo/src/components/EnvironmentOverview/hooks/useEnvironmentDeployedComponents.ts
@@ -89,6 +89,7 @@ export function useEnvironmentDeployedComponents(
           filter: {
             kind: 'Component',
             'spec.system': projectName,
+            'metadata.namespace': namespaceName,
           },
         });
 

--- a/plugins/openchoreo/src/components/Projects/hooks/useComponentsWithDeployment.ts
+++ b/plugins/openchoreo/src/components/Projects/hooks/useComponentsWithDeployment.ts
@@ -62,6 +62,7 @@ export function useComponentsWithDeployment(
         filter: {
           kind: 'Component',
           'spec.system': projectName,
+          'metadata.namespace': namespace,
         },
       });
 


### PR DESCRIPTION
  Add metadata.namespace filter to catalog getEntities calls in
  useComponentsWithDeployment and useEnvironmentDeployedComponents hooks.
  Without this, systems sharing the same name across different namespaces
  (e.g. team-alpha/microservices and team-beta/microservices) would return
  components from all namespaces in the "Has Components" section
  
  Related to: https://github.com/openchoreo/openchoreo/issues/1518