### PR TITLE
Improve Environment entity page UX

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -80,7 +80,6 @@ import {
   EnvironmentStatusSummaryCard,
   EnvironmentDeployedComponentsCard,
   EnvironmentPromotionCard,
-  EnvironmentPipelinesTab,
   DataplaneStatusCard,
   DataplaneEnvironmentsCard,
   BuildPlaneStatusCard,
@@ -608,9 +607,6 @@ const environmentPage = (
           />
         </Grid>
       </Grid>
-    </EntityLayout.Route>
-    <EntityLayout.Route path="/pipelines" title="Pipelines">
-      <EnvironmentPipelinesTab />
     </EntityLayout.Route>
   </EntityLayout>
 );

--- a/plugins/openchoreo/src/components/EnvironmentOverview/EnvironmentPromotionCard.tsx
+++ b/plugins/openchoreo/src/components/EnvironmentOverview/EnvironmentPromotionCard.tsx
@@ -1,8 +1,7 @@
-import { Box, Typography, List, ListItem, Button } from '@material-ui/core';
+import { Box, Typography, List, ListItem } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import TimelineIcon from '@material-ui/icons/Timeline';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
-import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import { Link } from '@backstage/core-components';
 import { parseEntityRef } from '@backstage/catalog-model';
 import { Card } from '@openchoreo/backstage-design-system';
@@ -18,10 +17,6 @@ const useLocalStyles = makeStyles(theme => ({
     alignItems: 'center',
     justifyContent: 'space-between',
     marginBottom: theme.spacing(1),
-  },
-  viewAllButton: {
-    textTransform: 'none',
-    fontSize: theme.typography.caption.fontSize,
   },
   list: {
     padding: 0,
@@ -86,7 +81,7 @@ export const EnvironmentPromotionCard = () => {
       <Card padding={24} className={classes.card}>
         <Box className={classes.cardHeader}>
           <Typography className={classes.cardTitle}>
-            Deployment Pipelines
+            Pipelines Deploying to this Environment
           </Typography>
         </Box>
         <Box className={classes.emptyState}>
@@ -110,17 +105,9 @@ export const EnvironmentPromotionCard = () => {
   return (
     <Card padding={24} className={classes.card}>
       <Box className={localClasses.headerWithAction}>
-        <Typography variant="h5">Deployment Pipelines</Typography>
-        <Link to="pipelines" style={{ textDecoration: 'none' }}>
-          <Button
-            size="small"
-            color="primary"
-            endIcon={<ArrowForwardIcon />}
-            className={localClasses.viewAllButton}
-          >
-            View All
-          </Button>
-        </Link>
+        <Typography variant="h5">
+          Pipelines Deploying to this Environment
+        </Typography>
       </Box>
 
       <Box className={classes.content}>

--- a/plugins/openchoreo/src/components/EnvironmentOverview/EnvironmentStatusSummaryCard.tsx
+++ b/plugins/openchoreo/src/components/EnvironmentOverview/EnvironmentStatusSummaryCard.tsx
@@ -5,8 +5,10 @@ import WarningIcon from '@material-ui/icons/Warning';
 import ErrorIcon from '@material-ui/icons/Error';
 import HourglassEmptyIcon from '@material-ui/icons/HourglassEmpty';
 import CloudOffIcon from '@material-ui/icons/CloudOff';
+import StorageIcon from '@material-ui/icons/Storage';
 import clsx from 'clsx';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { Link } from '@backstage/core-components';
 import { Card } from '@openchoreo/backstage-design-system';
 import { useEnvironmentDeployedComponents } from './hooks';
 import { useEnvironmentOverviewStyles } from './styles';
@@ -37,7 +39,7 @@ export const EnvironmentStatusSummaryCard = () => {
       <Card padding={24} className={classes.card}>
         <Box className={classes.cardHeader}>
           <Typography className={classes.cardTitle}>
-            Deployment Health
+            Component Health
           </Typography>
         </Box>
         <Box className={classes.emptyState}>
@@ -55,7 +57,7 @@ export const EnvironmentStatusSummaryCard = () => {
       <Card padding={24} className={classes.card}>
         <Box className={classes.cardHeader}>
           <Typography className={classes.cardTitle}>
-            Deployment Health
+            Component Health
           </Typography>
         </Box>
         <Box className={classes.emptyState}>
@@ -68,14 +70,43 @@ export const EnvironmentStatusSummaryCard = () => {
     );
   }
 
+  const handleStatusClick = (status: string) => {
+    // Update URL with status filter and scroll to deployed components card
+    const url = new URL(window.location.href);
+    url.searchParams.set('status', status);
+    window.history.pushState({}, '', url.toString());
+
+    // Scroll to deployed components card
+    const deployedComponentsCard = document.getElementById(
+      'deployed-components-card',
+    );
+    if (deployedComponentsCard) {
+      deployedComponentsCard.scrollIntoView({ behavior: 'smooth' });
+    }
+
+    // Dispatch a custom event to notify the deployed components card
+    window.dispatchEvent(
+      new CustomEvent('statusFilterChange', { detail: { status } }),
+    );
+  };
+
+  // Get dataPlaneRef from entity spec
+  const dataPlaneRef = (entity.spec as { dataPlaneRef?: string })?.dataPlaneRef;
+
   return (
     <Card padding={24} className={classes.card}>
       <Box className={classes.cardHeader}>
-        <Typography variant="h5">Deployment Health</Typography>
+        <Typography variant="h5">Component Health</Typography>
       </Box>
 
       <Box className={classes.statusGrid}>
-        <Box className={classes.statusItem}>
+        <Box
+          className={clsx(classes.statusItem, classes.statusItemClickable)}
+          onClick={() => handleStatusClick('healthy')}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => e.key === 'Enter' && handleStatusClick('healthy')}
+        >
           <CheckCircleIcon
             className={clsx(classes.statusIcon, classes.statusHealthy)}
           />
@@ -87,7 +118,13 @@ export const EnvironmentStatusSummaryCard = () => {
           </Box>
         </Box>
 
-        <Box className={classes.statusItem}>
+        <Box
+          className={clsx(classes.statusItem, classes.statusItemClickable)}
+          onClick={() => handleStatusClick('degraded')}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => e.key === 'Enter' && handleStatusClick('degraded')}
+        >
           <WarningIcon
             className={clsx(classes.statusIcon, classes.statusDegraded)}
           />
@@ -99,7 +136,13 @@ export const EnvironmentStatusSummaryCard = () => {
           </Box>
         </Box>
 
-        <Box className={classes.statusItem}>
+        <Box
+          className={clsx(classes.statusItem, classes.statusItemClickable)}
+          onClick={() => handleStatusClick('failed')}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => e.key === 'Enter' && handleStatusClick('failed')}
+        >
           <ErrorIcon
             className={clsx(classes.statusIcon, classes.statusFailed)}
           />
@@ -111,7 +154,13 @@ export const EnvironmentStatusSummaryCard = () => {
           </Box>
         </Box>
 
-        <Box className={classes.statusItem}>
+        <Box
+          className={clsx(classes.statusItem, classes.statusItemClickable)}
+          onClick={() => handleStatusClick('pending')}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => e.key === 'Enter' && handleStatusClick('pending')}
+        >
           <HourglassEmptyIcon
             className={clsx(classes.statusIcon, classes.statusPending)}
           />
@@ -123,6 +172,23 @@ export const EnvironmentStatusSummaryCard = () => {
           </Box>
         </Box>
       </Box>
+
+      {dataPlaneRef && (
+        <Box className={classes.dataPlaneInfo}>
+          <StorageIcon className={classes.dataPlaneIcon} />
+          <Typography variant="body2" className={classes.dataPlaneLabel}>
+            Hosted on:
+          </Typography>
+          <Link
+            to={`/catalog/${
+              entity.metadata.namespace || 'default'
+            }/dataplane/${dataPlaneRef}`}
+            className={classes.dataPlaneLink}
+          >
+            {dataPlaneRef}
+          </Link>
+        </Box>
+      )}
     </Card>
   );
 };

--- a/plugins/openchoreo/src/components/EnvironmentOverview/styles.ts
+++ b/plugins/openchoreo/src/components/EnvironmentOverview/styles.ts
@@ -39,6 +39,18 @@ export const useEnvironmentOverviewStyles = makeStyles(theme => ({
     borderRadius: theme.spacing(1),
     backgroundColor: theme.palette.background.default,
   },
+  statusItemClickable: {
+    cursor: 'pointer',
+    transition: 'all 0.2s ease-in-out',
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+      transform: 'translateY(-1px)',
+    },
+    '&:focus': {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: '2px',
+    },
+  },
   statusIcon: {
     fontSize: '1.25rem',
   },
@@ -157,6 +169,29 @@ export const useEnvironmentOverviewStyles = makeStyles(theme => ({
   arrow: {
     color: theme.palette.text.secondary,
     fontSize: '1rem',
+  },
+  dataPlaneInfo: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(2),
+    paddingTop: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  dataPlaneIcon: {
+    fontSize: '1.25rem',
+    color: theme.palette.text.secondary,
+  },
+  dataPlaneLabel: {
+    color: theme.palette.text.secondary,
+  },
+  dataPlaneLink: {
+    color: theme.palette.primary.main,
+    textDecoration: 'none',
+    fontWeight: 500,
+    '&:hover': {
+      textDecoration: 'underline',
+    },
   },
   activityList: {
     padding: 0,


### PR DESCRIPTION
  - Rename "Deployment Health" to "Component Health"
  - Make health status boxes clickable to filter deployed components table
  - Add URL query parameter support for status filtering (?status=healthy|degraded|failed|pending)
  - Rename "Deployment Pipelines" to "Pipelines Deploying to this Environment"
  - Remove "View All" button and Pipelines tab from environment page
  - Add "Hosted on DataPlane" info with clickable link to DataPlane entity

Related to: https://github.com/openchoreo/openchoreo/issues/1635


https://github.com/user-attachments/assets/ce8819fa-d90f-4651-9d85-2ad1bf3756e2

