### PR TITLE
Make Timestamp field for logs view selected by default

### DIFF
--- a/plugins/openchoreo-observability/src/hooks/useUrlFiltersForRuntimeLogs.ts
+++ b/plugins/openchoreo-observability/src/hooks/useUrlFiltersForRuntimeLogs.ts
@@ -4,6 +4,7 @@ import {
   Environment,
   RuntimeLogsFilters,
   LogEntryField,
+  SELECTED_FIELDS,
 } from '../components/RuntimeLogs/types';
 
 const DEFAULT_TIME_RANGE = '1h';
@@ -54,9 +55,13 @@ export function useUrlFiltersForRuntimeLogs({
       if (!selectedFields.includes(LogEntryField.Log)) {
         selectedFields.push(LogEntryField.Log);
       }
+      // Sort by the order of the SELECTED_FIELDS array to maintain consistent column order
+      selectedFields = SELECTED_FIELDS.filter(field =>
+        selectedFields.includes(field),
+      );
     } else {
-      // Default to just Log field
-      selectedFields = [LogEntryField.Log];
+      // Default to Timestamp and Log fields
+      selectedFields = [LogEntryField.Timestamp, LogEntryField.Log];
     }
 
     // Find environment by ID
@@ -117,8 +122,12 @@ export function useUrlFiltersForRuntimeLogs({
         if (!fields.includes(LogEntryField.Log)) {
           fields = [...fields, LogEntryField.Log];
         }
-        // Only store in URL if not just the default [Log] field
-        if (fields.length === 1 && fields[0] === LogEntryField.Log) {
+        // Only store in URL if not the default [Timestamp, Log] fields
+        const isDefaultFields =
+          fields.length === 2 &&
+          fields.includes(LogEntryField.Log) &&
+          fields.includes(LogEntryField.Timestamp);
+        if (isDefaultFields) {
           newParams.delete('fields');
         } else {
           newParams.set('fields', fields.join(','));


### PR DESCRIPTION
## Purpose
Improve UX of the logs view by making the timestamp column selected by default. Can be deselect and kept only the log column is user wants.

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

https://github.com/user-attachments/assets/acaa8638-b9f6-49f1-8c87-6c7223377670


## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
