### PR TITLE
Add PE catalog entities for ComponentType, TraitType, Workflow, and ComponentWorkflow

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -60,6 +60,10 @@ import DnsIcon from '@material-ui/icons/Dns';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import BuildIcon from '@material-ui/icons/Build';
+import CategoryIcon from '@material-ui/icons/Category';
+import ExtensionIcon from '@material-ui/icons/Extension';
+import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
+import SettingsApplicationsIcon from '@material-ui/icons/SettingsApplications';
 import { AccessControlPage } from '@openchoreo/backstage-plugin';
 import { UnifiedThemeProvider } from '@backstage/theme';
 import { VisitListener } from '@backstage/plugin-home';
@@ -110,6 +114,10 @@ const app = createApp({
     'kind:deploymentpipeline': AccountTreeIcon,
     'kind:observabilityplane': VisibilityIcon,
     'kind:buildplane': BuildIcon,
+    'kind:componenttype': CategoryIcon,
+    'kind:traittype': ExtensionIcon,
+    'kind:workflow': PlayCircleOutlineIcon,
+    'kind:componentworkflow': SettingsApplicationsIcon,
   },
   bindRoutes({ bind }) {
     bind(catalogPlugin.externalRoutes, {

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -41,6 +41,10 @@ import DnsIcon from '@material-ui/icons/Dns';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import BuildIcon from '@material-ui/icons/Build';
+import CategoryIcon from '@material-ui/icons/Category';
+import ExtensionIcon from '@material-ui/icons/Extension';
+import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
+import SettingsApplicationsIcon from '@material-ui/icons/SettingsApplications';
 
 // Re-export for use by App.tsx and other components
 export { openChoreoAuthApiRef };
@@ -165,6 +169,10 @@ export const apis: AnyApiFactory[] = [
           deploymentpipeline: AccountTreeIcon,
           observabilityplane: VisibilityIcon,
           buildplane: BuildIcon,
+          componenttype: CategoryIcon,
+          traittype: ExtensionIcon,
+          workflow: PlayCircleOutlineIcon,
+          componentworkflow: SettingsApplicationsIcon,
         },
       }),
   }),

--- a/packages/app/src/components/catalog/ChoreoEntityKindPicker.tsx
+++ b/packages/app/src/components/catalog/ChoreoEntityKindPicker.tsx
@@ -25,6 +25,10 @@ const kindDisplayNames: Record<string, string> = {
   observabilityplane: 'Observability Plane',
   environment: 'Environment',
   deploymentpipeline: 'Deployment Pipeline',
+  componenttype: 'Component Type',
+  traittype: 'Trait Type',
+  workflow: 'Workflow',
+  componentworkflow: 'Component Workflow',
 };
 
 // Custom order for displaying entity kinds in the dropdown
@@ -44,6 +48,10 @@ const kindDisplayOrder: string[] = [
   'observabilityplane',
   'environment',
   'deploymentpipeline',
+  'componenttype',
+  'traittype',
+  'workflow',
+  'componentworkflow',
 ];
 
 // Hook to fetch all available Choreo entity kinds from the catalog
@@ -233,7 +241,11 @@ export const ChoreoEntityKindPicker = (props: ChoreoEntityKindPickerProps) => {
             lowerKey !== 'buildplane' &&
             lowerKey !== 'observabilityplane' &&
             lowerKey !== 'environment' &&
-            lowerKey !== 'deploymentpipeline'
+            lowerKey !== 'deploymentpipeline' &&
+            lowerKey !== 'componenttype' &&
+            lowerKey !== 'traittype' &&
+            lowerKey !== 'workflow' &&
+            lowerKey !== 'componentworkflow'
           );
         }),
       );

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -58,6 +58,8 @@ import {
   RELATION_HOSTS,
   RELATION_OBSERVED_BY,
   RELATION_OBSERVES,
+  RELATION_USES_WORKFLOW,
+  RELATION_WORKFLOW_USED_BY,
 } from '@openchoreo/backstage-plugin-common';
 
 import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
@@ -87,6 +89,10 @@ import {
   ObservabilityPlaneLinkedPlanesCard,
   DeploymentPipelineVisualization,
   PromotionPathsCard,
+  ComponentTypeOverviewCard,
+  TraitTypeOverviewCard,
+  WorkflowOverviewCard,
+  ComponentWorkflowOverviewCard,
 } from '@openchoreo/backstage-plugin';
 import { EntityLayoutWithDelete } from './EntityLayoutWithDelete';
 
@@ -735,6 +741,105 @@ const deploymentPipelinePage = (
   </EntityLayout>
 );
 
+const componentTypePage = (
+  <EntityLayout UNSTABLE_contextMenuOptions={{ disableUnregister: 'hidden' }}>
+    <EntityLayout.Route path="/" title="Overview">
+      <Grid container spacing={3} alignItems="stretch">
+        {entityWarningContent}
+        <Grid item md={6} xs={12}>
+          <ComponentTypeOverviewCard />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <EntityCatalogGraphCard
+            variant="gridItem"
+            height={400}
+            relations={[
+              RELATION_PART_OF,
+              RELATION_HAS_PART,
+              RELATION_USES_WORKFLOW,
+              RELATION_WORKFLOW_USED_BY,
+            ]}
+            renderNode={CustomGraphNode}
+          />
+        </Grid>
+        <Grid item md={12} xs={12}>
+          <EntityAboutCard variant="gridItem" />
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
+const traitTypePage = (
+  <EntityLayout UNSTABLE_contextMenuOptions={{ disableUnregister: 'hidden' }}>
+    <EntityLayout.Route path="/" title="Overview">
+      <Grid container spacing={3} alignItems="stretch">
+        {entityWarningContent}
+        <Grid item md={6} xs={12}>
+          <TraitTypeOverviewCard />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <EntityCatalogGraphCard
+            variant="gridItem"
+            height={400}
+            renderNode={CustomGraphNode}
+          />
+        </Grid>
+        <Grid item md={12} xs={12}>
+          <EntityAboutCard variant="gridItem" />
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
+const workflowPage = (
+  <EntityLayout UNSTABLE_contextMenuOptions={{ disableUnregister: 'hidden' }}>
+    <EntityLayout.Route path="/" title="Overview">
+      <Grid container spacing={3} alignItems="stretch">
+        {entityWarningContent}
+        <Grid item md={6} xs={12}>
+          <WorkflowOverviewCard />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <EntityCatalogGraphCard
+            variant="gridItem"
+            height={400}
+            renderNode={CustomGraphNode}
+          />
+        </Grid>
+        <Grid item md={12} xs={12}>
+          <EntityAboutCard variant="gridItem" />
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
+const componentWorkflowPage = (
+  <EntityLayout UNSTABLE_contextMenuOptions={{ disableUnregister: 'hidden' }}>
+    <EntityLayout.Route path="/" title="Overview">
+      <Grid container spacing={3} alignItems="stretch">
+        {entityWarningContent}
+        <Grid item md={6} xs={12}>
+          <ComponentWorkflowOverviewCard />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <EntityCatalogGraphCard
+            variant="gridItem"
+            height={400}
+            relations={[RELATION_USES_WORKFLOW, RELATION_WORKFLOW_USED_BY]}
+            renderNode={CustomGraphNode}
+          />
+        </Grid>
+        <Grid item md={12} xs={12}>
+          <EntityAboutCard variant="gridItem" />
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
 export const entityPage = (
   <EntitySwitch>
     <EntitySwitch.Case if={isKind('component')} children={componentPage} />
@@ -754,6 +859,16 @@ export const entityPage = (
     <EntitySwitch.Case
       if={isKind('deploymentpipeline')}
       children={deploymentPipelinePage}
+    />
+    <EntitySwitch.Case
+      if={isKind('componenttype')}
+      children={componentTypePage}
+    />
+    <EntitySwitch.Case if={isKind('traittype')} children={traitTypePage} />
+    <EntitySwitch.Case if={isKind('workflow')} children={workflowPage} />
+    <EntitySwitch.Case
+      if={isKind('componentworkflow')}
+      children={componentWorkflowPage}
     />
 
     <EntitySwitch.Case>{defaultEntityPage}</EntitySwitch.Case>

--- a/packages/app/src/components/catalog/graphUtils.ts
+++ b/packages/app/src/components/catalog/graphUtils.ts
@@ -23,6 +23,10 @@ export const ENTITY_KIND_COLORS: Record<string, string> = {
   deploymentpipeline: '#f59e0b', // warning.main - Orange for pipelines
   observabilityplane: '#8b5cf6', // Purple for observability planes
   buildplane: '#3b82f6', // Blue for build planes
+  componenttype: '#f59e0b', // Orange for component types
+  traittype: '#10b981', // Green for trait types
+  workflow: '#8b5cf6', // Purple for workflows
+  componentworkflow: '#3b82f6', // Blue for component workflows
 };
 
 /**
@@ -40,6 +44,10 @@ export const KIND_LABEL_PREFIXES: Record<string, string> = {
   deploymentpipeline: 'Pipeline',
   observabilityplane: 'Obs',
   buildplane: 'BP',
+  componenttype: 'CT',
+  traittype: 'Trait',
+  workflow: 'WF',
+  componentworkflow: 'CWF',
 };
 
 /**

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/ComponentTypeEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/ComponentTypeEntityV1alpha1.ts
@@ -1,0 +1,38 @@
+import { Entity } from '@backstage/catalog-model';
+
+/**
+ * Backstage catalog ComponentType kind Entity. Represents an OpenChoreo component type definition.
+ *
+ * @public
+ */
+export interface ComponentTypeEntityV1alpha1 extends Entity {
+  /**
+   * The apiVersion string of the ComponentType.
+   */
+  apiVersion: 'backstage.io/v1alpha1';
+  /**
+   * The kind of the entity
+   */
+  kind: 'ComponentType';
+  /**
+   * The specification of the ComponentType Entity
+   */
+  spec: {
+    /**
+     * The type of entity (always 'component-type')
+     */
+    type: string;
+    /**
+     * The domain this component type belongs to
+     */
+    domain?: string;
+    /**
+     * Workload type: deployment, statefulset, cronjob, job, proxy
+     */
+    workloadType: string;
+    /**
+     * List of allowed component workflow names
+     */
+    allowedWorkflows?: string[];
+  };
+}

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/ComponentWorkflowEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/ComponentWorkflowEntityV1alpha1.ts
@@ -1,0 +1,30 @@
+import { Entity } from '@backstage/catalog-model';
+
+/**
+ * Backstage catalog ComponentWorkflow kind Entity. Represents an OpenChoreo component workflow (build workflow).
+ *
+ * @public
+ */
+export interface ComponentWorkflowEntityV1alpha1 extends Entity {
+  /**
+   * The apiVersion string of the ComponentWorkflow.
+   */
+  apiVersion: 'backstage.io/v1alpha1';
+  /**
+   * The kind of the entity
+   */
+  kind: 'ComponentWorkflow';
+  /**
+   * The specification of the ComponentWorkflow Entity
+   */
+  spec: {
+    /**
+     * The type of entity (always 'component-workflow')
+     */
+    type: string;
+    /**
+     * The domain this component workflow belongs to
+     */
+    domain?: string;
+  };
+}

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/TraitTypeEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/TraitTypeEntityV1alpha1.ts
@@ -1,0 +1,30 @@
+import { Entity } from '@backstage/catalog-model';
+
+/**
+ * Backstage catalog TraitType kind Entity. Represents an OpenChoreo trait definition.
+ *
+ * @public
+ */
+export interface TraitTypeEntityV1alpha1 extends Entity {
+  /**
+   * The apiVersion string of the TraitType.
+   */
+  apiVersion: 'backstage.io/v1alpha1';
+  /**
+   * The kind of the entity
+   */
+  kind: 'TraitType';
+  /**
+   * The specification of the TraitType Entity
+   */
+  spec: {
+    /**
+     * The type of entity (always 'trait-type')
+     */
+    type: string;
+    /**
+     * The domain this trait type belongs to
+     */
+    domain?: string;
+  };
+}

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/WorkflowEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/WorkflowEntityV1alpha1.ts
@@ -1,0 +1,30 @@
+import { Entity } from '@backstage/catalog-model';
+
+/**
+ * Backstage catalog Workflow kind Entity. Represents an OpenChoreo generic workflow.
+ *
+ * @public
+ */
+export interface WorkflowEntityV1alpha1 extends Entity {
+  /**
+   * The apiVersion string of the Workflow.
+   */
+  apiVersion: 'backstage.io/v1alpha1';
+  /**
+   * The kind of the entity
+   */
+  kind: 'Workflow';
+  /**
+   * The specification of the Workflow Entity
+   */
+  spec: {
+    /**
+     * The type of entity (always 'workflow')
+     */
+    type: string;
+    /**
+     * The domain this workflow belongs to
+     */
+    domain?: string;
+  };
+}

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/index.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/index.ts
@@ -7,3 +7,7 @@ export type {
   PromotionPath,
   TargetEnvironmentRef,
 } from './DeploymentPipelineEntityV1alpha1';
+export type { ComponentTypeEntityV1alpha1 } from './ComponentTypeEntityV1alpha1';
+export type { TraitTypeEntityV1alpha1 } from './TraitTypeEntityV1alpha1';
+export type { WorkflowEntityV1alpha1 } from './WorkflowEntityV1alpha1';
+export type { ComponentWorkflowEntityV1alpha1 } from './ComponentWorkflowEntityV1alpha1';

--- a/plugins/catalog-backend-module-openchoreo/src/module.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/module.ts
@@ -15,6 +15,10 @@ import {
   BuildPlaneEntityProcessor,
   ObservabilityPlaneEntityProcessor,
   DeploymentPipelineEntityProcessor,
+  ComponentTypeEntityProcessor,
+  TraitTypeEntityProcessor,
+  WorkflowEntityProcessor,
+  ComponentWorkflowEntityProcessor,
 } from './processors';
 import {
   immediateCatalogServiceRef,
@@ -78,6 +82,18 @@ export const catalogModuleOpenchoreo = createBackendModule({
 
         // Register the DeploymentPipeline entity processor
         catalog.addProcessor(new DeploymentPipelineEntityProcessor());
+
+        // Register the ComponentType entity processor
+        catalog.addProcessor(new ComponentTypeEntityProcessor());
+
+        // Register the TraitType entity processor
+        catalog.addProcessor(new TraitTypeEntityProcessor());
+
+        // Register the Workflow entity processor
+        catalog.addProcessor(new WorkflowEntityProcessor());
+
+        // Register the ComponentWorkflow entity processor
+        catalog.addProcessor(new ComponentWorkflowEntityProcessor());
 
         // Register the scheduled OpenChoreo entity provider
         catalog.addEntityProvider(

--- a/plugins/catalog-backend-module-openchoreo/src/processors/ComponentTypeEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/ComponentTypeEntityProcessor.ts
@@ -1,0 +1,119 @@
+import {
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  processingResult,
+} from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { RELATION_PART_OF, parseEntityRef } from '@backstage/catalog-model';
+import {
+  RELATION_USES_WORKFLOW,
+  RELATION_WORKFLOW_USED_BY,
+} from '@openchoreo/backstage-plugin-common';
+import { ComponentTypeEntityV1alpha1 } from '../kinds/ComponentTypeEntityV1alpha1';
+
+/**
+ * Processor for ComponentType entities
+ */
+export class ComponentTypeEntityProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'ComponentTypeEntityProcessor';
+  }
+
+  async validateEntityKind(
+    entity: ComponentTypeEntityV1alpha1,
+  ): Promise<boolean> {
+    return entity.kind === 'ComponentType';
+  }
+
+  async postProcessEntity(
+    entity: ComponentTypeEntityV1alpha1,
+    _location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<ComponentTypeEntityV1alpha1> {
+    if (entity.kind === 'ComponentType') {
+      if (!entity.spec?.type) {
+        throw new Error('ComponentType entity must have spec.type');
+      }
+
+      const sourceRef = {
+        kind: entity.kind.toLowerCase(),
+        namespace: entity.metadata.namespace || 'default',
+        name: entity.metadata.name,
+      };
+
+      // Emit partOf relationship to domain
+      if (entity.spec.domain) {
+        const domainRef = parseEntityRef(entity.spec.domain, {
+          defaultKind: 'domain',
+          defaultNamespace: entity.metadata.namespace || 'default',
+        });
+        emit(
+          processingResult.relation({
+            source: sourceRef,
+            target: {
+              kind: domainRef.kind,
+              namespace: domainRef.namespace,
+              name: domainRef.name,
+            },
+            type: RELATION_PART_OF,
+          }),
+        );
+      }
+
+      // Emit usesWorkflow/workflowUsedBy relationships for each allowed workflow
+      if (entity.spec.allowedWorkflows) {
+        for (const workflowName of entity.spec.allowedWorkflows) {
+          const cwRef = {
+            kind: 'componentworkflow',
+            namespace: entity.metadata.namespace || 'default',
+            name: workflowName,
+          };
+          emit(
+            processingResult.relation({
+              source: sourceRef,
+              target: cwRef,
+              type: RELATION_USES_WORKFLOW,
+            }),
+          );
+          emit(
+            processingResult.relation({
+              source: cwRef,
+              target: sourceRef,
+              type: RELATION_WORKFLOW_USED_BY,
+            }),
+          );
+        }
+      }
+    }
+
+    return entity;
+  }
+
+  async preProcessEntity(
+    entity: ComponentTypeEntityV1alpha1,
+    _location: LocationSpec,
+    _emit: CatalogProcessorEmit,
+  ): Promise<ComponentTypeEntityV1alpha1> {
+    if (entity.kind === 'ComponentType' && entity.spec) {
+      if (!entity.spec.type) {
+        entity.spec.type = 'component-type';
+      }
+    }
+
+    return entity;
+  }
+
+  async processEntity(
+    entity: ComponentTypeEntityV1alpha1,
+    location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<ComponentTypeEntityV1alpha1> {
+    if (entity.kind !== 'ComponentType') {
+      return entity;
+    }
+
+    emit(processingResult.entity(location, entity));
+
+    return entity;
+  }
+}

--- a/plugins/catalog-backend-module-openchoreo/src/processors/ComponentWorkflowEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/ComponentWorkflowEntityProcessor.ts
@@ -1,0 +1,90 @@
+import {
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  processingResult,
+} from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { RELATION_PART_OF, parseEntityRef } from '@backstage/catalog-model';
+import { ComponentWorkflowEntityV1alpha1 } from '../kinds/ComponentWorkflowEntityV1alpha1';
+
+/**
+ * Processor for ComponentWorkflow entities
+ */
+export class ComponentWorkflowEntityProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'ComponentWorkflowEntityProcessor';
+  }
+
+  async validateEntityKind(
+    entity: ComponentWorkflowEntityV1alpha1,
+  ): Promise<boolean> {
+    return entity.kind === 'ComponentWorkflow';
+  }
+
+  async postProcessEntity(
+    entity: ComponentWorkflowEntityV1alpha1,
+    _location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<ComponentWorkflowEntityV1alpha1> {
+    if (entity.kind === 'ComponentWorkflow') {
+      if (!entity.spec?.type) {
+        throw new Error('ComponentWorkflow entity must have spec.type');
+      }
+
+      const sourceRef = {
+        kind: entity.kind.toLowerCase(),
+        namespace: entity.metadata.namespace || 'default',
+        name: entity.metadata.name,
+      };
+
+      // Emit partOf relationship to domain
+      if (entity.spec.domain) {
+        const domainRef = parseEntityRef(entity.spec.domain, {
+          defaultKind: 'domain',
+          defaultNamespace: entity.metadata.namespace || 'default',
+        });
+        emit(
+          processingResult.relation({
+            source: sourceRef,
+            target: {
+              kind: domainRef.kind,
+              namespace: domainRef.namespace,
+              name: domainRef.name,
+            },
+            type: RELATION_PART_OF,
+          }),
+        );
+      }
+    }
+
+    return entity;
+  }
+
+  async preProcessEntity(
+    entity: ComponentWorkflowEntityV1alpha1,
+    _location: LocationSpec,
+    _emit: CatalogProcessorEmit,
+  ): Promise<ComponentWorkflowEntityV1alpha1> {
+    if (entity.kind === 'ComponentWorkflow' && entity.spec) {
+      if (!entity.spec.type) {
+        entity.spec.type = 'component-workflow';
+      }
+    }
+
+    return entity;
+  }
+
+  async processEntity(
+    entity: ComponentWorkflowEntityV1alpha1,
+    location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<ComponentWorkflowEntityV1alpha1> {
+    if (entity.kind !== 'ComponentWorkflow') {
+      return entity;
+    }
+
+    emit(processingResult.entity(location, entity));
+
+    return entity;
+  }
+}

--- a/plugins/catalog-backend-module-openchoreo/src/processors/TraitTypeEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/TraitTypeEntityProcessor.ts
@@ -1,0 +1,88 @@
+import {
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  processingResult,
+} from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { RELATION_PART_OF, parseEntityRef } from '@backstage/catalog-model';
+import { TraitTypeEntityV1alpha1 } from '../kinds/TraitTypeEntityV1alpha1';
+
+/**
+ * Processor for TraitType entities
+ */
+export class TraitTypeEntityProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'TraitTypeEntityProcessor';
+  }
+
+  async validateEntityKind(entity: TraitTypeEntityV1alpha1): Promise<boolean> {
+    return entity.kind === 'TraitType';
+  }
+
+  async postProcessEntity(
+    entity: TraitTypeEntityV1alpha1,
+    _location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<TraitTypeEntityV1alpha1> {
+    if (entity.kind === 'TraitType') {
+      if (!entity.spec?.type) {
+        throw new Error('TraitType entity must have spec.type');
+      }
+
+      const sourceRef = {
+        kind: entity.kind.toLowerCase(),
+        namespace: entity.metadata.namespace || 'default',
+        name: entity.metadata.name,
+      };
+
+      // Emit partOf relationship to domain
+      if (entity.spec.domain) {
+        const domainRef = parseEntityRef(entity.spec.domain, {
+          defaultKind: 'domain',
+          defaultNamespace: entity.metadata.namespace || 'default',
+        });
+        emit(
+          processingResult.relation({
+            source: sourceRef,
+            target: {
+              kind: domainRef.kind,
+              namespace: domainRef.namespace,
+              name: domainRef.name,
+            },
+            type: RELATION_PART_OF,
+          }),
+        );
+      }
+    }
+
+    return entity;
+  }
+
+  async preProcessEntity(
+    entity: TraitTypeEntityV1alpha1,
+    _location: LocationSpec,
+    _emit: CatalogProcessorEmit,
+  ): Promise<TraitTypeEntityV1alpha1> {
+    if (entity.kind === 'TraitType' && entity.spec) {
+      if (!entity.spec.type) {
+        entity.spec.type = 'trait-type';
+      }
+    }
+
+    return entity;
+  }
+
+  async processEntity(
+    entity: TraitTypeEntityV1alpha1,
+    location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<TraitTypeEntityV1alpha1> {
+    if (entity.kind !== 'TraitType') {
+      return entity;
+    }
+
+    emit(processingResult.entity(location, entity));
+
+    return entity;
+  }
+}

--- a/plugins/catalog-backend-module-openchoreo/src/processors/WorkflowEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/WorkflowEntityProcessor.ts
@@ -1,0 +1,88 @@
+import {
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  processingResult,
+} from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { RELATION_PART_OF, parseEntityRef } from '@backstage/catalog-model';
+import { WorkflowEntityV1alpha1 } from '../kinds/WorkflowEntityV1alpha1';
+
+/**
+ * Processor for Workflow entities
+ */
+export class WorkflowEntityProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'WorkflowEntityProcessor';
+  }
+
+  async validateEntityKind(entity: WorkflowEntityV1alpha1): Promise<boolean> {
+    return entity.kind === 'Workflow';
+  }
+
+  async postProcessEntity(
+    entity: WorkflowEntityV1alpha1,
+    _location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<WorkflowEntityV1alpha1> {
+    if (entity.kind === 'Workflow') {
+      if (!entity.spec?.type) {
+        throw new Error('Workflow entity must have spec.type');
+      }
+
+      const sourceRef = {
+        kind: entity.kind.toLowerCase(),
+        namespace: entity.metadata.namespace || 'default',
+        name: entity.metadata.name,
+      };
+
+      // Emit partOf relationship to domain
+      if (entity.spec.domain) {
+        const domainRef = parseEntityRef(entity.spec.domain, {
+          defaultKind: 'domain',
+          defaultNamespace: entity.metadata.namespace || 'default',
+        });
+        emit(
+          processingResult.relation({
+            source: sourceRef,
+            target: {
+              kind: domainRef.kind,
+              namespace: domainRef.namespace,
+              name: domainRef.name,
+            },
+            type: RELATION_PART_OF,
+          }),
+        );
+      }
+    }
+
+    return entity;
+  }
+
+  async preProcessEntity(
+    entity: WorkflowEntityV1alpha1,
+    _location: LocationSpec,
+    _emit: CatalogProcessorEmit,
+  ): Promise<WorkflowEntityV1alpha1> {
+    if (entity.kind === 'Workflow' && entity.spec) {
+      if (!entity.spec.type) {
+        entity.spec.type = 'workflow';
+      }
+    }
+
+    return entity;
+  }
+
+  async processEntity(
+    entity: WorkflowEntityV1alpha1,
+    location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<WorkflowEntityV1alpha1> {
+    if (entity.kind !== 'Workflow') {
+      return entity;
+    }
+
+    emit(processingResult.entity(location, entity));
+
+    return entity;
+  }
+}

--- a/plugins/catalog-backend-module-openchoreo/src/processors/index.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/index.ts
@@ -3,3 +3,7 @@ export { DataplaneEntityProcessor } from './DataplaneEntityProcessor';
 export { BuildPlaneEntityProcessor } from './BuildPlaneEntityProcessor';
 export { ObservabilityPlaneEntityProcessor } from './ObservabilityPlaneEntityProcessor';
 export { DeploymentPipelineEntityProcessor } from './DeploymentPipelineEntityProcessor';
+export { ComponentTypeEntityProcessor } from './ComponentTypeEntityProcessor';
+export { TraitTypeEntityProcessor } from './TraitTypeEntityProcessor';
+export { WorkflowEntityProcessor } from './WorkflowEntityProcessor';
+export { ComponentWorkflowEntityProcessor } from './ComponentWorkflowEntityProcessor';

--- a/plugins/openchoreo-common/src/constants.ts
+++ b/plugins/openchoreo-common/src/constants.ts
@@ -91,3 +91,15 @@ export const RELATION_OBSERVED_BY = 'observedBy';
  * This is the inverse of RELATION_OBSERVED_BY.
  */
 export const RELATION_OBSERVES = 'observes';
+
+/**
+ * A relation indicating that a ComponentType uses a ComponentWorkflow (via allowedWorkflows).
+ * The source is the ComponentType, the target is the ComponentWorkflow.
+ */
+export const RELATION_USES_WORKFLOW = 'usesWorkflow';
+
+/**
+ * A relation indicating that a ComponentWorkflow is used by a ComponentType.
+ * This is the inverse of RELATION_USES_WORKFLOW.
+ */
+export const RELATION_WORKFLOW_USED_BY = 'workflowUsedBy';

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -9,6 +9,8 @@ export {
   RELATION_HOSTS,
   RELATION_OBSERVED_BY,
   RELATION_OBSERVES,
+  RELATION_USES_WORKFLOW,
+  RELATION_WORKFLOW_USED_BY,
 } from './constants';
 
 // Permissions

--- a/plugins/openchoreo/src/components/ComponentTypeOverview/ComponentTypeOverviewCard.tsx
+++ b/plugins/openchoreo/src/components/ComponentTypeOverview/ComponentTypeOverviewCard.tsx
@@ -1,0 +1,118 @@
+import { useMemo } from 'react';
+import { Box, Chip, Typography } from '@material-ui/core';
+import CategoryIcon from '@material-ui/icons/Category';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import { parseEntityRef } from '@backstage/catalog-model';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { Link } from '@backstage/core-components';
+import { Card } from '@openchoreo/backstage-design-system';
+import {
+  CHOREO_ANNOTATIONS,
+  RELATION_USES_WORKFLOW,
+} from '@openchoreo/backstage-plugin-common';
+import { useDataplaneOverviewStyles } from '../DataplaneOverview/styles';
+
+export const ComponentTypeOverviewCard = () => {
+  const classes = useDataplaneOverviewStyles();
+  const { entity } = useEntity();
+
+  const spec = entity.spec as any;
+  const annotations = entity.metadata.annotations || {};
+
+  const workloadType = spec?.workloadType || 'Unknown';
+  const allowedWorkflows: string[] = spec?.allowedWorkflows || [];
+  const createdAt = annotations[CHOREO_ANNOTATIONS.CREATED_AT];
+
+  // Build workflow links from relations
+  const workflowLinks = useMemo(() => {
+    const relations = entity.relations || [];
+    return relations
+      .filter(r => r.type === RELATION_USES_WORKFLOW)
+      .map(r => {
+        try {
+          const ref = parseEntityRef(r.targetRef);
+          return {
+            name: ref.name,
+            link: `/catalog/${ref.namespace}/${ref.kind.toLowerCase()}/${
+              ref.name
+            }`,
+          };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean) as { name: string; link: string }[];
+  }, [entity.relations]);
+
+  const formatDate = (isoString: string) => {
+    try {
+      return new Date(isoString).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return isoString;
+    }
+  };
+
+  return (
+    <Card padding={24} className={classes.card}>
+      <Box className={classes.cardHeader}>
+        <Typography variant="h5">Component Type Details</Typography>
+      </Box>
+
+      <Box className={classes.statusGrid}>
+        <Box className={classes.statusItem}>
+          <CategoryIcon className={classes.statusIcon} />
+          <Box>
+            <Typography className={classes.statusLabel}>
+              Workload Type
+            </Typography>
+            <Chip label={workloadType} size="small" />
+          </Box>
+        </Box>
+
+        {createdAt && (
+          <Box className={classes.statusItem}>
+            <AccessTimeIcon className={classes.statusIcon} />
+            <Box>
+              <Typography className={classes.statusLabel}>Created</Typography>
+              <Typography className={classes.statusValue}>
+                {formatDate(createdAt)}
+              </Typography>
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {allowedWorkflows.length > 0 && (
+        <Box mt={2}>
+          <Typography className={classes.statusLabel} gutterBottom>
+            Allowed Workflows ({allowedWorkflows.length})
+          </Typography>
+          <Box display="flex" flexWrap="wrap" gridGap={8}>
+            {allowedWorkflows.map(wfName => {
+              const wfLink = workflowLinks.find(wl => wl.name === wfName);
+              return wfLink ? (
+                <Chip
+                  key={wfName}
+                  label={<Link to={wfLink.link}>{wfName}</Link>}
+                  size="small"
+                  variant="outlined"
+                />
+              ) : (
+                <Chip
+                  key={wfName}
+                  label={wfName}
+                  size="small"
+                  variant="outlined"
+                />
+              );
+            })}
+          </Box>
+        </Box>
+      )}
+    </Card>
+  );
+};

--- a/plugins/openchoreo/src/components/ComponentTypeOverview/index.ts
+++ b/plugins/openchoreo/src/components/ComponentTypeOverview/index.ts
@@ -1,0 +1,1 @@
+export { ComponentTypeOverviewCard } from './ComponentTypeOverviewCard';

--- a/plugins/openchoreo/src/components/ComponentWorkflowOverview/ComponentWorkflowOverviewCard.tsx
+++ b/plugins/openchoreo/src/components/ComponentWorkflowOverview/ComponentWorkflowOverviewCard.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from 'react';
+import { Box, Chip, Typography } from '@material-ui/core';
+import SettingsApplicationsIcon from '@material-ui/icons/SettingsApplications';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import { parseEntityRef } from '@backstage/catalog-model';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { Link } from '@backstage/core-components';
+import { Card } from '@openchoreo/backstage-design-system';
+import {
+  CHOREO_ANNOTATIONS,
+  RELATION_WORKFLOW_USED_BY,
+} from '@openchoreo/backstage-plugin-common';
+import { useDataplaneOverviewStyles } from '../DataplaneOverview/styles';
+
+export const ComponentWorkflowOverviewCard = () => {
+  const classes = useDataplaneOverviewStyles();
+  const { entity } = useEntity();
+
+  const annotations = entity.metadata.annotations || {};
+  const createdAt = annotations[CHOREO_ANNOTATIONS.CREATED_AT];
+  const description = entity.metadata.description;
+
+  // Find which ComponentTypes use this workflow via inverse relation
+  const usedByLinks = useMemo(() => {
+    const relations = entity.relations || [];
+    return relations
+      .filter(r => r.type === RELATION_WORKFLOW_USED_BY)
+      .map(r => {
+        try {
+          const ref = parseEntityRef(r.targetRef);
+          return {
+            name: ref.name,
+            link: `/catalog/${ref.namespace}/${ref.kind.toLowerCase()}/${
+              ref.name
+            }`,
+          };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean) as { name: string; link: string }[];
+  }, [entity.relations]);
+
+  const formatDate = (isoString: string) => {
+    try {
+      return new Date(isoString).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return isoString;
+    }
+  };
+
+  return (
+    <Card padding={24} className={classes.card}>
+      <Box className={classes.cardHeader}>
+        <Typography variant="h5">Component Workflow Details</Typography>
+      </Box>
+
+      <Box className={classes.statusGrid}>
+        <Box className={classes.statusItem}>
+          <SettingsApplicationsIcon className={classes.statusIcon} />
+          <Box>
+            <Typography className={classes.statusLabel}>Type</Typography>
+            <Typography className={classes.statusValue}>
+              Build Workflow
+            </Typography>
+          </Box>
+        </Box>
+
+        {createdAt && (
+          <Box className={classes.statusItem}>
+            <AccessTimeIcon className={classes.statusIcon} />
+            <Box>
+              <Typography className={classes.statusLabel}>Created</Typography>
+              <Typography className={classes.statusValue}>
+                {formatDate(createdAt)}
+              </Typography>
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {description && (
+        <Box mt={2}>
+          <Typography className={classes.statusLabel} gutterBottom>
+            Description
+          </Typography>
+          <Typography variant="body2">{description}</Typography>
+        </Box>
+      )}
+
+      {usedByLinks.length > 0 && (
+        <Box mt={2}>
+          <Typography className={classes.statusLabel} gutterBottom>
+            Used by Component Types ({usedByLinks.length})
+          </Typography>
+          <Box display="flex" flexWrap="wrap" gridGap={8}>
+            {usedByLinks.map(ct => (
+              <Chip
+                key={ct.name}
+                label={<Link to={ct.link}>{ct.name}</Link>}
+                size="small"
+                variant="outlined"
+              />
+            ))}
+          </Box>
+        </Box>
+      )}
+    </Card>
+  );
+};

--- a/plugins/openchoreo/src/components/ComponentWorkflowOverview/index.ts
+++ b/plugins/openchoreo/src/components/ComponentWorkflowOverview/index.ts
@@ -1,0 +1,1 @@
+export { ComponentWorkflowOverviewCard } from './ComponentWorkflowOverviewCard';

--- a/plugins/openchoreo/src/components/TraitTypeOverview/TraitTypeOverviewCard.tsx
+++ b/plugins/openchoreo/src/components/TraitTypeOverview/TraitTypeOverviewCard.tsx
@@ -1,0 +1,67 @@
+import { Box, Typography } from '@material-ui/core';
+import ExtensionIcon from '@material-ui/icons/Extension';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { Card } from '@openchoreo/backstage-design-system';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { useDataplaneOverviewStyles } from '../DataplaneOverview/styles';
+
+export const TraitTypeOverviewCard = () => {
+  const classes = useDataplaneOverviewStyles();
+  const { entity } = useEntity();
+
+  const annotations = entity.metadata.annotations || {};
+  const createdAt = annotations[CHOREO_ANNOTATIONS.CREATED_AT];
+  const description = entity.metadata.description;
+
+  const formatDate = (isoString: string) => {
+    try {
+      return new Date(isoString).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return isoString;
+    }
+  };
+
+  return (
+    <Card padding={24} className={classes.card}>
+      <Box className={classes.cardHeader}>
+        <Typography variant="h5">Trait Type Details</Typography>
+      </Box>
+
+      <Box className={classes.statusGrid}>
+        <Box className={classes.statusItem}>
+          <ExtensionIcon className={classes.statusIcon} />
+          <Box>
+            <Typography className={classes.statusLabel}>Type</Typography>
+            <Typography className={classes.statusValue}>Trait</Typography>
+          </Box>
+        </Box>
+
+        {createdAt && (
+          <Box className={classes.statusItem}>
+            <AccessTimeIcon className={classes.statusIcon} />
+            <Box>
+              <Typography className={classes.statusLabel}>Created</Typography>
+              <Typography className={classes.statusValue}>
+                {formatDate(createdAt)}
+              </Typography>
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {description && (
+        <Box mt={2}>
+          <Typography className={classes.statusLabel} gutterBottom>
+            Description
+          </Typography>
+          <Typography variant="body2">{description}</Typography>
+        </Box>
+      )}
+    </Card>
+  );
+};

--- a/plugins/openchoreo/src/components/TraitTypeOverview/index.ts
+++ b/plugins/openchoreo/src/components/TraitTypeOverview/index.ts
@@ -1,0 +1,1 @@
+export { TraitTypeOverviewCard } from './TraitTypeOverviewCard';

--- a/plugins/openchoreo/src/components/WorkflowOverview/WorkflowOverviewCard.tsx
+++ b/plugins/openchoreo/src/components/WorkflowOverview/WorkflowOverviewCard.tsx
@@ -1,0 +1,69 @@
+import { Box, Typography } from '@material-ui/core';
+import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
+import AccessTimeIcon from '@material-ui/icons/AccessTime';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { Card } from '@openchoreo/backstage-design-system';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { useDataplaneOverviewStyles } from '../DataplaneOverview/styles';
+
+export const WorkflowOverviewCard = () => {
+  const classes = useDataplaneOverviewStyles();
+  const { entity } = useEntity();
+
+  const annotations = entity.metadata.annotations || {};
+  const createdAt = annotations[CHOREO_ANNOTATIONS.CREATED_AT];
+  const description = entity.metadata.description;
+
+  const formatDate = (isoString: string) => {
+    try {
+      return new Date(isoString).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return isoString;
+    }
+  };
+
+  return (
+    <Card padding={24} className={classes.card}>
+      <Box className={classes.cardHeader}>
+        <Typography variant="h5">Workflow Details</Typography>
+      </Box>
+
+      <Box className={classes.statusGrid}>
+        <Box className={classes.statusItem}>
+          <PlayCircleOutlineIcon className={classes.statusIcon} />
+          <Box>
+            <Typography className={classes.statusLabel}>Type</Typography>
+            <Typography className={classes.statusValue}>
+              Generic Workflow
+            </Typography>
+          </Box>
+        </Box>
+
+        {createdAt && (
+          <Box className={classes.statusItem}>
+            <AccessTimeIcon className={classes.statusIcon} />
+            <Box>
+              <Typography className={classes.statusLabel}>Created</Typography>
+              <Typography className={classes.statusValue}>
+                {formatDate(createdAt)}
+              </Typography>
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {description && (
+        <Box mt={2}>
+          <Typography className={classes.statusLabel} gutterBottom>
+            Description
+          </Typography>
+          <Typography variant="body2">{description}</Typography>
+        </Box>
+      )}
+    </Card>
+  );
+};

--- a/plugins/openchoreo/src/components/WorkflowOverview/index.ts
+++ b/plugins/openchoreo/src/components/WorkflowOverview/index.ts
@@ -1,0 +1,1 @@
+export { WorkflowOverviewCard } from './WorkflowOverviewCard';

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -40,3 +40,7 @@ export {
   DeploymentPipelineVisualization,
   PromotionPathsCard,
 } from './components/DeploymentPipelineOverview';
+export { ComponentTypeOverviewCard } from './components/ComponentTypeOverview';
+export { TraitTypeOverviewCard } from './components/TraitTypeOverview';
+export { WorkflowOverviewCard } from './components/WorkflowOverview';
+export { ComponentWorkflowOverviewCard } from './components/ComponentWorkflowOverview';


### PR DESCRIPTION
 Sync four new OpenChoreo CRs as custom Backstage entity kinds so platform
  engineers can browse them in the catalog. ComponentType entities coexist
  alongside the existing CTD-to-Template conversion used by the scaffolder.

  Backend:
  - Define four new entity kinds with TypeScript interfaces
  - Add entity processors with RELATION_PART_OF to Domain and usesWorkflow/workflowUsedBy between ComponentType and ComponentWorkflow
  - Extend OpenChoreoEntityProvider to fetch and translate traits, workflows, and component workflows per namespace
  - Generate ComponentType entities from the same API data as Templates

  Frontend:
  - Add overview cards for each new kind showing relevant metadata
  - Register kind icons, display names, graph colors, and label prefixes
  - Add entity detail pages with overview card and catalog graph
  - Gate all four kinds behind platform engineer role in the kind picker

https://github.com/openchoreo/openchoreo/issues/1765

<img width="1728" height="871" alt="Screenshot 2026-02-03 at 15 07 44" src="https://github.com/user-attachments/assets/c3345797-f50d-40e8-8f22-568c9eff532e" />
<img width="1728" height="871" alt="Screenshot 2026-02-03 at 15 07 28" src="https://github.com/user-attachments/assets/d63a1d29-6c9a-4fd7-9e08-f9ebb7d17244" />
<img width="1728" height="871" alt="Screenshot 2026-02-03 at 15 07 17" src="https://github.com/user-attachments/assets/32ea7be3-78f0-4542-9503-c8eaaf9c1dbe" />
<img width="1728" height="871" alt="Screenshot 2026-02-03 at 15 06 50" src="https://github.com/user-attachments/assets/a53de19d-c9be-4df3-9aa2-3f6ed7bb2fdd" />
<img width="1728" height="871" alt="Screenshot 2026-02-03 at 15 06 38" src="https://github.com/user-attachments/assets/68134a8c-52d0-450a-ad75-89da41e20b6f" />

