### PR TITLE
feat: add custom annotation editing for catalog entities

### DIFF
--- a/packages/app/src/components/catalog/EntityLayoutWithDelete.tsx
+++ b/packages/app/src/components/catalog/EntityLayoutWithDelete.tsx
@@ -6,6 +6,7 @@ import { EmptyState, Progress } from '@backstage/core-components';
 import {
   useDeleteEntityMenuItems,
   useEntityExistsCheck,
+  useAnnotationEditorMenuItems,
 } from '@openchoreo/backstage-plugin';
 
 /**
@@ -31,9 +32,15 @@ function getEntityTypeLabel(kind: string): string {
  */
 export function EntityLayoutWithDelete({ children }: { children: ReactNode }) {
   const { entity } = useEntity();
-  const { extraMenuItems, DeleteConfirmationDialog } =
+  const { extraMenuItems: deleteMenuItems, DeleteConfirmationDialog } =
     useDeleteEntityMenuItems(entity);
+  const {
+    extraMenuItems: annotationMenuItems,
+    EditAnnotationsDialog: AnnotationEditorDialog,
+  } = useAnnotationEditorMenuItems(entity);
   const { loading, status, message } = useEntityExistsCheck(entity);
+
+  const extraMenuItems = [...annotationMenuItems, ...deleteMenuItems];
 
   // Get display label for the entity type
   const entityTypeLabel = getEntityTypeLabel(entity.kind);
@@ -100,6 +107,7 @@ export function EntityLayoutWithDelete({ children }: { children: ReactNode }) {
         {children}
       </EntityLayout>
       <DeleteConfirmationDialog />
+      <AnnotationEditorDialog />
     </>
   );
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -9,7 +9,10 @@
 import { createBackend } from '@backstage/backend-defaults';
 import { OpenChoreoAuthModule } from '@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth';
 import { rootHttpRouterServiceFactory } from '@backstage/backend-defaults/rootHttpRouter';
-import { immediateCatalogServiceFactory } from '@openchoreo/backstage-plugin-catalog-backend-module';
+import {
+  immediateCatalogServiceFactory,
+  annotationStoreFactory,
+} from '@openchoreo/backstage-plugin-catalog-backend-module';
 import { createIdpTokenHeaderMiddleware } from '@openchoreo/openchoreo-auth';
 
 const backend = createBackend();
@@ -37,6 +40,7 @@ backend.add(
   }),
 );
 backend.add(immediateCatalogServiceFactory);
+backend.add(annotationStoreFactory);
 
 backend.add(import('@backstage/plugin-app-backend'));
 backend.add(import('@backstage/plugin-proxy-backend'));

--- a/plugins/catalog-backend-module-openchoreo/package.json
+++ b/plugins/catalog-backend-module-openchoreo/package.json
@@ -43,7 +43,8 @@
     "@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy": "workspace:^",
     "@openchoreo/openchoreo-auth": "workspace:^",
     "@openchoreo/openchoreo-client-node": "workspace:^",
-    "json-schema": "0.4.0"
+    "json-schema": "0.4.0",
+    "knex": "3.1.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "1.9.0",

--- a/plugins/catalog-backend-module-openchoreo/src/index.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/index.ts
@@ -7,6 +7,7 @@
 export {
   catalogModuleOpenchoreo as default,
   immediateCatalogServiceFactory,
+  annotationStoreFactory,
 } from './module';
 export { OpenChoreoEntityProvider } from './provider/OpenChoreoEntityProvider';
 export { ScaffolderEntityProvider } from './provider/ScaffolderEntityProvider';
@@ -14,6 +15,10 @@ export {
   immediateCatalogServiceRef,
   type ImmediateCatalogService,
 } from './service/ImmediateCatalogService';
+export {
+  annotationStoreRef,
+  type AnnotationStore,
+} from './service/AnnotationStore';
 export {
   translateComponentToEntity,
   type ComponentEntityTranslationConfig,

--- a/plugins/catalog-backend-module-openchoreo/src/processors/CustomAnnotationProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/CustomAnnotationProcessor.ts
@@ -1,0 +1,52 @@
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
+import { AnnotationStore } from '../service/AnnotationStore';
+
+/**
+ * Processor that merges user-defined custom annotations into catalog entities.
+ *
+ * Custom annotations are stored in a separate database table (via AnnotationStore)
+ * and re-applied during every processing cycle. This ensures annotations survive
+ * entity provider full mutations, which replace unprocessed entities entirely.
+ */
+export class CustomAnnotationProcessor implements CatalogProcessor {
+  constructor(private readonly annotationStore: AnnotationStore) {}
+
+  getProcessorName(): string {
+    return 'CustomAnnotationProcessor';
+  }
+
+  async preProcessEntity(
+    entity: Entity,
+    _location: LocationSpec,
+  ): Promise<Entity> {
+    // Only process managed OpenChoreo entities
+    if (entity.metadata.labels?.[CHOREO_LABELS.MANAGED] !== 'true') {
+      return entity;
+    }
+
+    const entityRef = stringifyEntityRef(entity);
+    const customAnnotations = await this.annotationStore.getAnnotations(
+      entityRef,
+    );
+
+    if (Object.keys(customAnnotations).length === 0) {
+      return entity;
+    }
+
+    // Merge custom annotations into entity.
+    // Custom annotations take precedence over provider annotations for the same key.
+    return {
+      ...entity,
+      metadata: {
+        ...entity.metadata,
+        annotations: {
+          ...entity.metadata.annotations,
+          ...customAnnotations,
+        },
+      },
+    };
+  }
+}

--- a/plugins/catalog-backend-module-openchoreo/src/processors/index.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/index.ts
@@ -7,3 +7,4 @@ export { ComponentTypeEntityProcessor } from './ComponentTypeEntityProcessor';
 export { TraitTypeEntityProcessor } from './TraitTypeEntityProcessor';
 export { WorkflowEntityProcessor } from './WorkflowEntityProcessor';
 export { ComponentWorkflowEntityProcessor } from './ComponentWorkflowEntityProcessor';
+export { CustomAnnotationProcessor } from './CustomAnnotationProcessor';

--- a/plugins/openchoreo-backend/package.json
+++ b/plugins/openchoreo-backend/package.json
@@ -41,6 +41,7 @@
     "@backstage/plugin-kubernetes-backend": "0.20.2",
     "@backstage/plugin-kubernetes-node": "0.3.4",
     "@backstage/plugin-permission-common": "0.9.1",
+    "@openchoreo/backstage-plugin-catalog-backend-module": "workspace:^",
     "@openchoreo/backstage-plugin-common": "workspace:^",
     "@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy": "workspace:^",
     "@openchoreo/openchoreo-auth": "workspace:^",

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -22,6 +22,7 @@ import {
   matchesCapability,
   openchoreoComponentResourceRef,
 } from '@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy';
+import { annotationStoreRef } from '@openchoreo/backstage-plugin-catalog-backend-module';
 
 /**
  * choreoPlugin backend plugin
@@ -43,6 +44,7 @@ export const choreoPlugin = createBackendPlugin({
         discovery: coreServices.discovery,
         config: coreServices.rootConfig,
         tokenService: openChoreoTokenServiceRef,
+        annotationStore: annotationStoreRef,
       },
       async init({
         logger,
@@ -52,6 +54,7 @@ export const choreoPlugin = createBackendPlugin({
         catalog,
         permissionsRegistry,
         auth,
+        annotationStore,
       }) {
         const openchoreoConfig = config.getOptionalConfig('openchoreo');
 
@@ -151,6 +154,9 @@ export const choreoPlugin = createBackendPlugin({
             gitSecretsService,
             authzService,
             dataPlaneInfoService,
+            annotationStore,
+            catalogService: catalog,
+            auth,
             tokenService,
             authEnabled,
             logger,

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -1,5 +1,5 @@
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import {
   CHOREO_ANNOTATIONS,
   ModelsWorkload,
@@ -66,6 +66,7 @@ const API_ENDPOINTS = {
   NAMESPACES: '/namespaces',
   PROJECTS: '/projects', // GET /namespaces/{namespaceName}/projects
   COMPONENTS: '/components', // GET /namespaces/{namespaceName}/projects/{projectName}/components
+  ENTITY_ANNOTATIONS: '/entity-annotations',
 } as const;
 
 // ============================================
@@ -835,6 +836,36 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
         method: 'DELETE',
       },
     );
+  }
+
+  // ============================================
+  // Custom Annotation Operations
+  // ============================================
+
+  async fetchEntityAnnotations(
+    entity: Entity,
+  ): Promise<Record<string, string>> {
+    const entityRef = stringifyEntityRef(entity);
+    const result = await this.apiFetch<{
+      annotations: Record<string, string>;
+    }>(API_ENDPOINTS.ENTITY_ANNOTATIONS, {
+      params: { entityRef },
+    });
+    return result.annotations;
+  }
+
+  async updateEntityAnnotations(
+    entity: Entity,
+    annotations: Record<string, string | null>,
+  ): Promise<Record<string, string>> {
+    const entityRef = stringifyEntityRef(entity);
+    const result = await this.apiFetch<{
+      annotations: Record<string, string>;
+    }>(API_ENDPOINTS.ENTITY_ANNOTATIONS, {
+      method: 'PATCH',
+      body: { entityRef, annotations },
+    });
+    return result.annotations;
   }
 
   async deleteProject(entity: Entity): Promise<void> {

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -450,6 +450,17 @@ export interface OpenChoreoClientApi {
 
   /** Delete a project */
   deleteProject(entity: Entity): Promise<void>;
+
+  // === Custom Annotation Operations ===
+
+  /** Fetch custom annotations for an entity */
+  fetchEntityAnnotations(entity: Entity): Promise<Record<string, string>>;
+
+  /** Update custom annotations on an entity. Use null value to delete a key. */
+  updateEntityAnnotations(
+    entity: Entity,
+    annotations: Record<string, string | null>,
+  ): Promise<Record<string, string>>;
 }
 
 // ============================================

--- a/plugins/openchoreo/src/components/AnnotationEditor/EditAnnotationsDialog.tsx
+++ b/plugins/openchoreo/src/components/AnnotationEditor/EditAnnotationsDialog.tsx
@@ -1,0 +1,474 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  IconButton,
+  TextField,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  CircularProgress,
+  Box,
+  Chip,
+  Tooltip,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import DeleteIcon from '@material-ui/icons/Delete';
+import AddIcon from '@material-ui/icons/Add';
+import { useApi, alertApiRef } from '@backstage/core-plugin-api';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
+
+interface AnnotationSuggestion {
+  key: string;
+  description: string;
+  placeholder: string;
+}
+
+const ANNOTATION_SUGGESTIONS: AnnotationSuggestion[] = [
+  {
+    key: 'jenkins.io/job-full-name',
+    description: 'Jenkins job name (e.g., folder/job-name)',
+    placeholder: 'my-folder/my-job',
+  },
+  {
+    key: 'github.com/project-slug',
+    description: 'GitHub repository slug',
+    placeholder: 'org/repo-name',
+  },
+  {
+    key: 'sonarqube.org/project-key',
+    description: 'SonarQube project key',
+    placeholder: 'my-project-key',
+  },
+  {
+    key: 'pagerduty.com/service-id',
+    description: 'PagerDuty service ID',
+    placeholder: 'PXXXXXX',
+  },
+  {
+    key: 'pagerduty.com/integration-key',
+    description: 'PagerDuty integration key',
+    placeholder: 'abc123def456',
+  },
+  {
+    key: 'backstage.io/techdocs-ref',
+    description: 'TechDocs content location',
+    placeholder: 'dir:.',
+  },
+  {
+    key: 'grafana/dashboard-selector',
+    description: 'Grafana dashboard selector',
+    placeholder: 'title:My Dashboard',
+  },
+  {
+    key: 'grafana/alert-label-selector',
+    description: 'Grafana alert label selector',
+    placeholder: 'service=my-service',
+  },
+  {
+    key: 'jira/project-key',
+    description: 'Jira project key',
+    placeholder: 'PROJ',
+  },
+  {
+    key: 'sentry.io/project-slug',
+    description: 'Sentry project slug',
+    placeholder: 'my-sentry-project',
+  },
+];
+
+const BLOCKED_PREFIXES = [
+  'openchoreo.io/',
+  'openchoreo.dev/',
+  'backstage.io/managed-by-',
+  'kubernetes.io/',
+  'kubectl.kubernetes.io/',
+];
+
+function isBlockedKey(key: string): boolean {
+  return BLOCKED_PREFIXES.some(prefix => key.startsWith(prefix));
+}
+
+interface AnnotationRow {
+  key: string;
+  value: string;
+  isNew?: boolean;
+}
+
+const useStyles = makeStyles(theme => ({
+  dialogContent: {
+    paddingTop: theme.spacing(1),
+    minWidth: 500,
+  },
+  keyCell: {
+    width: '40%',
+  },
+  valueCell: {
+    width: '50%',
+  },
+  actionCell: {
+    width: '10%',
+  },
+  addButton: {
+    marginTop: theme.spacing(1),
+  },
+  suggestionsSection: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(1),
+  },
+  suggestionsLabel: {
+    fontSize: '0.8rem',
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(0.5),
+  },
+  suggestionsContainer: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: theme.spacing(0.5),
+  },
+  emptyState: {
+    padding: theme.spacing(3),
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  },
+  errorText: {
+    color: theme.palette.error.main,
+    fontSize: '0.75rem',
+    marginTop: theme.spacing(0.5),
+  },
+}));
+
+interface EditAnnotationsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  entity: Entity;
+}
+
+export function EditAnnotationsDialog({
+  open,
+  onClose,
+  entity,
+}: EditAnnotationsDialogProps) {
+  const classes = useStyles();
+  const openChoreoClient = useApi(openChoreoClientApiRef);
+  const alertApi = useApi(alertApiRef);
+
+  const [rows, setRows] = useState<AnnotationRow[]>([]);
+  const [originalAnnotations, setOriginalAnnotations] = useState<
+    Record<string, string>
+  >({});
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load existing annotations when dialog opens
+  useEffect(() => {
+    if (!open) return;
+
+    setLoading(true);
+    setError(null);
+
+    openChoreoClient
+      .fetchEntityAnnotations(entity)
+      .then(annotations => {
+        setOriginalAnnotations(annotations);
+        setRows(
+          Object.entries(annotations).map(([key, value]) => ({
+            key,
+            value,
+          })),
+        );
+      })
+      .catch(err => {
+        setError(err.message || 'Failed to load annotations');
+        setRows([]);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [open, entity, openChoreoClient]);
+
+  const handleAddRow = useCallback(() => {
+    setRows(prev => [...prev, { key: '', value: '', isNew: true }]);
+  }, []);
+
+  const handleRemoveRow = useCallback((index: number) => {
+    setRows(prev => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleKeyChange = useCallback((index: number, newKey: string) => {
+    setRows(prev =>
+      prev.map((row, i) => (i === index ? { ...row, key: newKey } : row)),
+    );
+  }, []);
+
+  const handleValueChange = useCallback((index: number, newValue: string) => {
+    setRows(prev =>
+      prev.map((row, i) => (i === index ? { ...row, value: newValue } : row)),
+    );
+  }, []);
+
+  const getKeyError = useCallback(
+    (key: string, index: number): string | null => {
+      if (!key.trim()) return null; // Don't show error for empty fields yet
+      if (isBlockedKey(key)) return 'This annotation prefix is system-managed';
+      // Check for duplicate keys
+      const duplicateIndex = rows.findIndex(
+        (r, i) => i !== index && r.key === key,
+      );
+      if (duplicateIndex !== -1) return 'Duplicate annotation key';
+      return null;
+    },
+    [rows],
+  );
+
+  const handleSave = useCallback(async () => {
+    // Validate all rows
+    const validRows = rows.filter(r => r.key.trim() && r.value.trim());
+    const invalidRows = rows.filter(
+      r =>
+        (r.key.trim() && !r.value.trim()) || (!r.key.trim() && r.value.trim()),
+    );
+
+    if (invalidRows.length > 0) {
+      setError('Each annotation must have both a key and a value');
+      return;
+    }
+
+    // Check for blocked keys
+    const blockedKeys = validRows.filter(r => isBlockedKey(r.key));
+    if (blockedKeys.length > 0) {
+      setError(
+        `Cannot set system-managed annotations: ${blockedKeys
+          .map(r => r.key)
+          .join(', ')}`,
+      );
+      return;
+    }
+
+    // Check for duplicate keys
+    const keys = validRows.map(r => r.key);
+    const uniqueKeys = new Set(keys);
+    if (uniqueKeys.size !== keys.length) {
+      setError('Duplicate annotation keys are not allowed');
+      return;
+    }
+
+    // Compute diff: what to set and what to delete
+    const annotations: Record<string, string | null> = {};
+
+    // Add/update annotations from current rows
+    for (const row of validRows) {
+      annotations[row.key] = row.value;
+    }
+
+    // Delete annotations that were in original but not in current rows
+    for (const originalKey of Object.keys(originalAnnotations)) {
+      if (!validRows.some(r => r.key === originalKey)) {
+        annotations[originalKey] = null;
+      }
+    }
+
+    // If no changes, just close
+    if (Object.keys(annotations).length === 0) {
+      onClose();
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      await openChoreoClient.updateEntityAnnotations(entity, annotations);
+
+      alertApi.post({
+        message: `Annotations updated for ${stringifyEntityRef(entity)}`,
+        severity: 'success',
+        display: 'transient',
+      });
+
+      onClose();
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to update annotations';
+      setError(errorMessage);
+    } finally {
+      setSaving(false);
+    }
+  }, [rows, originalAnnotations, entity, openChoreoClient, alertApi, onClose]);
+
+  const availableSuggestions = useMemo(() => {
+    const usedKeys = new Set(rows.map(r => r.key));
+    return ANNOTATION_SUGGESTIONS.filter(s => !usedKeys.has(s.key));
+  }, [rows]);
+
+  const handleAddSuggestion = useCallback(
+    (suggestion: AnnotationSuggestion) => {
+      setRows(prev => [
+        ...prev,
+        { key: suggestion.key, value: '', isNew: true },
+      ]);
+    },
+    [],
+  );
+
+  const handleClose = useCallback(() => {
+    if (!saving) {
+      onClose();
+    }
+  }, [saving, onClose]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="edit-annotations-dialog-title"
+    >
+      <DialogTitle id="edit-annotations-dialog-title" disableTypography>
+        <Typography variant="h4">Edit Custom Annotations</Typography>
+      </DialogTitle>
+
+      <DialogContent className={classes.dialogContent}>
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <>
+            {rows.length === 0 ? (
+              <Typography className={classes.emptyState}>
+                No custom annotations. Click "Add Annotation" to get started.
+              </Typography>
+            ) : (
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell className={classes.keyCell}>Key</TableCell>
+                    <TableCell className={classes.valueCell}>Value</TableCell>
+                    <TableCell className={classes.actionCell} />
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row, index) => {
+                    const keyError = getKeyError(row.key, index);
+                    return (
+                      <TableRow key={index}>
+                        <TableCell className={classes.keyCell}>
+                          <TextField
+                            fullWidth
+                            size="small"
+                            variant="outlined"
+                            placeholder="e.g., jenkins.io/job-name"
+                            value={row.key}
+                            onChange={e =>
+                              handleKeyChange(index, e.target.value)
+                            }
+                            error={!!keyError}
+                            helperText={keyError}
+                            disabled={saving}
+                          />
+                        </TableCell>
+                        <TableCell className={classes.valueCell}>
+                          <TextField
+                            fullWidth
+                            size="small"
+                            variant="outlined"
+                            placeholder={
+                              ANNOTATION_SUGGESTIONS.find(
+                                s => s.key === row.key,
+                              )?.placeholder || 'Value'
+                            }
+                            value={row.value}
+                            onChange={e =>
+                              handleValueChange(index, e.target.value)
+                            }
+                            disabled={saving}
+                          />
+                        </TableCell>
+                        <TableCell className={classes.actionCell}>
+                          <IconButton
+                            size="small"
+                            onClick={() => handleRemoveRow(index)}
+                            disabled={saving}
+                            aria-label="Remove annotation"
+                          >
+                            <DeleteIcon fontSize="small" />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
+
+            <Button
+              className={classes.addButton}
+              startIcon={<AddIcon />}
+              onClick={handleAddRow}
+              disabled={saving}
+              size="small"
+            >
+              Add Annotation
+            </Button>
+
+            {availableSuggestions.length > 0 && (
+              <Box className={classes.suggestionsSection}>
+                <Typography className={classes.suggestionsLabel}>
+                  Suggestions
+                </Typography>
+                <Box className={classes.suggestionsContainer}>
+                  {availableSuggestions.map(suggestion => (
+                    <Tooltip
+                      key={suggestion.key}
+                      title={suggestion.description}
+                    >
+                      <Chip
+                        label={suggestion.key}
+                        size="small"
+                        variant="outlined"
+                        onClick={() => handleAddSuggestion(suggestion)}
+                        disabled={saving}
+                        clickable
+                      />
+                    </Tooltip>
+                  ))}
+                </Box>
+              </Box>
+            )}
+
+            {error && (
+              <Typography className={classes.errorText}>{error}</Typography>
+            )}
+          </>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={handleClose} disabled={saving} variant="contained">
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          color="primary"
+          variant="outlined"
+          disabled={saving || loading}
+          startIcon={
+            saving ? <CircularProgress size={16} color="inherit" /> : null
+          }
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/plugins/openchoreo/src/components/AnnotationEditor/index.ts
+++ b/plugins/openchoreo/src/components/AnnotationEditor/index.ts
@@ -1,0 +1,2 @@
+export { useAnnotationEditorMenuItems } from './useAnnotationEditorMenuItems';
+export { EditAnnotationsDialog } from './EditAnnotationsDialog';

--- a/plugins/openchoreo/src/components/AnnotationEditor/useAnnotationEditorMenuItems.tsx
+++ b/plugins/openchoreo/src/components/AnnotationEditor/useAnnotationEditorMenuItems.tsx
@@ -1,0 +1,88 @@
+import { useState, useCallback, useMemo } from 'react';
+import EditIcon from '@material-ui/icons/Edit';
+import { IconComponent } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
+import { EditAnnotationsDialog } from './EditAnnotationsDialog';
+
+interface ExtraContextMenuItem {
+  title: string;
+  Icon: IconComponent;
+  onClick: () => void;
+}
+
+interface UseAnnotationEditorMenuItemsResult {
+  extraMenuItems: ExtraContextMenuItem[];
+  EditAnnotationsDialog: React.FC;
+}
+
+/**
+ * Hook that provides annotation editor menu items for EntityLayout's UNSTABLE_extraContextMenuItems.
+ *
+ * Only enabled for managed OpenChoreo entities (Component and System kinds).
+ *
+ * Usage:
+ * ```tsx
+ * function MyEntityLayout({ children }) {
+ *   const { entity } = useEntity();
+ *   const { extraMenuItems, EditAnnotationsDialog } = useAnnotationEditorMenuItems(entity);
+ *
+ *   return (
+ *     <>
+ *       <EntityLayout UNSTABLE_extraContextMenuItems={extraMenuItems}>
+ *         {children}
+ *       </EntityLayout>
+ *       <EditAnnotationsDialog />
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+export function useAnnotationEditorMenuItems(
+  entity: Entity,
+): UseAnnotationEditorMenuItemsResult {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const entityKind = entity.kind.toLowerCase();
+  const isManaged = entity.metadata.labels?.[CHOREO_LABELS.MANAGED] === 'true';
+  const canEdit =
+    isManaged && (entityKind === 'component' || entityKind === 'system');
+
+  const handleOpenDialog = useCallback(() => {
+    setDialogOpen(true);
+  }, []);
+
+  const handleCloseDialog = useCallback(() => {
+    setDialogOpen(false);
+  }, []);
+
+  const extraMenuItems = useMemo<ExtraContextMenuItem[]>(() => {
+    if (!canEdit) {
+      return [];
+    }
+
+    return [
+      {
+        title: 'Edit Annotations',
+        Icon: EditIcon as IconComponent,
+        onClick: handleOpenDialog,
+      },
+    ];
+  }, [canEdit, handleOpenDialog]);
+
+  const AnnotationsDialog: React.FC = useCallback(
+    () => (
+      <EditAnnotationsDialog
+        open={dialogOpen}
+        onClose={handleCloseDialog}
+        entity={entity}
+      />
+    ),
+    [dialogOpen, handleCloseDialog, entity],
+  );
+
+  return {
+    extraMenuItems,
+    EditAnnotationsDialog: AnnotationsDialog,
+  };
+}

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -21,6 +21,7 @@ export {
   isMarkedForDeletion,
   getDeletionTimestamp,
 } from './components/DeleteEntity';
+export { useAnnotationEditorMenuItems } from './components/AnnotationEditor';
 export {
   EnvironmentStatusSummaryCard,
   EnvironmentDeployedComponentsCard,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9640,6 +9640,7 @@ __metadata:
     "@backstage/plugin-kubernetes-backend": "npm:0.20.2"
     "@backstage/plugin-kubernetes-node": "npm:0.3.4"
     "@backstage/plugin-permission-common": "npm:0.9.1"
+    "@openchoreo/backstage-plugin-catalog-backend-module": "workspace:^"
     "@openchoreo/backstage-plugin-common": "workspace:^"
     "@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy": "workspace:^"
     "@openchoreo/openchoreo-auth": "workspace:^"
@@ -9686,6 +9687,7 @@ __metadata:
     "@openchoreo/openchoreo-auth": "workspace:^"
     "@openchoreo/openchoreo-client-node": "workspace:^"
     json-schema: "npm:0.4.0"
+    knex: "npm:3.1.0"
   languageName: unknown
   linkType: soft
 
@@ -26589,7 +26591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"knex@npm:3, knex@npm:^3.0.0":
+"knex@npm:3, knex@npm:3.1.0, knex@npm:^3.0.0":
   version: 3.1.0
   resolution: "knex@npm:3.1.0"
   dependencies:


### PR DESCRIPTION
  Persist user-defined annotations (e.g., Jenkins, SonarQube, PagerDuty)
  across OpenChoreo entity provider sync cycles by storing them in a
  dedicated DB table and re-applying via a CatalogProcessor.

  - Add AnnotationStore service with DB migration for entity_custom_annotations table
  - Add CustomAnnotationProcessor to merge stored annotations during processing
  - Add GET/PATCH /entity-annotations backend API routes
  - Add Edit Annotations dialog with validation, blocked prefix checks, and pre-built suggestions for common Backstage plugin annotations
  - Integrate annotation editor into entity context menu

Fixes https://github.com/openchoreo/openchoreo/issues/1767

Upon finalizing on https://github.com/openchoreo/openchoreo/discussions/1718, the implementation could be changed.

https://github.com/user-attachments/assets/e2712396-5716-46e9-9861-39084fda6f8f

