### PR TITLE
feat: add YAML editor for platform resource definitions

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -93,6 +93,7 @@ import {
   TraitTypeOverviewCard,
   WorkflowOverviewCard,
   ComponentWorkflowOverviewCard,
+  ResourceDefinitionTab,
 } from '@openchoreo/backstage-plugin';
 import { EntityLayoutWithDelete } from './EntityLayoutWithDelete';
 
@@ -767,6 +768,9 @@ const componentTypePage = (
         </Grid>
       </Grid>
     </EntityLayout.Route>
+    <EntityLayout.Route path="/definition" title="Definition">
+      <ResourceDefinitionTab />
+    </EntityLayout.Route>
   </EntityLayout>
 );
 
@@ -789,6 +793,9 @@ const traitTypePage = (
           <EntityAboutCard variant="gridItem" />
         </Grid>
       </Grid>
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/definition" title="Definition">
+      <ResourceDefinitionTab />
     </EntityLayout.Route>
   </EntityLayout>
 );
@@ -813,6 +820,9 @@ const workflowPage = (
         </Grid>
       </Grid>
     </EntityLayout.Route>
+    <EntityLayout.Route path="/definition" title="Definition">
+      <ResourceDefinitionTab />
+    </EntityLayout.Route>
   </EntityLayout>
 );
 
@@ -836,6 +846,9 @@ const componentWorkflowPage = (
           <EntityAboutCard variant="gridItem" />
         </Grid>
       </Grid>
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/definition" title="Definition">
+      <ResourceDefinitionTab />
     </EntityLayout.Route>
   </EntityLayout>
 );

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -682,6 +682,22 @@ components:
         default:
           type: string
 
+    # Resource CRUD Response (for definition endpoints)
+    ResourceCRUDResponse:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        name:
+          type: string
+        namespace:
+          type: string
+        operation:
+          type: string
+          description: The operation performed - created, updated, deleted, or not_found
+
     # ComponentType
     ComponentTypeResponse:
       type: object
@@ -2519,6 +2535,106 @@ paths:
         '404':
           description: Component type not found
 
+  /namespaces/{namespaceName}/component-types/{ctName}/definition:
+    get:
+      summary: Get the full CRD definition for a specific component type
+      operationId: getComponentTypeDefinition
+      tags:
+        - ComponentTypes
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ctName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Full Kubernetes CRD as unstructured JSON
+                        additionalProperties: true
+        '404':
+          description: Component type not found
+    put:
+      summary: Create or update a component type definition
+      operationId: updateComponentTypeDefinition
+      tags:
+        - ComponentTypes
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ctName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Full Kubernetes CRD as unstructured JSON
+              additionalProperties: true
+      responses:
+        '200':
+          description: Resource applied successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ResourceCRUDResponse'
+    delete:
+      summary: Delete a component type definition
+      operationId: deleteComponentTypeDefinition
+      tags:
+        - ComponentTypes
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ctName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource deleted successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ResourceCRUDResponse'
+        '404':
+          description: Component type not found
+
   # Workflows (generic workflows)
   /namespaces/{namespaceName}/workflows:
     get:
@@ -2583,6 +2699,106 @@ paths:
                         type: object
                         description: JSON Schema for the workflow
                         additionalProperties: true
+        '404':
+          description: Workflow not found
+
+  /namespaces/{namespaceName}/workflows/{workflowName}/definition:
+    get:
+      summary: Get the full CRD definition for a specific workflow
+      operationId: getWorkflowDefinition
+      tags:
+        - Workflows
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: workflowName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Full Kubernetes CRD as unstructured JSON
+                        additionalProperties: true
+        '404':
+          description: Workflow not found
+    put:
+      summary: Create or update a workflow definition
+      operationId: updateWorkflowDefinition
+      tags:
+        - Workflows
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: workflowName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Full Kubernetes CRD as unstructured JSON
+              additionalProperties: true
+      responses:
+        '200':
+          description: Resource applied successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ResourceCRUDResponse'
+    delete:
+      summary: Delete a workflow definition
+      operationId: deleteWorkflowDefinition
+      tags:
+        - Workflows
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: workflowName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource deleted successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ResourceCRUDResponse'
         '404':
           description: Workflow not found
 
@@ -2653,6 +2869,106 @@ paths:
         '404':
           description: Component workflow not found
 
+  /namespaces/{namespaceName}/component-workflows/{cwName}/definition:
+    get:
+      summary: Get the full CRD definition for a specific component workflow
+      operationId: getComponentWorkflowDefinition
+      tags:
+        - ComponentWorkflows
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: cwName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Full Kubernetes CRD as unstructured JSON
+                        additionalProperties: true
+        '404':
+          description: Component workflow not found
+    put:
+      summary: Create or update a component workflow definition
+      operationId: updateComponentWorkflowDefinition
+      tags:
+        - ComponentWorkflows
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: cwName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Full Kubernetes CRD as unstructured JSON
+              additionalProperties: true
+      responses:
+        '200':
+          description: Resource applied successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ResourceCRUDResponse'
+    delete:
+      summary: Delete a component workflow definition
+      operationId: deleteComponentWorkflowDefinition
+      tags:
+        - ComponentWorkflows
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: cwName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource deleted successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ResourceCRUDResponse'
+        '404':
+          description: Component workflow not found
+
   # Traits
   /namespaces/{namespaceName}/traits:
     get:
@@ -2717,6 +3033,106 @@ paths:
                         type: object
                         description: JSON Schema for the trait
                         additionalProperties: true
+        '404':
+          description: Trait not found
+
+  /namespaces/{namespaceName}/traits/{traitName}/definition:
+    get:
+      summary: Get the full CRD definition for a specific trait
+      operationId: getTraitDefinition
+      tags:
+        - Traits
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: traitName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: Full Kubernetes CRD as unstructured JSON
+                        additionalProperties: true
+        '404':
+          description: Trait not found
+    put:
+      summary: Create or update a trait definition
+      operationId: updateTraitDefinition
+      tags:
+        - Traits
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: traitName
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Full Kubernetes CRD as unstructured JSON
+              additionalProperties: true
+      responses:
+        '200':
+          description: Resource applied successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ResourceCRUDResponse'
+    delete:
+      summary: Delete a trait definition
+      operationId: deleteTraitDefinition
+      tags:
+        - Traits
+      parameters:
+        - name: namespaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: traitName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource deleted successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/APIResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ResourceCRUDResponse'
         '404':
           description: Trait not found
 

--- a/packages/openchoreo-client-node/src/generated/openchoreo/index.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/index.ts
@@ -6,4 +6,3 @@
  */
 
 export * from './types';
-export * from './component-type';

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -401,6 +401,25 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/namespaces/{namespaceName}/component-types/{ctName}/definition': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the full CRD definition for a specific component type */
+    get: operations['getComponentTypeDefinition'];
+    /** Create or update a component type definition */
+    put: operations['updateComponentTypeDefinition'];
+    post?: never;
+    /** Delete a component type definition */
+    delete: operations['deleteComponentTypeDefinition'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/namespaces/{namespaceName}/workflows': {
     parameters: {
       query?: never;
@@ -430,6 +449,25 @@ export interface paths {
     put?: never;
     post?: never;
     delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/namespaces/{namespaceName}/workflows/{workflowName}/definition': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the full CRD definition for a specific workflow */
+    get: operations['getWorkflowDefinition'];
+    /** Create or update a workflow definition */
+    put: operations['updateWorkflowDefinition'];
+    post?: never;
+    /** Delete a workflow definition */
+    delete: operations['deleteWorkflowDefinition'];
     options?: never;
     head?: never;
     patch?: never;
@@ -469,6 +507,25 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/namespaces/{namespaceName}/component-workflows/{cwName}/definition': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the full CRD definition for a specific component workflow */
+    get: operations['getComponentWorkflowDefinition'];
+    /** Create or update a component workflow definition */
+    put: operations['updateComponentWorkflowDefinition'];
+    post?: never;
+    /** Delete a component workflow definition */
+    delete: operations['deleteComponentWorkflowDefinition'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/namespaces/{namespaceName}/traits': {
     parameters: {
       query?: never;
@@ -498,6 +555,25 @@ export interface paths {
     put?: never;
     post?: never;
     delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/namespaces/{namespaceName}/traits/{traitName}/definition': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the full CRD definition for a specific trait */
+    get: operations['getTraitDefinition'];
+    /** Create or update a trait definition */
+    put: operations['updateTraitDefinition'];
+    post?: never;
+    /** Delete a trait definition */
+    delete: operations['deleteTraitDefinition'];
     options?: never;
     head?: never;
     patch?: never;
@@ -1375,6 +1451,14 @@ export interface components {
     BuildTemplateParameter: {
       name: string;
       default?: string;
+    };
+    ResourceCRUDResponse: {
+      apiVersion?: string;
+      kind?: string;
+      name?: string;
+      namespace?: string;
+      /** @description The operation performed - created, updated, deleted, or not_found */
+      operation?: string;
     };
     ComponentTypeResponse: {
       name: string;
@@ -2586,6 +2670,104 @@ export interface operations {
       };
     };
   };
+  getComponentTypeDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        ctName: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            /** @description Full Kubernetes CRD as unstructured JSON */
+            data?: {
+              [key: string]: unknown;
+            };
+          };
+        };
+      };
+      /** @description Component type not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  updateComponentTypeDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        ctName: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          [key: string]: unknown;
+        };
+      };
+    };
+    responses: {
+      /** @description Resource applied successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            data?: components['schemas']['ResourceCRUDResponse'];
+          };
+        };
+      };
+    };
+  };
+  deleteComponentTypeDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        ctName: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            data?: components['schemas']['ResourceCRUDResponse'];
+          };
+        };
+      };
+      /** @description Component type not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   listWorkflows: {
     parameters: {
       query?: never;
@@ -2635,6 +2817,104 @@ export interface operations {
             data?: {
               [key: string]: unknown;
             };
+          };
+        };
+      };
+      /** @description Workflow not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getWorkflowDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        workflowName: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            /** @description Full Kubernetes CRD as unstructured JSON */
+            data?: {
+              [key: string]: unknown;
+            };
+          };
+        };
+      };
+      /** @description Workflow not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  updateWorkflowDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        workflowName: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          [key: string]: unknown;
+        };
+      };
+    };
+    responses: {
+      /** @description Resource applied successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            data?: components['schemas']['ResourceCRUDResponse'];
+          };
+        };
+      };
+    };
+  };
+  deleteWorkflowDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        workflowName: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            data?: components['schemas']['ResourceCRUDResponse'];
           };
         };
       };
@@ -2708,6 +2988,104 @@ export interface operations {
       };
     };
   };
+  getComponentWorkflowDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        cwName: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            /** @description Full Kubernetes CRD as unstructured JSON */
+            data?: {
+              [key: string]: unknown;
+            };
+          };
+        };
+      };
+      /** @description Component workflow not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  updateComponentWorkflowDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        cwName: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          [key: string]: unknown;
+        };
+      };
+    };
+    responses: {
+      /** @description Resource applied successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            data?: components['schemas']['ResourceCRUDResponse'];
+          };
+        };
+      };
+    };
+  };
+  deleteComponentWorkflowDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        cwName: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            data?: components['schemas']['ResourceCRUDResponse'];
+          };
+        };
+      };
+      /** @description Component workflow not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   listTraits: {
     parameters: {
       query?: never;
@@ -2757,6 +3135,104 @@ export interface operations {
             data?: {
               [key: string]: unknown;
             };
+          };
+        };
+      };
+      /** @description Trait not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getTraitDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        traitName: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            /** @description Full Kubernetes CRD as unstructured JSON */
+            data?: {
+              [key: string]: unknown;
+            };
+          };
+        };
+      };
+      /** @description Trait not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  updateTraitDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        traitName: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          [key: string]: unknown;
+        };
+      };
+    };
+    responses: {
+      /** @description Resource applied successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            data?: components['schemas']['ResourceCRUDResponse'];
+          };
+        };
+      };
+    };
+  };
+  deleteTraitDefinition: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        namespaceName: string;
+        traitName: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['APIResponse'] & {
+            data?: components['schemas']['ResourceCRUDResponse'];
           };
         };
       };

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
@@ -1,8 +1,8 @@
-import { CtdToTemplateConverter } from './CtdToTemplateConverter';
-import { OpenChoreoAPI } from '@openchoreo/openchoreo-client-node';
+import {
+  CtdToTemplateConverter,
+  ComponentType,
+} from './CtdToTemplateConverter';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
-
-type ComponentType = OpenChoreoAPI.ComponentType;
 
 describe('CtdToTemplateConverter', () => {
   let converter: CtdToTemplateConverter;

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
@@ -1,12 +1,28 @@
 import { Entity } from '@backstage/catalog-model';
-import { OpenChoreoAPI } from '@openchoreo/openchoreo-client-node';
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import {
   CHOREO_ANNOTATIONS,
   sanitizeLabel,
 } from '@openchoreo/backstage-plugin-common';
 
-type ComponentType = OpenChoreoAPI.ComponentType;
+/**
+ * ComponentType CRD structure as returned by the Kubernetes API.
+ * This represents the full CRD object with metadata and spec.
+ */
+export interface ComponentType {
+  metadata: {
+    name: string;
+    displayName?: string;
+    description?: string;
+    workloadType: string;
+    allowedWorkflows?: string[];
+    tags?: string[];
+    createdAt?: string;
+  };
+  spec: {
+    inputParametersSchema?: JSONSchema7;
+  };
+}
 
 /**
  * Fields that are considered "advanced" and should be hidden in a collapsible section.

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -16,6 +16,7 @@ import { SecretReferencesService } from './services/SecretReferencesService/Secr
 import { GitSecretsService } from './services/GitSecretsService/GitSecretsService';
 import { AuthzService } from './services/AuthzService/AuthzService';
 import { DataPlaneInfoService } from './services/DataPlaneService/DataPlaneInfoService';
+import { PlatformResourceService } from './services/PlatformResourceService/PlatformResourceService';
 import { openChoreoTokenServiceRef } from '@openchoreo/openchoreo-auth';
 import { openchoreoPermissions } from '@openchoreo/backstage-plugin-common';
 import {
@@ -106,6 +107,11 @@ export const choreoPlugin = createBackendPlugin({
 
         const dataPlaneInfoService = new DataPlaneInfoService(logger, baseUrl);
 
+        const platformResourceService = new PlatformResourceService(
+          logger,
+          baseUrl,
+        );
+
         // Register OpenChoreo component permissions with the permissions registry
         // This enables CONDITIONAL permission checks against catalog entities
         const componentPermissions = openchoreoPermissions.filter(
@@ -154,6 +160,7 @@ export const choreoPlugin = createBackendPlugin({
             gitSecretsService,
             authzService,
             dataPlaneInfoService,
+            platformResourceService,
             annotationStore,
             catalogService: catalog,
             auth,

--- a/plugins/openchoreo-backend/src/services/PlatformResourceService/PlatformResourceService.ts
+++ b/plugins/openchoreo-backend/src/services/PlatformResourceService/PlatformResourceService.ts
@@ -1,0 +1,364 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  createOpenChoreoApiClient,
+  type OpenChoreoComponents,
+} from '@openchoreo/openchoreo-client-node';
+
+// Type for GET definition response - returns full CRD as unstructured JSON
+type ResourceDefinitionResponse =
+  OpenChoreoComponents['schemas']['APIResponse'] & {
+    data?: {
+      [key: string]: unknown;
+    };
+  };
+
+// Type for PUT/DELETE response
+type ResourceCRUDResponse = OpenChoreoComponents['schemas']['APIResponse'] & {
+  data?: OpenChoreoComponents['schemas']['ResourceCRUDResponse'];
+};
+
+// Supported resource kinds and their API path segments
+type ResourceKind =
+  | 'component-types'
+  | 'traits'
+  | 'workflows'
+  | 'component-workflows';
+
+export class PlatformResourceService {
+  private logger: LoggerService;
+  private baseUrl: string;
+
+  constructor(logger: LoggerService, baseUrl: string) {
+    this.logger = logger;
+    this.baseUrl = baseUrl;
+  }
+
+  /**
+   * Get the full CRD definition for a platform resource
+   */
+  async getResourceDefinition(
+    kind: ResourceKind,
+    namespaceName: string,
+    resourceName: string,
+    token?: string,
+  ): Promise<ResourceDefinitionResponse> {
+    this.logger.debug(
+      `Fetching ${kind} definition: ${resourceName} in namespace: ${namespaceName}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      let data: ResourceDefinitionResponse | undefined;
+      let error: unknown;
+      let response: Response;
+
+      // Call the appropriate endpoint based on kind
+      switch (kind) {
+        case 'component-types': {
+          const result = await client.GET(
+            '/namespaces/{namespaceName}/component-types/{ctName}/definition',
+            {
+              params: {
+                path: { namespaceName, ctName: resourceName },
+              },
+            },
+          );
+          data = result.data as ResourceDefinitionResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'traits': {
+          const result = await client.GET(
+            '/namespaces/{namespaceName}/traits/{traitName}/definition',
+            {
+              params: {
+                path: { namespaceName, traitName: resourceName },
+              },
+            },
+          );
+          data = result.data as ResourceDefinitionResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'workflows': {
+          const result = await client.GET(
+            '/namespaces/{namespaceName}/workflows/{workflowName}/definition',
+            {
+              params: {
+                path: { namespaceName, workflowName: resourceName },
+              },
+            },
+          );
+          data = result.data as ResourceDefinitionResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'component-workflows': {
+          const result = await client.GET(
+            '/namespaces/{namespaceName}/component-workflows/{cwName}/definition',
+            {
+              params: {
+                path: { namespaceName, cwName: resourceName },
+              },
+            },
+          );
+          data = result.data as ResourceDefinitionResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        default:
+          throw new Error(`Unsupported resource kind: ${kind}`);
+      }
+
+      if (error || !response.ok) {
+        throw new Error(
+          `Failed to fetch ${kind} definition: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      if (!data?.success) {
+        throw new Error('API request was not successful');
+      }
+
+      this.logger.debug(
+        `Successfully fetched ${kind} definition: ${resourceName}`,
+      );
+      return data;
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch ${kind} definition for ${resourceName} in namespace ${namespaceName}: ${error}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Update (or create) a platform resource definition
+   */
+  async updateResourceDefinition(
+    kind: ResourceKind,
+    namespaceName: string,
+    resourceName: string,
+    resource: Record<string, unknown>,
+    token?: string,
+  ): Promise<ResourceCRUDResponse> {
+    this.logger.debug(
+      `Updating ${kind} definition: ${resourceName} in namespace: ${namespaceName}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      let data: ResourceCRUDResponse | undefined;
+      let error: unknown;
+      let response: Response;
+
+      // Call the appropriate endpoint based on kind
+      switch (kind) {
+        case 'component-types': {
+          const result = await client.PUT(
+            '/namespaces/{namespaceName}/component-types/{ctName}/definition',
+            {
+              params: {
+                path: { namespaceName, ctName: resourceName },
+              },
+              body: resource,
+            },
+          );
+          data = result.data as ResourceCRUDResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'traits': {
+          const result = await client.PUT(
+            '/namespaces/{namespaceName}/traits/{traitName}/definition',
+            {
+              params: {
+                path: { namespaceName, traitName: resourceName },
+              },
+              body: resource,
+            },
+          );
+          data = result.data as ResourceCRUDResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'workflows': {
+          const result = await client.PUT(
+            '/namespaces/{namespaceName}/workflows/{workflowName}/definition',
+            {
+              params: {
+                path: { namespaceName, workflowName: resourceName },
+              },
+              body: resource,
+            },
+          );
+          data = result.data as ResourceCRUDResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'component-workflows': {
+          const result = await client.PUT(
+            '/namespaces/{namespaceName}/component-workflows/{cwName}/definition',
+            {
+              params: {
+                path: { namespaceName, cwName: resourceName },
+              },
+              body: resource,
+            },
+          );
+          data = result.data as ResourceCRUDResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        default:
+          throw new Error(`Unsupported resource kind: ${kind}`);
+      }
+
+      if (error || !response.ok) {
+        throw new Error(
+          `Failed to update ${kind} definition: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      if (!data?.success) {
+        throw new Error('API request was not successful');
+      }
+
+      this.logger.debug(
+        `Successfully updated ${kind} definition: ${resourceName}`,
+      );
+      return data;
+    } catch (error) {
+      this.logger.error(
+        `Failed to update ${kind} definition for ${resourceName} in namespace ${namespaceName}: ${error}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a platform resource definition
+   */
+  async deleteResourceDefinition(
+    kind: ResourceKind,
+    namespaceName: string,
+    resourceName: string,
+    token?: string,
+  ): Promise<ResourceCRUDResponse> {
+    this.logger.debug(
+      `Deleting ${kind} definition: ${resourceName} in namespace: ${namespaceName}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      let data: ResourceCRUDResponse | undefined;
+      let error: unknown;
+      let response: Response;
+
+      // Call the appropriate endpoint based on kind
+      switch (kind) {
+        case 'component-types': {
+          const result = await client.DELETE(
+            '/namespaces/{namespaceName}/component-types/{ctName}/definition',
+            {
+              params: {
+                path: { namespaceName, ctName: resourceName },
+              },
+            },
+          );
+          data = result.data as ResourceCRUDResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'traits': {
+          const result = await client.DELETE(
+            '/namespaces/{namespaceName}/traits/{traitName}/definition',
+            {
+              params: {
+                path: { namespaceName, traitName: resourceName },
+              },
+            },
+          );
+          data = result.data as ResourceCRUDResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'workflows': {
+          const result = await client.DELETE(
+            '/namespaces/{namespaceName}/workflows/{workflowName}/definition',
+            {
+              params: {
+                path: { namespaceName, workflowName: resourceName },
+              },
+            },
+          );
+          data = result.data as ResourceCRUDResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        case 'component-workflows': {
+          const result = await client.DELETE(
+            '/namespaces/{namespaceName}/component-workflows/{cwName}/definition',
+            {
+              params: {
+                path: { namespaceName, cwName: resourceName },
+              },
+            },
+          );
+          data = result.data as ResourceCRUDResponse;
+          error = result.error;
+          response = result.response;
+          break;
+        }
+        default:
+          throw new Error(`Unsupported resource kind: ${kind}`);
+      }
+
+      if (error || !response.ok) {
+        throw new Error(
+          `Failed to delete ${kind} definition: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      if (!data?.success) {
+        throw new Error('API request was not successful');
+      }
+
+      this.logger.debug(
+        `Successfully deleted ${kind} definition: ${resourceName}`,
+      );
+      return data;
+    } catch (error) {
+      this.logger.error(
+        `Failed to delete ${kind} definition for ${resourceName} in namespace ${namespaceName}: ${error}`,
+      );
+      throw error;
+    }
+  }
+}

--- a/plugins/openchoreo-backend/src/services/PlatformResourceService/index.ts
+++ b/plugins/openchoreo-backend/src/services/PlatformResourceService/index.ts
@@ -1,0 +1,1 @@
+export { PlatformResourceService } from './PlatformResourceService';

--- a/plugins/openchoreo-react/package.json
+++ b/plugins/openchoreo-react/package.json
@@ -36,13 +36,19 @@
     "@backstage/plugin-catalog-react": "1.21.1",
     "@backstage/plugin-permission-react": "^0.4.39",
     "@backstage/theme": "0.6.8",
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/legacy-modes": "^6.1.0",
+    "@codemirror/view": "^6.0.0",
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
     "@openchoreo/backstage-design-system": "workspace:^",
     "@openchoreo/backstage-plugin-common": "workspace:^",
     "@openchoreo/openchoreo-client-node": "workspace:^",
-    "clsx": "^2.1.1"
+    "@react-hookz/web": "^24.0.0",
+    "@uiw/react-codemirror": "^4.9.3",
+    "clsx": "^2.1.1",
+    "yaml": "^2.0.0"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
+++ b/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
@@ -1,0 +1,232 @@
+import { useMemo, useState } from 'react';
+import { StreamLanguage } from '@codemirror/language';
+import { yaml as yamlSupport } from '@codemirror/legacy-modes/mode/yaml';
+import { showPanel } from '@codemirror/view';
+import IconButton from '@material-ui/core/IconButton';
+import Paper from '@material-ui/core/Paper';
+import Tooltip from '@material-ui/core/Tooltip';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { makeStyles } from '@material-ui/core/styles';
+import SaveIcon from '@material-ui/icons/Save';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import DeleteIcon from '@material-ui/icons/Delete';
+import Brightness4Icon from '@material-ui/icons/Brightness4';
+import Brightness7Icon from '@material-ui/icons/Brightness7';
+import { useKeyboardEvent } from '@react-hookz/web';
+import CodeMirror from '@uiw/react-codemirror';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    minHeight: 400,
+  },
+  codeMirror: {
+    height: '100%',
+    '& .cm-editor': {
+      height: '100%',
+    },
+    '& .cm-scroller': {
+      overflow: 'auto',
+    },
+  },
+  errorPanel: {
+    color: theme.palette.error.main,
+    lineHeight: 2,
+    margin: theme.spacing(0, 1),
+    padding: theme.spacing(1),
+    backgroundColor: theme.palette.type === 'dark' ? '#2d2d2d' : '#f5f5f5',
+    borderTop: `1px solid ${theme.palette.error.main}`,
+    fontFamily: 'monospace',
+    fontSize: '0.875rem',
+  },
+  floatingButtons: {
+    position: 'absolute',
+    top: theme.spacing(1),
+    right: theme.spacing(3),
+    zIndex: 10,
+  },
+  floatingButton: {
+    padding: theme.spacing(1),
+  },
+  saveButton: {
+    color: theme.palette.primary.main,
+  },
+  discardButton: {
+    color: theme.palette.warning.main,
+  },
+  deleteButton: {
+    color: theme.palette.error.main,
+  },
+  themeToggleButton: {
+    color: theme.palette.text.secondary,
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  savingIndicator: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(1),
+  },
+}));
+
+export interface YamlEditorProps {
+  /** The YAML content to display */
+  content: string;
+  /** Called when content changes */
+  onChange: (content: string) => void;
+  /** Called when save is triggered (Ctrl/Cmd+S or button click) */
+  onSave?: () => void;
+  /** Called when discard is triggered */
+  onDiscard?: () => void;
+  /** Called when delete is triggered */
+  onDelete?: () => void;
+  /** Error text to display in the error panel */
+  errorText?: string;
+  /** Whether there are unsaved changes */
+  isDirty?: boolean;
+  /** Whether a save operation is in progress */
+  isSaving?: boolean;
+  /** Whether the editor is read-only */
+  readOnly?: boolean;
+}
+
+/**
+ * A YAML editor component built on CodeMirror 6.
+ *
+ * Features:
+ * - YAML syntax highlighting
+ * - Ctrl/Cmd+S keyboard shortcut for saving
+ * - Floating toolbar with Save, Discard, and Delete buttons
+ * - Error panel for displaying validation errors
+ * - Dark theme support
+ */
+export function YamlEditor({
+  content,
+  onChange,
+  onSave,
+  onDiscard,
+  onDelete,
+  errorText,
+  isDirty = false,
+  isSaving = false,
+  readOnly = false,
+}: YamlEditorProps) {
+  const classes = useStyles();
+  const [isDarkTheme, setIsDarkTheme] = useState(false);
+
+  // Error panel extension
+  const panelExtension = useMemo(() => {
+    if (!errorText) {
+      return showPanel.of(null);
+    }
+
+    const dom = document.createElement('div');
+    dom.classList.add(classes.errorPanel);
+    dom.textContent = errorText;
+    return showPanel.of(() => ({ dom, bottom: true }));
+  }, [classes.errorPanel, errorText]);
+
+  // Keyboard shortcut for save (Ctrl/Cmd+S)
+  useKeyboardEvent(
+    e => e.key === 's' && (e.ctrlKey || e.metaKey),
+    e => {
+      e.preventDefault();
+      if (onSave && isDirty && !isSaving && !readOnly) {
+        onSave();
+      }
+    },
+  );
+
+  return (
+    <div className={classes.container}>
+      <CodeMirror
+        className={classes.codeMirror}
+        theme={isDarkTheme ? 'dark' : 'light'}
+        height="100%"
+        extensions={[StreamLanguage.define(yamlSupport), panelExtension]}
+        value={content}
+        onChange={onChange}
+        readOnly={readOnly}
+        editable={!readOnly}
+      />
+      <div className={classes.floatingButtons}>
+        <Paper>
+          {isSaving ? (
+            <div className={classes.savingIndicator}>
+              <CircularProgress size={20} />
+            </div>
+          ) : (
+            <>
+              <Tooltip
+                title={
+                  isDarkTheme ? 'Switch to light theme' : 'Switch to dark theme'
+                }
+              >
+                <IconButton
+                  className={`${classes.floatingButton} ${classes.themeToggleButton}`}
+                  onClick={() => setIsDarkTheme(!isDarkTheme)}
+                  size="small"
+                >
+                  {isDarkTheme ? <Brightness7Icon /> : <Brightness4Icon />}
+                </IconButton>
+              </Tooltip>
+              {onSave && (
+                <Tooltip
+                  title={
+                    isDirty ? 'Save changes (Ctrl+S)' : 'No changes to save'
+                  }
+                >
+                  <span>
+                    <IconButton
+                      className={`${classes.floatingButton} ${
+                        classes.saveButton
+                      } ${!isDirty ? classes.disabledButton : ''}`}
+                      onClick={onSave}
+                      disabled={!isDirty || readOnly}
+                      size="small"
+                    >
+                      <SaveIcon />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              )}
+              {onDiscard && (
+                <Tooltip
+                  title={isDirty ? 'Discard changes' : 'No changes to discard'}
+                >
+                  <span>
+                    <IconButton
+                      className={`${classes.floatingButton} ${
+                        classes.discardButton
+                      } ${!isDirty ? classes.disabledButton : ''}`}
+                      onClick={onDiscard}
+                      disabled={!isDirty || readOnly}
+                      size="small"
+                    >
+                      <RefreshIcon />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              )}
+              {onDelete && (
+                <Tooltip title="Delete resource">
+                  <IconButton
+                    className={`${classes.floatingButton} ${classes.deleteButton}`}
+                    onClick={onDelete}
+                    disabled={readOnly}
+                    size="small"
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </Paper>
+      </div>
+    </div>
+  );
+}

--- a/plugins/openchoreo-react/src/components/YamlEditor/index.ts
+++ b/plugins/openchoreo-react/src/components/YamlEditor/index.ts
@@ -1,0 +1,6 @@
+export { YamlEditor, type YamlEditorProps } from './YamlEditor';
+export {
+  useYamlEditor,
+  type UseYamlEditorOptions,
+  type UseYamlEditorResult,
+} from './useYamlEditor';

--- a/plugins/openchoreo-react/src/components/YamlEditor/useYamlEditor.ts
+++ b/plugins/openchoreo-react/src/components/YamlEditor/useYamlEditor.ts
@@ -1,0 +1,173 @@
+import { useState, useCallback, useEffect } from 'react';
+import YAML from 'yaml';
+
+export interface UseYamlEditorOptions {
+  /** Initial content (JSON object or YAML string) */
+  initialContent: Record<string, unknown> | string;
+  /** Called when save is triggered with parsed JSON object */
+  onSave?: (content: Record<string, unknown>) => Promise<void>;
+  /** Called when delete is triggered */
+  onDelete?: () => Promise<void>;
+}
+
+export interface UseYamlEditorResult {
+  /** Current YAML content as string */
+  content: string;
+  /** Update the content */
+  setContent: (content: string) => void;
+  /** Whether there are unsaved changes */
+  isDirty: boolean;
+  /** Whether a save operation is in progress */
+  isSaving: boolean;
+  /** Whether a delete operation is in progress */
+  isDeleting: boolean;
+  /** YAML parse error if any */
+  parseError: string | undefined;
+  /** Handle save action */
+  handleSave: () => Promise<void>;
+  /** Handle discard action (reset to initial content) */
+  handleDiscard: () => void;
+  /** Handle delete action */
+  handleDelete: () => Promise<void>;
+  /** Reset to new initial content */
+  reset: (newContent: Record<string, unknown> | string) => void;
+  /** Parse the current YAML content to JSON */
+  parseYaml: () => Record<string, unknown> | null;
+}
+
+/**
+ * Hook for managing YAML editor state.
+ *
+ * Handles:
+ * - Dirty tracking (comparing against initial content)
+ * - YAML parsing and validation
+ * - Save/discard/delete operations with loading states
+ * - Converting between JSON objects and YAML strings
+ */
+export function useYamlEditor({
+  initialContent,
+  onSave,
+  onDelete,
+}: UseYamlEditorOptions): UseYamlEditorResult {
+  // Convert initial content to YAML string if it's an object
+  const toYamlString = useCallback(
+    (value: Record<string, unknown> | string): string => {
+      if (typeof value === 'string') {
+        return value;
+      }
+      return YAML.stringify(value, {
+        indent: 2,
+        lineWidth: 0, // Disable line wrapping
+      });
+    },
+    [],
+  );
+
+  const [originalContent, setOriginalContent] = useState(() =>
+    toYamlString(initialContent),
+  );
+  const [content, setContent] = useState(originalContent);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [parseError, setParseError] = useState<string | undefined>(undefined);
+
+  // Update original content when initialContent prop changes
+  useEffect(() => {
+    const newOriginal = toYamlString(initialContent);
+    setOriginalContent(newOriginal);
+    setContent(newOriginal);
+    setParseError(undefined);
+  }, [initialContent, toYamlString]);
+
+  // Check if content has changed
+  const isDirty = content !== originalContent;
+
+  // Validate YAML when content changes
+  useEffect(() => {
+    try {
+      YAML.parse(content);
+      setParseError(undefined);
+    } catch (error) {
+      if (error instanceof Error) {
+        setParseError(`YAML Parse Error: ${error.message}`);
+      } else {
+        setParseError('Invalid YAML');
+      }
+    }
+  }, [content]);
+
+  // Parse current content to JSON
+  const parseYaml = useCallback((): Record<string, unknown> | null => {
+    try {
+      return YAML.parse(content) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }, [content]);
+
+  // Handle save
+  const handleSave = useCallback(async () => {
+    if (!onSave || !isDirty || parseError) {
+      return;
+    }
+
+    const parsed = parseYaml();
+    if (!parsed) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSave(parsed);
+      // Update original content to current content after successful save
+      setOriginalContent(content);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [onSave, isDirty, parseError, parseYaml, content]);
+
+  // Handle discard
+  const handleDiscard = useCallback(() => {
+    setContent(originalContent);
+    setParseError(undefined);
+  }, [originalContent]);
+
+  // Handle delete
+  const handleDelete = useCallback(async () => {
+    if (!onDelete) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      await onDelete();
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [onDelete]);
+
+  // Reset to new content
+  const reset = useCallback(
+    (newContent: Record<string, unknown> | string) => {
+      const newYaml = toYamlString(newContent);
+      setOriginalContent(newYaml);
+      setContent(newYaml);
+      setParseError(undefined);
+    },
+    [toYamlString],
+  );
+
+  return {
+    content,
+    setContent,
+    isDirty,
+    isSaving,
+    isDeleting,
+    parseError,
+    handleSave,
+    handleDiscard,
+    handleDelete,
+    reset,
+    parseYaml,
+  };
+}

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -95,6 +95,13 @@ export {
   PipelineFlowVisualization,
   type PipelineFlowVisualizationProps,
 } from './components/PipelineFlowVisualization';
+export {
+  YamlEditor,
+  useYamlEditor,
+  type YamlEditorProps,
+  type UseYamlEditorOptions,
+  type UseYamlEditorResult,
+} from './components/YamlEditor';
 
 // Hooks
 export { useInfiniteScroll } from './hooks/useInfiniteScroll';

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -25,6 +25,8 @@ import type {
   ComponentSummary,
   GitSecret,
   GitSecretsListResponse,
+  PlatformResourceKind,
+  ResourceCRUDResponse,
 } from './OpenChoreoClientApi';
 import type { Environment } from '../components/RuntimeLogs/types';
 
@@ -67,6 +69,8 @@ const API_ENDPOINTS = {
   PROJECTS: '/projects', // GET /namespaces/{namespaceName}/projects
   COMPONENTS: '/components', // GET /namespaces/{namespaceName}/projects/{projectName}/components
   ENTITY_ANNOTATIONS: '/entity-annotations',
+  // Platform resource definition endpoint
+  PLATFORM_RESOURCE_DEFINITION: '/platform-resource/definition',
 } as const;
 
 // ============================================
@@ -935,5 +939,82 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
         params: { namespaceName },
       },
     );
+  }
+
+  // ============================================
+  // Platform Resource Definition Operations
+  // ============================================
+
+  async getResourceDefinition(
+    kind: PlatformResourceKind,
+    namespaceName: string,
+    resourceName: string,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.apiFetch<{
+      success: boolean;
+      data?: Record<string, unknown>;
+    }>(API_ENDPOINTS.PLATFORM_RESOURCE_DEFINITION, {
+      params: {
+        kind,
+        namespaceName,
+        resourceName,
+      },
+    });
+
+    if (!response.data) {
+      throw new Error(`No data returned for ${kind} ${resourceName}`);
+    }
+
+    return response.data;
+  }
+
+  async updateResourceDefinition(
+    kind: PlatformResourceKind,
+    namespaceName: string,
+    resourceName: string,
+    resource: Record<string, unknown>,
+  ): Promise<ResourceCRUDResponse> {
+    const response = await this.apiFetch<{
+      success: boolean;
+      data?: ResourceCRUDResponse;
+    }>(API_ENDPOINTS.PLATFORM_RESOURCE_DEFINITION, {
+      method: 'PUT',
+      params: {
+        kind,
+        namespaceName,
+        resourceName,
+      },
+      body: { resource },
+    });
+
+    if (!response.data) {
+      throw new Error(`Failed to update ${kind} ${resourceName}`);
+    }
+
+    return response.data;
+  }
+
+  async deleteResourceDefinition(
+    kind: PlatformResourceKind,
+    namespaceName: string,
+    resourceName: string,
+  ): Promise<ResourceCRUDResponse> {
+    const response = await this.apiFetch<{
+      success: boolean;
+      data?: ResourceCRUDResponse;
+    }>(API_ENDPOINTS.PLATFORM_RESOURCE_DEFINITION, {
+      method: 'DELETE',
+      params: {
+        kind,
+        namespaceName,
+        resourceName,
+      },
+    });
+
+    if (!response.data) {
+      throw new Error(`Failed to delete ${kind} ${resourceName}`);
+    }
+
+    return response.data;
   }
 }

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -206,6 +206,20 @@ export interface ComponentTrait {
   parameters?: Record<string, unknown>;
 }
 
+/** Platform resource kind for definition CRUD operations */
+export type PlatformResourceKind =
+  | 'component-types'
+  | 'traits'
+  | 'workflows'
+  | 'component-workflows';
+
+/** Response for resource CRUD operations */
+export interface ResourceCRUDResponse {
+  operation: string;
+  name?: string;
+  kind?: string;
+}
+
 // ============================================
 // OpenChoreo Client API Interface
 // ============================================
@@ -461,6 +475,49 @@ export interface OpenChoreoClientApi {
     entity: Entity,
     annotations: Record<string, string | null>,
   ): Promise<Record<string, string>>;
+
+  // === Platform Resource Definition Operations ===
+
+  /**
+   * Get the full CRD definition for a platform resource
+   * @param kind - Resource kind (component-types, traits, workflows, component-workflows)
+   * @param namespaceName - Kubernetes namespace
+   * @param resourceName - Name of the resource
+   * @returns The full CRD as an unstructured JSON object
+   */
+  getResourceDefinition(
+    kind: PlatformResourceKind,
+    namespaceName: string,
+    resourceName: string,
+  ): Promise<Record<string, unknown>>;
+
+  /**
+   * Update (or create) a platform resource definition
+   * @param kind - Resource kind (component-types, traits, workflows, component-workflows)
+   * @param namespaceName - Kubernetes namespace
+   * @param resourceName - Name of the resource
+   * @param resource - Full CRD as JSON
+   * @returns Operation result
+   */
+  updateResourceDefinition(
+    kind: PlatformResourceKind,
+    namespaceName: string,
+    resourceName: string,
+    resource: Record<string, unknown>,
+  ): Promise<ResourceCRUDResponse>;
+
+  /**
+   * Delete a platform resource definition
+   * @param kind - Resource kind (component-types, traits, workflows, component-workflows)
+   * @param namespaceName - Kubernetes namespace
+   * @param resourceName - Name of the resource
+   * @returns Operation result
+   */
+  deleteResourceDefinition(
+    kind: PlatformResourceKind,
+    namespaceName: string,
+    resourceName: string,
+  ): Promise<ResourceCRUDResponse>;
 }
 
 // ============================================

--- a/plugins/openchoreo/src/components/ResourceDefinition/ResourceDefinitionTab.tsx
+++ b/plugins/openchoreo/src/components/ResourceDefinition/ResourceDefinitionTab.tsx
@@ -1,0 +1,370 @@
+import { useState, useCallback, useEffect, useRef, useContext } from 'react';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useNavigate,
+  UNSAFE_NavigationContext as NavigationContext,
+} from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogActions from '@material-ui/core/DialogActions';
+import Snackbar from '@material-ui/core/Snackbar';
+import Alert from '@material-ui/lab/Alert';
+import {
+  YamlEditor,
+  useYamlEditor,
+  LoadingState,
+  ErrorState,
+  UnsavedChangesDialog,
+} from '@openchoreo/backstage-plugin-react';
+import { useResourceDefinition } from './useResourceDefinition';
+import { isSupportedKind } from './utils';
+
+// Navigator type for overriding push/replace methods
+interface Navigator {
+  push: (to: string | { pathname: string }, state?: any) => void;
+  replace: (to: string | { pathname: string }, state?: any) => void;
+}
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  header: {
+    marginBottom: theme.spacing(2),
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  editorContainer: {
+    flex: 1,
+    minHeight: 500,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'hidden',
+  },
+  unsupportedMessage: {
+    padding: theme.spacing(4),
+    textAlign: 'center',
+  },
+  syncNote: {
+    marginTop: theme.spacing(2),
+    padding: theme.spacing(1, 2),
+    backgroundColor: theme.palette.type === 'dark' ? '#2d2d2d' : '#f5f5f5',
+    borderRadius: theme.shape.borderRadius,
+  },
+}));
+
+/**
+ * Tab component for viewing and editing platform resource CRD definitions.
+ *
+ * Displays a YAML editor with the full CRD for ComponentType, TraitType,
+ * Workflow, and ComponentWorkflow entities.
+ */
+export function ResourceDefinitionTab() {
+  const classes = useStyles();
+  const { entity } = useEntity();
+  const navigate = useNavigate();
+  const navigation = useContext(NavigationContext);
+
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'error'>(
+    'success',
+  );
+  const [unsavedChangesDialogOpen, setUnsavedChangesDialogOpen] =
+    useState(false);
+
+  // Refs for navigation blocking
+  const allowNavigationRef = useRef(false);
+  const pendingNavigationRef = useRef<{
+    to: string;
+    action: 'push' | 'replace';
+  } | null>(null);
+
+  const {
+    definition,
+    isLoading,
+    error: fetchError,
+    save,
+    deleteResource,
+    isSaving,
+  } = useResourceDefinition({ entity });
+
+  // Show success/error snackbar
+  const showSnackbar = useCallback(
+    (message: string, severity: 'success' | 'error') => {
+      setSnackbarMessage(message);
+      setSnackbarSeverity(severity);
+      setSnackbarOpen(true);
+    },
+    [],
+  );
+
+  // Handle save
+  const handleSave = useCallback(
+    async (content: Record<string, unknown>) => {
+      try {
+        await save(content);
+        showSnackbar('Resource saved successfully', 'success');
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to save resource';
+        showSnackbar(message, 'error');
+        throw err; // Re-throw so useYamlEditor knows it failed
+      }
+    },
+    [save, showSnackbar],
+  );
+
+  // Handle delete
+  const handleDelete = useCallback(async () => {
+    try {
+      await deleteResource();
+      showSnackbar('Resource deleted successfully', 'success');
+      setDeleteDialogOpen(false);
+      // Navigate back to catalog after deletion
+      navigate('/catalog');
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to delete resource';
+      showSnackbar(message, 'error');
+    }
+  }, [deleteResource, showSnackbar, navigate]);
+
+  // YAML editor hook - only initialize when we have definition
+  const yamlEditor = useYamlEditor({
+    initialContent: definition || {},
+    onSave: handleSave,
+    onDelete: async () => {
+      setDeleteDialogOpen(true);
+    },
+  });
+
+  // Update editor when definition changes
+  useEffect(() => {
+    if (definition) {
+      yamlEditor.reset(definition);
+    }
+  }, [definition]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Warn user before leaving page with unsaved changes (browser navigation/tab close)
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (yamlEditor.isDirty && !allowNavigationRef.current) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [yamlEditor.isDirty]);
+
+  // Block in-app navigation when there are unsaved changes
+  useEffect(() => {
+    if (!yamlEditor.isDirty || !navigation) {
+      return undefined;
+    }
+
+    const navigator = navigation.navigator as Navigator;
+    const originalPush = navigator.push;
+    const originalReplace = navigator.replace;
+
+    // Override push method
+    navigator.push = (to: any, state?: any) => {
+      if (allowNavigationRef.current) {
+        originalPush.call(navigator, to, state);
+        return;
+      }
+
+      // Store pending navigation
+      pendingNavigationRef.current = {
+        to: typeof to === 'string' ? to : to.pathname,
+        action: 'push',
+      };
+
+      // Show confirmation dialog
+      setUnsavedChangesDialogOpen(true);
+    };
+
+    // Override replace method
+    navigator.replace = (to: any, state?: any) => {
+      if (allowNavigationRef.current) {
+        originalReplace.call(navigator, to, state);
+        return;
+      }
+
+      // Store pending navigation
+      pendingNavigationRef.current = {
+        to: typeof to === 'string' ? to : to.pathname,
+        action: 'replace',
+      };
+
+      // Show confirmation dialog
+      setUnsavedChangesDialogOpen(true);
+    };
+
+    // Cleanup - restore original methods
+    return () => {
+      navigator.push = originalPush;
+      navigator.replace = originalReplace;
+    };
+  }, [yamlEditor.isDirty, navigation]);
+
+  // Handle discard from unsaved changes dialog
+  const handleDiscardAndNavigate = useCallback(() => {
+    allowNavigationRef.current = true;
+    setUnsavedChangesDialogOpen(false);
+
+    if (pendingNavigationRef.current) {
+      const { to, action } = pendingNavigationRef.current;
+      if (action === 'push') {
+        navigate(to);
+      } else {
+        navigate(to, { replace: true });
+      }
+      pendingNavigationRef.current = null;
+    }
+
+    // Reset flag after navigation
+    setTimeout(() => {
+      allowNavigationRef.current = false;
+    }, 100);
+  }, [navigate]);
+
+  // Handle stay from unsaved changes dialog
+  const handleStay = useCallback(() => {
+    setUnsavedChangesDialogOpen(false);
+    pendingNavigationRef.current = null;
+  }, []);
+
+  // Check if entity kind is supported
+  if (!isSupportedKind(entity.kind)) {
+    return (
+      <Box className={classes.unsupportedMessage}>
+        <Typography variant="h6" color="textSecondary">
+          Definition editing is not supported for {entity.kind} entities.
+        </Typography>
+        <Typography variant="body2" color="textSecondary">
+          Supported kinds: ComponentType, TraitType, Workflow, ComponentWorkflow
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Loading state
+  if (isLoading) {
+    return <LoadingState message="Loading resource definition..." />;
+  }
+
+  // Error state
+  if (fetchError && !definition) {
+    return (
+      <ErrorState
+        title="Failed to load resource definition"
+        message={fetchError}
+        onRetry={() => window.location.reload()}
+      />
+    );
+  }
+
+  // No definition found
+  if (!definition) {
+    return (
+      <ErrorState
+        title="Resource definition not found"
+        message="The resource definition could not be retrieved from the cluster."
+      />
+    );
+  }
+
+  // Combine parse error and fetch error for display
+  const editorError =
+    yamlEditor.parseError ||
+    (fetchError ? `Warning: ${fetchError}` : undefined);
+
+  return (
+    <Box className={classes.container}>
+      <Box className={classes.header}>
+        <Typography variant="h6">
+          {entity.kind} Definition: {entity.metadata.name}
+        </Typography>
+      </Box>
+
+      <Box className={classes.editorContainer}>
+        <YamlEditor
+          content={yamlEditor.content}
+          onChange={yamlEditor.setContent}
+          onSave={yamlEditor.handleSave}
+          onDiscard={yamlEditor.handleDiscard}
+          onDelete={() => setDeleteDialogOpen(true)}
+          errorText={editorError}
+          isDirty={yamlEditor.isDirty}
+          isSaving={isSaving}
+        />
+      </Box>
+
+      <Box className={classes.syncNote}>
+        <Typography variant="body2" color="textSecondary">
+          Note: Changes made here will be reflected in the catalog after the
+          next entity provider sync cycle.
+        </Typography>
+      </Box>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+      >
+        <DialogTitle>Delete {entity.kind}?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to delete "{entity.metadata.name}"? This
+            action cannot be undone and will remove the resource from the
+            Kubernetes cluster.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialogOpen(false)} color="default">
+            Cancel
+          </Button>
+          <Button onClick={handleDelete} color="secondary">
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Unsaved changes confirmation dialog */}
+      <UnsavedChangesDialog
+        open={unsavedChangesDialogOpen}
+        onDiscard={handleDiscardAndNavigate}
+        onStay={handleStay}
+        changeCount={1}
+      />
+
+      {/* Snackbar for success/error messages */}
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={6000}
+        onClose={() => setSnackbarOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setSnackbarOpen(false)}
+          severity={snackbarSeverity}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/plugins/openchoreo/src/components/ResourceDefinition/index.ts
+++ b/plugins/openchoreo/src/components/ResourceDefinition/index.ts
@@ -1,0 +1,12 @@
+export { ResourceDefinitionTab } from './ResourceDefinitionTab';
+export {
+  useResourceDefinition,
+  type UseResourceDefinitionOptions,
+  type UseResourceDefinitionResult,
+} from './useResourceDefinition';
+export {
+  mapKindToApiKind,
+  mapKindToCrdKind,
+  cleanCrdForEditing,
+  isSupportedKind,
+} from './utils';

--- a/plugins/openchoreo/src/components/ResourceDefinition/useResourceDefinition.ts
+++ b/plugins/openchoreo/src/components/ResourceDefinition/useResourceDefinition.ts
@@ -1,0 +1,149 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
+import { mapKindToApiKind, cleanCrdForEditing, isSupportedKind } from './utils';
+
+export interface UseResourceDefinitionOptions {
+  entity: Entity;
+}
+
+export interface UseResourceDefinitionResult {
+  /** The full CRD as JSON (cleaned for editing) */
+  definition: Record<string, unknown> | null;
+  /** Whether the definition is loading */
+  isLoading: boolean;
+  /** Error message if loading failed */
+  error: string | null;
+  /** Refresh the definition from the API */
+  refresh: () => Promise<void>;
+  /** Save the updated definition */
+  save: (resource: Record<string, unknown>) => Promise<void>;
+  /** Delete the resource */
+  deleteResource: () => Promise<void>;
+  /** Whether a save operation is in progress */
+  isSaving: boolean;
+  /** Whether the entity kind is supported */
+  isSupported: boolean;
+}
+
+/**
+ * Hook for fetching and managing a platform resource definition
+ */
+export function useResourceDefinition({
+  entity,
+}: UseResourceDefinitionOptions): UseResourceDefinitionResult {
+  const client = useApi(openChoreoClientApiRef);
+
+  const [definition, setDefinition] = useState<Record<string, unknown> | null>(
+    null,
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const kind = entity.kind;
+  const namespace = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
+  const resourceName = entity.metadata.name;
+  const isSupported = isSupportedKind(kind);
+
+  const fetchDefinition = useCallback(async () => {
+    if (!isSupported || !namespace || !resourceName) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const apiKind = mapKindToApiKind(kind);
+      const data = await client.getResourceDefinition(
+        apiKind,
+        namespace,
+        resourceName,
+      );
+      const cleaned = cleanCrdForEditing(data);
+      setDefinition(cleaned);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Failed to fetch resource definition';
+      setError(message);
+      setDefinition(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [client, kind, namespace, resourceName, isSupported]);
+
+  // Fetch on mount and when entity changes
+  useEffect(() => {
+    fetchDefinition();
+  }, [fetchDefinition]);
+
+  const save = useCallback(
+    async (resource: Record<string, unknown>) => {
+      if (!isSupported || !namespace || !resourceName) {
+        throw new Error(
+          'Cannot save: entity not supported or missing required fields',
+        );
+      }
+
+      setIsSaving(true);
+      setError(null);
+
+      try {
+        const apiKind = mapKindToApiKind(kind);
+        await client.updateResourceDefinition(
+          apiKind,
+          namespace,
+          resourceName,
+          resource,
+        );
+        // Refresh to get the latest version from the server
+        await fetchDefinition();
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Failed to save resource definition';
+        setError(message);
+        throw err;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [client, kind, namespace, resourceName, isSupported, fetchDefinition],
+  );
+
+  const deleteResource = useCallback(async () => {
+    if (!isSupported || !namespace || !resourceName) {
+      throw new Error(
+        'Cannot delete: entity not supported or missing required fields',
+      );
+    }
+
+    try {
+      const apiKind = mapKindToApiKind(kind);
+      await client.deleteResourceDefinition(apiKind, namespace, resourceName);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to delete resource';
+      setError(message);
+      throw err;
+    }
+  }, [client, kind, namespace, resourceName, isSupported]);
+
+  return {
+    definition,
+    isLoading,
+    error,
+    refresh: fetchDefinition,
+    save,
+    deleteResource,
+    isSaving,
+    isSupported,
+  };
+}

--- a/plugins/openchoreo/src/components/ResourceDefinition/utils.ts
+++ b/plugins/openchoreo/src/components/ResourceDefinition/utils.ts
@@ -1,0 +1,87 @@
+import type { PlatformResourceKind } from '../../api/OpenChoreoClientApi';
+
+/**
+ * Maps a Backstage entity kind to the API path kind
+ */
+export function mapKindToApiKind(backstageKind: string): PlatformResourceKind {
+  const kindLower = backstageKind.toLowerCase();
+  switch (kindLower) {
+    case 'componenttype':
+      return 'component-types';
+    case 'traittype':
+      return 'traits';
+    case 'workflow':
+      return 'workflows';
+    case 'componentworkflow':
+      return 'component-workflows';
+    default:
+      throw new Error(`Unsupported entity kind: ${backstageKind}`);
+  }
+}
+
+/**
+ * Maps a Backstage entity kind to the actual CRD kind
+ * (used to extract the resource name from the CRD)
+ */
+export function mapKindToCrdKind(backstageKind: string): string {
+  const kindLower = backstageKind.toLowerCase();
+  switch (kindLower) {
+    case 'componenttype':
+      return 'ComponentType';
+    case 'traittype':
+      return 'Trait'; // TraitType in Backstage maps to Trait CRD
+    case 'workflow':
+      return 'Workflow';
+    case 'componentworkflow':
+      return 'ComponentWorkflow';
+    default:
+      throw new Error(`Unsupported entity kind: ${backstageKind}`);
+  }
+}
+
+/**
+ * Server-managed fields that should be stripped from CRD before displaying
+ */
+const SERVER_MANAGED_FIELDS = [
+  'managedFields',
+  'resourceVersion',
+  'uid',
+  'creationTimestamp',
+  'generation',
+];
+
+/**
+ * Cleans a CRD for editing by removing server-managed fields
+ */
+export function cleanCrdForEditing(
+  crd: Record<string, unknown>,
+): Record<string, unknown> {
+  const cleaned = { ...crd };
+
+  // Clean metadata
+  if (cleaned.metadata && typeof cleaned.metadata === 'object') {
+    const metadata = { ...(cleaned.metadata as Record<string, unknown>) };
+    for (const field of SERVER_MANAGED_FIELDS) {
+      delete metadata[field];
+    }
+    cleaned.metadata = metadata;
+  }
+
+  // Remove status (should not be edited by users)
+  delete cleaned.status;
+
+  return cleaned;
+}
+
+/**
+ * Checks if an entity kind is supported for definition editing
+ */
+export function isSupportedKind(kind: string): boolean {
+  const kindLower = kind.toLowerCase();
+  return [
+    'componenttype',
+    'traittype',
+    'workflow',
+    'componentworkflow',
+  ].includes(kindLower);
+}

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -46,3 +46,4 @@ export { ComponentTypeOverviewCard } from './components/ComponentTypeOverview';
 export { TraitTypeOverviewCard } from './components/TraitTypeOverview';
 export { WorkflowOverviewCard } from './components/WorkflowOverview';
 export { ComponentWorkflowOverviewCard } from './components/ComponentWorkflowOverview';
+export { ResourceDefinitionTab } from './components/ResourceDefinition';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9911,16 +9911,22 @@ __metadata:
     "@backstage/plugin-catalog-react": "npm:1.21.1"
     "@backstage/plugin-permission-react": "npm:^0.4.39"
     "@backstage/theme": "npm:0.6.8"
+    "@codemirror/language": "npm:^6.0.0"
+    "@codemirror/legacy-modes": "npm:^6.1.0"
+    "@codemirror/view": "npm:^6.0.0"
     "@material-ui/core": "npm:4.12.4"
     "@material-ui/icons": "npm:4.11.3"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
     "@openchoreo/backstage-design-system": "workspace:^"
     "@openchoreo/backstage-plugin-common": "workspace:^"
     "@openchoreo/openchoreo-client-node": "workspace:^"
+    "@react-hookz/web": "npm:^24.0.0"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:14.3.1"
     "@types/react": "npm:^18.0.0"
+    "@uiw/react-codemirror": "npm:^4.9.3"
     clsx: "npm:^2.1.1"
+    yaml: "npm:^2.0.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0


### PR DESCRIPTION
  Add a Definition tab to ComponentType, TraitType, Workflow, and
  ComponentWorkflow entity pages that allows platform engineers to
  view and edit the full Kubernetes CRD directly from the Backstage UI.

  - Reusable YamlEditor component (CodeMirror 6) with syntax highlighting
  - Light/dark theme toggle
  - Save, discard, and delete operations with keyboard shortcuts (Ctrl+S)
  - Unsaved changes warning on navigation (in-app and browser)
  - Backend service and API client for resource definition CRUD

  Closes openchoreo/openchoreo#1765


https://github.com/user-attachments/assets/b055a864-046d-444f-a9c4-15d683818537

