### PR TITLE
fix(backend): add conditional Jenkins plugin to prevent startup failures

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -46,6 +46,7 @@
     "@openchoreo/backstage-plugin-backend": "workspace:^",
     "@openchoreo/backstage-plugin-catalog-backend-module": "workspace:^",
     "@openchoreo/backstage-plugin-catalog-backend-module-openchoreo-users": "workspace:^",
+    "@openchoreo/backstage-plugin-jenkins-backend-conditional": "workspace:^",
     "@openchoreo/backstage-plugin-openchoreo-ci-backend": "workspace:^",
     "@openchoreo/backstage-plugin-openchoreo-observability-backend": "workspace:^",
     "@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy": "workspace:^",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -113,8 +113,8 @@ backend.add(
 backend.add(import('@openchoreo/backstage-plugin-openchoreo-ci-backend'));
 
 // External CI Platform Integrations
-// Jenkins: Handles missing config gracefully (API calls fail, not startup)
-backend.add(import('@backstage-community/plugin-jenkins-backend'));
+// Jenkins: Conditional wrapper - only initializes if jenkins.baseUrl config exists
+backend.add(import('@openchoreo/backstage-plugin-jenkins-backend-conditional'));
 // GitLab: Requires integrations.gitlab config at startup. Uncomment after configuring in app-config.local.yaml
 // For production, config is in app-config.production.yaml with Helm-injected env vars
 // backend.add(import('@immobiliarelabs/backstage-plugin-gitlab-backend'));

--- a/plugins/jenkins-backend-conditional/.eslintrc.js
+++ b/plugins/jenkins-backend-conditional/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/jenkins-backend-conditional/package.json
+++ b/plugins/jenkins-backend-conditional/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@openchoreo/backstage-plugin-jenkins-backend-conditional",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "private": true,
+  "description": "Conditional Jenkins backend plugin that only initializes when Jenkins configuration exists",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin",
+    "pluginId": "jenkins"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage-community/plugin-jenkins-backend": "^0.24.1",
+    "@backstage/backend-plugin-api": "^1.1.1",
+    "@backstage/plugin-catalog-node": "^1.16.1"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.34.3"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/jenkins-backend-conditional/src/index.ts
+++ b/plugins/jenkins-backend-conditional/src/index.ts
@@ -1,0 +1,1 @@
+export { jenkinsBackendConditional as default } from './plugin';

--- a/plugins/jenkins-backend-conditional/src/plugin.ts
+++ b/plugins/jenkins-backend-conditional/src/plugin.ts
@@ -1,0 +1,74 @@
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
+
+/**
+ * Conditional Jenkins backend plugin that only initializes when Jenkins
+ * configuration exists. This prevents startup failures when Jenkins is not
+ * configured (e.g., when backstage.externalCI.jenkins.enabled=false in Helm).
+ */
+export const jenkinsBackendConditional = createBackendPlugin({
+  pluginId: 'jenkins',
+  register(env) {
+    env.registerInit({
+      deps: {
+        config: coreServices.rootConfig,
+        logger: coreServices.logger,
+        httpRouter: coreServices.httpRouter,
+        auth: coreServices.auth,
+        httpAuth: coreServices.httpAuth,
+        permissions: coreServices.permissions,
+        discovery: coreServices.discovery,
+        catalog: catalogServiceRef,
+      },
+      async init({
+        config,
+        logger,
+        httpRouter,
+        auth,
+        httpAuth,
+        permissions,
+        discovery,
+        catalog,
+      }) {
+        const jenkinsBaseUrl = config.getOptionalString('jenkins.baseUrl');
+
+        if (!jenkinsBaseUrl) {
+          logger.info(
+            'Jenkins backend disabled - no jenkins.baseUrl configuration found',
+          );
+          return;
+        }
+
+        // Dynamically import Jenkins components to build the router
+        const { JenkinsBuilder, DefaultJenkinsInfoProvider } = await import(
+          '@backstage-community/plugin-jenkins-backend'
+        );
+
+        const jenkinsInfoProvider = DefaultJenkinsInfoProvider.fromConfig({
+          config,
+          catalog,
+          discovery,
+          auth,
+          httpAuth,
+          logger,
+        });
+
+        const { router } = await JenkinsBuilder.createBuilder({
+          config,
+          logger,
+          permissions,
+          jenkinsInfoProvider,
+          discovery,
+          auth,
+          httpAuth,
+        }).build();
+
+        httpRouter.use(router);
+        logger.info('Jenkins backend plugin initialized');
+      },
+    });
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2532,7 +2532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-node@npm:^0.2.17":
+"@backstage/cli-node@npm:^0.2.15, @backstage/cli-node@npm:^0.2.17":
   version: 0.2.17
   resolution: "@backstage/cli-node@npm:0.2.17"
   dependencies:
@@ -2692,6 +2692,147 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/cli@npm:^0.34.3":
+  version: 0.34.5
+  resolution: "@backstage/cli@npm:0.34.5"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.7.6"
+    "@backstage/cli-common": "npm:^0.1.15"
+    "@backstage/cli-node": "npm:^0.2.15"
+    "@backstage/config": "npm:^1.3.6"
+    "@backstage/config-loader": "npm:^1.10.6"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/eslint-plugin": "npm:^0.2.0"
+    "@backstage/integration": "npm:^1.18.2"
+    "@backstage/release-manifests": "npm:^0.0.13"
+    "@backstage/types": "npm:^1.2.2"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@module-federation/enhanced": "npm:^0.9.0"
+    "@octokit/request": "npm:^8.0.0"
+    "@rollup/plugin-commonjs": "npm:^26.0.0"
+    "@rollup/plugin-json": "npm:^6.0.0"
+    "@rollup/plugin-node-resolve": "npm:^15.0.0"
+    "@rollup/plugin-yaml": "npm:^4.0.0"
+    "@rspack/core": "npm:^1.4.11"
+    "@rspack/dev-server": "npm:^1.1.4"
+    "@rspack/plugin-react-refresh": "npm:^1.4.3"
+    "@spotify/eslint-config-base": "npm:^15.0.0"
+    "@spotify/eslint-config-react": "npm:^15.0.0"
+    "@spotify/eslint-config-typescript": "npm:^15.0.0"
+    "@swc/core": "npm:^1.3.46"
+    "@swc/helpers": "npm:^0.5.0"
+    "@swc/jest": "npm:^0.2.22"
+    "@types/jest": "npm:^29.5.11"
+    "@types/webpack-env": "npm:^1.15.2"
+    "@typescript-eslint/eslint-plugin": "npm:^8.17.0"
+    "@typescript-eslint/parser": "npm:^8.16.0"
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    "@yarnpkg/parsers": "npm:^3.0.0"
+    bfj: "npm:^8.0.0"
+    buffer: "npm:^6.0.3"
+    chalk: "npm:^4.0.0"
+    chokidar: "npm:^3.3.1"
+    commander: "npm:^12.0.0"
+    cross-fetch: "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.3"
+    css-loader: "npm:^6.5.1"
+    ctrlc-windows: "npm:^2.1.0"
+    esbuild: "npm:^0.25.0"
+    eslint: "npm:^8.6.0"
+    eslint-config-prettier: "npm:^9.0.0"
+    eslint-formatter-friendly: "npm:^7.0.0"
+    eslint-plugin-deprecation: "npm:^3.0.0"
+    eslint-plugin-import: "npm:^2.31.0"
+    eslint-plugin-jest: "npm:^28.9.0"
+    eslint-plugin-jsx-a11y: "npm:^6.10.2"
+    eslint-plugin-react: "npm:^7.37.2"
+    eslint-plugin-react-hooks: "npm:^5.0.0"
+    eslint-plugin-unused-imports: "npm:^4.1.4"
+    eslint-rspack-plugin: "npm:^4.2.1"
+    express: "npm:^4.17.1"
+    fs-extra: "npm:^11.2.0"
+    git-url-parse: "npm:^15.0.0"
+    glob: "npm:^7.1.7"
+    global-agent: "npm:^3.0.0"
+    globby: "npm:^11.1.0"
+    handlebars: "npm:^4.7.3"
+    html-webpack-plugin: "npm:^5.6.3"
+    inquirer: "npm:^8.2.0"
+    jest: "npm:^29.7.0"
+    jest-cli: "npm:^29.7.0"
+    jest-css-modules: "npm:^2.1.0"
+    jest-environment-jsdom: "npm:^29.0.2"
+    jest-runtime: "npm:^29.0.2"
+    json-schema: "npm:^0.4.0"
+    lodash: "npm:^4.17.21"
+    minimatch: "npm:^9.0.0"
+    node-stdlib-browser: "npm:^1.3.1"
+    npm-packlist: "npm:^5.0.0"
+    ora: "npm:^5.3.0"
+    p-queue: "npm:^6.6.2"
+    pirates: "npm:^4.0.6"
+    postcss: "npm:^8.1.0"
+    process: "npm:^0.11.10"
+    raw-loader: "npm:^4.0.2"
+    react-dev-utils: "npm:^12.0.0-next.60"
+    react-refresh: "npm:^0.17.0"
+    recursive-readdir: "npm:^2.2.2"
+    replace-in-file: "npm:^7.1.0"
+    rollup: "npm:^4.27.3"
+    rollup-plugin-dts: "npm:^6.1.0"
+    rollup-plugin-esbuild: "npm:^6.1.1"
+    rollup-plugin-postcss: "npm:^4.0.0"
+    rollup-pluginutils: "npm:^2.8.2"
+    semver: "npm:^7.5.3"
+    style-loader: "npm:^3.3.1"
+    sucrase: "npm:^3.20.2"
+    swc-loader: "npm:^0.2.3"
+    tar: "npm:^6.1.12"
+    ts-checker-rspack-plugin: "npm:^1.1.5"
+    ts-morph: "npm:^24.0.0"
+    undici: "npm:^7.2.3"
+    util: "npm:^0.12.3"
+    yaml: "npm:^2.0.0"
+    yargs: "npm:^16.2.0"
+    yml-loader: "npm:^2.1.0"
+    yn: "npm:^4.0.0"
+    zod: "npm:^3.22.4"
+    zod-validation-error: "npm:^3.4.0"
+  peerDependencies:
+    "@module-federation/enhanced": ^0.9.0
+    "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
+    esbuild-loader: ^4.0.0
+    eslint-webpack-plugin: ^4.2.0
+    fork-ts-checker-webpack-plugin: ^9.0.0
+    mini-css-extract-plugin: ^2.4.2
+    terser-webpack-plugin: ^5.1.3
+    webpack: ~5.96.0
+    webpack-dev-server: ^5.0.0
+  peerDependenciesMeta:
+    "@module-federation/enhanced":
+      optional: true
+    "@pmmmwh/react-refresh-webpack-plugin":
+      optional: true
+    esbuild-loader:
+      optional: true
+    eslint-webpack-plugin:
+      optional: true
+    fork-ts-checker-webpack-plugin:
+      optional: true
+    mini-css-extract-plugin:
+      optional: true
+    terser-webpack-plugin:
+      optional: true
+    webpack:
+      optional: true
+    webpack-dev-server:
+      optional: true
+  bin:
+    backstage-cli: bin/backstage-cli
+  checksum: 10c0/1ab82d24f1f09796f89c12056fd16b291c4be1304e58c564a368e5192c716afaaedf8b9cd1ec0752a4de385e2390f4cedb3701ed27f2755047e1b7743d67c91d
+  languageName: node
+  linkType: hard
+
 "@backstage/config-loader@npm:^1.10.3":
   version: 1.10.4
   resolution: "@backstage/config-loader@npm:1.10.4"
@@ -2738,7 +2879,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:^1.10.7, @backstage/config-loader@npm:^1.9.1":
+"@backstage/config-loader@npm:^1.10.6, @backstage/config-loader@npm:^1.10.7, @backstage/config-loader@npm:^1.9.1":
   version: 1.10.7
   resolution: "@backstage/config-loader@npm:1.10.7"
   dependencies:
@@ -3315,6 +3456,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/eslint-plugin@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@backstage/eslint-plugin@npm:0.2.0"
+  dependencies:
+    "@manypkg/get-packages": "npm:^1.1.3"
+    minimatch: "npm:^9.0.0"
+  checksum: 10c0/7f57cd42629084b0363cf9adb37d33479fd540226a29705da623db9032890a6e67d1eb15b8076ea2fe3b502e36810ad819c93936406524e56e33801b561d6ff3
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-app-api@npm:^0.13.0":
   version: 0.13.0
   resolution: "@backstage/frontend-app-api@npm:0.13.0"
@@ -3754,7 +3905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration@npm:^1.17.1, @backstage/integration@npm:^1.19.2":
+"@backstage/integration@npm:^1.17.1, @backstage/integration@npm:^1.18.2, @backstage/integration@npm:^1.19.2":
   version: 1.19.2
   resolution: "@backstage/integration@npm:1.19.2"
   dependencies:
@@ -4439,6 +4590,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-catalog-node@npm:^1.16.1, @backstage/plugin-catalog-node@npm:^1.20.1":
+  version: 1.20.1
+  resolution: "@backstage/plugin-catalog-node@npm:1.20.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.6.0"
+    "@backstage/catalog-client": "npm:^1.12.1"
+    "@backstage/catalog-model": "npm:^1.7.6"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/plugin-catalog-common": "npm:^1.1.7"
+    "@backstage/plugin-permission-common": "npm:^0.9.3"
+    "@backstage/plugin-permission-node": "npm:^0.10.7"
+    "@backstage/types": "npm:^1.2.2"
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  checksum: 10c0/820e84dbc072e83eac57173702baa50b373e17665997c148dcb8e61a499145d023209ad5a100c61d1a877eef4e847956dc88de113fd45a6566be508a5533d9b5
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-node@npm:^1.19.1":
   version: 1.19.1
   resolution: "@backstage/plugin-catalog-node@npm:1.19.1"
@@ -4454,24 +4623,6 @@ __metadata:
     lodash: "npm:^4.17.21"
     yaml: "npm:^2.0.0"
   checksum: 10c0/a22684a34e1ebf15dcc72b900f97c2ca1a24ee5292e834e55354f4a4e2ead04d795650f2ea31f676c98ea5246bb97eaa73a51f9d4a74c4117fcd01eeb48bb4ba
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-catalog-node@npm:^1.20.1":
-  version: 1.20.1
-  resolution: "@backstage/plugin-catalog-node@npm:1.20.1"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.6.0"
-    "@backstage/catalog-client": "npm:^1.12.1"
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-catalog-common": "npm:^1.1.7"
-    "@backstage/plugin-permission-common": "npm:^0.9.3"
-    "@backstage/plugin-permission-node": "npm:^0.10.7"
-    "@backstage/types": "npm:^1.2.2"
-    lodash: "npm:^4.17.21"
-    yaml: "npm:^2.0.0"
-  checksum: 10c0/820e84dbc072e83eac57173702baa50b373e17665997c148dcb8e61a499145d023209ad5a100c61d1a877eef4e847956dc88de113fd45a6566be508a5533d9b5
   languageName: node
   linkType: hard
 
@@ -10645,6 +10796,17 @@ __metadata:
     "@backstage/config": "npm:1.3.4"
     "@backstage/plugin-permission-common": "npm:0.9.1"
     "@openchoreo/openchoreo-client-node": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
+"@openchoreo/backstage-plugin-jenkins-backend-conditional@workspace:^, @openchoreo/backstage-plugin-jenkins-backend-conditional@workspace:plugins/jenkins-backend-conditional":
+  version: 0.0.0-use.local
+  resolution: "@openchoreo/backstage-plugin-jenkins-backend-conditional@workspace:plugins/jenkins-backend-conditional"
+  dependencies:
+    "@backstage-community/plugin-jenkins-backend": "npm:^0.24.1"
+    "@backstage/backend-plugin-api": "npm:^1.1.1"
+    "@backstage/cli": "npm:^0.34.3"
+    "@backstage/plugin-catalog-node": "npm:^1.16.1"
   languageName: unknown
   linkType: soft
 
@@ -18665,6 +18827,7 @@ __metadata:
     "@openchoreo/backstage-plugin-backend": "workspace:^"
     "@openchoreo/backstage-plugin-catalog-backend-module": "workspace:^"
     "@openchoreo/backstage-plugin-catalog-backend-module-openchoreo-users": "workspace:^"
+    "@openchoreo/backstage-plugin-jenkins-backend-conditional": "workspace:^"
     "@openchoreo/backstage-plugin-openchoreo-ci-backend": "workspace:^"
     "@openchoreo/backstage-plugin-openchoreo-observability-backend": "workspace:^"
     "@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy": "workspace:^"


### PR DESCRIPTION
  Create a wrapper plugin that checks for jenkins.baseUrl config before
  initializing the Jenkins backend. This prevents "Jenkins configuration
  is missing" errors when Jenkins is not configured (e.g., when
  backstage.externalCI.jenkins.enabled=false in Helm)
