### PR TITLE
fix: prevent table creation race condition in AnnotationStore

### DIFF
--- a/plugins/catalog-backend-module-openchoreo/src/service/AnnotationStore.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/service/AnnotationStore.ts
@@ -49,7 +49,7 @@ export async function applyAnnotationStoreMigrations(
 ): Promise<void> {
   const hasTable = await knex.schema.hasTable(TABLE_NAME);
   if (!hasTable) {
-    await knex.schema.createTable(TABLE_NAME, table => {
+    await knex.schema.createTableIfNotExists(TABLE_NAME, table => {
       table.string('entity_ref', 255).notNullable();
       table.string('annotation_key', 255).notNullable();
       table.text('annotation_value').notNullable();


### PR DESCRIPTION
  The annotation store factory could be invoked concurrently by multiple
  plugins during startup. Both callers would pass the hasTable() check
  and attempt createTable(), causing the second to crash with
  "table entity_custom_annotations already exists". This crashed the
  container on first start, requiring a Kubernetes restart to recover.

  Use createTableIfNotExists to make the migration idempotent.