### PR TITLE
fix: change default owner to openchoreo-users in prod config

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -121,7 +121,7 @@ openchoreo:
 
   # Default owner for built-in Backstage entity kinds (Domain, System, Component, API)
   # Required by Backstage schema validation. Custom OpenChoreo kinds don't use owner.
-  defaultOwner: 'guests'
+  defaultOwner: 'openchoreo-users'
 
   schedule:
     frequency: 30 # seconds between runs (default: 30)


### PR DESCRIPTION
## Purpose

OpenChoreo does not have a concept for representing ownership of the resources in its Access Control implementation.
This default user is used as a placeholder value to make sure Backstage UI does not break due to missing ownershipt references, until we find a proper way to represent ownership in OpenChoreo side.

This PR will change the default user group to a hard-coded group called openchoreo-owners


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed the default owner for built-in Backstage entities in production from "guests" to "openchoreo-users". This updates the default ownership assignment for newly created or unassigned entities in the production environment, ensuring they are associated with the new default owner going forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->