### PR TITLE
fix: decouple openchoreo-clent-node from Backstage dependencies

### DIFF
--- a/packages/openchoreo-client-node/package.json
+++ b/packages/openchoreo-client-node/package.json
@@ -26,10 +26,20 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-plugin-api": "1.4.3",
-    "@backstage/config": "1.3.4",
     "json-schema": "0.4.0",
     "openapi-fetch": "0.13.8"
+  },
+  "peerDependencies": {
+    "@backstage/backend-plugin-api": ">=1.0.0",
+    "@backstage/config": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@backstage/backend-plugin-api": {
+      "optional": true
+    },
+    "@backstage/config": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@backstage/cli": "0.34.3",

--- a/packages/openchoreo-client-node/src/backstage.ts
+++ b/packages/openchoreo-client-node/src/backstage.ts
@@ -1,0 +1,52 @@
+/**
+ * Backstage-specific factory functions.
+ *
+ * Isolates the `@backstage/config` dependency so the core client
+ * can be consumed by non-Backstage projects.
+ *
+ * @packageDocumentation
+ */
+
+import { Config } from '@backstage/config';
+import type { Logger } from './logger';
+import { createOpenChoreoApiClient } from './factory';
+
+/**
+ * Creates OpenChoreo API clients from Backstage configuration
+ *
+ * @param config - Backstage Config object
+ * @param logger - Optional logger service
+ * @returns Object containing the main API client
+ *
+ * @example
+ * ```typescript
+ * // In your Backstage backend module
+ * const client = createOpenChoreoClientFromConfig(config, logger);
+ * const { data: projects } = await client.GET('/namespaces/{namespaceName}/projects', {
+ *   params: { path: { namespaceName: 'my-namespace' } }
+ * });
+ * ```
+ *
+ * @remarks
+ * Expects the following configuration in app-config.yaml:
+ * ```yaml
+ * openchoreo:
+ *   baseUrl: https://openchoreo.example.com
+ *   token: ${OPENCHOREO_TOKEN}
+ * ```
+ */
+export function createOpenChoreoClientFromConfig(
+  config: Config,
+  logger?: Logger,
+) {
+  const baseUrl = config.getString('openchoreo.baseUrl');
+  const token = config.getOptionalString('openchoreo.token');
+
+  logger?.info('Initializing OpenChoreo API client');
+
+  return createOpenChoreoApiClient({
+    baseUrl,
+    token,
+    logger,
+  });
+}

--- a/packages/openchoreo-client-node/src/factory.ts
+++ b/packages/openchoreo-client-node/src/factory.ts
@@ -4,8 +4,7 @@
  * @packageDocumentation
  */
 
-import { Config } from '@backstage/config';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import type { Logger } from './logger';
 import createClient, { type ClientOptions } from 'openapi-fetch';
 import type { paths as OpenChoreoPaths } from './generated/openchoreo/types';
 import type { paths as ObservabilityPaths } from './generated/observability/types';
@@ -37,7 +36,7 @@ export interface OpenChoreoClientConfig {
   /**
    * Optional logger for debugging
    */
-  logger?: LoggerService;
+  logger?: Logger;
 }
 
 /**
@@ -66,7 +65,7 @@ export interface OpenChoreoObservabilityClientConfig {
   /**
    * Optional logger for debugging
    */
-  logger?: LoggerService;
+  logger?: Logger;
 }
 
 /**
@@ -94,7 +93,7 @@ export interface OpenChoreoAIRCAAgentClientConfig {
   /**
    * Optional logger for debugging
    */
-  logger?: LoggerService;
+  logger?: Logger;
 }
 
 /**
@@ -247,46 +246,6 @@ export function createOpenChoreoAIRCAAgentApiClient(
 }
 
 /**
- * Creates OpenChoreo API clients from Backstage configuration
- *
- * @param config - Backstage Config object
- * @param logger - Optional logger service
- * @returns Object containing the main API client
- *
- * @example
- * ```typescript
- * // In your Backstage backend module
- * const client = createOpenChoreoClientFromConfig(config, logger);
- * const { data: projects } = await client.GET('/namespaces/{namespaceName}/projects', {
- *   params: { path: { namespaceName: 'my-namespace' } }
- * });
- * ```
- *
- * @remarks
- * Expects the following configuration in app-config.yaml:
- * ```yaml
- * openchoreo:
- *   baseUrl: https://openchoreo.example.com
- *   token: ${OPENCHOREO_TOKEN}
- * ```
- */
-export function createOpenChoreoClientFromConfig(
-  config: Config,
-  logger?: LoggerService,
-) {
-  const baseUrl = config.getString('openchoreo.baseUrl');
-  const token = config.getOptionalString('openchoreo.token');
-
-  logger?.info('Initializing OpenChoreo API client');
-
-  return createOpenChoreoApiClient({
-    baseUrl,
-    token,
-    logger,
-  });
-}
-
-/**
  * Helper function to create an observability client with a dynamically resolved base URL
  *
  * @param observerBaseUrl - The dynamically resolved observer URL
@@ -304,7 +263,7 @@ export function createOpenChoreoClientFromConfig(
 export function createObservabilityClientWithUrl(
   observerBaseUrl: string,
   token?: string,
-  logger?: LoggerService,
+  logger?: Logger,
 ) {
   return createOpenChoreoObservabilityApiClient({
     baseUrl: observerBaseUrl,

--- a/packages/openchoreo-client-node/src/index.ts
+++ b/packages/openchoreo-client-node/src/index.ts
@@ -6,17 +6,22 @@
  * @packageDocumentation
  */
 
+// Export logger interface
+export type { Logger } from './logger';
+
 // Export factory functions
 export {
   createOpenChoreoApiClient,
   createOpenChoreoObservabilityApiClient,
   createOpenChoreoAIRCAAgentApiClient,
-  createOpenChoreoClientFromConfig,
   createObservabilityClientWithUrl,
   type OpenChoreoClientConfig,
   type OpenChoreoObservabilityClientConfig,
   type OpenChoreoAIRCAAgentClientConfig,
 } from './factory';
+
+// Export Backstage-specific factory (requires @backstage/config peer dependency)
+export { createOpenChoreoClientFromConfig } from './backstage';
 
 // Export tracing utilities
 export {

--- a/packages/openchoreo-client-node/src/logger.ts
+++ b/packages/openchoreo-client-node/src/logger.ts
@@ -1,0 +1,15 @@
+/**
+ * Standalone logger interface for OpenChoreo API clients.
+ *
+ * Structurally compatible with Backstage LoggerService —
+ * existing callers can pass their LoggerService instance without changes.
+ *
+ * @packageDocumentation
+ */
+
+export interface Logger {
+  info(message: string): void;
+  debug(message: string): void;
+  error(message: string): void;
+  warn(message: string): void;
+}

--- a/packages/openchoreo-client-node/src/tracing.ts
+++ b/packages/openchoreo-client-node/src/tracing.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Middleware } from 'openapi-fetch';
-import type { LoggerService } from '@backstage/backend-plugin-api';
+import type { Logger } from './logger';
 
 /** Environment variable name to enable/disable tracing */
 export const TRACE_ENV_VAR = 'CHOREO_CLIENT_TRACE_ENABLED';
@@ -40,7 +40,7 @@ export function isTracingEnabled(): boolean {
  * client.use(createTracingMiddleware(logger));
  * ```
  */
-export function createTracingMiddleware(logger?: LoggerService): Middleware {
+export function createTracingMiddleware(logger?: Logger): Middleware {
   return {
     async onRequest({ request, schemaPath }) {
       if (!isTracingEnabled()) return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11032,14 +11032,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openchoreo/openchoreo-client-node@workspace:packages/openchoreo-client-node"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.3"
     "@backstage/cli": "npm:0.34.3"
-    "@backstage/config": "npm:1.3.4"
     "@openchoreo/openapi-client-generator-node": "workspace:^"
     json-schema: "npm:0.4.0"
     openapi-fetch: "npm:0.13.8"
     openapi-typescript: "npm:7.10.1"
     rimraf: "npm:5.0.10"
+  peerDependencies:
+    "@backstage/backend-plugin-api": ">=1.0.0"
+    "@backstage/config": ">=1.0.0"
+  peerDependenciesMeta:
+    "@backstage/backend-plugin-api":
+      optional: true
+    "@backstage/config":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
  Extract a standalone Logger interface and move the Backstage-specific
  createOpenChoreoClientFromConfig factory into a dedicated backstage.ts
  module, so the core client can be consumed by non-Backstage projects
  (e.g. the VSCode extension). Backstage packages are now optional peer
  dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a new logger abstraction interface enabling flexible logger implementations and better decoupling.
  * Restructured core dependencies as optional peer dependencies for streamlined package management.
  * Reorganized factory functions to isolate Backstage-specific configuration handling into a dedicated module for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->