### PR TITLE
feat(home): replace role-based home page logic with permission-based visibility

### DIFF
--- a/packages/app/src/components/Home/HomePage.tsx
+++ b/packages/app/src/components/Home/HomePage.tsx
@@ -2,65 +2,22 @@ import { Content, Page, Header } from '@backstage/core-components';
 import {
   HomePageRecentlyVisited,
   HomePageStarredEntities,
-  HomePageToolkit,
 } from '@backstage/plugin-home';
 import { HomePageSearchBar } from '@backstage/plugin-search';
 import { SearchContextProvider } from '@backstage/plugin-search-react';
 import { Grid, Typography, Box } from '@material-ui/core';
 import { useStyles } from './styles';
 import { useUserGroups } from '../../hooks';
+import { useNamespacePermission } from '@openchoreo/backstage-plugin-react';
 import { HomePagePlatformDetailsCard } from '@openchoreo/backstage-plugin-platform-engineer-core';
-import { MyProjectsWidget } from '@openchoreo/backstage-plugin';
-import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
-import ViewListIcon from '@material-ui/icons/ViewList';
-import AppsIcon from '@material-ui/icons/Apps';
-import FeaturedPlayListOutlinedIcon from '@material-ui/icons/FeaturedPlayListOutlined';
-import CreateNewFolderIcon from '@material-ui/icons/CreateNewFolder';
 
 /**
- * Toolkit tools for the home page
- */
-const toolkitTools = [
-  {
-    url: '/create/templates/default/create-openchoreo-component',
-    label: 'Create Component',
-    icon: <AddCircleOutlineIcon color="primary" />,
-  },
-  {
-    url: '/create/templates/default/create-openchoreo-project',
-    label: 'Create Project',
-    icon: <CreateNewFolderIcon color="primary" />,
-  },
-  {
-    url: '/catalog?filters[kind]=System&filters[user]=owned',
-    label: 'View My Projects',
-    icon: <ViewListIcon color="primary" />,
-  },
-  {
-    url: '/catalog?filters[kind]=Component&filters[user]=owned',
-    label: 'View My Components',
-    icon: <AppsIcon color="primary" />,
-  },
-  {
-    url: '/create',
-    label: 'Browse Templates',
-    icon: <FeaturedPlayListOutlinedIcon color="primary" />,
-  },
-];
-
-/**
- * Custom HomePage that shows different content based on user groups
+ * Custom HomePage that shows content based on user permissions
  */
 export const HomePage = () => {
   const classes = useStyles();
-  const { userGroups, userName, loading } = useUserGroups();
-
-  // Determine user role based on groups
-  const getUserRole = () => {
-    if (userGroups.includes('platformengineer')) return 'platformengineer';
-    if (userGroups.includes('developer')) return 'developer';
-    return 'user';
-  };
+  const { userName, loading } = useUserGroups();
+  const { canView: canViewPlatformDetails } = useNamespacePermission();
 
   if (loading) {
     return (
@@ -76,7 +33,7 @@ export const HomePage = () => {
   return (
     <SearchContextProvider>
       <Page themeId="home">
-        <Header title={`Welcome, ${userName}!`} subtitle={getUserRole()} />
+        <Header title={`Welcome, ${userName}!`} />
         <Content>
           <Grid container spacing={3}>
             {/* Search Bar */}
@@ -92,79 +49,30 @@ export const HomePage = () => {
               />
             </Grid>
 
-            {/* Platform Engineer: Starred and Recently Visited + Platform Details */}
-            {getUserRole() === 'platformengineer' && (
-              <>
-                <Grid item xs={12}>
-                  <Grid container spacing={3} alignItems="stretch">
-                    <Grid item xs={12} md={6} style={{ display: 'flex' }}>
-                      <Box className={classes.starredEntitiesWrapper}>
-                        <HomePageStarredEntities />
-                      </Box>
-                    </Grid>
-                    <Grid item xs={12} md={6} style={{ display: 'flex' }}>
-                      <Box className={classes.starredEntitiesWrapper}>
-                        <HomePageRecentlyVisited />
-                      </Box>
-                    </Grid>
-                  </Grid>
-                </Grid>
-                <Grid item xs={12}>
-                  <Box className={classes.platformDetailsSection}>
-                    <HomePagePlatformDetailsCard />
+            {/* Starred Entities and Recently Visited */}
+            <Grid item xs={12}>
+              <Grid container spacing={3} alignItems="stretch">
+                <Grid item xs={12} md={6} style={{ display: 'flex' }}>
+                  <Box className={classes.starredEntitiesWrapper}>
+                    <HomePageStarredEntities />
                   </Box>
                 </Grid>
-              </>
-            )}
+                <Grid item xs={12} md={6} style={{ display: 'flex' }}>
+                  <Box className={classes.starredEntitiesWrapper}>
+                    <HomePageRecentlyVisited />
+                  </Box>
+                </Grid>
+              </Grid>
+            </Grid>
 
-            {/* Recent Activity - Only for non-PE users (PEs have it above) */}
-            {getUserRole() !== 'platformengineer' && (
+            {/* Platform Details - visible only with namespace read permission */}
+            {canViewPlatformDetails && (
               <Grid item xs={12}>
                 <Box className={classes.platformDetailsSection}>
                   <HomePagePlatformDetailsCard />
                 </Box>
               </Grid>
             )}
-
-            {/* Recent Activity - Full-width, horizontal layout */}
-            <Grid item xs={12}>
-              <Typography
-                variant="h4"
-                color="secondary"
-                style={{ marginBottom: 16 }}
-              >
-                Recent Activity
-              </Typography>
-              <Grid container spacing={3}>
-                <Grid item xs={12} md={6}>
-                  <HomePageStarredEntities />
-                </Grid>
-                <Grid item xs={12} md={6}>
-                  <HomePageRecentlyVisited />
-                </Grid>
-              </Grid>
-            </Grid>
-
-            {/* Main content column */}
-            <Grid item xs={12} md={8}>
-              {/* Developer Overview Section */}
-              {getUserRole() === 'developer' && (
-                <Box className={classes.overviewSection}>
-                  <Typography variant="h3">Overview</Typography>
-                  <Grid container className={classes.widgetContainer}>
-                    <Grid item xs={12} md={5} sm={12}>
-                      <MyProjectsWidget />
-                    </Grid>
-                  </Grid>
-                </Box>
-              )}
-              {/* Toolkit - conditional based on role */}
-              {(userGroups.includes('admin') ||
-                userGroups.includes('manager') ||
-                userGroups.includes('developer')) && (
-                <HomePageToolkit title="Quick Actions" tools={toolkitTools} />
-              )}
-            </Grid>
           </Grid>
         </Content>
       </Page>

--- a/packages/app/src/components/Home/styles.ts
+++ b/packages/app/src/components/Home/styles.ts
@@ -1,105 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 export const useStyles = makeStyles(theme => ({
-  searchSection: {
-    display: 'flex',
-    marginBottom: theme.spacing(4),
-    justifyContent: 'center',
-    width: '100%',
-  },
-  searchPaper: {
-    padding: theme.spacing(1.5, 3), // More generous padding
-    display: 'flex',
-    alignItems: 'center',
-    width: theme.spacing(100),
-    backgroundColor: theme.palette.background.paper,
-    border: `2px solid ${theme.palette.grey[200]}`, // Slightly thicker, lighter border
-    borderRadius: theme.spacing(6), // Less extreme rounding for modern look
-    cursor: 'pointer',
-    transition: 'all 0.2s ease-in-out',
-    boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.05)', // Subtle shadow
-    '&:hover': {
-      borderColor: theme.palette.primary.light,
-      boxShadow:
-        '0 4px 6px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -1px rgba(0, 0, 0, 0.04)',
-      transform: 'translateY(-1px)',
-    },
-    '&:focus-within': {
-      borderColor: theme.palette.primary.main,
-      boxShadow: `0 0 0 3px ${theme.palette.primary.main}20, 0 4px 6px -1px rgba(0, 0, 0, 0.08)`,
-    },
-  },
-  searchPlaceholder: {
-    flex: 1,
-    fontSize: '1rem',
-    color: theme.palette.text.secondary,
-    marginLeft: theme.spacing(1),
-    cursor: 'pointer',
-  },
-  searchModal: {
-    '& .MuiDialog-paper': {
-      borderRadius: theme.shape.borderRadius * 2,
-      maxHeight: '80vh',
-    },
-  },
-  searchModalContent: {
-    padding: theme.spacing(2),
-    paddingBottom: theme.spacing(1),
-  },
-  searchModalHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    width: '100%',
-    gap: theme.spacing(2),
-    marginBottom: theme.spacing(2),
-    '& .MuiInputBase-root': {
-      flex: 1,
-      backgroundColor: theme.palette.background.default,
-      borderRadius: theme.shape.borderRadius,
-      padding: theme.spacing(1, 2),
-    },
-  },
-  searchModalClose: {
-    cursor: 'pointer',
-    color: theme.palette.text.secondary,
-    '&:hover': {
-      color: theme.palette.text.primary,
-    },
-  },
-  searchModalResults: {
-    maxHeight: '60vh',
-    overflow: 'auto',
-    '& .MuiList-root': {
-      padding: 0,
-    },
-    '& .MuiListItem-root': {
-      borderRadius: theme.shape.borderRadius,
-      marginBottom: theme.spacing(0.5),
-      '&:hover': {
-        backgroundColor: theme.palette.action.hover,
-      },
-    },
-  },
-  overviewSection: {
-    marginBottom: theme.spacing(4),
-  },
-  widgetContainer: {
-    display: 'flex',
-    gap: theme.spacing(4), // Increased from 3 to 4 for more breathing room
-    marginTop: theme.spacing(4), // Increased from 3 to 4
-    flexWrap: 'wrap',
-    '& > *': {
-      flex: '1 1 300px',
-      minWidth: '300px',
-    },
-    [theme.breakpoints.down('sm')]: {
-      flexDirection: 'column',
-      '& > *': {
-        flex: '1 1 auto',
-        minWidth: 'auto',
-      },
-    },
-  },
   platformDetailsSection: {
     marginBottom: theme.spacing(4),
   },
@@ -119,46 +20,6 @@ export const useStyles = makeStyles(theme => ({
       flexDirection: 'column',
     },
   },
-  quickActionsContainer: {
-    marginTop: theme.spacing(3),
-  },
-  quickActionCard: {
-    height: '100%',
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.spacing(1),
-    transition: 'all 0.2s ease-in-out',
-    '&:hover': {
-      borderColor: theme.palette.primary.main,
-      boxShadow: theme.shadows[4],
-      transform: 'translateY(-2px)',
-    },
-  },
-  quickActionCardAction: {
-    height: '100%',
-    display: 'flex',
-    alignItems: 'flex-start',
-    textDecoration: 'none',
-    '&:hover': {
-      textDecoration: 'none',
-    },
-  },
-  quickActionCardContent: {
-    width: '100%',
-    padding: theme.spacing(4), // Increased from 3 to 4 for more internal spacing
-  },
-  quickActionHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: theme.spacing(1),
-  },
-  quickActionTitle: {
-    fontWeight: 600,
-  },
-  quickActionIcon: {
-    color: theme.palette.text.secondary,
-    opacity: 0.6,
-  },
   searchBarInput: {
     maxWidth: '60vw',
     margin: 'auto',
@@ -168,21 +29,5 @@ export const useStyles = makeStyles(theme => ({
   },
   searchBarOutline: {
     borderStyle: 'none',
-  },
-  welcomeCard: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-  },
-  groupBadge: {
-    display: 'inline-block',
-    padding: '6px 14px', // More generous padding
-    margin: '4px',
-    borderRadius: '16px', // More rounded
-    backgroundColor: `${theme.palette.primary.light}30`, // Softer, translucent background
-    color: theme.palette.primary.dark,
-    fontSize: '0.875rem',
-    fontWeight: 500,
-    border: `1px solid ${theme.palette.primary.light}60`,
   },
 }));

--- a/plugins/openchoreo-react/src/hooks/useNamespacePermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useNamespacePermission.ts
@@ -1,0 +1,43 @@
+import { usePermission } from '@backstage/plugin-permission-react';
+import { openchoreoNamespaceReadPermission } from '@openchoreo/backstage-plugin-common';
+
+/**
+ * Result of the useNamespacePermission hook.
+ */
+export interface UseNamespacePermissionResult {
+  /** Whether the user has permission to view namespace/platform details */
+  canView: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+  /** Tooltip message for view permission denied (empty string when allowed/loading) */
+  deniedTooltip: string;
+}
+
+/**
+ * Hook for checking if the current user has permission to view namespace/platform details.
+ *
+ * This is an org-level permission (no resource context required).
+ *
+ * @example
+ * ```tsx
+ * const { canView, loading } = useNamespacePermission();
+ *
+ * if (loading) return <Skeleton />;
+ * if (!canView) return null;
+ * return <HomePagePlatformDetailsCard />;
+ * ```
+ */
+export const useNamespacePermission = (): UseNamespacePermissionResult => {
+  const { allowed: canView, loading } = usePermission({
+    permission: openchoreoNamespaceReadPermission,
+  });
+
+  return {
+    canView,
+    loading,
+    deniedTooltip:
+      !canView && !loading
+        ? 'You do not have permission to view platform details'
+        : '',
+  };
+};

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -207,6 +207,10 @@ export {
   type UseRoleMappingPermissionsResult,
 } from './hooks/useRoleMappingPermissions';
 export {
+  useNamespacePermission,
+  type UseNamespacePermissionResult,
+} from './hooks/useNamespacePermission';
+export {
   useAsyncOperation,
   type AsyncStatus,
   type AsyncState,


### PR DESCRIPTION
  Remove hardcoded PE/developer/user role switching from the home page.
  Platform Details Card is now gated by namespace.read permission instead
  of group membership. Remove duplicate Starred Entities and Recently
  Visited cards. Remove MyProjectsWidget and Quick Actions Toolkit
  (to be revisited with proper developer-focused cards later).

  - Create useNamespacePermission hook in openchoreo-react
  - Remove getUserRole() and all role-based conditional rendering
  - Remove unused styles and icon imports

<img width="1727" height="867" alt="image" src="https://github.com/user-attachments/assets/87642f50-8085-4fd5-9b33-fea9ebcd1a1c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-level permission gating controls visibility of the Platform Details card.

* **UI Updates**
  * Home page simplified and consolidated into a consistent two-column layout.
  * Removed role-specific sections and the toolkit area.
  * Starred Entities, Recently Visited, and search remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->