### PR TITLE
Sort generic workflow runs by created time by default

### DIFF
--- a/plugins/openchoreo-workflows/src/components/WorkflowDetailsPage/WorkflowDetailsPage.tsx
+++ b/plugins/openchoreo-workflows/src/components/WorkflowDetailsPage/WorkflowDetailsPage.tsx
@@ -115,6 +115,7 @@ export const WorkflowDetailsPage = () => {
     {
       title: 'Created',
       field: 'createdAt',
+      defaultSort: 'desc',
       render: (row: WorkflowRun) => formatRelativeTime(row.createdAt),
     },
     {


### PR DESCRIPTION
## Purpose
Sort generic workflow runs by created time by default

## Screenshot
<img width="1490" height="460" alt="image" src="https://github.com/user-attachments/assets/23b6f3a3-91e8-4e5e-b116-4c4bf68e13f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default sort order of the workflow runs table to display recently created workflows first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->