### PR TITLE
fix: namespace template entities by source OC namespace to avoid dedup

### DIFF
--- a/packages/app/src/components/scaffolder/CustomTemplateCard.tsx
+++ b/packages/app/src/components/scaffolder/CustomTemplateCard.tsx
@@ -88,6 +88,15 @@ export const CustomTemplateCard = ({
       </IconButton>
       <Box className={classes.resourceCardIcon}>{icon}</Box>
       <Typography className={classes.resourceCardTitle}>{title}</Typography>
+      {template.metadata.namespace &&
+        template.metadata.namespace !== 'default' && (
+          <Chip
+            label={template.metadata.namespace}
+            size="small"
+            variant="outlined"
+            className={classes.namespaceChip}
+          />
+        )}
       {description && (
         <Typography className={classes.resourceCardDescription}>
           {description}

--- a/packages/app/src/components/scaffolder/styles.ts
+++ b/packages/app/src/components/scaffolder/styles.ts
@@ -170,6 +170,13 @@ export const useStyles = makeStyles(theme => ({
     height: 24,
     fontSize: '0.75rem',
   },
+  namespaceChip: {
+    height: 22,
+    fontSize: '0.7rem',
+    marginTop: theme.spacing(0.75),
+    color: theme.palette.text.secondary,
+    borderColor: theme.palette.divider,
+  },
   cardDisabled: {
     opacity: 0.5,
     cursor: 'not-allowed',

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
@@ -10,7 +10,6 @@ describe('CtdToTemplateConverter', () => {
   beforeEach(() => {
     converter = new CtdToTemplateConverter({
       defaultOwner: 'test-owner',
-      namespace: 'test-namespace',
     });
   });
 
@@ -48,10 +47,8 @@ describe('CtdToTemplateConverter', () => {
       expect(result.kind).toBe('Template');
 
       // Check metadata
-      expect(result.metadata.name).toBe(
-        'template-test-namespace-simple-service',
-      );
-      expect(result.metadata.namespace).toBe('test-namespace');
+      expect(result.metadata.name).toBe('template-simple-service');
+      expect(result.metadata.namespace).toBe('test-org');
       expect(result.metadata.title).toBe('Simple Service');
       expect(result.metadata.description).toBe('A simple service for testing');
       // Tags are not generated (tag inference was removed)
@@ -610,7 +607,7 @@ describe('CtdToTemplateConverter', () => {
       );
 
       expect(result.spec?.owner).toBe('guests');
-      expect(result.metadata.namespace).toBe('openchoreo');
+      expect(result.metadata.namespace).toBe('test-org');
     });
   });
 });

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
@@ -29,10 +29,6 @@ export interface CtdConverterConfig {
    * Default owner for generated templates (required by Backstage Template kind schema)
    */
   defaultOwner?: string;
-  /**
-   * Namespace for template entity names
-   */
-  namespace?: string;
 }
 
 /**
@@ -40,11 +36,9 @@ export interface CtdConverterConfig {
  */
 export class CtdToTemplateConverter {
   private readonly defaultOwner: string;
-  private readonly namespace: string;
 
   constructor(config?: CtdConverterConfig) {
     this.defaultOwner = config?.defaultOwner || 'guests';
-    this.namespace = config?.namespace || 'openchoreo';
   }
 
   /**
@@ -67,7 +61,7 @@ export class CtdToTemplateConverter {
       kind: 'Template',
       metadata: {
         name: templateName,
-        namespace: this.namespace,
+        namespace: namespaceName,
         title,
         description,
         // tags,
@@ -108,10 +102,10 @@ export class CtdToTemplateConverter {
 
   /**
    * Generate template name from component type name
-   * Example: "web-service" -> "template-openchoreo-web-service"
+   * Example: "web-service" -> "template-web-service"
    */
   private generateTemplateName(componentTypeName: string): string {
-    return `template-${this.namespace}-${componentTypeName}`;
+    return `template-${componentTypeName}`;
   }
 
   /**

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -99,7 +99,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     // Initialize CTD to Template converter
     this.ctdConverter = new CtdToTemplateConverter({
       defaultOwner: this.defaultOwner,
-      namespace: 'openchoreo',
     });
     // Initialize component type utilities from config
     this.componentTypeUtils = ComponentTypeUtils.fromConfig(config);


### PR DESCRIPTION
  ComponentTypes with the same name in different OpenChoreo namespaces
  (e.g. default/service and testns/service) produced templates with
  identical Backstage entity identity, causing one to overwrite the other.

  Use the source OpenChoreo namespace as the template's metadata.namespace
  instead of hardcoding 'openchoreo', and simplify template name to drop
  the redundant namespace prefix. Also show a namespace chip on template
  cards for non-default namespaces to help users distinguish them.
  
  
<img width="1727" height="867" alt="Screenshot 2026-02-14 at 14 25 41" src="https://github.com/user-attachments/assets/784db3d7-d527-4393-b24f-4f1c6d1bd0c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template cards now display the template's namespace as a badge next to the title when a namespace exists and is not the default.

* **Refactor**
  * Updated internal template namespace handling to derive namespace context from conversion parameters rather than constructor configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->