### PR TITLE
fix: correct workflow parameters nesting and populate defaults

### DIFF
--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.ts
@@ -100,7 +100,7 @@ export function buildComponentResource(
 
     resource.spec.workflow = {
       name: input.workflowName,
-      ...workflowSchema, // Spread parameters and systemParameters directly
+      parameters: workflowSchema,
     };
 
     // Build systemParameters.repository from standalone fields


### PR DESCRIPTION
The scaffolder produced Component resources with broken workflow parameters in two ways:

1. Parameters were spread directly onto spec.workflow instead of nested under spec.workflow.parameters, causing CEL evaluation errors.

2. The API schema wraps developer params under a "parameters" key which RJSF preserved, creating double nesting (parameters.parameters.docker). Unwrap this before rendering so RJSF produces flat parameter data.

3. RJSF does not fire onChange on initial render, so users who accepted displayed defaults without editing got parameters: {}. Compute defaults from schema via createSchemaUtils on load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Developer parameters now render directly as individual form fields (no extra nesting).
  * Default values are reliably computed and populated on initial load and when switching workflows.

* **Improvements**
  * Workflow parameter handling and initialization flow refined for more consistent form behavior and predictable parameter payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->