### PR TITLE
style: update BuildEvents and BuildLogs font styles

### DIFF
--- a/plugins/openchoreo-ci/src/components/BuildEvents/styles.ts
+++ b/plugins/openchoreo-ci/src/components/BuildEvents/styles.ts
@@ -27,7 +27,7 @@ export const useStyles = makeStyles(theme => ({
   },
   eventsContainer: {
     flex: 'auto',
-    backgroundColor: theme.palette.background.default,
+    backgroundColor: theme.palette.type === 'dark' ? '#1e1e1e' : '#f5f5f5',
     minHeight: '200px',
     overflow: 'auto',
     border: `1px solid ${theme.palette.divider}`,
@@ -58,11 +58,17 @@ export const useStyles = makeStyles(theme => ({
   },
   tableCell: {
     fontSize: '12px',
+    fontFamily:
+      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+    lineHeight: '1.6',
   },
   messageCell: {
     maxWidth: 480,
     whiteSpace: 'normal',
     wordBreak: 'break-word',
     fontSize: '12px',
+    fontFamily:
+      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+    lineHeight: '1.6',
   },
 }));

--- a/plugins/openchoreo-ci/src/components/BuildLogs/styles.ts
+++ b/plugins/openchoreo-ci/src/components/BuildLogs/styles.ts
@@ -27,9 +27,11 @@ export const useStyles = makeStyles(theme => ({
   },
   logsContainer: {
     flex: 'auto',
-    backgroundColor: theme.palette.background.default,
-    fontFamily: 'monospace',
+    backgroundColor: theme.palette.type === 'dark' ? '#1e1e1e' : '#f5f5f5',
+    fontFamily:
+      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
     fontSize: '12px',
+    lineHeight: '1.6',
     minHeight: '300px',
     overflow: 'auto',
     border: `1px solid ${theme.palette.divider}`,
@@ -40,6 +42,10 @@ export const useStyles = makeStyles(theme => ({
   logText: {
     fontSize: '12px',
     color: theme.palette.text.primary,
+    fontFamily:
+      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+    lineHeight: '1.6',
+    marginBottom: theme.spacing(0.5),
   },
   noLogsText: {
     fontSize: '12px',


### PR DESCRIPTION
## Purpose
Related: https://github.com/openchoreo/openchoreo/issues/1474

This pull request updates the styling for build events and build logs components to improve readability and ensure a more consistent appearance across different themes. The main focus is on enhancing the background color handling for dark and light modes and standardizing the font to use a more legible monospace stack.

**Styling improvements for build logs and build events:**

* Background colors for `logsContainer` and `eventsContainer` are now explicitly set based on the theme's type, ensuring better support for dark and light modes. [[1]](diffhunk://#diff-3cae6afd59fedf9937139f5d15e612bf7b31c9723830518ec2cf76aab83ca78eL30-R34) [[2]](diffhunk://#diff-a071f45c55599dbd4bddfa03424586caa9cf41c02e37df9076b27b9701866dfaL30-R30)
* Font family for log and event text is updated to a comprehensive monospace stack for improved readability and consistency. [[1]](diffhunk://#diff-3cae6afd59fedf9937139f5d15e612bf7b31c9723830518ec2cf76aab83ca78eL30-R34) [[2]](diffhunk://#diff-3cae6afd59fedf9937139f5d15e612bf7b31c9723830518ec2cf76aab83ca78eR45-R48) [[3]](diffhunk://#diff-a071f45c55599dbd4bddfa03424586caa9cf41c02e37df9076b27b9701866dfaR61-R72)
* Added consistent `lineHeight` to log and event text for better spacing and legibility. [[1]](diffhunk://#diff-3cae6afd59fedf9937139f5d15e612bf7b31c9723830518ec2cf76aab83ca78eL30-R34) [[2]](diffhunk://#diff-3cae6afd59fedf9937139f5d15e612bf7b31c9723830518ec2cf76aab83ca78eR45-R48) [[3]](diffhunk://#diff-a071f45c55599dbd4bddfa03424586caa9cf41c02e37df9076b27b9701866dfaR61-R72)
## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
- Adjust background color based on theme type for better contrast.
- Set font family to a monospace type for table and message cells.
- Enhance line height for improved text legibility.
- Add margin to log text for better spacing.

Before:
<img width="1216" height="566" alt="image" src="https://github.com/user-attachments/assets/afbbad36-1414-4648-8c82-52f1e0222459" />

<img width="1228" height="564" alt="image" src="https://github.com/user-attachments/assets/1655c4f6-c4e2-4fca-8116-0d5a23f527d1" />

After:
<img width="1259" height="583" alt="image" src="https://github.com/user-attachments/assets/5647cb73-bf83-46cf-a4bf-874373cb7499" />

<img width="1238" height="585" alt="image" src="https://github.com/user-attachments/assets/31113804-c1d8-4177-99c3-98a0f7c54283" />


## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark and light theme support for build events and logs display with theme-aware background colors
  * Enhanced code readability with monospace font families applied to build event cells and log text
  * Refined typography with adjusted line heights and spacing for better log visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->