### PR TITLE
fix: remove branch filter from Jenkins overview card to support simple jobs

### DIFF
--- a/packages/app/src/components/catalog/WorkflowsOrExternalCICard.tsx
+++ b/packages/app/src/components/catalog/WorkflowsOrExternalCICard.tsx
@@ -40,10 +40,7 @@ export function WorkflowsOrExternalCICard() {
       <>
         <AnnotationGate annotation="jenkins.io/job-full-name">
           <Grid item md={4} xs={12}>
-            <EntityLatestJenkinsRunCard
-              branch="main,master"
-              variant="gridItem"
-            />
+            <EntityLatestJenkinsRunCard branch="" variant="gridItem" />
           </Grid>
         </AnnotationGate>
 


### PR DESCRIPTION

  The EntityLatestJenkinsRunCard was passing branch="main,master" which
  causes the backend to construct branch sub-paths (e.g. /job/oc-demo-build/job/main).
  This 404s for simple/freestyle Jenkins jobs that don't have branch sub-jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Jenkins run card no longer enforces an explicit branch filter; it now relies on default branch behavior.
  * Other external CI cards and fallback behavior remain unchanged, preserving existing integrations and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->