### PR TITLE
refactor: remove meaningless spec.type from platform entity kinds

### DIFF
--- a/plugins/catalog-backend-module-openchoreo/src/kinds/BuildPlaneEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/BuildPlaneEntityV1alpha1.ts
@@ -19,10 +19,6 @@ export interface BuildPlaneEntityV1alpha1 extends Entity {
    */
   spec: {
     /**
-     * The type of build plane (e.g., 'kubernetes')
-     */
-    type: string;
-    /**
      * The domain this build plane belongs to
      */
     domain?: string;

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/ComponentTypeEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/ComponentTypeEntityV1alpha1.ts
@@ -19,10 +19,6 @@ export interface ComponentTypeEntityV1alpha1 extends Entity {
    */
   spec: {
     /**
-     * The type of entity (always 'component-type')
-     */
-    type: string;
-    /**
      * The domain this component type belongs to
      */
     domain?: string;

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/ComponentWorkflowEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/ComponentWorkflowEntityV1alpha1.ts
@@ -19,10 +19,6 @@ export interface ComponentWorkflowEntityV1alpha1 extends Entity {
    */
   spec: {
     /**
-     * The type of entity (always 'component-workflow')
-     */
-    type: string;
-    /**
      * The domain this component workflow belongs to
      */
     domain?: string;

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/DataplaneEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/DataplaneEntityV1alpha1.ts
@@ -19,10 +19,6 @@ export interface DataplaneEntityV1alpha1 extends Entity {
    */
   spec: {
     /**
-     * The type of dataplane (e.g., 'kubernetes', 'cloud')
-     */
-    type: string;
-    /**
      * The domain this dataplane belongs to
      */
     domain?: string;

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/DeploymentPipelineEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/DeploymentPipelineEntityV1alpha1.ts
@@ -65,10 +65,6 @@ export interface DeploymentPipelineEntityV1alpha1 extends Entity {
    */
   spec: {
     /**
-     * The type of deployment pipeline (e.g., 'promotion-pipeline')
-     */
-    type: string;
-    /**
      * References to the parent projects/systems that use this pipeline
      */
     projectRefs?: string[];

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/ObservabilityPlaneEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/ObservabilityPlaneEntityV1alpha1.ts
@@ -19,10 +19,6 @@ export interface ObservabilityPlaneEntityV1alpha1 extends Entity {
    */
   spec: {
     /**
-     * The type of observability plane (e.g., 'kubernetes')
-     */
-    type: string;
-    /**
      * The domain this observability plane belongs to
      */
     domain?: string;

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/TraitTypeEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/TraitTypeEntityV1alpha1.ts
@@ -19,10 +19,6 @@ export interface TraitTypeEntityV1alpha1 extends Entity {
    */
   spec: {
     /**
-     * The type of entity (always 'trait-type')
-     */
-    type: string;
-    /**
      * The domain this trait type belongs to
      */
     domain?: string;

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/WorkflowEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/WorkflowEntityV1alpha1.ts
@@ -19,10 +19,6 @@ export interface WorkflowEntityV1alpha1 extends Entity {
    */
   spec: {
     /**
-     * The type of entity (always 'workflow')
-     */
-    type: string;
-    /**
      * The domain this workflow belongs to
      */
     domain?: string;

--- a/plugins/catalog-backend-module-openchoreo/src/processors/BuildPlaneEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/BuildPlaneEntityProcessor.ts
@@ -33,10 +33,6 @@ export class BuildPlaneEntityProcessor implements CatalogProcessor {
     emit: CatalogProcessorEmit,
   ): Promise<BuildPlaneEntityV1alpha1> {
     if (entity.kind === 'BuildPlane') {
-      if (!entity.spec?.type) {
-        throw new Error('BuildPlane entity must have spec.type');
-      }
-
       const sourceRef = {
         kind: entity.kind.toLowerCase(),
         namespace: entity.metadata.namespace || 'default',
@@ -109,12 +105,6 @@ export class BuildPlaneEntityProcessor implements CatalogProcessor {
     _location: LocationSpec,
     _emit: CatalogProcessorEmit,
   ): Promise<BuildPlaneEntityV1alpha1> {
-    if (entity.kind === 'BuildPlane' && entity.spec) {
-      if (!entity.spec.type) {
-        entity.spec.type = 'kubernetes';
-      }
-    }
-
     return entity;
   }
 

--- a/plugins/catalog-backend-module-openchoreo/src/processors/ComponentTypeEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/ComponentTypeEntityProcessor.ts
@@ -35,10 +35,6 @@ export class ComponentTypeEntityProcessor implements CatalogProcessor {
     emit: CatalogProcessorEmit,
   ): Promise<ComponentTypeEntityV1alpha1> {
     if (entity.kind === 'ComponentType') {
-      if (!entity.spec?.type) {
-        throw new Error('ComponentType entity must have spec.type');
-      }
-
       const sourceRef = {
         kind: entity.kind.toLowerCase(),
         namespace: entity.metadata.namespace || 'default',
@@ -106,12 +102,6 @@ export class ComponentTypeEntityProcessor implements CatalogProcessor {
     _location: LocationSpec,
     _emit: CatalogProcessorEmit,
   ): Promise<ComponentTypeEntityV1alpha1> {
-    if (entity.kind === 'ComponentType' && entity.spec) {
-      if (!entity.spec.type) {
-        entity.spec.type = 'component-type';
-      }
-    }
-
     return entity;
   }
 

--- a/plugins/catalog-backend-module-openchoreo/src/processors/ComponentWorkflowEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/ComponentWorkflowEntityProcessor.ts
@@ -31,10 +31,6 @@ export class ComponentWorkflowEntityProcessor implements CatalogProcessor {
     emit: CatalogProcessorEmit,
   ): Promise<ComponentWorkflowEntityV1alpha1> {
     if (entity.kind === 'ComponentWorkflow') {
-      if (!entity.spec?.type) {
-        throw new Error('ComponentWorkflow entity must have spec.type');
-      }
-
       const sourceRef = {
         kind: entity.kind.toLowerCase(),
         namespace: entity.metadata.namespace || 'default',
@@ -77,12 +73,6 @@ export class ComponentWorkflowEntityProcessor implements CatalogProcessor {
     _location: LocationSpec,
     _emit: CatalogProcessorEmit,
   ): Promise<ComponentWorkflowEntityV1alpha1> {
-    if (entity.kind === 'ComponentWorkflow' && entity.spec) {
-      if (!entity.spec.type) {
-        entity.spec.type = 'component-workflow';
-      }
-    }
-
     return entity;
   }
 

--- a/plugins/catalog-backend-module-openchoreo/src/processors/DataplaneEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/DataplaneEntityProcessor.ts
@@ -34,11 +34,6 @@ export class DataplaneEntityProcessor implements CatalogProcessor {
   ): Promise<DataplaneEntityV1alpha1> {
     // Validate required fields
     if (entity.kind === 'Dataplane') {
-      if (!entity.spec?.type) {
-        throw new Error('Dataplane entity must have spec.type');
-      }
-
-      // Emit relationships based on spec fields
       const sourceRef = {
         kind: entity.kind.toLowerCase(),
         namespace: entity.metadata.namespace || 'default',
@@ -111,14 +106,6 @@ export class DataplaneEntityProcessor implements CatalogProcessor {
     _location: LocationSpec,
     _emit: CatalogProcessorEmit,
   ): Promise<DataplaneEntityV1alpha1> {
-    // Set default values if needed
-    if (entity.kind === 'Dataplane' && entity.spec) {
-      // Set default type if not specified
-      if (!entity.spec.type) {
-        entity.spec.type = 'kubernetes';
-      }
-    }
-
     return entity;
   }
 

--- a/plugins/catalog-backend-module-openchoreo/src/processors/DeploymentPipelineEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/DeploymentPipelineEntityProcessor.ts
@@ -46,12 +46,6 @@ export class DeploymentPipelineEntityProcessor implements CatalogProcessor {
       return entity;
     }
 
-    // Validate required fields
-    if (!entity.spec?.type) {
-      throw new Error('DeploymentPipeline entity must have spec.type');
-    }
-
-    // Emit relationships based on spec fields
     const sourceRef = {
       kind: entity.kind.toLowerCase(),
       namespace: entity.metadata.namespace || 'default',
@@ -161,14 +155,6 @@ export class DeploymentPipelineEntityProcessor implements CatalogProcessor {
   ): Promise<Entity> {
     if (!isDeploymentPipelineEntity(entity)) {
       return entity;
-    }
-
-    // Set default values if needed
-    if (entity.spec) {
-      // Set default type if not specified
-      if (!entity.spec.type) {
-        entity.spec.type = 'promotion-pipeline';
-      }
     }
 
     return entity;

--- a/plugins/catalog-backend-module-openchoreo/src/processors/ObservabilityPlaneEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/ObservabilityPlaneEntityProcessor.ts
@@ -31,10 +31,6 @@ export class ObservabilityPlaneEntityProcessor implements CatalogProcessor {
     emit: CatalogProcessorEmit,
   ): Promise<ObservabilityPlaneEntityV1alpha1> {
     if (entity.kind === 'ObservabilityPlane') {
-      if (!entity.spec?.type) {
-        throw new Error('ObservabilityPlane entity must have spec.type');
-      }
-
       const sourceRef = {
         kind: entity.kind.toLowerCase(),
         namespace: entity.metadata.namespace || 'default',
@@ -77,12 +73,6 @@ export class ObservabilityPlaneEntityProcessor implements CatalogProcessor {
     _location: LocationSpec,
     _emit: CatalogProcessorEmit,
   ): Promise<ObservabilityPlaneEntityV1alpha1> {
-    if (entity.kind === 'ObservabilityPlane' && entity.spec) {
-      if (!entity.spec.type) {
-        entity.spec.type = 'kubernetes';
-      }
-    }
-
     return entity;
   }
 

--- a/plugins/catalog-backend-module-openchoreo/src/processors/TraitTypeEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/TraitTypeEntityProcessor.ts
@@ -29,10 +29,6 @@ export class TraitTypeEntityProcessor implements CatalogProcessor {
     emit: CatalogProcessorEmit,
   ): Promise<TraitTypeEntityV1alpha1> {
     if (entity.kind === 'TraitType') {
-      if (!entity.spec?.type) {
-        throw new Error('TraitType entity must have spec.type');
-      }
-
       const sourceRef = {
         kind: entity.kind.toLowerCase(),
         namespace: entity.metadata.namespace || 'default',
@@ -75,12 +71,6 @@ export class TraitTypeEntityProcessor implements CatalogProcessor {
     _location: LocationSpec,
     _emit: CatalogProcessorEmit,
   ): Promise<TraitTypeEntityV1alpha1> {
-    if (entity.kind === 'TraitType' && entity.spec) {
-      if (!entity.spec.type) {
-        entity.spec.type = 'trait-type';
-      }
-    }
-
     return entity;
   }
 

--- a/plugins/catalog-backend-module-openchoreo/src/processors/WorkflowEntityProcessor.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/WorkflowEntityProcessor.ts
@@ -29,10 +29,6 @@ export class WorkflowEntityProcessor implements CatalogProcessor {
     emit: CatalogProcessorEmit,
   ): Promise<WorkflowEntityV1alpha1> {
     if (entity.kind === 'Workflow') {
-      if (!entity.spec?.type) {
-        throw new Error('Workflow entity must have spec.type');
-      }
-
       const sourceRef = {
         kind: entity.kind.toLowerCase(),
         namespace: entity.metadata.namespace || 'default',
@@ -75,12 +71,6 @@ export class WorkflowEntityProcessor implements CatalogProcessor {
     _location: LocationSpec,
     _emit: CatalogProcessorEmit,
   ): Promise<WorkflowEntityV1alpha1> {
-    if (entity.kind === 'Workflow' && entity.spec) {
-      if (!entity.spec.type) {
-        entity.spec.type = 'workflow';
-      }
-    }
-
     return entity;
   }
 

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -1789,7 +1789,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'kubernetes',
         // Domain entities (mapped from OpenChoreo namespaces) live in the Backstage 'default' namespace
         domain: `default/${namespaceName}`,
         publicVirtualHost: dataplane.publicVirtualHost,
@@ -1843,7 +1842,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'kubernetes',
         domain: `default/${namespaceName}`,
         observabilityPlaneRef: this.normalizeObservabilityPlaneRef(
           buildplane.observabilityPlaneRef,
@@ -1889,7 +1887,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'kubernetes',
         domain: `default/${namespaceName}`,
         observerURL: obsplane.observerURL,
       },
@@ -2006,7 +2003,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'promotion-pipeline',
         projectRefs: [projectName],
         namespaceName: namespaceName,
         promotionPaths,
@@ -2269,7 +2265,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'workflow',
         domain: `default/${namespaceName}`,
       },
     };
@@ -2368,7 +2363,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'kubernetes',
         domain: `default/${namespaceName}`,
         publicVirtualHost: gateway?.publicVirtualHost,
         namespaceVirtualHost: gateway?.organizationVirtualHost,
@@ -2419,7 +2413,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'kubernetes',
         domain: `default/${namespaceName}`,
         observabilityPlaneRef: normalizedObsRef,
       },
@@ -2461,7 +2454,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'kubernetes',
         domain: `default/${namespaceName}`,
         observerURL: op.spec?.observerURL,
       },
@@ -2625,7 +2617,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'promotion-pipeline',
         projectRefs: projectName ? [projectName] : [],
         namespaceName: namespaceName,
         promotionPaths,
@@ -2702,7 +2693,6 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'workflow',
         domain: `default/${namespaceName}`,
       },
     };

--- a/plugins/catalog-backend-module-openchoreo/src/utils/entityTranslation.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/utils/entityTranslation.ts
@@ -299,7 +299,6 @@ export function translateComponentTypeToEntity(
       },
     },
     spec: {
-      type: 'component-type',
       domain: `default/${namespaceName}`,
       workloadType: ct.workloadType,
       allowedWorkflows: ct.allowedWorkflows,
@@ -342,7 +341,6 @@ export function translateTraitToEntity(
       },
     },
     spec: {
-      type: 'trait-type',
       domain: `default/${namespaceName}`,
     },
   };
@@ -382,7 +380,6 @@ export function translateComponentWorkflowToEntity(
       },
     },
     spec: {
-      type: 'component-workflow',
       domain: `default/${namespaceName}`,
     },
   };


### PR DESCRIPTION
  The hardcoded types like 'kubernetes', 'workflow', 'component-type',
  etc. provided no useful information. Remove spec.type from kind
  interfaces, processor defaults/validation, entity provider, and
  translation utils. Environment is kept as its type (production/
  non-production) is meaningful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the spec.type field from entity specifications for Dataplane, BuildPlane, ObservabilityPlane, DeploymentPipeline, Workflow, ComponentType, TraitType, and ComponentWorkflow.
  * Removed runtime validation and automatic defaulting of spec.type during entity processing and translation, changing the emitted entity shapes; downstream code should no longer rely on spec.type being present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->