### PR TITLE
feat: hide Docs tab when backstage.io/techdocs-ref annotation is missing

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -149,6 +149,9 @@ const hasGitlabAnnotation = (entity: Entity) =>
       entity.metadata.annotations?.['gitlab.com/project-id'],
   );
 
+const hasTechdocsAnnotation = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.['backstage.io/techdocs-ref']);
+
 const techdocsContent = (
   <EntityTechdocsContent>
     <TechDocsAddons>
@@ -288,7 +291,7 @@ const serviceEntityPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="/docs" title="Docs" if={hasTechdocsAnnotation}>
       {techdocsContent}
     </EntityLayout.Route>
 
@@ -370,7 +373,7 @@ const genericComponentEntityPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="/docs" title="Docs" if={hasTechdocsAnnotation}>
       {techdocsContent}
     </EntityLayout.Route>
 
@@ -410,7 +413,7 @@ const defaultEntityPage = (
       <OverviewContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="/docs" title="Docs" if={hasTechdocsAnnotation}>
       {techdocsContent}
     </EntityLayout.Route>
   </EntityLayout>


### PR DESCRIPTION
  Add hasTechdocsAnnotation predicate and apply it to all three Docs
  routes (service, generic component, default) so the tab is only
  shown for entities that actually have TechDocs configured.

https://github.com/user-attachments/assets/ce7c8ff0-868e-4409-b629-35ef4f6dd168



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docs tab visibility on entity pages to only display when technical documentation is available, improving the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->