### PR TITLE
feat: simplify workload to have single container

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-api-legacy.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api-legacy.yaml
@@ -1148,10 +1148,8 @@ components:
         spec:
           type: object
           additionalProperties: true
-        containers:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/Container'
+        container:
+          $ref: '#/components/schemas/Container'
         endpoints:
           type: object
           additionalProperties:
@@ -1291,10 +1289,8 @@ components:
     WorkloadOverrides:
       type: object
       properties:
-        containers:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/ContainerOverride'
+        container:
+          $ref: '#/components/schemas/ContainerOverride'
 
     ContainerOverride:
       type: object

--- a/packages/openchoreo-client-node/src/generated/openchoreo-legacy/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo-legacy/types.ts
@@ -1895,9 +1895,7 @@ export interface components {
       spec?: {
         [key: string]: unknown;
       };
-      containers?: {
-        [key: string]: components['schemas']['Container'];
-      };
+      container?: components['schemas']['Container'];
       endpoints?: {
         [key: string]: components['schemas']['WorkloadEndpoint'];
       };
@@ -1973,9 +1971,7 @@ export interface components {
       workloadOverrides?: components['schemas']['WorkloadOverrides'];
     };
     WorkloadOverrides: {
-      containers?: {
-        [key: string]: components['schemas']['ContainerOverride'];
-      };
+      container?: components['schemas']['ContainerOverride'];
     };
     ContainerOverride: {
       env?: components['schemas']['EnvVar'][];

--- a/plugins/openchoreo-react/src/utils/envVarUtils.ts
+++ b/plugins/openchoreo-react/src/utils/envVarUtils.ts
@@ -87,9 +87,8 @@ export function mergeEnvVarsWithStatus(
  */
 export function getBaseEnvVarsForContainer(
   baseWorkload: ModelsWorkload | null,
-  containerName: string,
 ): EnvVar[] {
-  return baseWorkload?.containers?.[containerName]?.env || [];
+  return baseWorkload?.container?.env || [];
 }
 
 /**

--- a/plugins/openchoreo-react/src/utils/fileVarUtils.ts
+++ b/plugins/openchoreo-react/src/utils/fileVarUtils.ts
@@ -89,9 +89,8 @@ export function mergeFileVarsWithStatus(
  */
 export function getBaseFileVarsForContainer(
   baseWorkload: ModelsWorkload | null,
-  containerName: string,
 ): FileVar[] {
-  return (baseWorkload?.containers?.[containerName] as any)?.files || [];
+  return (baseWorkload?.container as any)?.files || [];
 }
 
 /**

--- a/plugins/openchoreo/src/components/Environments/EnvironmentOverridesPage.tsx
+++ b/plugins/openchoreo/src/components/Environments/EnvironmentOverridesPage.tsx
@@ -306,277 +306,129 @@ export const EnvironmentOverridesPage = ({
     }
   }, [loading, formState.baseWorkloadData, tabs, activeTab, setActiveTab]);
 
-  // Workload container management functions
-  const handleContainerChange = (
-    containerName: string,
-    field: string,
-    value: any,
-  ) => {
+  // Workload container management functions.
+  const handleContainerChange = (field: string, value: any) => {
     setWorkloadFormData((prev: any) => ({
       ...prev,
-      containers: {
-        ...prev.containers,
-        [containerName]: {
-          ...(prev.containers?.[containerName] || {}),
-          [field]: value,
-        },
-      },
+      container: { ...(prev.container || {}), [field]: value },
     }));
   };
 
   const handleEnvVarChange = (
-    containerName: string,
     envIndex: number,
     field: string,
     value: string,
   ) => {
     setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const env = container.env || [];
-      const updatedEnv = [...env];
-      if (!updatedEnv[envIndex]) {
-        updatedEnv[envIndex] = {};
-      }
-      updatedEnv[envIndex] = {
-        ...updatedEnv[envIndex],
-        [field]: value,
-      };
-      return {
-        ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            env: updatedEnv,
-          },
-        },
-      };
+      const container = prev.container || {};
+      const env = [...(container.env || [])];
+      env[envIndex] = { ...env[envIndex], [field]: value };
+      return { ...prev, container: { ...container, env } };
     });
   };
 
-  const handleEnvVarReplace = (
-    containerName: string,
-    envIndex: number,
-    envVar: EnvVar,
-  ) => {
+  const handleEnvVarReplace = (envIndex: number, envVar: EnvVar) => {
     setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const env = container.env || [];
-      const updatedEnv = [...env];
-      updatedEnv[envIndex] = envVar;
-      return {
-        ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            env: updatedEnv,
-          },
-        },
-      };
+      const container = prev.container || {};
+      const env = [...(container.env || [])];
+      env[envIndex] = envVar;
+      return { ...prev, container: { ...container, env } };
     });
   };
 
   const handleFileVarChange = (
-    containerName: string,
     fileIndex: number,
     field: string,
     value: string,
   ) => {
     setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const files = (container as any).files || [];
-      const updatedFiles = [...files];
-      if (!updatedFiles[fileIndex]) {
-        updatedFiles[fileIndex] = {};
-      }
-      updatedFiles[fileIndex] = {
-        ...updatedFiles[fileIndex],
-        [field]: value,
-      };
+      const container = prev.container || {};
+      const files = [...((container.files as any[]) || [])];
+      files[fileIndex] = { ...files[fileIndex], [field]: value };
+      return { ...prev, container: { ...container, files } };
+    });
+  };
+
+  const handleAddEnvVar = () => {
+    setWorkloadFormData((prev: any) => {
+      const container = prev.container || {};
       return {
         ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            files: updatedFiles,
-          },
+        container: {
+          ...container,
+          env: [...(container.env || []), { key: '', value: '' }],
         },
       };
     });
   };
 
-  const handleAddContainer = () => {
-    const containerNames = Object.keys(
-      formState.workloadFormData.containers || {},
-    );
-    const newName =
-      containerNames.length === 0
-        ? 'main'
-        : `container-${containerNames.length}`;
-    setWorkloadFormData((prev: any) => ({
-      ...prev,
-      containers: {
-        ...prev.containers,
-        [newName]: {
-          image: '',
-          env: [],
-          files: [],
-        },
-      },
-    }));
-  };
-
-  const handleRemoveContainer = (containerName: string) => {
+  const handleRemoveEnvVar = (envIndex: number) => {
     setWorkloadFormData((prev: any) => {
-      const containers = { ...prev.containers };
-      delete containers[containerName];
-      return {
-        ...prev,
-        containers,
-      };
-    });
-  };
-
-  const handleAddEnvVar = (containerName: string) => {
-    setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const env = container.env || [];
-      return {
-        ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            env: [...env, { key: '', value: '' }],
-          },
-        },
-      };
-    });
-  };
-
-  const handleRemoveEnvVar = (containerName: string, envIndex: number) => {
-    setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const env = container.env || [];
-      const updatedEnv = env.filter(
+      const container = prev.container || {};
+      const env = (container.env || []).filter(
         (_: any, index: number) => index !== envIndex,
       );
+      return { ...prev, container: { ...container, env } };
+    });
+  };
+
+  const handleAddFileVar = () => {
+    setWorkloadFormData((prev: any) => {
+      const container = prev.container || {};
       return {
         ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            env: updatedEnv,
-          },
+        container: {
+          ...container,
+          files: [
+            ...((container.files as any[]) || []),
+            { key: '', mountPath: '', value: '' },
+          ],
         },
       };
     });
   };
 
-  const handleAddFileVar = (containerName: string) => {
+  const handleRemoveFileVar = (fileIndex: number) => {
     setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const files = (container as any).files || [];
-      return {
-        ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            files: [...files, { key: '', mountPath: '', value: '' }],
-          },
-        },
-      };
-    });
-  };
-
-  const handleRemoveFileVar = (containerName: string, fileIndex: number) => {
-    setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const files = (container as any).files || [];
-      const updatedFiles = files.filter(
+      const container = prev.container || {};
+      const files = ((container.files as any[]) || []).filter(
         (_: any, index: number) => index !== fileIndex,
       );
-      return {
-        ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            files: updatedFiles,
-          },
-        },
-      };
+      return { ...prev, container: { ...container, files } };
     });
   };
 
-  const handleArrayFieldChange = (
-    containerName: string,
-    field: string,
-    value: string,
-  ) => {
+  const handleArrayFieldChange = (field: string, value: string) => {
     const arrayValue = value
       .split(',')
       .map((item: string) => item.trim())
       .filter((item: string) => item);
     setWorkloadFormData((prev: any) => ({
       ...prev,
-      containers: {
-        ...prev.containers,
-        [containerName]: {
-          ...(prev.containers?.[containerName] || {}),
-          [field]: arrayValue,
-        },
-      },
+      container: { ...(prev.container || {}), [field]: arrayValue },
     }));
   };
 
   // Handle starting override of an inherited env var
-  const handleStartOverride = (containerName: string, envVar: EnvVar) => {
+  const handleStartOverride = (envVar: EnvVar) => {
     setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const existingEnv = container.env || [];
-
-      // Check if already overridden
-      if (existingEnv.some((e: EnvVar) => e.key === envVar.key)) {
-        return prev;
-      }
-
+      const container = prev.container || {};
+      const existingEnv: EnvVar[] = container.env || [];
+      if (existingEnv.some((e: EnvVar) => e.key === envVar.key)) return prev;
       return {
         ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            env: [...existingEnv, { ...envVar }],
-          },
-        },
+        container: { ...container, env: [...existingEnv, { ...envVar }] },
       };
     });
   };
 
   // Handle starting override of an inherited file var
   const handleStartFileOverride = (
-    containerName: string,
     fileVar: import('@openchoreo/backstage-plugin-common').FileVar,
   ) => {
     setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const existingFiles = (container as any).files || [];
-
-      // Check if already overridden
+      const container = prev.container || {};
+      const existingFiles: any[] = (container.files as any[]) || [];
       if (
         existingFiles.some(
           (f: import('@openchoreo/backstage-plugin-common').FileVar) =>
@@ -585,42 +437,23 @@ export const EnvironmentOverridesPage = ({
       ) {
         return prev;
       }
-
       return {
         ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            files: [...existingFiles, { ...fileVar }],
-          },
-        },
+        container: { ...container, files: [...existingFiles, { ...fileVar }] },
       };
     });
   };
 
   // Handle replacing an entire file var at once (atomic update)
   const handleFileVarReplace = (
-    containerName: string,
     fileIndex: number,
     fileVar: import('@openchoreo/backstage-plugin-common').FileVar,
   ) => {
     setWorkloadFormData((prev: any) => {
-      const containers = prev.containers || {};
-      const container = containers[containerName] || {};
-      const files = (container as any).files || [];
-      const updatedFiles = [...files];
-      updatedFiles[fileIndex] = fileVar;
-      return {
-        ...prev,
-        containers: {
-          ...containers,
-          [containerName]: {
-            ...container,
-            files: updatedFiles,
-          },
-        },
-      };
+      const container = prev.container || {};
+      const files = [...((container.files as any[]) || [])];
+      files[fileIndex] = fileVar;
+      return { ...prev, container: { ...container, files } };
     });
   };
 
@@ -908,21 +741,18 @@ export const EnvironmentOverridesPage = ({
           hasInitialData={initialOverrides.hasWorkloadOverrides}
           customContent={
             <ContainerContent
-              containers={formState.workloadFormData.containers || {}}
+              container={formState.workloadFormData.container}
               onContainerChange={handleContainerChange}
               onEnvVarChange={handleEnvVarChange}
               onEnvVarReplace={handleEnvVarReplace}
               onFileVarChange={handleFileVarChange}
               onFileVarReplace={handleFileVarReplace}
-              onAddContainer={handleAddContainer}
-              onRemoveContainer={handleRemoveContainer}
               onAddEnvVar={handleAddEnvVar}
               onRemoveEnvVar={handleRemoveEnvVar}
               onAddFileVar={handleAddFileVar}
               onRemoveFileVar={handleRemoveFileVar}
               onArrayFieldChange={handleArrayFieldChange}
               disabled={saving || deleting || loading}
-              singleContainerMode
               hideContainerFields
               secretReferences={secretReferences}
               baseWorkloadData={formState.baseWorkloadData}

--- a/plugins/openchoreo/src/components/Environments/Workload/WorkloadSaveConfirmationDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/Workload/WorkloadSaveConfirmationDialog.tsx
@@ -28,10 +28,10 @@ export const WorkloadSaveConfirmationDialog: FC<
   const sections: ChangesSection[] = useMemo(() => {
     const result: ChangesSection[] = [];
 
-    if (changes.containers.length > 0) {
+    if (changes.container.length > 0) {
       result.push({
-        title: 'Containers',
-        changes: changes.containers,
+        title: 'Container',
+        changes: changes.container,
       });
     }
 

--- a/plugins/openchoreo/src/components/Environments/Workload/hooks/useWorkloadChanges.ts
+++ b/plugins/openchoreo/src/components/Environments/Workload/hooks/useWorkloadChanges.ts
@@ -9,8 +9,8 @@ import type { ModelsWorkload } from '@openchoreo/backstage-plugin-common';
  * Workload changes grouped by section
  */
 export interface WorkloadChanges {
-  /** Changes in containers (env vars, files, images, etc.) */
-  containers: Change[];
+  /** Changes in container (env vars, files, images, etc.) */
+  container: Change[];
   /** Changes in endpoints */
   endpoints: Change[];
   /** Changes in connections */
@@ -34,10 +34,10 @@ export function useWorkloadChanges(
   currentWorkload: ModelsWorkload | null,
 ): WorkloadChanges {
   return useMemo(() => {
-    // Compare containers
+    // Compare container (single container, wrapped for deepCompareObjects)
     const containerChanges = deepCompareObjects(
-      initialWorkload?.containers || {},
-      currentWorkload?.containers || {},
+      initialWorkload?.container || {},
+      currentWorkload?.container || {},
     );
 
     // Compare endpoints
@@ -58,35 +58,11 @@ export function useWorkloadChanges(
       connectionChanges.length;
 
     return {
-      containers: containerChanges,
+      container: containerChanges,
       endpoints: endpointChanges,
       connections: connectionChanges,
       total,
       hasChanges: total > 0,
     };
   }, [initialWorkload, currentWorkload]);
-}
-
-/**
- * Get changes for a specific container
- */
-export function getContainerChanges(
-  changes: WorkloadChanges,
-  containerName: string,
-): Change[] {
-  return changes.containers.filter(
-    c =>
-      c.path.startsWith(containerName) ||
-      c.path.startsWith(`${containerName}.`),
-  );
-}
-
-/**
- * Check if a specific container has changes
- */
-export function hasContainerChanges(
-  changes: WorkloadChanges,
-  containerName: string,
-): boolean {
-  return getContainerChanges(changes, containerName).length > 0;
 }

--- a/plugins/openchoreo/src/components/Environments/wrappers/WorkloadConfigWrapper.tsx
+++ b/plugins/openchoreo/src/components/Environments/wrappers/WorkloadConfigWrapper.tsx
@@ -14,8 +14,8 @@ export const WorkloadConfigWrapper = () => {
   const { lowestEnvironment } = useEnvironmentsContext();
   const { navigateToList, navigateToOverrides } = useEnvironmentRouting();
 
-  // Get active tab from URL (containers, endpoints, connections)
-  const activeTab = searchParams.get('tab') || 'containers';
+  // Get active tab from URL (container, endpoints, connections)
+  const activeTab = searchParams.get('tab') || 'container';
 
   // Handle tab change - update URL
   // When replace is true (default tab initialization), don't add to history

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.test.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.test.ts
@@ -254,7 +254,7 @@ describe('buildWorkloadResource', () => {
     expect(result.metadata.namespace).toBe('default');
     expect(result.spec.owner.projectName).toBe('my-project');
     expect(result.spec.owner.componentName).toBe('my-service');
-    expect(result.spec.containers.main.image).toBe('nginx:latest');
+    expect(result.spec.container?.image).toBe('nginx:latest');
     expect(result.spec.endpoints).toBeUndefined();
   });
 

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.ts
@@ -191,26 +191,25 @@ export function buildWorkloadResource(
         projectName: input.projectName,
         componentName: input.componentName,
       },
-      containers: {},
     },
   };
 
   if (hasImage) {
-    const mainContainer: Record<string, any> = {
+    const container: Record<string, any> = {
       image: input.containerImage,
     };
 
     // Add environment variables
     if (input.envVars && input.envVars.length > 0) {
-      mainContainer.env = input.envVars;
+      container.env = input.envVars;
     }
 
     // Add file mounts
     if (input.fileMounts && input.fileMounts.length > 0) {
-      mainContainer.files = input.fileMounts;
+      container.files = input.fileMounts;
     }
 
-    resource.spec.containers = { main: mainContainer };
+    resource.spec.container = container;
   }
 
   // Add endpoints from the new endpoints map

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceInterface.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceInterface.ts
@@ -130,7 +130,7 @@ export interface WorkloadEndpoint {
  */
 export interface WorkloadSpec {
   owner: WorkloadOwner;
-  containers: Record<string, WorkloadContainer>;
+  container?: WorkloadContainer;
   endpoints?: Record<string, WorkloadEndpoint>;
 }
 


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/2001

This pull request refactors the workload configuration and override logic throughout the OpenChoreo frontend and OpenAPI schema to support only a single container per workload, rather than a map of multiple containers. This simplifies the data model, UI components, and API definitions, making the codebase easier to maintain and reducing unnecessary complexity.

The most important changes are:

**OpenAPI Schema Changes:**

* Updated `openchoreo-api-legacy.yaml` to replace `containers` (object map) with a single `container` field in both the `WorkloadSpec` and `WorkloadOverrides` schemas, aligning the API with the new single-container model. [[1]](diffhunk://#diff-778a8622e9a8c512370d2d913085e102f08203e29385e41d58a2a4ae23c3e5f3L1151-R1151) [[2]](diffhunk://#diff-778a8622e9a8c512370d2d913085e102f08203e29385e41d58a2a4ae23c3e5f3L1294-R1292)

**Frontend Data Model & Logic:**

* Refactored state and update logic in `EnvironmentOverridesPage.tsx` to use a single `container` object instead of a `containers` map, simplifying all related handler functions for environment variables and file mounts. [[1]](diffhunk://#diff-6694c8a49b3b70a36e586f9fbfb01d9b95ccdff12d5cbcb014c0db21b2816deaL309-R423) [[2]](diffhunk://#diff-6694c8a49b3b70a36e586f9fbfb01d9b95ccdff12d5cbcb014c0db21b2816deaL588-R448)
* Updated utility functions in `envVarUtils.ts` and `fileVarUtils.ts` to reference `container` directly, removing the need to look up by container name. [[1]](diffhunk://#diff-f930d88b36fae9fbf3211aba06b55473b215410e73226948a8b79dccbd43ffd1L92-R92) [[2]](diffhunk://#diff-cb7fa6a17c802cf20fcd0dbcef7d06ef25053e8aa4086d7e18ce5ded98019459L94-R94)

**UI Component Simplification:**

* Rewrote `ContainerContent` and related prop interfaces to operate on a single `container` rather than a map of containers, and removed all logic and UI for adding/removing multiple containers. [[1]](diffhunk://#diff-515d05d5f8aa46e0013d87cd83700ed2d6de055a1c8b0e49606226b9b81efb0eR33-L81) [[2]](diffhunk://#diff-515d05d5f8aa46e0013d87cd83700ed2d6de055a1c8b0e49606226b9b81efb0eL93-R74) [[3]](diffhunk://#diff-515d05d5f8aa46e0013d87cd83700ed2d6de055a1c8b0e49606226b9b81efb0eL121-L146)
* Updated all usages of `ContainerContent` to pass the single `container` prop and simplified callback signatures accordingly.

**Workload Initialization:**

* When initializing a new workload (e.g., for pre-built images), explicitly sets up a default single-container structure in the workload spec to ensure the editor renders correctly.

These changes collectively enforce and streamline the single-container-per-workload approach across both the backend schema and the frontend UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * UI and flows converted from multi-container to a single-container model for a simpler editing experience.

* **New Features / UX**
  * Editor pre-fills a minimal workload when a pre-built image exists so the form loads without prior data.
  * Save/confirmation and change summaries now reference "Container" instead of "Containers".

* **Validation**
  * Progress/navigation is blocked until a container image is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



https://github.com/user-attachments/assets/4c9a007c-ccd0-4c07-8efb-3e10df0df3cf

