### PR TITLE
fix: handle data-wrapped API responses in events and pod logs viewers

### DIFF
--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceEventsTable.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceEventsTable.tsx
@@ -111,10 +111,11 @@ export const ResourceEventsTable: FC<ResourceEventsTableProps> = ({
         );
 
         if (!cancelled) {
-          const fetched = response?.events ?? [];
+          const responseData = (response as any)?.data ?? response;
+          const fetched = responseData?.events ?? [];
           // Sort by lastTimestamp descending (newest first)
           fetched.sort(
-            (a, b) =>
+            (a: ResourceEvent, b: ResourceEvent) =>
               new Date(b.lastTimestamp).getTime() -
               new Date(a.lastTimestamp).getTime(),
           );

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.tsx
@@ -84,7 +84,8 @@ export const ResourcePodLogsViewer: FC<ResourcePodLogsViewerProps> = ({
         });
 
         if (!cancelled) {
-          setLogEntries(response?.logEntries ?? []);
+          const responseData = (response as any)?.data ?? response;
+          setLogEntries(responseData?.logEntries ?? []);
         }
       } catch (err: any) {
         if (!cancelled) {


### PR DESCRIPTION
## Purpose

$subject


  - Fixed resource events and pod logs not displaying in the resource tree detail panel despite data being fetched successfully                            
  - The upstream API wraps responses in a data property (consistent with ResourceTreeData and ReleaseData patterns), but the events table and pod logs viewer were accessing response.events and response.logEntries directly, which resolved to undefined and fell back to empty arrays 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API response handling for resource events and pod logs so the UI correctly reads data from either wrapped or unwrapped response formats, reducing missed events/log entries across varied back-end responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->