### PR TITLE
feat: convert GraphKindFilter from chip bar to multiselect dropdown

### DIFF
--- a/plugins/openchoreo-react/src/components/GraphKindFilter/GraphKindFilter.tsx
+++ b/plugins/openchoreo-react/src/components/GraphKindFilter/GraphKindFilter.tsx
@@ -1,17 +1,20 @@
-import { ReactNode, useMemo } from 'react';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
+import { ReactNode, useMemo, useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
-import Chip from '@material-ui/core/Chip';
-import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import Popover from '@material-ui/core/Popover';
+import MenuList from '@material-ui/core/MenuList';
+import MenuItem from '@material-ui/core/MenuItem';
+import Checkbox from '@material-ui/core/Checkbox';
+import Divider from '@material-ui/core/Divider';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import {
   FILTER_PRESETS,
   ALL_FILTERABLE_KINDS,
 } from '../../utils/platformOverviewConstants';
-import {
-  ENTITY_KIND_COLORS,
-  DEFAULT_NODE_COLOR,
-  getNodeTintFill,
-} from '../../utils/graphUtils';
+import { ENTITY_KIND_COLORS, DEFAULT_NODE_COLOR } from '../../utils/graphUtils';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -22,46 +25,42 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(1.5, 2),
     borderBottom: `1px solid ${theme.palette.divider}`,
   },
-  label: {
-    fontSize: '0.75rem',
-    fontWeight: 500,
-    color: theme.palette.text.secondary,
-    whiteSpace: 'nowrap',
-  },
-  presetChip: {
-    height: 26,
-    fontSize: '0.75rem',
-    fontWeight: 500,
-    cursor: 'pointer',
-    borderRadius: 6,
-    transition: 'background-color 150ms, border-color 150ms',
-  },
   divider: {
     width: 1,
     height: 20,
     backgroundColor: theme.palette.divider,
     margin: theme.spacing(0, 0.5),
   },
-  kindChip: {
-    height: 24,
-    fontSize: '0.72rem',
-    cursor: 'pointer',
+  triggerButton: {
+    textTransform: 'none',
+    fontSize: '0.8rem',
+    fontWeight: 500,
+    padding: theme.spacing(0.5, 1.5),
+    border: `1px solid ${theme.palette.divider}`,
     borderRadius: 6,
-    transition: 'opacity 150ms',
-    '& .MuiChip-label': {
-      display: 'flex',
-      alignItems: 'center',
+    color: theme.palette.text.primary,
+    whiteSpace: 'nowrap',
+    '&:hover': {
+      borderColor: theme.palette.text.secondary,
     },
-    '& .MuiChip-label::before': {
-      content: '""',
-      display: 'inline-block',
-      width: 7,
-      height: 7,
-      minWidth: 7,
-      borderRadius: '50%',
-      marginRight: 4,
-      backgroundColor: 'var(--dot-color)',
-    },
+  },
+  popoverPaper: {
+    minWidth: 220,
+  },
+  menuItem: {
+    minHeight: 36,
+    paddingTop: 2,
+    paddingBottom: 2,
+  },
+  kindDot: {
+    width: 8,
+    height: 8,
+    minWidth: 8,
+    borderRadius: '50%',
+    marginRight: theme.spacing(1),
+  },
+  checkbox: {
+    padding: 4,
   },
 }));
 
@@ -77,22 +76,39 @@ export function GraphKindFilter({
   leading,
 }: GraphKindFilterProps) {
   const classes = useStyles();
-  const theme = useTheme();
-  const isDark = theme.palette.type === 'dark';
   const selectedSet = useMemo(() => new Set(selectedKinds), [selectedKinds]);
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const open = Boolean(anchorEl);
 
-  const activePresetId = useMemo(() => {
+  const activePreset = useMemo(() => {
     for (const preset of FILTER_PRESETS) {
       const presetSet = new Set(preset.kinds);
       if (
         presetSet.size === selectedSet.size &&
         preset.kinds.every(k => selectedSet.has(k))
       ) {
-        return preset.id;
+        return preset;
       }
     }
     return undefined;
   }, [selectedSet]);
+
+  const buttonLabel = useMemo(() => {
+    if (activePreset) return `Kind: ${activePreset.label}`;
+    if (selectedSet.size === 1) {
+      const kindId = selectedKinds[0];
+      const kind = ALL_FILTERABLE_KINDS.find(k => k.id === kindId);
+      return `Kind: ${kind?.label ?? kindId}`;
+    }
+    return `Kind: ${selectedSet.size} selected`;
+  }, [activePreset, selectedSet, selectedKinds]);
+
+  const getPresetState = (presetKinds: string[]) => {
+    const selected = presetKinds.filter(k => selectedSet.has(k)).length;
+    if (selected === presetKinds.length) return 'checked';
+    if (selected > 0) return 'indeterminate';
+    return 'unchecked';
+  };
 
   const handlePresetClick = (presetId: string) => {
     const preset = FILTER_PRESETS.find(p => p.id === presetId);
@@ -114,62 +130,79 @@ export function GraphKindFilter({
     <Box className={classes.root}>
       {leading}
       {leading && <div className={classes.divider} />}
-      <Typography className={classes.label}>Kind</Typography>
-      {FILTER_PRESETS.map(preset => {
-        const isActive = activePresetId === preset.id;
-        return (
-          <Chip
-            key={preset.id}
-            label={preset.label}
-            size="small"
-            clickable
-            onClick={() => handlePresetClick(preset.id)}
-            className={classes.presetChip}
-            style={
-              isActive
-                ? {
-                    backgroundColor: theme.palette.primary.main,
-                    color: theme.palette.primary.contrastText,
-                    border: `1px solid ${theme.palette.primary.main}`,
-                  }
-                : {
-                    backgroundColor: 'transparent',
-                    color: theme.palette.text.primary,
-                    border: `1px solid ${theme.palette.divider}`,
-                  }
-            }
-          />
-        );
-      })}
-      <div className={classes.divider} />
-      {ALL_FILTERABLE_KINDS.map(kind => {
-        const isSelected = selectedSet.has(kind.id);
-        const color =
-          ENTITY_KIND_COLORS[kind.id.toLowerCase()] ?? DEFAULT_NODE_COLOR;
-        return (
-          <Chip
-            key={kind.id}
-            label={kind.label}
-            size="small"
-            clickable
-            onClick={() => handleKindToggle(kind.id)}
-            className={classes.kindChip}
-            style={{
-              backgroundColor: isSelected
-                ? getNodeTintFill(color, isDark)
-                : 'transparent',
-              border: `1px solid ${
-                isSelected ? `${color}B3` : theme.palette.divider
-              }`,
-              opacity: isSelected ? 1 : 0.5,
-              color: theme.palette.text.primary,
-              ['--dot-color' as string]: isSelected
-                ? color
-                : theme.palette.text.disabled,
-            }}
-          />
-        );
-      })}
+      <Button
+        className={classes.triggerButton}
+        endIcon={<ArrowDropDownIcon />}
+        onClick={e => setAnchorEl(e.currentTarget)}
+      >
+        {buttonLabel}
+      </Button>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{ className: classes.popoverPaper }}
+      >
+        <MenuList dense>
+          {FILTER_PRESETS.map(preset => {
+            const state = getPresetState(preset.kinds);
+            return (
+              <MenuItem
+                key={preset.id}
+                className={classes.menuItem}
+                onClick={() => handlePresetClick(preset.id)}
+              >
+                <ListItemIcon>
+                  <Checkbox
+                    className={classes.checkbox}
+                    checked={state === 'checked'}
+                    indeterminate={state === 'indeterminate'}
+                    color="primary"
+                    size="small"
+                    disableRipple
+                  />
+                </ListItemIcon>
+                <ListItemText primary={preset.label} />
+              </MenuItem>
+            );
+          })}
+        </MenuList>
+        <Divider />
+        <MenuList dense>
+          {ALL_FILTERABLE_KINDS.map(kind => {
+            const isSelected = selectedSet.has(kind.id);
+            const isLastSelected = isSelected && selectedSet.size <= 1;
+            const color =
+              ENTITY_KIND_COLORS[kind.id.toLowerCase()] ?? DEFAULT_NODE_COLOR;
+            return (
+              <MenuItem
+                key={kind.id}
+                className={classes.menuItem}
+                disabled={isLastSelected}
+                onClick={() => handleKindToggle(kind.id)}
+              >
+                <ListItemIcon>
+                  <Checkbox
+                    className={classes.checkbox}
+                    checked={isSelected}
+                    disabled={isLastSelected}
+                    color="primary"
+                    size="small"
+                    disableRipple
+                  />
+                </ListItemIcon>
+                <span
+                  className={classes.kindDot}
+                  style={{ backgroundColor: color }}
+                />
+                <ListItemText primary={kind.label} />
+              </MenuItem>
+            );
+          })}
+        </MenuList>
+      </Popover>
     </Box>
   );
 }


### PR DESCRIPTION
  Replace horizontal chip bar (3 presets + 7 kind chips + dividers) with a
  compact Button + Popover multiselect. Top section shows group presets
  with checked/indeterminate state; bottom section shows individual kinds
  with colored dots. Prevents empty selection by disabling the last
  remaining kind.

<img width="1484" height="849" alt="image" src="https://github.com/user-attachments/assets/8c2ae0bf-95c5-417a-b563-1ea6104015bd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the filter interface from inline display to a dropdown menu, significantly improving space efficiency and overall usability.
  * Enhanced visual feedback with clearer selection indicators and interactive checkboxes for all filter options.
  * Refined button styling, menu organization, and layout of filter categories for a more intuitive navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->