### PR TITLE
feat: sync openchoreo-api spec with upstream and migrate git secrets API

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -79,6 +79,8 @@ tags:
     description: Deployment pipeline management
   - name: ObservabilityAlertsNotificationChannels
     description: Observability alerts notification channel management
+  - name: GitSecrets
+    description: Git secret management for source code authentication
 
 paths:
   # =============================================================================
@@ -154,7 +156,12 @@ paths:
       summary: Get OAuth protected resource metadata
       description: |
         Returns OAuth 2.0 protected resource metadata as defined in RFC 9728.
-        Used by MCP clients to discover authorization server information.
+        Used by MCP clients and the CLI to discover authorization server information
+        and client configurations.
+
+        OpenChoreo-specific extension fields (RFC 9728 §2):
+        - `openchoreo_clients`: OAuth client configurations for integrations (e.g., CLI).
+        - `openchoreo_security_enabled`: Whether authentication is enforced on this server.
       tags: [Operations]
       security: []
       responses:
@@ -164,23 +171,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OAuthProtectedResourceMetadata'
-
-  /.well-known/openid-configuration:
-    get:
-      operationId: getOpenIDConfiguration
-      summary: Get OpenID configuration
-      description: |
-        Returns OpenID Connect configuration for CLI authentication.
-        Includes OAuth2 endpoints, external client configurations, and security status.
-      tags: [Operations]
-      security: []
-      responses:
-        '200':
-          description: OpenID configuration
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientConfigList'
 
   # =============================================================================
   # Namespace Endpoints
@@ -595,6 +585,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Environment'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    put:
+      operationId: updateEnvironment
+      summary: Update environment
+      description: Replaces an existing environment (full update).
+      tags: [Environments]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/EnvironmentNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Environment'
+      responses:
+        '200':
+          description: Environment updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Environment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    delete:
+      operationId: deleteEnvironment
+      summary: Delete environment
+      description: Deletes an environment by name.
+      tags: [Environments]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/EnvironmentNameParam'
+      responses:
+        '204':
+          description: Environment deleted successfully
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2892,51 +2936,29 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/authz/evaluate:
+  /api/v1/authz/evaluates:
     post:
-      operationId: evaluate
+      operationId: evaluates
       summary: Evaluate authorization
-      description: Evaluates a single authorization request.
+      description: Evaluates one or more authorization requests in a single call.
       tags: [Authorization]
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EvaluateRequest'
+              type: array
+              items:
+                $ref: '#/components/schemas/EvaluateRequest'
       responses:
         '200':
-          description: Authorization decision
+          description: Authorization decisions in the same order as the input requests (decision[i] corresponds to request[i])
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Decision'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalError'
-
-  /api/v1/authz/batch-evaluate:
-    post:
-      operationId: batchEvaluate
-      summary: Batch evaluate authorization
-      description: Evaluates multiple authorization requests in a single call.
-      tags: [Authorization]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BatchEvaluateRequest'
-      responses:
-        '200':
-          description: Authorization decisions
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BatchEvaluateResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Decision'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -2991,6 +3013,9 @@ paths:
       summary: List cluster roles
       description: Returns all cluster-scoped authorization roles.
       tags: [Authorization]
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
       responses:
         '200':
           description: List of cluster roles
@@ -3134,6 +3159,9 @@ paths:
       summary: List cluster role bindings
       description: Returns all cluster-scoped role bindings.
       tags: [Authorization]
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
       responses:
         '200':
           description: List of cluster role bindings
@@ -3279,6 +3307,8 @@ paths:
       tags: [Authorization]
       parameters:
         - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
       responses:
         '200':
           description: List of namespace roles
@@ -3435,6 +3465,8 @@ paths:
       tags: [Authorization]
       parameters:
         - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
       responses:
         '200':
           description: List of namespace role bindings
@@ -3702,7 +3734,7 @@ paths:
   # Secret Reference Endpoints
   # =============================================================================
 
-  /api/v1/namespaces/{namespaceName}/secret-references:
+  /api/v1/namespaces/{namespaceName}/secretreferences:
     get:
       operationId: listSecretReferences
       summary: List secret references
@@ -3757,7 +3789,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName}:
+  /api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}:
     get:
       operationId: getSecretReference
       summary: Get secret reference
@@ -4229,7 +4261,7 @@ paths:
   # Deployment Pipeline Endpoints
   # =============================================================================
 
-  /api/v1/namespaces/{namespaceName}/deployment-pipelines:
+  /api/v1/namespaces/{namespaceName}/deploymentpipelines:
     get:
       operationId: listDeploymentPipelines
       summary: List deployment pipelines
@@ -4284,7 +4316,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}:
+  /api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}:
     get:
       operationId: getDeploymentPipeline
       summary: Get deployment pipeline
@@ -4365,7 +4397,7 @@ paths:
   # Observability Alerts Notification Channel Endpoints
   # =============================================================================
 
-  /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels:
+  /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels:
     get:
       operationId: listObservabilityAlertsNotificationChannels
       summary: List observability alerts notification channels
@@ -4420,7 +4452,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName}:
+  /api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName}:
     get:
       operationId: getObservabilityAlertsNotificationChannel
       summary: Get observability alerts notification channel
@@ -4488,6 +4520,83 @@ paths:
       responses:
         '204':
           description: Observability alerts notification channel deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # =============================================================================
+  # Git Secrets (v1alpha1)
+  # =============================================================================
+  /api/v1alpha1/namespaces/{namespaceName}/gitsecrets:
+    get:
+      operationId: listGitSecrets
+      summary: List git secrets
+      description: Returns all git secrets in a namespace.
+      tags: [GitSecrets]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+      responses:
+        '200':
+          description: List of git secrets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GitSecretListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    post:
+      operationId: createGitSecret
+      summary: Create a git secret
+      description: Creates a new git secret for source code authentication.
+      tags: [GitSecrets]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGitSecretRequest'
+      responses:
+        '201':
+          description: Git secret created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GitSecretResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1alpha1/namespaces/{namespaceName}/gitsecrets/{gitSecretName}:
+    delete:
+      operationId: deleteGitSecret
+      summary: Delete a git secret
+      description: Deletes a git secret by name.
+      tags: [GitSecrets]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/GitSecretNameParam'
+      responses:
+        '204':
+          description: Git secret deleted successfully
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4780,6 +4889,15 @@ components:
         format: int64
         example: 123
 
+    GitSecretNameParam:
+      name: gitSecretName
+      in: path
+      required: true
+      description: Git secret name
+      schema:
+        type: string
+        example: my-git-secret
+
     LimitParam:
       name: limit
       in: query
@@ -5071,13 +5189,28 @@ components:
           description: Supported OAuth scopes
           items:
             type: string
+        openchoreo_clients:
+          type: array
+          description: |
+            OpenChoreo extension (RFC 9728 §2). OAuth client configurations for
+            external integrations (e.g., CLI). Used by clients to discover their
+            client_id and required scopes.
+          items:
+            $ref: '#/components/schemas/OpenChoreoClient'
+        openchoreo_security_enabled:
+          type: boolean
+          description: |
+            OpenChoreo extension (RFC 9728 §2). Indicates whether authentication
+            is enforced on this server. When false, requests without tokens are
+            accepted.
+          example: true
 
     # -------------------------------------------------------------------------
     # Client Configuration
     # -------------------------------------------------------------------------
-    ExternalClient:
+    OpenChoreoClient:
       type: object
-      description: External client configuration
+      description: OAuth client configuration for an OpenChoreo external integration (e.g., CLI)
       required:
         - name
         - client_id
@@ -5085,49 +5218,19 @@ components:
       properties:
         name:
           type: string
-          description: Name of the external client
+          description: Name of the client integration
           example: cli
         client_id:
           type: string
-          description: OAuth2 client ID for this client type
+          description: OAuth2 client ID
           example: openchoreo-cli
         scopes:
           type: array
-          description: OAuth2 scopes for this client
+          description: OAuth2 scopes required by this client
+          minItems: 1
           items:
             type: string
           example: ['openid', 'profile', 'email']
-
-    ClientConfigList:
-      type: object
-      description: OpenID Connect configuration response
-      required:
-        - token_endpoint
-        - authorization_endpoint
-        - external_clients
-        - security_enabled
-      properties:
-        issuer:
-          type: string
-          description: OIDC issuer URL
-          example: https://auth.openchoreo.dev
-        token_endpoint:
-          type: string
-          description: OAuth2 token endpoint URL
-          example: https://auth.openchoreo.dev/oauth2/token
-        authorization_endpoint:
-          type: string
-          description: OAuth2 authorization endpoint URL
-          example: https://auth.openchoreo.dev/authorize
-        security_enabled:
-          type: boolean
-          description: Whether authentication is enabled on the server
-          example: true
-        external_clients:
-          type: array
-          description: Array of external client configurations
-          items:
-            $ref: '#/components/schemas/ExternalClient'
 
     # -------------------------------------------------------------------------
     # User Type Configuration
@@ -7565,11 +7668,8 @@ components:
       type: object
       description: Environment-specific workload overrides
       properties:
-        containers:
-          type: object
-          description: Container overrides keyed by container name
-          additionalProperties:
-            $ref: '#/components/schemas/ContainerOverride'
+        container:
+          $ref: '#/components/schemas/ContainerOverride'
 
     ContainerOverride:
       type: object
@@ -8043,6 +8143,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AuthzClusterRole'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
 
     AuthzRole:
       type: object
@@ -8084,6 +8186,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AuthzRole'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
 
     AuthzClusterRoleBinding:
       type: object
@@ -8126,6 +8230,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AuthzClusterRoleBinding'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
 
     AuthzRoleBinding:
       type: object
@@ -8170,6 +8276,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AuthzRoleBinding'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
 
     AuthzEntitlementClaim:
       type: object
@@ -8334,30 +8442,6 @@ components:
               type: string
               description: Reason for the decision
               example: User has admin role
-
-    BatchEvaluateRequest:
-      type: object
-      description: Batch authorization evaluation request
-      required:
-        - requests
-      properties:
-        requests:
-          type: array
-          description: List of evaluation requests
-          items:
-            $ref: '#/components/schemas/EvaluateRequest'
-
-    BatchEvaluateResponse:
-      type: object
-      description: Batch authorization evaluation response
-      required:
-        - decisions
-      properties:
-        decisions:
-          type: array
-          description: List of decisions (in same order as requests)
-          items:
-            $ref: '#/components/schemas/Decision'
 
     ActionCapability:
       type: object
@@ -8918,7 +9002,7 @@ components:
       type: object
       description: |
         Workload resource (Kubernetes object without kind/apiVersion).
-        Defines the source code, containers, endpoints and connections for a component.
+        Defines the source code, container, endpoints and connections for a component.
       required:
         - metadata
       properties:
@@ -8952,11 +9036,6 @@ components:
               example: api-service
         container:
           $ref: '#/components/schemas/WorkloadContainer'
-        containers:
-          type: object
-          description: Named container specifications (mutually exclusive with container)
-          additionalProperties:
-            $ref: '#/components/schemas/WorkloadContainer'
         endpoints:
           type: object
           description: Named endpoint specifications
@@ -9387,3 +9466,71 @@ components:
           type: string
           description: Key within the secret
           example: password
+
+    # -------------------------------------------------------------------------
+    # Git Secrets
+    # -------------------------------------------------------------------------
+    CreateGitSecretRequest:
+      type: object
+      description: Request body for creating a git secret
+      required:
+        - secretName
+        - secretType
+      properties:
+        secretName:
+          type: string
+          description: Name of the git secret
+          example: my-git-secret
+        secretType:
+          type: string
+          description: Authentication type
+          enum:
+            - basic-auth
+            - ssh-auth
+          example: basic-auth
+        username:
+          type: string
+          description: Username for basic authentication (optional)
+        token:
+          type: string
+          description: Authentication token (required for basic-auth)
+        sshKey:
+          type: string
+          description: SSH private key (required for ssh-auth)
+        sshKeyId:
+          type: string
+          description: SSH key ID for AWS CodeCommit (optional for ssh-auth)
+
+    GitSecretResponse:
+      type: object
+      description: Git secret resource
+      properties:
+        name:
+          type: string
+          description: Name of the git secret
+          example: my-git-secret
+        namespace:
+          type: string
+          description: Namespace of the git secret
+          example: my-namespace
+
+    GitSecretListResponse:
+      type: object
+      description: List of git secrets
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          description: List of git secrets
+          items:
+            $ref: '#/components/schemas/GitSecretResponse'
+        totalCount:
+          type: integer
+          description: Total number of items
+        page:
+          type: integer
+          description: Current page number
+        pageSize:
+          type: integer
+          description: Number of items per page

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -94,30 +94,14 @@ export interface paths {
     /**
      * Get OAuth protected resource metadata
      * @description Returns OAuth 2.0 protected resource metadata as defined in RFC 9728.
-     *     Used by MCP clients to discover authorization server information.
+     *     Used by MCP clients and the CLI to discover authorization server information
+     *     and client configurations.
+     *
+     *     OpenChoreo-specific extension fields (RFC 9728 §2):
+     *     - `openchoreo_clients`: OAuth client configurations for integrations (e.g., CLI).
+     *     - `openchoreo_security_enabled`: Whether authentication is enforced on this server.
      */
     get: operations['getOAuthProtectedResourceMetadata'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/.well-known/openid-configuration': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get OpenID configuration
-     * @description Returns OpenID Connect configuration for CLI authentication.
-     *     Includes OAuth2 endpoints, external client configurations, and security status.
-     */
-    get: operations['getOpenIDConfiguration'];
     put?: never;
     post?: never;
     delete?: never;
@@ -294,9 +278,17 @@ export interface paths {
      * @description Returns details of a specific environment.
      */
     get: operations['getEnvironment'];
-    put?: never;
+    /**
+     * Update environment
+     * @description Replaces an existing environment (full update).
+     */
+    put: operations['updateEnvironment'];
     post?: never;
-    delete?: never;
+    /**
+     * Delete environment
+     * @description Deletes an environment by name.
+     */
+    delete: operations['deleteEnvironment'];
     options?: never;
     head?: never;
     patch?: never;
@@ -1378,7 +1370,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/authz/evaluate': {
+  '/api/v1/authz/evaluates': {
     parameters: {
       query?: never;
       header?: never;
@@ -1389,29 +1381,9 @@ export interface paths {
     put?: never;
     /**
      * Evaluate authorization
-     * @description Evaluates a single authorization request.
+     * @description Evaluates one or more authorization requests in a single call.
      */
-    post: operations['evaluate'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/authz/batch-evaluate': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Batch evaluate authorization
-     * @description Evaluates multiple authorization requests in a single call.
-     */
-    post: operations['batchEvaluate'];
+    post: operations['evaluates'];
     delete?: never;
     options?: never;
     head?: never;
@@ -1726,7 +1698,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/namespaces/{namespaceName}/secret-references': {
+  '/api/v1/namespaces/{namespaceName}/secretreferences': {
     parameters: {
       query?: never;
       header?: never;
@@ -1750,7 +1722,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/namespaces/{namespaceName}/secret-references/{secretReferenceName}': {
+  '/api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}': {
     parameters: {
       query?: never;
       header?: never;
@@ -1962,7 +1934,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/namespaces/{namespaceName}/deployment-pipelines': {
+  '/api/v1/namespaces/{namespaceName}/deploymentpipelines': {
     parameters: {
       query?: never;
       header?: never;
@@ -1986,7 +1958,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}': {
+  '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}': {
     parameters: {
       query?: never;
       header?: never;
@@ -2014,7 +1986,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels': {
+  '/api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels': {
     parameters: {
       query?: never;
       header?: never;
@@ -2038,7 +2010,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/namespaces/{namespaceName}/observability-alerts-notification-channels/{observabilityAlertsNotificationChannelName}': {
+  '/api/v1/namespaces/{namespaceName}/observabilityalertsnotificationchannels/{observabilityAlertsNotificationChannelName}': {
     parameters: {
       query?: never;
       header?: never;
@@ -2061,6 +2033,50 @@ export interface paths {
      * @description Deletes an observability alerts notification channel by name.
      */
     delete: operations['deleteObservabilityAlertsNotificationChannel'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1alpha1/namespaces/{namespaceName}/gitsecrets': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List git secrets
+     * @description Returns all git secrets in a namespace.
+     */
+    get: operations['listGitSecrets'];
+    put?: never;
+    /**
+     * Create a git secret
+     * @description Creates a new git secret for source code authentication.
+     */
+    post: operations['createGitSecret'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1alpha1/namespaces/{namespaceName}/gitsecrets/{gitSecretName}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Delete a git secret
+     * @description Deletes a git secret by name.
+     */
+    delete: operations['deleteGitSecret'];
     options?: never;
     head?: never;
     patch?: never;
@@ -2239,21 +2255,34 @@ export interface components {
       bearer_methods_supported: string[];
       /** @description Supported OAuth scopes */
       scopes_supported: string[];
-    };
-    /** @description External client configuration */
-    ExternalClient: {
       /**
-       * @description Name of the external client
+       * @description OpenChoreo extension (RFC 9728 §2). OAuth client configurations for
+       *     external integrations (e.g., CLI). Used by clients to discover their
+       *     client_id and required scopes.
+       */
+      openchoreo_clients?: components['schemas']['OpenChoreoClient'][];
+      /**
+       * @description OpenChoreo extension (RFC 9728 §2). Indicates whether authentication
+       *     is enforced on this server. When false, requests without tokens are
+       *     accepted.
+       * @example true
+       */
+      openchoreo_security_enabled?: boolean;
+    };
+    /** @description OAuth client configuration for an OpenChoreo external integration (e.g., CLI) */
+    OpenChoreoClient: {
+      /**
+       * @description Name of the client integration
        * @example cli
        */
       name: string;
       /**
-       * @description OAuth2 client ID for this client type
+       * @description OAuth2 client ID
        * @example openchoreo-cli
        */
       client_id: string;
       /**
-       * @description OAuth2 scopes for this client
+       * @description OAuth2 scopes required by this client
        * @example [
        *       "openid",
        *       "profile",
@@ -2261,31 +2290,6 @@ export interface components {
        *     ]
        */
       scopes: string[];
-    };
-    /** @description OpenID Connect configuration response */
-    ClientConfigList: {
-      /**
-       * @description OIDC issuer URL
-       * @example https://auth.openchoreo.dev
-       */
-      issuer?: string;
-      /**
-       * @description OAuth2 token endpoint URL
-       * @example https://auth.openchoreo.dev/oauth2/token
-       */
-      token_endpoint: string;
-      /**
-       * @description OAuth2 authorization endpoint URL
-       * @example https://auth.openchoreo.dev/authorize
-       */
-      authorization_endpoint: string;
-      /**
-       * @description Whether authentication is enabled on the server
-       * @example true
-       */
-      security_enabled: boolean;
-      /** @description Array of external client configurations */
-      external_clients: components['schemas']['ExternalClient'][];
     };
     /** @description Configuration for a user type used in authentication and authorization */
     UserTypeConfig: {
@@ -4016,10 +4020,7 @@ export interface components {
     };
     /** @description Environment-specific workload overrides */
     WorkloadOverrides: {
-      /** @description Container overrides keyed by container name */
-      containers?: {
-        [key: string]: components['schemas']['ContainerOverride'];
-      };
+      container?: components['schemas']['ContainerOverride'];
     };
     /** @description Container-level overrides */
     ContainerOverride: {
@@ -4344,6 +4345,7 @@ export interface components {
     /** @description List of cluster-scoped authorization roles */
     AuthzClusterRoleList: {
       items: components['schemas']['AuthzClusterRole'][];
+      pagination?: components['schemas']['Pagination'];
     };
     /**
      * @description Namespace-scoped authorization role (Kubernetes CRD).
@@ -4372,6 +4374,7 @@ export interface components {
     /** @description List of namespace-scoped authorization roles */
     AuthzRoleList: {
       items: components['schemas']['AuthzRole'][];
+      pagination?: components['schemas']['Pagination'];
     };
     /**
      * @description Cluster-scoped role binding (Kubernetes CRD).
@@ -4396,6 +4399,7 @@ export interface components {
     /** @description List of cluster-scoped role bindings */
     AuthzClusterRoleBindingList: {
       items: components['schemas']['AuthzClusterRoleBinding'][];
+      pagination?: components['schemas']['Pagination'];
     };
     /**
      * @description Namespace-scoped role binding (Kubernetes CRD).
@@ -4421,6 +4425,7 @@ export interface components {
     /** @description List of namespace-scoped role bindings */
     AuthzRoleBindingList: {
       items: components['schemas']['AuthzRoleBinding'][];
+      pagination?: components['schemas']['Pagination'];
     };
     /** @description Entitlement claim-value pair for subject identification */
     AuthzEntitlementClaim: {
@@ -4559,16 +4564,6 @@ export interface components {
          */
         reason?: string;
       };
-    };
-    /** @description Batch authorization evaluation request */
-    BatchEvaluateRequest: {
-      /** @description List of evaluation requests */
-      requests: components['schemas']['EvaluateRequest'][];
-    };
-    /** @description Batch authorization evaluation response */
-    BatchEvaluateResponse: {
-      /** @description List of decisions (in same order as requests) */
-      decisions: components['schemas']['Decision'][];
     };
     /** @description Capabilities for a specific action */
     ActionCapability: {
@@ -4995,7 +4990,7 @@ export interface components {
     };
     /**
      * @description Workload resource (Kubernetes object without kind/apiVersion).
-     *     Defines the source code, containers, endpoints and connections for a component.
+     *     Defines the source code, container, endpoints and connections for a component.
      */
     Workload: {
       metadata: components['schemas']['ObjectMeta'];
@@ -5018,10 +5013,6 @@ export interface components {
         componentName: string;
       };
       container?: components['schemas']['WorkloadContainer'];
-      /** @description Named container specifications (mutually exclusive with container) */
-      containers?: {
-        [key: string]: components['schemas']['WorkloadContainer'];
-      };
       /** @description Named endpoint specifications */
       endpoints?: {
         [key: string]: components['schemas']['WorkloadEndpoint'];
@@ -5288,6 +5279,52 @@ export interface components {
        */
       key?: string;
     };
+    /** @description Request body for creating a git secret */
+    CreateGitSecretRequest: {
+      /**
+       * @description Name of the git secret
+       * @example my-git-secret
+       */
+      secretName: string;
+      /**
+       * @description Authentication type
+       * @example basic-auth
+       * @enum {string}
+       */
+      secretType: 'basic-auth' | 'ssh-auth';
+      /** @description Username for basic authentication (optional) */
+      username?: string;
+      /** @description Authentication token (required for basic-auth) */
+      token?: string;
+      /** @description SSH private key (required for ssh-auth) */
+      sshKey?: string;
+      /** @description SSH key ID for AWS CodeCommit (optional for ssh-auth) */
+      sshKeyId?: string;
+    };
+    /** @description Git secret resource */
+    GitSecretResponse: {
+      /**
+       * @description Name of the git secret
+       * @example my-git-secret
+       */
+      name?: string;
+      /**
+       * @description Namespace of the git secret
+       * @example my-namespace
+       */
+      namespace?: string;
+    };
+    /** @description List of git secrets */
+    GitSecretListResponse: {
+      /** @description List of git secrets */
+      items: components['schemas']['GitSecretResponse'][];
+      /** @description Total number of items */
+      totalCount?: number;
+      /** @description Current page number */
+      page?: number;
+      /** @description Number of items per page */
+      pageSize?: number;
+    };
   };
   responses: {
     /** @description Invalid request parameters */
@@ -5446,6 +5483,8 @@ export interface components {
     RoleNameParam: string;
     /** @description Role mapping ID */
     MappingIdParam: number;
+    /** @description Git secret name */
+    GitSecretNameParam: string;
     /** @description Maximum number of items to return per page */
     LimitParam: number;
     /**
@@ -5556,26 +5595,6 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['OAuthProtectedResourceMetadata'];
-        };
-      };
-    };
-  };
-  getOpenIDConfiguration: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OpenID configuration */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ClientConfigList'];
         };
       };
     };
@@ -6039,6 +6058,68 @@ export interface operations {
         content: {
           'application/json': components['schemas']['Environment'];
         };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  updateEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Environment name */
+        envName: components['parameters']['EnvironmentNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['Environment'];
+      };
+    };
+    responses: {
+      /** @description Environment updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Environment'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Environment name */
+        envName: components['parameters']['EnvironmentNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Environment deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
@@ -8549,7 +8630,7 @@ export interface operations {
       500: components['responses']['InternalError'];
     };
   };
-  evaluate: {
+  evaluates: {
     parameters: {
       query?: never;
       header?: never;
@@ -8558,44 +8639,17 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['EvaluateRequest'];
+        'application/json': components['schemas']['EvaluateRequest'][];
       };
     };
     responses: {
-      /** @description Authorization decision */
+      /** @description Authorization decisions in the same order as the input requests (decision[i] corresponds to request[i]) */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['Decision'];
-        };
-      };
-      400: components['responses']['BadRequest'];
-      401: components['responses']['Unauthorized'];
-      500: components['responses']['InternalError'];
-    };
-  };
-  batchEvaluate: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['BatchEvaluateRequest'];
-      };
-    };
-    responses: {
-      /** @description Authorization decisions */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['BatchEvaluateResponse'];
+          'application/json': components['schemas']['Decision'][];
         };
       };
       400: components['responses']['BadRequest'];
@@ -8636,7 +8690,15 @@ export interface operations {
   };
   listClusterRoles: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -8773,7 +8835,15 @@ export interface operations {
   };
   listClusterRoleBindings: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -8910,7 +8980,15 @@ export interface operations {
   };
   listNamespaceRoles: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
       header?: never;
       path: {
         /** @description Namespace name */
@@ -9062,7 +9140,15 @@ export interface operations {
   };
   listNamespaceRoleBindings: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
       header?: never;
       path: {
         /** @description Namespace name */
@@ -10229,6 +10315,91 @@ export interface operations {
     requestBody?: never;
     responses: {
       /** @description Observability alerts notification channel deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  listGitSecrets: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of git secrets */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['GitSecretListResponse'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  createGitSecret: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateGitSecretRequest'];
+      };
+    };
+    responses: {
+      /** @description Git secret created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['GitSecretResponse'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteGitSecret: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Git secret name */
+        gitSecretName: components['parameters']['GitSecretNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Git secret deleted successfully */
       204: {
         headers: {
           [name: string]: unknown;

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.test.ts
@@ -332,7 +332,7 @@ describe('OpenChoreoEntityProvider', () => {
         '/api/v1/namespaces/{namespaceName}/projects': okData({
           items: [k8sProject],
         }),
-        '/api/v1/namespaces/{namespaceName}/deployment-pipelines': okData({
+        '/api/v1/namespaces/{namespaceName}/deploymentpipelines': okData({
           items: [k8sPipeline],
         }),
         '/api/v1/namespaces/{namespaceName}/components': okData({
@@ -472,7 +472,7 @@ describe('OpenChoreoEntityProvider', () => {
         '/api/v1/namespaces/{namespaceName}/projects': okData({
           items: [project1, project2],
         }),
-        '/api/v1/namespaces/{namespaceName}/deployment-pipelines': okData({
+        '/api/v1/namespaces/{namespaceName}/deploymentpipelines': okData({
           items: [sharedPipeline],
         }),
         '/api/v1/namespaces': okData({ items: [k8sNamespace] }),
@@ -494,7 +494,7 @@ describe('OpenChoreoEntityProvider', () => {
         '/api/v1/namespaces/{namespaceName}/projects': okData({
           items: [k8sProject],
         }),
-        '/api/v1/namespaces/{namespaceName}/deployment-pipelines': okData({
+        '/api/v1/namespaces/{namespaceName}/deploymentpipelines': okData({
           items: [k8sPipeline],
         }),
         '/api/v1/namespaces/{namespaceName}/components': okData({

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -379,14 +379,11 @@ export class OpenChoreoEntityProvider implements EntityProvider {
           try {
             const pipelines = await fetchAllPages<NewDeploymentPipeline>(() =>
               client
-                .GET(
-                  '/api/v1/namespaces/{namespaceName}/deployment-pipelines',
-                  {
-                    params: {
-                      path: { namespaceName: nsName },
-                    },
+                .GET('/api/v1/namespaces/{namespaceName}/deploymentpipelines', {
+                  params: {
+                    path: { namespaceName: nsName },
                   },
-                )
+                })
                 .then(res => {
                   if (res.error)
                     throw new Error(

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -147,7 +147,7 @@ export class EnvironmentInfoService implements EnvironmentService {
       const pipelinePromise = createTimedPromise(
         (async () => {
           const { data, error, response } = await client.GET(
-            '/api/v1/namespaces/{namespaceName}/deployment-pipelines',
+            '/api/v1/namespaces/{namespaceName}/deploymentpipelines',
             {
               params: {
                 path: { namespaceName: request.namespaceName },

--- a/plugins/openchoreo-backend/src/services/GitSecretsService/GitSecretsService.ts
+++ b/plugins/openchoreo-backend/src/services/GitSecretsService/GitSecretsService.ts
@@ -1,5 +1,5 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { createOpenChoreoLegacyApiClient } from '@openchoreo/openchoreo-client-node';
+import { createOpenChoreoApiClient } from '@openchoreo/openchoreo-client-node';
 import type { GitSecretResponse } from '@openchoreo/backstage-plugin-common';
 
 export type { GitSecretResponse };
@@ -27,14 +27,14 @@ export class GitSecretsService {
     this.logger.debug(`Listing git secrets for namespace: ${namespaceName}`);
 
     try {
-      const client = createOpenChoreoLegacyApiClient({
+      const client = createOpenChoreoApiClient({
         baseUrl: this.baseUrl,
         token,
         logger: this.logger,
       });
 
       const { data, error, response } = await client.GET(
-        '/namespaces/{namespaceName}/git-secrets',
+        '/api/v1alpha1/namespaces/{namespaceName}/gitsecrets',
         {
           params: {
             path: { namespaceName },
@@ -48,20 +48,12 @@ export class GitSecretsService {
         );
       }
 
-      if (!data?.success) {
-        throw new Error(
-          `API returned unsuccessful response: ${JSON.stringify(data)}`,
-        );
-      }
-
-      // Extract the list response data
-      const listData = data.data as GitSecretListResponse;
       this.logger.debug(
         `Successfully listed ${
-          listData.items?.length || 0
+          data.items?.length || 0
         } git secrets for namespace: ${namespaceName}`,
       );
-      return listData;
+      return data as GitSecretListResponse;
     } catch (err) {
       this.logger.error(
         `Failed to list git secrets for ${namespaceName}: ${err}`,
@@ -85,14 +77,14 @@ export class GitSecretsService {
     );
 
     try {
-      const client = createOpenChoreoLegacyApiClient({
+      const client = createOpenChoreoApiClient({
         baseUrl: this.baseUrl,
         token: userToken,
         logger: this.logger,
       });
 
       const { data, error, response } = await client.POST(
-        '/namespaces/{namespaceName}/git-secrets',
+        '/api/v1alpha1/namespaces/{namespaceName}/gitsecrets',
         {
           params: {
             path: { namespaceName },
@@ -116,17 +108,10 @@ export class GitSecretsService {
         throw new Error(errorMessage);
       }
 
-      if (!data?.success) {
-        throw new Error(
-          `API returned unsuccessful response: ${JSON.stringify(data)}`,
-        );
-      }
-
-      const secretResponse = data.data as GitSecretResponse;
       this.logger.debug(
         `Successfully created git secret ${secretName} in namespace: ${namespaceName}`,
       );
-      return secretResponse;
+      return data as GitSecretResponse;
     } catch (err) {
       this.logger.error(
         `Failed to create git secret ${secretName} in ${namespaceName}: ${err}`,
@@ -145,17 +130,17 @@ export class GitSecretsService {
     );
 
     try {
-      const client = createOpenChoreoLegacyApiClient({
+      const client = createOpenChoreoApiClient({
         baseUrl: this.baseUrl,
         token: userToken,
         logger: this.logger,
       });
 
       const { error, response } = await client.DELETE(
-        '/namespaces/{namespaceName}/git-secrets/{secretName}',
+        '/api/v1alpha1/namespaces/{namespaceName}/gitsecrets/{gitSecretName}',
         {
           params: {
-            path: { namespaceName, secretName },
+            path: { namespaceName, gitSecretName: secretName },
           },
         },
       );

--- a/plugins/openchoreo-backend/src/services/PlatformResourceService/PlatformResourceService.ts
+++ b/plugins/openchoreo-backend/src/services/PlatformResourceService/PlatformResourceService.ts
@@ -324,7 +324,7 @@ export class PlatformResourceService {
         }
         case 'deploymentpipelines': {
           const { data, error, response } = await client.GET(
-            '/api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}',
+            '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
             {
               params: {
                 path: { namespaceName, deploymentPipelineName: resourceName },
@@ -462,7 +462,7 @@ export class PlatformResourceService {
         }
         case 'deploymentpipelines': {
           const { error, response } = await client.PUT(
-            '/api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}',
+            '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
             {
               params: {
                 path: { namespaceName, deploymentPipelineName: resourceName },
@@ -600,7 +600,7 @@ export class PlatformResourceService {
         }
         case 'deploymentpipelines': {
           const { error, response } = await client.DELETE(
-            '/api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}',
+            '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
             {
               params: {
                 path: { namespaceName, deploymentPipelineName: resourceName },

--- a/plugins/openchoreo-backend/src/services/ProjectService/ProjectInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/ProjectService/ProjectInfoService.ts
@@ -103,7 +103,7 @@ export class ProjectInfoService {
 
       // Then fetch the deployment pipeline by name
       const { data, error, response } = await client.GET(
-        '/api/v1/namespaces/{namespaceName}/deployment-pipelines/{deploymentPipelineName}',
+        '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
         {
           params: {
             path: { namespaceName, deploymentPipelineName: pipelineName },

--- a/plugins/openchoreo-backend/src/services/SecretReferencesService/SecretReferencesService.ts
+++ b/plugins/openchoreo-backend/src/services/SecretReferencesService/SecretReferencesService.ts
@@ -39,7 +39,7 @@ export class SecretReferencesService {
       });
 
       const { data, error, response } = await client.GET(
-        '/api/v1/namespaces/{namespaceName}/secret-references',
+        '/api/v1/namespaces/{namespaceName}/secretreferences',
         {
           params: {
             path: { namespaceName },


### PR DESCRIPTION
  Update OpenAPI spec with upstream changes (excluding workflow-related
  changes which are being handled separately). Regenerate TypeScript
  client and fix code to match new API paths.

  - Add git secrets v1alpha1 endpoints and migrate GitSecretsService from legacy client to new typed API client
  - Rename URL paths to match upstream: secret-references → secretreferences, deployment-pipelines → deploymentpipelines
  - Add environment PUT/DELETE, authz pagination, workload schema updates
  - Remove deprecated openid-configuration endpoint

Related to https://github.com/openchoreo/openchoreo/issues/2282
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Git Secrets management with list, create, and delete operations
  * Introduced OpenChoreo client configuration support for OAuth integrations
  * Added pagination support to authorization list responses

* **Bug Fixes**
  * Consolidated API endpoint paths for improved consistency
  * Updated workload configuration to use single container reference instead of multiple containers
  * Enhanced batch authorization evaluation API for better request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->