### PR TITLE
feat: migrate RuntimeLogsService and EnvironmentInfoService to v1 API

### DIFF
--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -2,7 +2,6 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { EnvironmentService, Environment, EndpointInfo } from '../../types';
 import {
   createOpenChoreoApiClient,
-  createOpenChoreoLegacyApiClient,
   fetchAllPages,
   getName,
   type OpenChoreoComponents,
@@ -843,19 +842,18 @@ export class EnvironmentInfoService implements EnvironmentService {
     );
 
     try {
-      const client = createOpenChoreoLegacyApiClient({
+      const client = createOpenChoreoApiClient({
         baseUrl: this.baseUrl,
         token,
         logger: this.logger,
       });
 
       const { data, error, response } = await client.POST(
-        '/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/component-releases',
+        '/api/v1/namespaces/{namespaceName}/components/{componentName}/generate-release',
         {
           params: {
             path: {
               namespaceName: request.namespaceName,
-              projectName: request.projectName,
               componentName: request.componentName,
             },
           },

--- a/plugins/openchoreo-backend/src/services/RuntimeLogsService/RuntimeLogsService.ts
+++ b/plugins/openchoreo-backend/src/services/RuntimeLogsService/RuntimeLogsService.ts
@@ -1,7 +1,7 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { RuntimeLogsService, RuntimeLogsResponse } from '../../types';
 import {
-  createOpenChoreoLegacyApiClient,
+  createOpenChoreoApiClient,
   createObservabilityClientWithUrl,
 } from '@openchoreo/openchoreo-client-node';
 
@@ -75,7 +75,7 @@ export class RuntimeLogsInfoService implements RuntimeLogsService {
       );
 
       // First, get the observer URL from the main API
-      const mainClient = createOpenChoreoLegacyApiClient({
+      const mainClient = createOpenChoreoApiClient({
         baseUrl: this.baseUrl,
         token,
         logger: this.logger,
@@ -86,14 +86,12 @@ export class RuntimeLogsInfoService implements RuntimeLogsService {
         error: urlError,
         response: urlResponse,
       } = await mainClient.GET(
-        '/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/observer-url',
+        '/api/v1/namespaces/{namespaceName}/environments/{envName}/observer-url',
         {
           params: {
             path: {
               namespaceName,
-              projectName,
-              componentName,
-              environmentName,
+              envName: environmentName,
             },
           },
         },
@@ -105,13 +103,7 @@ export class RuntimeLogsInfoService implements RuntimeLogsService {
         );
       }
 
-      if (!urlData.success || !urlData.data) {
-        throw new Error(
-          `API returned unsuccessful response: ${JSON.stringify(urlData)}`,
-        );
-      }
-
-      const observerUrl = urlData.data.observerUrl;
+      const observerUrl = urlData?.observerUrl;
       if (!observerUrl) {
         throw new ObservabilityNotConfiguredError(componentName);
       }


### PR DESCRIPTION
  Replace createOpenChoreoLegacyApiClient with createOpenChoreoApiClient
  in RuntimeLogsService (observer-url) and EnvironmentInfoService
  (generate-release), removing legacy response unwrapping and simplifying
  path parameters. Remove unused legacy client import from
  EnvironmentInfoService.

Related to https://github.com/openchoreo/openchoreo/issues/2282
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Successfully migrated internal API client infrastructure from legacy to the current standard version, benefiting environment management and runtime logging services with improved compatibility and maintainability.
  * Simplified and streamlined API endpoint paths and request parameter handling for component release creation and observer URL retrieval operations.
  * Enhanced error handling mechanisms to properly validate new API response structures and accurately identify missing observability configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->