### PR TITLE
feat(auth): add JWKS sign. verification & fix pre-caching of capabilities

### DIFF
--- a/plugins/auth-backend-module-openchoreo-auth/src/jwtUtils.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/jwtUtils.ts
@@ -38,14 +38,6 @@ let jwksCache: {
 const JWKS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
- * Clears the JWKS cache, forcing a fresh fetch on next verification.
- * Used when token signature verification fails (e.g., after IDP recreation).
- */
-export function clearJwksCache(): void {
-  jwksCache = null;
-}
-
-/**
  * Derives the JWKS URL from the token URL
  * e.g., http://thunder.localhost:8080/oauth2/token -> http://thunder.localhost:8080/.well-known/jwks.json
  */
@@ -61,13 +53,11 @@ export function deriveJwksUrl(tokenUrl: string): string {
 async function fetchJwks(
   jwksUrl: string,
   logger?: LoggerService,
-  bypassCache?: boolean,
 ): Promise<jose.JSONWebKeySet> {
   const now = Date.now();
 
   // Return cached JWKS if still valid
   if (
-    !bypassCache &&
     jwksCache &&
     jwksCache.url === jwksUrl &&
     jwksCache.jwks &&
@@ -106,19 +96,17 @@ async function fetchJwks(
  *
  * @param token - The JWT token to verify
  * @param jwksUrl - The URL to fetch JWKS from
- * @param options - Optional settings: logger for debugging, bypassCache to force fresh JWKS fetch
+ * @param logger - Optional logger for debugging
  * @returns The verified token payload
  * @throws Error if verification fails
  */
 export async function verifyAndDecodeJwt(
   token: string,
   jwksUrl: string,
-  options?: { logger?: LoggerService; bypassCache?: boolean },
+  logger?: LoggerService,
 ): Promise<OpenChoreoTokenPayload> {
-  const { logger, bypassCache } = options ?? {};
-
   try {
-    const jwks = await fetchJwks(jwksUrl, logger, bypassCache);
+    const jwks = await fetchJwks(jwksUrl, logger);
     const JWKS = jose.createLocalJWKSet(jwks);
 
     const { payload } = await jose.jwtVerify(token, JWKS);

--- a/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.ts
@@ -14,7 +14,6 @@ import {
   isTokenExpired,
   getTimeUntilExpiry,
   verifyAndDecodeJwt,
-  clearJwksCache,
   deriveJwksUrl,
 } from './jwtUtils';
 import syncFetch from 'sync-fetch';
@@ -271,11 +270,8 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
         if (!trustedJwksUrl) {
           throw new Error('JWKS URL not configured');
         }
-        await verifyAndDecodeJwt(accessToken, trustedJwksUrl, {
-          bypassCache: true,
-        });
+        await verifyAndDecodeJwt(accessToken, trustedJwksUrl);
       } catch {
-        clearJwksCache();
         throw new Error(
           'Access token signature verification failed, re-authentication required',
         );


### PR DESCRIPTION
  Verify access token signatures against current JWKS during pseudo-refresh,
  catching stale tokens from a recreated IDP instance and forcing re-login.
  
  Also includes a fix where pre-caching reused previously cached capabilities causing permission issues.

Fixes https://github.com/openchoreo/openchoreo/issues/2284
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a control to clear the JWKS (key) cache and enforce fresh key retrieval.
  * Enhanced token refresh to verify access token signatures against a trusted JWKS source.

* **Bug Fixes**
  * Pre-caching of capabilities now always fetches fresh data from the API and updates token- and user-based caches with appropriate TTLs for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->