### PR TITLE
fix(auth): resolve JWKS URL via OIDC discovery

### DIFF
--- a/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.ts
@@ -271,15 +271,14 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
       // Verify token signature against current JWKS
       // This catches stale tokens from a recreated IDP instance
       // Uses trusted JWKS URL from config/discovery, not the unverified token payload
-      try {
-        if (!trustedJwksUrl) {
-          throw new Error('JWKS URL not configured');
+      if (trustedJwksUrl) {
+        try {
+          await verifyAndDecodeJwt(accessToken, trustedJwksUrl);
+        } catch {
+          throw new Error(
+            'Access token signature verification failed, re-authentication required',
+          );
         }
-        await verifyAndDecodeJwt(accessToken, trustedJwksUrl);
-      } catch {
-        throw new Error(
-          'Access token signature verification failed, re-authentication required',
-        );
       }
 
       const timeUntilExpiry = getTimeUntilExpiry(payload);


### PR DESCRIPTION
  deriveJwksUrl() assumed JWKS was at /.well-known/jwks.json, but Thunder
  serves it at /oauth2/jwks. This caused a 401 on every pseudo-refresh,
  forcing users to re-login after every page reload.

  Now always performs OIDC discovery (deriving the discovery URL from the
  tokenUrl origin when metadataUrl is not configured) to get the correct
  jwks_uri from the IDP itself

 **reason for jwks verification when refresh token grant is not enabled from IDP**
 In the pseudo-refresh path, when Backstage needs to refresh the session:          
                                     
  1. Extract the original access token from the pseudo-refresh token                                
  2. Decode the JWT unsafely to check claims                                                        
  3. Check expiry — if expired or within 60s of expiry, force re-login                              
  4. JWKS verification — verify the token signature against the IDP's current keys (catches         
  recreated IDP)
  5. Return the same session — reuse the original access token with the same profile/session data

  In the standard refresh path, it just calls helper.refresh(input) which does a normal
  OAuth2 refresh token grant to the IDP and gets back a fresh access token. No JWKS verification
  needed because the IDP itself is issuing a new token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC authentication flexibility: supports explicit metadata URLs and automatic discovery derived from token endpoints.
  * Discovery now populates authorization/token endpoints only when not explicitly provided.
  * JWKS verification is performed only when a trusted JWKS URL is available; verification failures now surface a re-authentication error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->