### PR TITLE
refactor(observability): resolve observer URLs via ObservabilityPlane resource chain

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-api-legacy.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api-legacy.yaml
@@ -1174,27 +1174,6 @@ components:
           additionalProperties: true
           description: Developer-defined workflow parameters as arbitrary JSON
 
-    # Observer URL
-    ObserverUrlData:
-      type: object
-      properties:
-        observerUrl:
-          type: string
-        message:
-          type: string
-          description: Message returned when observability is not configured
-
-    # RCA Agent URL
-    RCAAgentUrlData:
-      type: object
-      properties:
-        rcaAgentUrl:
-          type: string
-          description: URL to the RCA agent service for AI-powered root cause analysis
-        message:
-          type: string
-          description: Additional information or status message
-
     # ComponentRelease
     ComponentReleaseResponse:
       type: object
@@ -2663,71 +2642,6 @@ paths:
                     properties:
                       data:
                         $ref: '#/components/schemas/EnvironmentResponse'
-
-  /namespaces/{namespaceName}/environments/{envName}/observer-url:
-    get:
-      summary: Get environment observer URL
-      operationId: getEnvironmentObserverURL
-      tags:
-        - Observability
-      parameters:
-        - name: namespaceName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: envName
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/APIResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/ObserverUrlData'
-        '404':
-          description: Environment or DataPlane not found
-
-  /namespaces/{namespaceName}/environments/{envName}/rca-agent-url:
-    get:
-      summary: Get RCA agent URL
-      description: Returns the RCA agent URL for AI-powered root cause analysis for this environment.
-      operationId: getRCAAgentURL
-      tags:
-        - Environments
-      parameters:
-        - name: namespaceName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: envName
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: RCA agent URL information
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/APIResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/RCAAgentUrlData'
-        '404':
-          description: Environment or RCA agent not found
 
   # BuildPlanes
   /namespaces/{namespaceName}/buildplanes:
@@ -4804,82 +4718,6 @@ paths:
                                 type: array
                                 items:
                                   $ref: '#/components/schemas/BindingResponse'
-
-  # Observer URLs
-  /namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/observer-url:
-    get:
-      summary: Get runtime logs observer URL
-      operationId: getComponentObserverURL
-      tags:
-        - Observability
-      parameters:
-        - name: namespaceName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: projectName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: componentName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: environmentName
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/APIResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/ObserverUrlData'
-
-  /namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/observer-url:
-    get:
-      summary: Get build logs observer URL
-      operationId: getBuildObserverURL
-      tags:
-        - Observability
-      parameters:
-        - name: namespaceName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: projectName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: componentName
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/APIResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/ObserverUrlData'
 
   /namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/release:
     get:

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -646,56 +646,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/namespaces/{namespaceName}/environments/{envName}/observer-url:
-    get:
-      operationId: getEnvironmentObserverURL
-      summary: Get environment observer URL
-      description: Returns the observer URL for accessing logs and metrics for this environment.
-      tags: [Environments]
-      parameters:
-        - $ref: '#/components/parameters/NamespaceNameParam'
-        - $ref: '#/components/parameters/EnvironmentNameParam'
-      responses:
-        '200':
-          description: Observer URL information
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ObserverURLResponse'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalError'
-
-  /api/v1/namespaces/{namespaceName}/environments/{envName}/rca-agent-url:
-    get:
-      operationId: getRCAAgentURL
-      summary: Get RCA agent URL
-      description: Returns the RCA agent URL for AI-powered root cause analysis for this environment.
-      tags: [Environments]
-      parameters:
-        - $ref: '#/components/parameters/NamespaceNameParam'
-        - $ref: '#/components/parameters/EnvironmentNameParam'
-      responses:
-        '200':
-          description: RCA agent URL information
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RCAAgentURLResponse'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalError'
-
   # =============================================================================
   # DataPlane Endpoints
   # =============================================================================
@@ -5713,32 +5663,6 @@ components:
             $ref: '#/components/schemas/Environment'
         pagination:
           $ref: '#/components/schemas/Pagination'
-
-    ObserverURLResponse:
-      type: object
-      description: Observer URL response for accessing logs and metrics
-      properties:
-        observerUrl:
-          type: string
-          description: URL to the observer service for logs and metrics
-          example: https://observer.example.com/api/v1
-        message:
-          type: string
-          description: Additional information or status message
-          example: Observer URL is available
-
-    RCAAgentURLResponse:
-      type: object
-      description: RCA agent URL response for AI-powered root cause analysis
-      properties:
-        rcaAgentUrl:
-          type: string
-          description: URL to the RCA agent service for AI-powered root cause analysis
-          example: https://rca-agent.example.com
-        message:
-          type: string
-          description: Additional information or status message
-          example: RCA agent URL is available
 
     # -------------------------------------------------------------------------
     # DataPlanes

--- a/packages/openchoreo-client-node/src/generated/openchoreo-legacy/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo-legacy/types.ts
@@ -297,43 +297,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/namespaces/{namespaceName}/environments/{envName}/observer-url': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get environment observer URL */
-    get: operations['getEnvironmentObserverURL'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/namespaces/{namespaceName}/environments/{envName}/rca-agent-url': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get RCA agent URL
-     * @description Returns the RCA agent URL for AI-powered root cause analysis for this environment.
-     */
-    get: operations['getRCAAgentURL'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/namespaces/{namespaceName}/buildplanes': {
     parameters: {
       query?: never;
@@ -1022,40 +985,6 @@ export interface paths {
     put?: never;
     /** Promote component to environment */
     post: operations['promoteComponent'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/environments/{environmentName}/observer-url': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get runtime logs observer URL */
-    get: operations['getComponentObserverURL'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/observer-url': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get build logs observer URL */
-    get: operations['getBuildObserverURL'];
-    put?: never;
-    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -1908,17 +1837,6 @@ export interface components {
       parameters?: {
         [key: string]: unknown;
       };
-    };
-    ObserverUrlData: {
-      observerUrl?: string;
-      /** @description Message returned when observability is not configured */
-      message?: string;
-    };
-    RCAAgentUrlData: {
-      /** @description URL to the RCA agent service for AI-powered root cause analysis */
-      rcaAgentUrl?: string;
-      /** @description Additional information or status message */
-      message?: string;
     };
     /**
      * @description Immutable snapshot of component configuration.
@@ -2911,70 +2829,6 @@ export interface operations {
             data?: components['schemas']['EnvironmentResponse'];
           };
         };
-      };
-    };
-  };
-  getEnvironmentObserverURL: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        namespaceName: string;
-        envName: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['APIResponse'] & {
-            data?: components['schemas']['ObserverUrlData'];
-          };
-        };
-      };
-      /** @description Environment or DataPlane not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getRCAAgentURL: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        namespaceName: string;
-        envName: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description RCA agent URL information */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['APIResponse'] & {
-            data?: components['schemas']['RCAAgentUrlData'];
-          };
-        };
-      };
-      /** @description Environment or RCA agent not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
       };
     };
   };
@@ -4853,59 +4707,6 @@ export interface operations {
             data?: components['schemas']['ListResponse'] & {
               items?: components['schemas']['BindingResponse'][];
             };
-          };
-        };
-      };
-    };
-  };
-  getComponentObserverURL: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        namespaceName: string;
-        projectName: string;
-        componentName: string;
-        environmentName: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['APIResponse'] & {
-            data?: components['schemas']['ObserverUrlData'];
-          };
-        };
-      };
-    };
-  };
-  getBuildObserverURL: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        namespaceName: string;
-        projectName: string;
-        componentName: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['APIResponse'] & {
-            data?: components['schemas']['ObserverUrlData'];
           };
         };
       };

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -294,46 +294,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/namespaces/{namespaceName}/environments/{envName}/observer-url': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get environment observer URL
-     * @description Returns the observer URL for accessing logs and metrics for this environment.
-     */
-    get: operations['getEnvironmentObserverURL'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/namespaces/{namespaceName}/environments/{envName}/rca-agent-url': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get RCA agent URL
-     * @description Returns the RCA agent URL for AI-powered root cause analysis for this environment.
-     */
-    get: operations['getRCAAgentURL'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/api/v1/namespaces/{namespaceName}/dataplanes': {
     parameters: {
       query?: never;
@@ -2628,32 +2588,6 @@ export interface components {
     EnvironmentList: {
       items: components['schemas']['Environment'][];
       pagination?: components['schemas']['Pagination'];
-    };
-    /** @description Observer URL response for accessing logs and metrics */
-    ObserverURLResponse: {
-      /**
-       * @description URL to the observer service for logs and metrics
-       * @example https://observer.example.com/api/v1
-       */
-      observerUrl?: string;
-      /**
-       * @description Additional information or status message
-       * @example Observer URL is available
-       */
-      message?: string;
-    };
-    /** @description RCA agent URL response for AI-powered root cause analysis */
-    RCAAgentURLResponse: {
-      /**
-       * @description URL to the RCA agent service for AI-powered root cause analysis
-       * @example https://rca-agent.example.com
-       */
-      rcaAgentUrl?: string;
-      /**
-       * @description Additional information or status message
-       * @example RCA agent URL is available
-       */
-      message?: string;
     };
     /** @description Paginated list of data planes */
     DataPlaneList: {
@@ -5906,64 +5840,6 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
-      };
-      401: components['responses']['Unauthorized'];
-      403: components['responses']['Forbidden'];
-      404: components['responses']['NotFound'];
-      500: components['responses']['InternalError'];
-    };
-  };
-  getEnvironmentObserverURL: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Namespace name */
-        namespaceName: components['parameters']['NamespaceNameParam'];
-        /** @description Environment name */
-        envName: components['parameters']['EnvironmentNameParam'];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Observer URL information */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ObserverURLResponse'];
-        };
-      };
-      401: components['responses']['Unauthorized'];
-      403: components['responses']['Forbidden'];
-      404: components['responses']['NotFound'];
-      500: components['responses']['InternalError'];
-    };
-  };
-  getRCAAgentURL: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Namespace name */
-        namespaceName: components['parameters']['NamespaceNameParam'];
-        /** @description Environment name */
-        envName: components['parameters']['EnvironmentNameParam'];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description RCA agent URL information */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['RCAAgentURLResponse'];
-        };
       };
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];

--- a/packages/openchoreo-client-node/src/index.ts
+++ b/packages/openchoreo-client-node/src/index.ts
@@ -27,6 +27,13 @@ export {
   TRACE_ENV_VAR,
 } from './tracing';
 
+// Export observability URL resolver
+export {
+  ObservabilityUrlResolver,
+  type ObservabilityUrlsResult,
+  type ObservabilityUrlResolverOptions,
+} from './observability-url-resolver';
+
 // Export resource utilities (new API)
 export {
   getName,

--- a/packages/openchoreo-client-node/src/observability-url-resolver.ts
+++ b/packages/openchoreo-client-node/src/observability-url-resolver.ts
@@ -1,0 +1,351 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  createOpenChoreoApiClient,
+  type OpenChoreoClientConfig,
+} from './factory';
+
+/** Resolved observability URLs for an environment or build context. */
+export interface ObservabilityUrlsResult {
+  observerUrl?: string;
+  rcaAgentUrl?: string;
+}
+
+/** Options for constructing an ObservabilityUrlResolver. */
+export interface ObservabilityUrlResolverOptions {
+  baseUrl: string;
+  logger?: LoggerService;
+  /** Cache TTL in milliseconds. Defaults to 5 minutes. */
+  cacheTtlMs?: number;
+}
+
+interface CacheEntry {
+  result: ObservabilityUrlsResult;
+  expiresAt: number;
+}
+
+const DEFAULT_PLANE_NAME = 'default';
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Resolves observer and RCA agent URLs by traversing the Kubernetes resource
+ * reference chain using the OpenChoreo CRUD API.
+ *
+ * **Runtime observability** (environment-based):
+ *   Environment → DataPlane (or ClusterDataPlane) → ObservabilityPlane → observerURL / rcaAgentURL
+ *
+ * **Build observability** (project-based):
+ *   Project → BuildPlane (or ClusterBuildPlane) → ObservabilityPlane → observerURL
+ */
+export class ObservabilityUrlResolver {
+  private readonly baseUrl: string;
+  private readonly logger?: LoggerService;
+  private readonly cacheTtlMs: number;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(options: ObservabilityUrlResolverOptions) {
+    this.baseUrl = options.baseUrl;
+    this.logger = options.logger;
+    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  }
+
+  /**
+   * Resolve observability URLs for a runtime environment.
+   *
+   * Chain: Environment → DataPlane/ClusterDataPlane → ObservabilityPlane/ClusterObservabilityPlane
+   */
+  async resolveForEnvironment(
+    namespaceName: string,
+    envName: string,
+    token?: string,
+  ): Promise<ObservabilityUrlsResult> {
+    const cacheKey = `env:${namespaceName}/${envName}`;
+    const cached = this.getFromCache(cacheKey);
+    if (cached) return cached;
+
+    const client = this.createClient(token);
+
+    // Step 1: Get the environment to read its dataPlaneRef
+    const {
+      data: env,
+      error: envError,
+      response: envResp,
+    } = await client.GET(
+      '/api/v1/namespaces/{namespaceName}/environments/{envName}',
+      { params: { path: { namespaceName, envName } } },
+    );
+    if (envError || !envResp.ok) {
+      throw new Error(
+        `Failed to get environment '${envName}': ${envResp.status} ${envResp.statusText}`,
+      );
+    }
+
+    const dataPlaneRef = (env as any)?.spec?.dataPlaneRef;
+
+    // Step 2: Get the DataPlane or ClusterDataPlane
+    let observabilityPlaneRef: { kind: string; name: string } | undefined;
+
+    if (!dataPlaneRef || dataPlaneRef.kind === 'DataPlane') {
+      const dpName = dataPlaneRef?.name ?? DEFAULT_PLANE_NAME;
+      const {
+        data: dp,
+        error: dpError,
+        response: dpResp,
+      } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/dataplanes/{dpName}',
+        { params: { path: { namespaceName, dpName } } },
+      );
+      if (dpError || !dpResp.ok) {
+        throw new Error(
+          `Failed to get DataPlane '${dpName}': ${dpResp.status} ${dpResp.statusText}`,
+        );
+      }
+      const ref = (dp as any)?.spec?.observabilityPlaneRef;
+      observabilityPlaneRef = ref ?? {
+        kind: 'ObservabilityPlane',
+        name: DEFAULT_PLANE_NAME,
+      };
+    } else if (dataPlaneRef.kind === 'ClusterDataPlane') {
+      const cdpName = dataPlaneRef.name;
+      const {
+        data: cdp,
+        error: cdpError,
+        response: cdpResp,
+      } = await client.GET('/api/v1/clusterdataplanes/{cdpName}', {
+        params: { path: { cdpName } },
+      });
+      if (cdpError || !cdpResp.ok) {
+        throw new Error(
+          `Failed to get ClusterDataPlane '${cdpName}': ${cdpResp.status} ${cdpResp.statusText}`,
+        );
+      }
+      const ref = (cdp as any)?.spec?.observabilityPlaneRef;
+      observabilityPlaneRef = ref ?? {
+        kind: 'ClusterObservabilityPlane',
+        name: DEFAULT_PLANE_NAME,
+      };
+    } else {
+      throw new Error(`Unsupported dataPlaneRef kind '${dataPlaneRef.kind}'`);
+    }
+
+    // Step 3: Get the ObservabilityPlane or ClusterObservabilityPlane
+    const result = await this.getObservabilityPlaneUrls(
+      client,
+      namespaceName,
+      observabilityPlaneRef!,
+    );
+
+    this.putInCache(cacheKey, result);
+    return result;
+  }
+
+  /**
+   * Resolve observability URLs for build logs (project-based).
+   *
+   * Chain: Project → BuildPlane/ClusterBuildPlane → ObservabilityPlane/ClusterObservabilityPlane
+   */
+  async resolveForBuild(
+    namespaceName: string,
+    projectName: string,
+    token?: string,
+  ): Promise<ObservabilityUrlsResult> {
+    const cacheKey = `build:${namespaceName}/${projectName}`;
+    const cached = this.getFromCache(cacheKey);
+    if (cached) return cached;
+
+    const client = this.createClient(token);
+
+    // Step 1: Get the project to read its buildPlaneRef
+    const {
+      data: project,
+      error: projError,
+      response: projResp,
+    } = await client.GET(
+      '/api/v1/namespaces/{namespaceName}/projects/{projectName}',
+      { params: { path: { namespaceName, projectName } } },
+    );
+    if (projError || !projResp.ok) {
+      throw new Error(
+        `Failed to get project '${projectName}': ${projResp.status} ${projResp.statusText}`,
+      );
+    }
+
+    const buildPlaneRef = (project as any)?.spec?.buildPlaneRef;
+
+    // Step 2: Get the BuildPlane or ClusterBuildPlane
+    let observabilityPlaneRef: { kind: string; name: string } | undefined;
+
+    if (!buildPlaneRef || buildPlaneRef.kind === 'BuildPlane') {
+      const bpName = buildPlaneRef?.name ?? DEFAULT_PLANE_NAME;
+      const {
+        data: bp,
+        error: bpError,
+        response: bpResp,
+      } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/buildplanes/{buildPlaneName}',
+        { params: { path: { namespaceName, buildPlaneName: bpName } } },
+      );
+
+      if (bpError || !bpResp.ok) {
+        // Fallback: try ClusterBuildPlane "default" (matches Go backend behavior)
+        if (bpResp.status === 404 && !buildPlaneRef) {
+          this.logger?.debug(
+            `BuildPlane '${bpName}' not found in namespace '${namespaceName}', trying ClusterBuildPlane '${DEFAULT_PLANE_NAME}'`,
+          );
+          return this.resolveForBuildViaClusterBuildPlane(
+            client,
+            namespaceName,
+            DEFAULT_PLANE_NAME,
+            cacheKey,
+          );
+        }
+        throw new Error(
+          `Failed to get BuildPlane '${bpName}': ${bpResp.status} ${bpResp.statusText}`,
+        );
+      }
+      const ref = (bp as any)?.spec?.observabilityPlaneRef;
+      observabilityPlaneRef = ref ?? {
+        kind: 'ObservabilityPlane',
+        name: DEFAULT_PLANE_NAME,
+      };
+    } else if (buildPlaneRef.kind === 'ClusterBuildPlane') {
+      return this.resolveForBuildViaClusterBuildPlane(
+        client,
+        namespaceName,
+        buildPlaneRef.name,
+        cacheKey,
+      );
+    } else {
+      throw new Error(`Unsupported buildPlaneRef kind '${buildPlaneRef.kind}'`);
+    }
+
+    // Step 3: Get the ObservabilityPlane or ClusterObservabilityPlane
+    const result = await this.getObservabilityPlaneUrls(
+      client,
+      namespaceName,
+      observabilityPlaneRef!,
+    );
+
+    this.putInCache(cacheKey, result);
+    return result;
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  private createClient(token?: string) {
+    return createOpenChoreoApiClient({
+      baseUrl: this.baseUrl,
+      token,
+      logger: this.logger,
+    } as OpenChoreoClientConfig);
+  }
+
+  private async resolveForBuildViaClusterBuildPlane(
+    client: ReturnType<typeof createOpenChoreoApiClient>,
+    namespaceName: string,
+    clusterBuildPlaneName: string,
+    cacheKey: string,
+  ): Promise<ObservabilityUrlsResult> {
+    const {
+      data: cbp,
+      error: cbpError,
+      response: cbpResp,
+    } = await client.GET('/api/v1/clusterbuildplanes/{clusterBuildPlaneName}', {
+      params: { path: { clusterBuildPlaneName } },
+    });
+    if (cbpError || !cbpResp.ok) {
+      throw new Error(
+        `Failed to get ClusterBuildPlane '${clusterBuildPlaneName}': ${cbpResp.status} ${cbpResp.statusText}`,
+      );
+    }
+    const ref = (cbp as any)?.spec?.observabilityPlaneRef;
+    const observabilityPlaneRef = ref ?? {
+      kind: 'ClusterObservabilityPlane',
+      name: DEFAULT_PLANE_NAME,
+    };
+
+    const result = await this.getObservabilityPlaneUrls(
+      client,
+      namespaceName,
+      observabilityPlaneRef,
+    );
+    this.putInCache(cacheKey, result);
+    return result;
+  }
+
+  private async getObservabilityPlaneUrls(
+    client: ReturnType<typeof createOpenChoreoApiClient>,
+    namespaceName: string,
+    ref: { kind: string; name: string },
+  ): Promise<ObservabilityUrlsResult> {
+    if (ref.kind === 'ObservabilityPlane') {
+      const {
+        data: op,
+        error: opError,
+        response: opResp,
+      } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/observabilityplanes/{observabilityPlaneName}',
+        {
+          params: {
+            path: { namespaceName, observabilityPlaneName: ref.name },
+          },
+        },
+      );
+      if (opError || !opResp.ok) {
+        throw new Error(
+          `Failed to get ObservabilityPlane '${ref.name}': ${opResp.status} ${opResp.statusText}`,
+        );
+      }
+      return {
+        observerUrl: (op as any)?.spec?.observerURL,
+        rcaAgentUrl: (op as any)?.spec?.rcaAgentURL,
+      };
+    }
+
+    if (ref.kind === 'ClusterObservabilityPlane') {
+      const {
+        data: cop,
+        error: copError,
+        response: copResp,
+      } = await client.GET(
+        '/api/v1/clusterobservabilityplanes/{clusterObservabilityPlaneName}',
+        {
+          params: {
+            path: { clusterObservabilityPlaneName: ref.name },
+          },
+        },
+      );
+      if (copError || !copResp.ok) {
+        throw new Error(
+          `Failed to get ClusterObservabilityPlane '${ref.name}': ${copResp.status} ${copResp.statusText}`,
+        );
+      }
+      return {
+        observerUrl: (cop as any)?.spec?.observerURL,
+        rcaAgentUrl: (cop as any)?.spec?.rcaAgentURL,
+      };
+    }
+
+    throw new Error(`Unsupported observabilityPlaneRef kind '${ref.kind}'`);
+  }
+
+  private getFromCache(key: string): ObservabilityUrlsResult | undefined {
+    const entry = this.cache.get(key);
+    if (entry && Date.now() < entry.expiresAt) {
+      this.logger?.debug(`ObservabilityUrlResolver cache hit for '${key}'`);
+      return entry.result;
+    }
+    if (entry) {
+      this.cache.delete(key);
+    }
+    return undefined;
+  }
+
+  private putInCache(key: string, result: ObservabilityUrlsResult): void {
+    this.cache.set(key, {
+      result,
+      expiresAt: Date.now() + this.cacheTtlMs,
+    });
+  }
+}

--- a/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
+++ b/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
@@ -1,9 +1,9 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 import {
   createOpenChoreoApiClient,
-  createOpenChoreoLegacyApiClient,
   createObservabilityClientWithUrl,
   fetchAllPages,
+  ObservabilityUrlResolver,
 } from '@openchoreo/openchoreo-client-node';
 import type {
   ComponentWorkflowRunResponse,
@@ -105,10 +105,12 @@ export class ObservabilityNotConfiguredError extends Error {
 export class WorkflowService {
   private logger: LoggerService;
   private baseUrl: string;
+  private readonly resolver: ObservabilityUrlResolver;
 
   constructor(logger: LoggerService, baseUrl: string) {
     this.logger = logger;
     this.baseUrl = baseUrl;
+    this.resolver = new ObservabilityUrlResolver({ baseUrl, logger });
   }
 
   // ==================== Build Operations ====================
@@ -378,48 +380,16 @@ export class WorkflowService {
     );
 
     try {
-      // First, get the observer URL from the main API (deferred — stays on legacy)
-      const mainClient = createOpenChoreoLegacyApiClient({
-        baseUrl: this.baseUrl,
+      const { observerUrl } = await this.resolver.resolveForBuild(
+        namespaceName,
+        projectName,
         token,
-        logger: this.logger,
-      });
-
-      const {
-        data: urlData,
-        error: urlError,
-        response: urlResponse,
-      } = await mainClient.GET(
-        '/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/observer-url',
-        {
-          params: {
-            path: {
-              namespaceName,
-              projectName,
-              componentName,
-            },
-          },
-        },
       );
 
-      if (urlError || !urlResponse.ok) {
-        throw new Error(
-          `Failed to get observer URL: ${urlResponse.status} ${urlResponse.statusText}`,
-        );
-      }
-
-      if (!urlData.success || !urlData.data) {
-        throw new Error(
-          `API returned unsuccessful response: ${JSON.stringify(urlData)}`,
-        );
-      }
-
-      const observerUrl = urlData.data.observerUrl;
       if (!observerUrl) {
         throw new ObservabilityNotConfiguredError(componentName);
       }
 
-      // Now use the observability client with the resolved URL
       const obsClient = createObservabilityClientWithUrl(
         observerUrl,
         token,
@@ -551,44 +521,16 @@ export class WorkflowService {
       }
 
       // Use observer API for older workflow runs
-      // First, get the observer URL from the main API (deferred — stays on legacy)
-      const mainClient = createOpenChoreoLegacyApiClient({
-        baseUrl: this.baseUrl,
+      const { observerUrl } = await this.resolver.resolveForBuild(
+        namespaceName,
+        projectName,
         token,
-        logger: this.logger,
-      });
-
-      const {
-        data: urlData,
-        error: urlError,
-        response: urlResponse,
-      } = await mainClient.GET(
-        '/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/observer-url',
-        {
-          params: {
-            path: { namespaceName, projectName, componentName },
-          },
-        },
       );
 
-      if (urlError || !urlResponse.ok) {
-        throw new Error(
-          `Failed to get observer URL: ${urlResponse.status} ${urlResponse.statusText}`,
-        );
-      }
-
-      if (!urlData.success || !urlData.data) {
-        throw new Error(
-          `API returned unsuccessful response: ${JSON.stringify(urlData)}`,
-        );
-      }
-
-      const observerUrl = urlData.data.observerUrl;
       if (!observerUrl) {
         throw new ObservabilityNotConfiguredError(componentName);
       }
 
-      // Now use the observability client with the resolved URL
       const obsClient = createObservabilityClientWithUrl(
         observerUrl,
         token,
@@ -724,44 +666,16 @@ export class WorkflowService {
       }
 
       // Use observer API for older workflow runs
-      // First, get the observer URL from the main API (deferred — stays on legacy)
-      const mainClient = createOpenChoreoLegacyApiClient({
-        baseUrl: this.baseUrl,
+      const { observerUrl } = await this.resolver.resolveForBuild(
+        namespaceName,
+        projectName,
         token,
-        logger: this.logger,
-      });
-
-      const {
-        data: urlData,
-        error: urlError,
-        response: urlResponse,
-      } = await mainClient.GET(
-        '/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/observer-url',
-        {
-          params: {
-            path: { namespaceName, projectName, componentName },
-          },
-        },
       );
 
-      if (urlError || !urlResponse.ok) {
-        throw new Error(
-          `Failed to get observer URL: ${urlResponse.status} ${urlResponse.statusText}`,
-        );
-      }
-
-      if (!urlData.success || !urlData.data) {
-        throw new Error(
-          `API returned unsuccessful response: ${JSON.stringify(urlData)}`,
-        );
-      }
-
-      const observerUrl = urlData.data.observerUrl;
       if (!observerUrl) {
         throw new ObservabilityNotConfiguredError(componentName);
       }
 
-      // Now use the observability client with the resolved URL
       const obsClient = createObservabilityClientWithUrl(
         observerUrl,
         token,


### PR DESCRIPTION
  Replace dedicated observer-url/rca-agent-url API endpoints with
  client-side resolution through the K8s resource reference chain
  (Environment → DataPlane → ObservabilityPlane → observerURL).

  - Add ObservabilityUrlResolver class with caching (5min TTL)
  - Support both namespaced and cluster-scoped plane resources
  - Remove deprecated observer-url endpoints from OpenAPI specs
  - Regenerate TypeScript clients
  - Migrate all 6 backend services to use the new resolver

  Implements openchoreo/openchoreo#2279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Removed deprecated observer URL and RCA agent URL endpoints from the public API.

* **New Features**
  * Added ObservabilityUrlResolver for programmatic observability URL resolution.

* **Refactor**
  * Replaced direct API calls with a unified URL resolution mechanism across backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->