### PR TITLE
feat(scaffolder): add workload type display to component type cards

### DIFF
--- a/packages/app/src/components/scaffolder/CustomTemplateCard.tsx
+++ b/packages/app/src/components/scaffolder/CustomTemplateCard.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography, Chip, IconButton, Tooltip } from '@material-ui/core';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import StarIcon from '@material-ui/icons/Star';
 import StarBorderIcon from '@material-ui/icons/StarBorder';
 import FolderOutlinedIcon from '@material-ui/icons/FolderOutlined';
@@ -45,6 +46,8 @@ export const CustomTemplateCard = ({
   const tags = template.metadata.tags ?? [];
   const type = template.spec.type;
   const icon = TYPE_ICONS[type] ?? DEFAULT_ICON;
+  const workloadType =
+    template.metadata.annotations?.[CHOREO_ANNOTATIONS.WORKLOAD_TYPE];
 
   const handleClick = () => {
     if (!disabled) onSelected?.(template);
@@ -72,6 +75,11 @@ export const CustomTemplateCard = ({
       tabIndex={disabled ? -1 : 0}
       aria-disabled={disabled}
     >
+      {workloadType && (
+        <Typography className={classes.workloadTypeBadge}>
+          {workloadType}
+        </Typography>
+      )}
       <IconButton
         size="small"
         className={`${classes.starButton} ${

--- a/packages/app/src/components/scaffolder/styles.ts
+++ b/packages/app/src/components/scaffolder/styles.ts
@@ -147,6 +147,16 @@ export const useStyles = makeStyles(theme => ({
     marginTop: theme.spacing(0.5),
     lineHeight: 1.4,
   },
+  workloadTypeBadge: {
+    position: 'absolute',
+    top: theme.spacing(1),
+    left: theme.spacing(1.5),
+    fontSize: '0.65rem',
+    fontWeight: 600,
+    color: theme.palette.primary.main,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+  },
   starButton: {
     position: 'absolute',
     top: theme.spacing(1),

--- a/packages/openchoreo-client-node/src/resource-utils.test.ts
+++ b/packages/openchoreo-client-node/src/resource-utils.test.ts
@@ -164,15 +164,15 @@ describe('getDisplayName', () => {
     expect(getDisplayName(fullResource)).toBe('My Resource');
   });
 
-  it('falls back to resource name when annotation is missing', () => {
+  it('returns empty string when annotation is missing', () => {
     const noAnnotations = {
       metadata: { name: 'fallback-name' },
     };
-    expect(getDisplayName(noAnnotations)).toBe('fallback-name');
+    expect(getDisplayName(noAnnotations)).toBe('');
   });
 
-  it('returns undefined for empty resource', () => {
-    expect(getDisplayName(emptyResource)).toBeUndefined();
+  it('returns empty string for empty resource', () => {
+    expect(getDisplayName(emptyResource)).toBe('');
   });
 });
 

--- a/packages/openchoreo-client-node/src/resource-utils.ts
+++ b/packages/openchoreo-client-node/src/resource-utils.ts
@@ -81,9 +81,7 @@ export function getAnnotation(
  * resource name.
  */
 export function getDisplayName(resource: HasMetadata): string | undefined {
-  return (
-    getAnnotation(resource, 'openchoreo.dev/display-name') ?? getName(resource)
-  );
+  return getAnnotation(resource, 'openchoreo.dev/display-name') ?? '';
 }
 
 /**

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
@@ -69,6 +69,8 @@ export class CtdToTemplateConverter {
         annotations: {
           [CHOREO_ANNOTATIONS.CTD_NAME]: componentType.metadata.name,
           [CHOREO_ANNOTATIONS.CTD_GENERATED]: 'true',
+          [CHOREO_ANNOTATIONS.WORKLOAD_TYPE]:
+            componentType.metadata.workloadType,
         },
       },
       spec: {


### PR DESCRIPTION
## Purpose

Resolves: https://github.com/openchoreo/openchoreo/issues/2316

## Goals

Add workload type display to component type cards

<img width="2990" height="1730" alt="image" src="https://github.com/user-attachments/assets/0275c587-21b7-4be3-9483-8a175b1cb619" />


## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Template cards now prominently display workload type information as a badge in the card header, facilitating quicker identification and organization of different resource types within the scaffolder.

* **Bug Fixes**
  * Improved handling of display name resolution when annotations are missing, ensuring more consistent and predictable behavior across resource management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->