### PR TITLE
refactor(observability): move to v1 logs API

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
@@ -1,11 +1,12 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: OpenChoreo Observer API
   description: |
-    The OpenChoreo Observer API provides endpoints for querying build logs, component logs,
-    traces, and metrics from components, projects, gateways, and namespaces.
-    It integrates with OpenSearch for logs, build logs, and traces,
-    and with Prometheus for metrics.
+    The OpenChoreo Observer API provides endpoints for querying logs,
+    traces, and metrics from namespaces for components, projects, and environments,
+    as well as logs from workflows.
+    It integrates with separate observability modules to fetch the actual data via
+    API calls to the adaptors provided by the modules.
   version: 1.0.0
   contact:
     name: OpenChoreo Team
@@ -16,12 +17,11 @@ info:
 tags:
   - name: Logs
     description: Log retrieval endpoints
-  - name: Traces
-    description: Trace retrieval endpoints
-  - name: Metrics
-    description: Resource metrics endpoints
   - name: Health
     description: Health check endpoints
+
+security:
+  - BearerAuth: []
 
 paths:
   /health:
@@ -29,8 +29,9 @@ paths:
       tags:
         - Health
       summary: Health check
-      description: Check the health status of the observer service including OpenSearch and Prometheus connectivity
+      description: Check the health status of the observer service.
       operationId: health
+      security: []
       responses:
         '200':
           description: Service is healthy
@@ -56,47 +57,69 @@ paths:
                     type: string
                     example: 'opensearch: connection failed'
 
-  /api/logs/build/{buildId}:
+  # Logs query endpoint
+  /api/v1/logs/query:
     post:
       tags:
         - Logs
-      summary: Get build logs
-      description: Retrieve logs for a specific build
-      operationId: getBuildLogs
-      parameters:
-        - name: buildId
-          in: path
-          required: true
-          description: The unique identifier of the build
-          schema:
-            type: string
-            example: 'build-123'
+      summary: Query logs
+      description: Query logs from the observer service
+      operationId: queryLogs
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BuildLogsRequest'
+              $ref: '#/components/schemas/LogsQueryRequest'
       responses:
         '200':
-          description: Successfully retrieved build logs
+          description: Logs queried successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LogResponse'
+                $ref: '#/components/schemas/LogsQueryResponse'
         '400':
-          description: Bad request - invalid parameters
+          description: Invalid request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              example:
+                title: 'badRequest'
+                errorCode: ''
+                message: "Missing required fields 'startTime' and 'endTime'"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                title: 'unauthorized'
+                errorCode: ''
+                message: 'Invalid or missing token'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                title: 'forbidden'
+                errorCode: ''
+                message: 'Subject <xyz> has no permission to view logs of Namespace foo, Project bar, Component baz in Environment development'
         '500':
-          description: Internal server error
+          description: Internal Server Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              example:
+                title: 'internalServerError'
+                errorCode: 'OBS-V1-L-29'
+                message: ''
 
+  # TODO: Remove this in favor of /api/v1/logs/query
   /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/workflow-runs/{runName}/logs:
     get:
       tags:
@@ -193,6 +216,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  # TODO: Remove this as events support is not available in the observability plane yet
   /api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/workflow-runs/{runName}/events:
     get:
       tags:
@@ -270,162 +294,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Workflow run not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /api/logs/component/{componentId}:
-    post:
-      tags:
-        - Logs
-      summary: Get component logs
-      description: Retrieve logs for a specific component
-      operationId: getComponentLogs
-      parameters:
-        - name: componentId
-          in: path
-          required: true
-          description: The unique identifier of the component
-          schema:
-            type: string
-            example: 'comp-123'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ComponentLogsRequest'
-      responses:
-        '200':
-          description: Successfully retrieved component logs
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LogResponse'
-        '400':
-          description: Bad request - invalid parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /api/logs/project/{projectId}:
-    post:
-      tags:
-        - Logs
-      summary: Get project logs
-      description: Retrieve logs for all components in a specific project
-      operationId: getProjectLogs
-      parameters:
-        - name: projectId
-          in: path
-          required: true
-          description: The unique identifier of the project
-          schema:
-            type: string
-            example: 'proj-456'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProjectLogsRequest'
-      responses:
-        '200':
-          description: Successfully retrieved project logs
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LogResponse'
-        '400':
-          description: Bad request - invalid parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /api/logs/gateway:
-    post:
-      tags:
-        - Logs
-      summary: Get gateway logs
-      description: Retrieve logs from API gateway
-      operationId: getGatewayLogs
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GatewayLogsRequest'
-      responses:
-        '200':
-          description: Successfully retrieved gateway logs
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LogResponse'
-        '400':
-          description: Bad request - invalid parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /api/logs/namespace/{namespaceName}:
-    post:
-      tags:
-        - Logs
-      summary: Get namespace logs
-      description: Retrieve logs for an entire namespace
-      operationId: getNamespaceLogs
-      parameters:
-        - name: namespaceName
-          in: path
-          required: true
-          description: The unique identifier of the namespace
-          schema:
-            type: string
-            example: 'namespace-789'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NamespaceLogsRequest'
-      responses:
-        '200':
-          description: Successfully retrieved namespace logs
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LogResponse'
-        '400':
-          description: Bad request - invalid parameters
           content:
             application/json:
               schema:
@@ -538,228 +406,151 @@ paths:
 
 components:
   schemas:
-    BuildLogsRequest:
+    # Request schemas for logs
+    ComponentSearchScope:
       type: object
-      required:
-        - startTime
-        - endTime
-        - componentName
-        - projectName
-        - namespaceName
       properties:
-        startTime:
-          type: string
-          format: date-time
-          description: Start time for log query in RFC3339 format
-          example: '2025-01-10T00:00:00Z'
-        endTime:
-          type: string
-          format: date-time
-          description: End time for log query in RFC3339 format
-          example: '2025-01-10T23:59:59Z'
-        limit:
-          type: integer
-          description: Maximum number of log entries to return
-          default: 100
-          minimum: 1
-          maximum: 10000
-          example: 100
-        sortOrder:
-          type: string
-          description: Sort order for logs (build logs are sorted in ascending order by default)
-          enum: [asc, desc]
-          default: asc
-          example: 'asc'
-        componentName:
-          type: string
-          description: Component name
-          example: 'my-component'
-        projectName:
-          type: string
-          description: Project name
-          example: 'my-project'
-        namespaceName:
-          type: string
-          description: Namespace name
-          example: 'my-namespace'
-
-    ComponentLogsRequest:
-      type: object
-      required:
-        - startTime
-        - endTime
-        - environmentId
-        - componentName
-        - projectName
-        - namespaceName
-        - environmentName
-      properties:
-        startTime:
-          type: string
-          format: date-time
-          description: Start time for log query in RFC3339 format
-          example: '2025-01-10T00:00:00Z'
-        endTime:
-          type: string
-          format: date-time
-          description: End time for log query in RFC3339 format
-          example: '2025-01-10T23:59:59Z'
-        environmentId:
-          type: string
-          description: Environment identifier
-          example: 'env-dev'
         namespace:
           type: string
-          description: Kubernetes namespace
-          example: 'default'
-        searchPhrase:
+        project:
           type: string
-          description: Search phrase to filter logs
-          example: 'error'
-        logLevels:
-          type: array
-          items:
-            type: string
-          description: Filter by log levels
-          example: ['ERROR', 'WARN']
-        versions:
-          type: array
-          items:
-            type: string
-          description: Component versions to filter
-          example: ['v1.0.0', 'v1.0.1']
-        versionIds:
-          type: array
-          items:
-            type: string
-          description: Version IDs to filter
-          example: ['ver-123', 'ver-456']
-        limit:
-          type: integer
-          description: Maximum number of log entries to return
-          default: 100
-          minimum: 1
-          maximum: 10000
-          example: 100
-        sortOrder:
+        component:
           type: string
-          description: Sort order for logs
-          enum: [asc, desc]
-          default: desc
-          example: 'desc'
-        logType:
+        environment:
           type: string
-          description: Type of logs to retrieve
-          enum: [runtime, build]
-          example: 'runtime'
-        buildId:
-          type: string
-          description: Build ID for build logs
-          example: 'build-123'
-        buildUuid:
-          type: string
-          description: Build UUID for build logs
-          example: '550e8400-e29b-41d4-a716-446655440000'
-        componentName:
-          type: string
-          description: Component name
-          example: 'my-component'
-        projectName:
-          type: string
-          description: Project name
-          example: 'my-project'
-        environmentName:
-          type: string
-          description: Environment name
-          example: 'my-environment'
-        namespaceName:
-          type: string
-          description: Namespace name
-          example: 'my-namespace'
+      required: [namespace]
 
-    ProjectLogsRequest:
-      allOf:
-        - $ref: '#/components/schemas/ComponentLogsRequest'
-        - type: object
-          properties:
-            componentIds:
-              type: array
-              items:
-                type: string
-              description: Filter logs by specific component IDs
-              example: ['comp-123', 'comp-456']
-
-    GatewayLogsRequest:
+    WorkflowSearchScope:
       type: object
-      required:
-        - startTime
-        - endTime
-        - namespaceName
+      properties:
+        namespace:
+          type: string
+        workflowRunName:
+          type: string
+      required: [namespace]
+
+    LogsQueryRequest:
+      type: object
       properties:
         startTime:
           type: string
+          description: The start time of the query
           format: date-time
-          description: Start time for log query in RFC3339 format
-          example: '2025-01-10T00:00:00Z'
         endTime:
           type: string
+          description: The end time of the query
           format: date-time
-          description: End time for log query in RFC3339 format
-          example: '2025-01-10T23:59:59Z'
-        namespaceName:
-          type: string
-          description: Namespace identifier
-          example: 'namespace-789'
-        searchPhrase:
-          type: string
-          description: Search phrase to filter logs
-          example: 'error'
-        apiIdToVersionMap:
-          type: object
-          additionalProperties:
-            type: string
-          description: Map of API IDs to their versions
-          example:
-            api-123: 'v1'
-            api-456: 'v2'
-        gatewayVHosts:
-          type: array
-          items:
-            type: string
-          description: Gateway virtual hosts to filter
-          example: ['api.example.com', 'gateway.example.com']
         limit:
           type: integer
-          description: Maximum number of log entries to return
           default: 100
           minimum: 1
-          maximum: 10000
-          example: 100
+          maximum: 1000
+          description: The maximum number of items to return
         sortOrder:
           type: string
-          description: Sort order for logs
-          enum: [asc, desc]
+          description: The sort order of the query
+          enum:
+            - asc
+            - desc
           default: desc
-          example: 'desc'
-        logType:
+        searchScope:
+          oneOf:
+            - $ref: '#/components/schemas/ComponentSearchScope'
+            - $ref: '#/components/schemas/WorkflowSearchScope'
+        logLevels:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            enum: ['DEBUG', 'INFO', 'WARN', 'ERROR']
+        searchPhrase:
           type: string
-          description: Type of logs to retrieve
-          enum: [runtime, build]
-          example: 'runtime'
+      required: [startTime, endTime, searchScope]
 
-    NamespaceLogsRequest:
-      allOf:
-        - $ref: '#/components/schemas/ComponentLogsRequest'
-        - type: object
+    # Response schemas for logs
+    ComponentLogEntry:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          description: The timestamp of the log entry
+          format: date-time
+        log:
+          type: string
+          description: The log message
+        level:
+          type: string
+          description: The log level
+        metadata:
+          type: object
+          description: The metadata of the log entry
           properties:
-            podLabels:
-              type: object
-              additionalProperties:
-                type: string
-              description: Kubernetes pod labels to filter logs
-              example:
-                app: 'myapp'
-                tier: 'backend'
+            componentName:
+              type: string
+              description: The OpenChoreo component name that generated the log
+            projectName:
+              type: string
+              description: The OpenChoreo project name that generated the log
+            environmentName:
+              type: string
+              description: The OpenChoreo environment name that generated the log
+            namespaceName:
+              type: string
+              description: The OpenChoreo namespace name that generated the log
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID that generated the log
+              format: uuid
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID that generated the log
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID that generated the log
+              format: uuid
+            containerName:
+              type: string
+              description: The container name that generated the log
+            podName:
+              type: string
+              description: The Kubernetes pod name that generated the log
+            podNamespace:
+              type: string
+              description: The namespace of the Kubernetes pod that generated the log
+
+    WorkflowLogEntry:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          description: The timestamp of the log entry
+          format: date-time
+        log:
+          type: string
+          description: The log message
+        metadata:
+          type: object
+          description: The metadata of the log entry
+
+    LogsQueryResponse:
+      type: object
+      properties:
+        logs:
+          oneOf:
+            - type: array
+              items:
+                $ref: '#/components/schemas/ComponentLogEntry'
+            - type: array
+              items:
+                $ref: '#/components/schemas/WorkflowLogEntry'
+          description: The logs queried successfully
+        total:
+          type: integer
+          description: The total number of logs queried
+        tookMs:
+          type: integer
+          description: The time taken to query the logs in milliseconds
 
     TracesRequest:
       type: object
@@ -898,48 +689,6 @@ components:
           type: string
           description: Namespace name
           example: 'my-namespace'
-
-    LogEntry:
-      type: object
-      properties:
-        timestamp:
-          type: string
-          format: date-time
-          description: Timestamp of the log entry
-          example: '2025-01-10T12:34:56.789Z'
-        log:
-          type: string
-          description: The actual log message
-          example: 'Request processed successfully'
-        level:
-          type: string
-          description: Log level
-          example: 'INFO'
-        stream:
-          type: string
-          description: Log stream (stdout/stderr)
-          example: 'stdout'
-        kubernetes:
-          type: object
-          description: Kubernetes metadata
-          additionalProperties: true
-
-    LogResponse:
-      type: object
-      properties:
-        logs:
-          type: array
-          items:
-            $ref: '#/components/schemas/LogEntry'
-          description: Array of log entries
-        totalCount:
-          type: integer
-          description: Total number of matching logs
-          example: 1234
-        tookMs:
-          type: integer
-          description: Query execution time in milliseconds
-          example: 42
 
     TraceResponse:
       type: object

--- a/packages/openchoreo-client-node/src/factory.ts
+++ b/packages/openchoreo-client-node/src/factory.ts
@@ -204,10 +204,9 @@ export function createOpenChoreoApiClient(config: OpenChoreoClientConfig) {
  *   token: 'your-auth-token'
  * });
  *
- * const { data, error } = await client.POST('/api/logs/component/{componentId}', {
- *   params: { path: { componentId: 'my-component' } },
+ * const { data, error } = await client.POST('/api/v1/logs/query', {
  *   body: {
- *     environmentId: 'dev',
+ *     searchScope: { namespace: 'my-namespace', component: 'my-component' },
  *     limit: 100
  *   }
  * });

--- a/packages/openchoreo-client-node/src/generated/observability/types.ts
+++ b/packages/openchoreo-client-node/src/generated/observability/types.ts
@@ -13,7 +13,7 @@ export interface paths {
     };
     /**
      * Health check
-     * @description Check the health status of the observer service including OpenSearch and Prometheus connectivity
+     * @description Check the health status of the observer service.
      */
     get: operations['health'];
     put?: never;
@@ -24,7 +24,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/logs/build/{buildId}': {
+  '/api/v1/logs/query': {
     parameters: {
       query?: never;
       header?: never;
@@ -34,10 +34,10 @@ export interface paths {
     get?: never;
     put?: never;
     /**
-     * Get build logs
-     * @description Retrieve logs for a specific build
+     * Query logs
+     * @description Query logs from the observer service
      */
-    post: operations['getBuildLogs'];
+    post: operations['queryLogs'];
     delete?: never;
     options?: never;
     head?: never;
@@ -81,86 +81,6 @@ export interface paths {
     get: operations['getWorkflowRunEvents'];
     put?: never;
     post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/logs/component/{componentId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Get component logs
-     * @description Retrieve logs for a specific component
-     */
-    post: operations['getComponentLogs'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/logs/project/{projectId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Get project logs
-     * @description Retrieve logs for all components in a specific project
-     */
-    post: operations['getProjectLogs'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/logs/gateway': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Get gateway logs
-     * @description Retrieve logs from API gateway
-     */
-    post: operations['getGatewayLogs'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/logs/namespace/{namespaceName}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Get namespace logs
-     * @description Retrieve logs for an entire namespace
-     */
-    post: operations['getNamespaceLogs'];
     delete?: never;
     options?: never;
     head?: never;
@@ -231,232 +151,107 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
-    BuildLogsRequest: {
-      /**
-       * Format: date-time
-       * @description Start time for log query in RFC3339 format
-       * @example 2025-01-10T00:00:00Z
-       */
-      startTime: string;
-      /**
-       * Format: date-time
-       * @description End time for log query in RFC3339 format
-       * @example 2025-01-10T23:59:59Z
-       */
-      endTime: string;
-      /**
-       * @description Maximum number of log entries to return
-       * @default 100
-       * @example 100
-       */
-      limit: number;
-      /**
-       * @description Sort order for logs (build logs are sorted in ascending order by default)
-       * @default asc
-       * @example asc
-       * @enum {string}
-       */
-      sortOrder: 'asc' | 'desc';
-      /**
-       * @description Component name
-       * @example my-component
-       */
-      componentName: string;
-      /**
-       * @description Project name
-       * @example my-project
-       */
-      projectName: string;
-      /**
-       * @description Namespace name
-       * @example my-namespace
-       */
-      namespaceName: string;
+    ComponentSearchScope: {
+      namespace: string;
+      project?: string;
+      component?: string;
+      environment?: string;
     };
-    ComponentLogsRequest: {
+    WorkflowSearchScope: {
+      namespace: string;
+      workflowRunName?: string;
+    };
+    LogsQueryRequest: {
       /**
        * Format: date-time
-       * @description Start time for log query in RFC3339 format
-       * @example 2025-01-10T00:00:00Z
+       * @description The start time of the query
        */
       startTime: string;
       /**
        * Format: date-time
-       * @description End time for log query in RFC3339 format
-       * @example 2025-01-10T23:59:59Z
+       * @description The end time of the query
        */
       endTime: string;
       /**
-       * @description Environment identifier
-       * @example env-dev
-       */
-      environmentId: string;
-      /**
-       * @description Kubernetes namespace
-       * @example default
-       */
-      namespace?: string;
-      /**
-       * @description Search phrase to filter logs
-       * @example error
-       */
-      searchPhrase?: string;
-      /**
-       * @description Filter by log levels
-       * @example [
-       *       "ERROR",
-       *       "WARN"
-       *     ]
-       */
-      logLevels?: string[];
-      /**
-       * @description Component versions to filter
-       * @example [
-       *       "v1.0.0",
-       *       "v1.0.1"
-       *     ]
-       */
-      versions?: string[];
-      /**
-       * @description Version IDs to filter
-       * @example [
-       *       "ver-123",
-       *       "ver-456"
-       *     ]
-       */
-      versionIds?: string[];
-      /**
-       * @description Maximum number of log entries to return
+       * @description The maximum number of items to return
        * @default 100
-       * @example 100
        */
       limit: number;
       /**
-       * @description Sort order for logs
+       * @description The sort order of the query
        * @default desc
-       * @example desc
        * @enum {string}
        */
       sortOrder: 'asc' | 'desc';
-      /**
-       * @description Type of logs to retrieve
-       * @example runtime
-       * @enum {string}
-       */
-      logType?: 'runtime' | 'build';
-      /**
-       * @description Build ID for build logs
-       * @example build-123
-       */
-      buildId?: string;
-      /**
-       * @description Build UUID for build logs
-       * @example 550e8400-e29b-41d4-a716-446655440000
-       */
-      buildUuid?: string;
-      /**
-       * @description Component name
-       * @example my-component
-       */
-      componentName: string;
-      /**
-       * @description Project name
-       * @example my-project
-       */
-      projectName: string;
-      /**
-       * @description Environment name
-       * @example my-environment
-       */
-      environmentName: string;
-      /**
-       * @description Namespace name
-       * @example my-namespace
-       */
-      namespaceName: string;
-    };
-    ProjectLogsRequest: components['schemas']['ComponentLogsRequest'] & {
-      /**
-       * @description Filter logs by specific component IDs
-       * @example [
-       *       "comp-123",
-       *       "comp-456"
-       *     ]
-       */
-      componentIds?: string[];
-    };
-    GatewayLogsRequest: {
-      /**
-       * Format: date-time
-       * @description Start time for log query in RFC3339 format
-       * @example 2025-01-10T00:00:00Z
-       */
-      startTime: string;
-      /**
-       * Format: date-time
-       * @description End time for log query in RFC3339 format
-       * @example 2025-01-10T23:59:59Z
-       */
-      endTime: string;
-      /**
-       * @description Namespace identifier
-       * @example namespace-789
-       */
-      namespaceName: string;
-      /**
-       * @description Search phrase to filter logs
-       * @example error
-       */
+      searchScope:
+        | components['schemas']['ComponentSearchScope']
+        | components['schemas']['WorkflowSearchScope'];
+      logLevels?: ('DEBUG' | 'INFO' | 'WARN' | 'ERROR')[];
       searchPhrase?: string;
-      /**
-       * @description Map of API IDs to their versions
-       * @example {
-       *       "api-123": "v1",
-       *       "api-456": "v2"
-       *     }
-       */
-      apiIdToVersionMap?: {
-        [key: string]: string;
-      };
-      /**
-       * @description Gateway virtual hosts to filter
-       * @example [
-       *       "api.example.com",
-       *       "gateway.example.com"
-       *     ]
-       */
-      gatewayVHosts?: string[];
-      /**
-       * @description Maximum number of log entries to return
-       * @default 100
-       * @example 100
-       */
-      limit: number;
-      /**
-       * @description Sort order for logs
-       * @default desc
-       * @example desc
-       * @enum {string}
-       */
-      sortOrder: 'asc' | 'desc';
-      /**
-       * @description Type of logs to retrieve
-       * @example runtime
-       * @enum {string}
-       */
-      logType?: 'runtime' | 'build';
     };
-    NamespaceLogsRequest: components['schemas']['ComponentLogsRequest'] & {
+    ComponentLogEntry: {
       /**
-       * @description Kubernetes pod labels to filter logs
-       * @example {
-       *       "app": "myapp",
-       *       "tier": "backend"
-       *     }
+       * Format: date-time
+       * @description The timestamp of the log entry
        */
-      podLabels?: {
-        [key: string]: string;
+      timestamp?: string;
+      /** @description The log message */
+      log?: string;
+      /** @description The log level */
+      level?: string;
+      /** @description The metadata of the log entry */
+      metadata?: {
+        /** @description The OpenChoreo component name that generated the log */
+        componentName?: string;
+        /** @description The OpenChoreo project name that generated the log */
+        projectName?: string;
+        /** @description The OpenChoreo environment name that generated the log */
+        environmentName?: string;
+        /** @description The OpenChoreo namespace name that generated the log */
+        namespaceName?: string;
+        /**
+         * Format: uuid
+         * @description The OpenChoreo component UID that generated the log
+         */
+        componentUid?: string;
+        /**
+         * Format: uuid
+         * @description The OpenChoreo project UID that generated the log
+         */
+        projectUid?: string;
+        /**
+         * Format: uuid
+         * @description The OpenChoreo environment UID that generated the log
+         */
+        environmentUid?: string;
+        /** @description The container name that generated the log */
+        containerName?: string;
+        /** @description The Kubernetes pod name that generated the log */
+        podName?: string;
+        /** @description The namespace of the Kubernetes pod that generated the log */
+        podNamespace?: string;
       };
+    };
+    WorkflowLogEntry: {
+      /**
+       * Format: date-time
+       * @description The timestamp of the log entry
+       */
+      timestamp?: string;
+      /** @description The log message */
+      log?: string;
+      /** @description The metadata of the log entry */
+      metadata?: Record<string, never>;
+    };
+    LogsQueryResponse: {
+      /** @description The logs queried successfully */
+      logs?:
+        | components['schemas']['ComponentLogEntry'][]
+        | components['schemas']['WorkflowLogEntry'][];
+      /** @description The total number of logs queried */
+      total?: number;
+      /** @description The time taken to query the logs in milliseconds */
+      tookMs?: number;
     };
     TracesRequest: {
       /**
@@ -590,47 +385,6 @@ export interface components {
        * @example my-namespace
        */
       namespaceName: string;
-    };
-    LogEntry: {
-      /**
-       * Format: date-time
-       * @description Timestamp of the log entry
-       * @example 2025-01-10T12:34:56.789Z
-       */
-      timestamp?: string;
-      /**
-       * @description The actual log message
-       * @example Request processed successfully
-       */
-      log?: string;
-      /**
-       * @description Log level
-       * @example INFO
-       */
-      level?: string;
-      /**
-       * @description Log stream (stdout/stderr)
-       * @example stdout
-       */
-      stream?: string;
-      /** @description Kubernetes metadata */
-      kubernetes?: {
-        [key: string]: unknown;
-      };
-    };
-    LogResponse: {
-      /** @description Array of log entries */
-      logs?: components['schemas']['LogEntry'][];
-      /**
-       * @description Total number of matching logs
-       * @example 1234
-       */
-      totalCount?: number;
-      /**
-       * @description Query execution time in milliseconds
-       * @example 42
-       */
-      tookMs?: number;
     };
     /** @example {
      *       "traces": [
@@ -997,32 +751,29 @@ export interface operations {
       };
     };
   };
-  getBuildLogs: {
+  queryLogs: {
     parameters: {
       query?: never;
       header?: never;
-      path: {
-        /** @description The unique identifier of the build */
-        buildId: string;
-      };
+      path?: never;
       cookie?: never;
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['BuildLogsRequest'];
+        'application/json': components['schemas']['LogsQueryRequest'];
       };
     };
     responses: {
-      /** @description Successfully retrieved build logs */
+      /** @description Logs queried successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['LogResponse'];
+          'application/json': components['schemas']['LogsQueryResponse'];
         };
       };
-      /** @description Bad request - invalid parameters */
+      /** @description Invalid request */
       400: {
         headers: {
           [name: string]: unknown;
@@ -1031,7 +782,25 @@ export interface operations {
           'application/json': components['schemas']['ErrorResponse'];
         };
       };
-      /** @description Internal server error */
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description Internal Server Error */
       500: {
         headers: {
           [name: string]: unknown;
@@ -1178,183 +947,6 @@ export interface operations {
       };
       /** @description Workflow run not found */
       404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getComponentLogs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The unique identifier of the component */
-        componentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['ComponentLogsRequest'];
-      };
-    };
-    responses: {
-      /** @description Successfully retrieved component logs */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogResponse'];
-        };
-      };
-      /** @description Bad request - invalid parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getProjectLogs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The unique identifier of the project */
-        projectId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['ProjectLogsRequest'];
-      };
-    };
-    responses: {
-      /** @description Successfully retrieved project logs */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogResponse'];
-        };
-      };
-      /** @description Bad request - invalid parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getGatewayLogs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['GatewayLogsRequest'];
-      };
-    };
-    responses: {
-      /** @description Successfully retrieved gateway logs */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogResponse'];
-        };
-      };
-      /** @description Bad request - invalid parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getNamespaceLogs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The unique identifier of the namespace */
-        namespaceName: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['NamespaceLogsRequest'];
-      };
-    };
-    responses: {
-      /** @description Successfully retrieved namespace logs */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogResponse'];
-        };
-      };
-      /** @description Bad request - invalid parameters */
-      400: {
         headers: {
           [name: string]: unknown;
         };

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -2,10 +2,7 @@ import { InputError } from '@backstage/errors';
 import express from 'express';
 import Router from 'express-promise-router';
 import { EnvironmentInfoService } from './services/EnvironmentService/EnvironmentInfoService';
-import {
-  BuildInfoService,
-  ObservabilityNotConfiguredError as BuildObservabilityNotConfiguredError,
-} from './services/BuildService/BuildInfoService';
+import { BuildInfoService } from './services/BuildService/BuildInfoService';
 import {
   CellDiagramService,
   WorkloadService,
@@ -531,39 +528,6 @@ export async function createRouter({
         userToken,
       ),
     );
-  });
-
-  router.get('/build-logs', async (req, res) => {
-    const { componentName, buildId, buildUuid, projectName, namespaceName } =
-      req.query;
-
-    if (!componentName || !buildId || !buildUuid) {
-      throw new InputError(
-        'componentName, buildId and buildUuid are required query parameters',
-      );
-    }
-
-    const userToken = getUserTokenFromRequest(req);
-
-    try {
-      const result = await buildInfoService.fetchBuildLogs(
-        namespaceName as string,
-        projectName as string,
-        componentName as string,
-        buildId as string,
-        undefined, // limit
-        undefined, // sortOrder
-        userToken,
-      );
-      return res.json(result);
-    } catch (error: unknown) {
-      if (error instanceof BuildObservabilityNotConfiguredError) {
-        return res.status(200).json({
-          message: "Observability hasn't been configured",
-        });
-      }
-      throw error;
-    }
   });
 
   router.get('/workload', async (req, res) => {

--- a/plugins/openchoreo-backend/src/services/BuildService/BuildInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/BuildService/BuildInfoService.ts
@@ -245,11 +245,8 @@ export class BuildInfoService {
       );
 
       const { data, error, response } = await obsClient.POST(
-        '/api/logs/build/{buildId}',
+        '/api/v1/logs/query',
         {
-          params: {
-            path: { buildId },
-          },
           body: {
             startTime: new Date(
               Date.now() - 30 * 24 * 60 * 60 * 1000,
@@ -257,9 +254,10 @@ export class BuildInfoService {
             endTime: new Date().toISOString(),
             limit: limit || 1000, // Default to 1000 until pagination is implemented
             sortOrder: sortOrder || 'asc',
-            componentName,
-            projectName,
-            namespaceName,
+            searchScope: {
+              namespace: namespaceName,
+              workflowRunName: buildId,
+            },
           },
         },
       );
@@ -283,7 +281,7 @@ export class BuildInfoService {
 
       return {
         logs: data.logs || [],
-        totalCount: data.totalCount || 0,
+        total: data.total || 0,
         tookMs: data.tookMs || 0,
       };
     } catch (error: unknown) {

--- a/plugins/openchoreo-backend/src/types.ts
+++ b/plugins/openchoreo-backend/src/types.ts
@@ -6,10 +6,13 @@ import type {
   GitSecretListResponse,
 } from './services/GitSecretsService/GitSecretsService';
 
-// Import generated types from observability client
-export type LogEntry = ObservabilityComponents['schemas']['LogEntry'];
-export type RuntimeLogsResponse =
-  ObservabilityComponents['schemas']['LogResponse'];
+// Log types from the unified /api/v1/logs/query endpoint
+export type LogEntry = ObservabilityComponents['schemas']['ComponentLogEntry'];
+export type RuntimeLogsResponse = {
+  logs: ObservabilityComponents['schemas']['ComponentLogEntry'][];
+  total?: number;
+  tookMs?: number;
+};
 
 export interface EnvironmentService {
   fetchDeploymentInfo(request: {
@@ -147,10 +150,8 @@ export interface RuntimeLogsService {
   fetchRuntimeLogs(
     request: {
       componentName: string;
-      componentId: string;
       environmentName: string;
-      environmentId: string;
-      logLevels?: ('TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'FATAL')[];
+      logLevels?: ('DEBUG' | 'INFO' | 'WARN' | 'ERROR')[];
       startTime?: string;
       endTime?: string;
       limit?: number;

--- a/plugins/openchoreo-ci-backend/src/router.ts
+++ b/plugins/openchoreo-ci-backend/src/router.ts
@@ -275,40 +275,5 @@ export async function createRouter({
     );
   });
 
-  router.get('/build-logs', async (req, res) => {
-    const { componentName, buildId, projectName, namespaceName } = req.query;
-
-    if (!componentName || !buildId || !projectName || !namespaceName) {
-      throw new InputError(
-        'componentName, buildId, projectName and namespaceName are required query parameters',
-      );
-    }
-
-    const userToken = getUserTokenFromRequest(req);
-
-    try {
-      const logs = await workflowService.fetchBuildLogs(
-        namespaceName as string,
-        projectName as string,
-        componentName as string,
-        buildId as string,
-        undefined,
-        undefined,
-        userToken,
-      );
-
-      res.json(logs);
-    } catch (error) {
-      if (error instanceof ObservabilityNotConfiguredError) {
-        res.status(503).json({
-          error: 'ObservabilityNotConfigured',
-          message: error.message,
-        });
-        return;
-      }
-      throw error;
-    }
-  });
-
   return router;
 }

--- a/plugins/openchoreo-ci-backend/src/types.ts
+++ b/plugins/openchoreo-ci-backend/src/types.ts
@@ -1,10 +1,24 @@
 import type { ObservabilityComponents } from '@openchoreo/openchoreo-client-node';
 import type { ComponentWorkflowRunEventEntry } from '@openchoreo/backstage-plugin-common';
 
-// Import generated types from observability client
-export type LogEntry = ObservabilityComponents['schemas']['LogEntry'];
-export type RuntimeLogsResponse =
-  ObservabilityComponents['schemas']['LogResponse'];
+// Log entry type from the unified /api/v1/logs/query endpoint
+export type ComponentLogEntry =
+  ObservabilityComponents['schemas']['ComponentLogEntry'];
+export type WorkflowLogEntry =
+  ObservabilityComponents['schemas']['WorkflowLogEntry'];
+
+/** Simple log entry used by fetchWorkflowRunLogs (Kubernetes pod logs) */
+export interface LogEntry {
+  timestamp: string;
+  log: string;
+}
+
+/** Response from /api/v1/logs/query for workflow/build scope */
+export interface RuntimeLogsResponse {
+  logs: WorkflowLogEntry[];
+  total?: number;
+  tookMs?: number;
+}
 
 // Kubernetes events from the OpenChoreo API
 export type { ComponentWorkflowRunEventEntry };

--- a/plugins/openchoreo-ci/src/api/OpenChoreoCiClient.ts
+++ b/plugins/openchoreo-ci/src/api/OpenChoreoCiClient.ts
@@ -3,7 +3,6 @@ import { Entity } from '@backstage/catalog-model';
 import {
   CHOREO_ANNOTATIONS,
   ModelsBuild,
-  RuntimeLogsResponse,
   WorkflowRunStatusResponse,
   LogEntry,
 } from '@openchoreo/backstage-plugin-common';
@@ -119,32 +118,6 @@ export class OpenChoreoCiClient implements OpenChoreoCiClientApi {
       method: 'PATCH',
       params: entityMetadataToParams(metadata),
       body: { systemParameters, parameters },
-    });
-  }
-
-  // TODO: Deprecate this method and use the new method fetchWorkflowRunLogs instead
-  async fetchBuildLogsForBuild(
-    build: ModelsBuild,
-  ): Promise<RuntimeLogsResponse> {
-    if (
-      !build.componentName ||
-      !build.name ||
-      !build.uuid ||
-      !build.projectName ||
-      !build.namespaceName
-    ) {
-      throw new Error(
-        'Build object is missing required fields for fetching logs',
-      );
-    }
-
-    return this.apiFetch<RuntimeLogsResponse>('/build-logs', {
-      params: {
-        componentName: build.componentName,
-        buildId: build.name,
-        projectName: build.projectName,
-        namespaceName: build.namespaceName,
-      },
     });
   }
 

--- a/plugins/openchoreo-ci/src/api/OpenChoreoCiClientApi.ts
+++ b/plugins/openchoreo-ci/src/api/OpenChoreoCiClientApi.ts
@@ -2,7 +2,6 @@ import { createApiRef } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import type {
   ModelsBuild,
-  RuntimeLogsResponse,
   LogEntry,
   WorkflowRunStatusResponse,
 } from '@openchoreo/backstage-plugin-common';
@@ -58,10 +57,6 @@ export interface OpenChoreoCiClientApi {
     systemParameters: Record<string, unknown> | null,
     parameters: Record<string, unknown> | null,
   ): Promise<any>;
-
-  /** Fetch build logs for a specific build */
-  // TODO: Deprecate this method and use the new method fetchWorkflowRunLogs instead
-  fetchBuildLogsForBuild(build: ModelsBuild): Promise<RuntimeLogsResponse>;
 
   /**
    * Fetch workflow run status for a specific build.

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -186,9 +186,37 @@ export type {
   AIRCAAgentComponents,
 } from '@openchoreo/openchoreo-client-node';
 
-// Observability types
+// Observability types — aligned with /api/v1/logs/query response schema
 import type { ObservabilityComponents } from '@openchoreo/openchoreo-client-node';
 
-export type RuntimeLogsResponse =
-  ObservabilityComponents['schemas']['LogResponse'];
-export type LogEntry = ObservabilityComponents['schemas']['LogEntry'];
+/** A single component log entry returned by the unified logs query endpoint */
+export type ComponentLogEntry =
+  ObservabilityComponents['schemas']['ComponentLogEntry'];
+
+/** A single workflow/build log entry returned by the unified logs query endpoint */
+export type WorkflowLogEntry =
+  ObservabilityComponents['schemas']['WorkflowLogEntry'];
+
+/**
+ * Response from the unified /api/v1/logs/query endpoint.
+ * `logs` is ComponentLogEntry[] when using ComponentSearchScope,
+ * WorkflowLogEntry[] when using WorkflowSearchScope.
+ */
+export type LogsQueryResponse =
+  ObservabilityComponents['schemas']['LogsQueryResponse'];
+
+/**
+ * @deprecated Use ComponentLogEntry or WorkflowLogEntry instead.
+ * Kept for backwards compatibility — will be removed once all callers are migrated.
+ */
+export type LogEntry = ComponentLogEntry;
+
+/**
+ * @deprecated Use LogsQueryResponse instead.
+ * Kept for backwards compatibility — will be removed once all callers are migrated.
+ */
+export interface RuntimeLogsResponse {
+  logs: ComponentLogEntry[];
+  total?: number;
+  tookMs?: number;
+}

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
@@ -352,9 +352,9 @@ export class ObservabilityClient implements ObservabilityApi {
   }
 
   async getRuntimeLogs(
-    componentId: string,
+    _componentId: string,
     _projectId: string,
-    environmentId: string,
+    _environmentId: string,
     namespaceName: string,
     projectName: string,
     environmentName: string,
@@ -374,7 +374,7 @@ export class ObservabilityClient implements ObservabilityApi {
     );
 
     const response = await this.fetchApi.fetch(
-      `${observerUrl}/api/logs/component/${encodeURIComponent(componentId)}`,
+      `${observerUrl}/api/v1/logs/query`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...DIRECT_HEADER },
@@ -383,11 +383,6 @@ export class ObservabilityClient implements ObservabilityApi {
             options?.startTime ||
             new Date(Date.now() - 60 * 60 * 1000).toISOString(),
           endTime: options?.endTime || new Date().toISOString(),
-          environmentId,
-          componentName,
-          projectName,
-          namespaceName,
-          environmentName,
           limit: options?.limit || 100,
           sortOrder: options?.sortOrder || 'desc',
           ...(options?.logLevels &&
@@ -395,6 +390,12 @@ export class ObservabilityClient implements ObservabilityApi {
           ...(options?.searchQuery && {
             searchPhrase: options.searchQuery,
           }),
+          searchScope: {
+            namespace: namespaceName,
+            project: projectName,
+            component: componentName,
+            environment: environmentName,
+          },
         }),
       },
     );

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.tsx
@@ -55,7 +55,7 @@ export const LogEntry: FC<LogEntryProps> = ({
     }
 
     try {
-      await navigator.clipboard.writeText(log.log);
+      await navigator.clipboard.writeText(log.log ?? '');
       setCopySuccess(true);
       setTimeout(() => setCopySuccess(false), 2000);
     } catch (err) {
@@ -95,16 +95,16 @@ export const LogEntry: FC<LogEntryProps> = ({
       >
         {selectedFields.includes(LogEntryField.Timestamp) && (
           <TableCell className={classes.timestampCell}>
-            {formatTimestamp(log.timestamp)}
+            {formatTimestamp(log.timestamp ?? '')}
           </TableCell>
         )}
         {selectedFields.includes(LogEntryField.LogLevel) && (
           <TableCell>
             <Chip
-              label={log.logLevel}
+              label={log.level}
               size="small"
               className={`${classes.logLevelChip} ${getLogLevelChipClass(
-                log.logLevel,
+                log.level ?? '',
               )}`}
             />
           </TableCell>
@@ -174,7 +174,7 @@ export const LogEntry: FC<LogEntryProps> = ({
                           Environment UID:
                         </span>
                         <span className={classes.metadataValue}>
-                          {log.environmentId}
+                          {log.metadata?.environmentUid}
                         </span>
                       </Box>
 
@@ -192,7 +192,7 @@ export const LogEntry: FC<LogEntryProps> = ({
                           Project UID:
                         </span>
                         <span className={classes.metadataValue}>
-                          {log.projectId}
+                          {log.metadata?.projectUid}
                         </span>
                       </Box>
 
@@ -210,35 +210,37 @@ export const LogEntry: FC<LogEntryProps> = ({
                           Component UID:
                         </span>
                         <span className={classes.metadataValue}>
-                          {log.componentId}
+                          {log.metadata?.componentUid}
                         </span>
                       </Box>
 
                       <Box className={classes.metadataItem}>
                         <span className={classes.metadataKey}>Pod Name:</span>
                         <span className={classes.metadataValue}>
-                          NOT AVAILABLE
+                          {log.metadata?.podName}
                         </span>
                       </Box>
 
                       <Box className={classes.metadataItem}>
-                        <span className={classes.metadataKey}>Pod ID:</span>
+                        <span className={classes.metadataKey}>
+                          Pod Namespace:
+                        </span>
                         <span className={classes.metadataValue}>
-                          {log.podId}
+                          {log.metadata?.podNamespace}
                         </span>
                       </Box>
 
                       <Box className={classes.metadataItem}>
                         <span className={classes.metadataKey}>Namespace:</span>
                         <span className={classes.metadataValue}>
-                          {log.namespace}
+                          {log.metadata?.namespaceName}
                         </span>
                       </Box>
 
                       <Box className={classes.metadataItem}>
                         <span className={classes.metadataKey}>Container:</span>
                         <span className={classes.metadataValue}>
-                          {log.containerName}
+                          {log.metadata?.containerName}
                         </span>
                       </Box>
                     </Box>

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/types.ts
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/types.ts
@@ -1,22 +1,16 @@
-export interface LogEntry {
-  timestamp: string;
-  log: string;
-  logLevel: 'ERROR' | 'WARN' | 'INFO' | 'DEBUG';
-  componentId: string;
-  environmentId: string;
-  projectId: string;
-  version: string;
-  versionId: string;
-  namespace: string;
-  podId: string;
-  containerName: string;
-  labels: Record<string, string>;
-}
+import type { ObservabilityComponents } from '@openchoreo/openchoreo-client-node';
+
+/**
+ * A single component log entry as returned by POST /api/v1/logs/query.
+ * Fields come from the ComponentLogEntry schema (new unified API).
+ */
+export type LogEntry = ObservabilityComponents['schemas']['ComponentLogEntry'];
 
 export interface LogsResponse {
   logs: LogEntry[];
-  totalCount: number;
-  tookMs: number;
+  /** Total number of matching logs (renamed from totalCount in old API) */
+  total?: number;
+  tookMs?: number;
 }
 
 export interface Environment {

--- a/plugins/openchoreo-observability/src/hooks/useRuntimeLogs.ts
+++ b/plugins/openchoreo-observability/src/hooks/useRuntimeLogs.ts
@@ -202,10 +202,10 @@ export function useRuntimeLogs(
           const sortOrder = options.sortOrder || 'desc';
           if (sortOrder === 'desc') {
             // For descending (newest first), use the timestamp of the last log as the new endTime
-            endTime = lastLog.timestamp;
+            endTime = lastLog.timestamp ?? endTime;
           } else {
             // For ascending (oldest first), use the timestamp of the last log as the new startTime
-            startTime = lastLog.timestamp;
+            startTime = lastLog.timestamp ?? startTime;
           }
         }
 
@@ -229,7 +229,7 @@ export function useRuntimeLogs(
 
         if (reset) {
           setLogs(response.logs);
-          setTotalCount(response.totalCount);
+          setTotalCount(response.total ?? 0);
         } else {
           setLogs(prev => [...prev, ...response.logs]);
         }

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -3,8 +3,6 @@ import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import {
   CHOREO_ANNOTATIONS,
   ModelsWorkload,
-  ModelsBuild,
-  RuntimeLogsResponse,
 } from '@openchoreo/backstage-plugin-common';
 import { CLUSTER_SCOPED_RESOURCE_KINDS } from './OpenChoreoClientApi';
 import type {
@@ -15,7 +13,6 @@ import type {
   WorkflowSchemaResponse,
   ComponentInfo,
   SecretReferencesResponse,
-  BuildLogsParams,
   ComponentTrait,
   UserTypeConfig,
   NamespaceSummary,
@@ -65,7 +62,6 @@ const API_ENDPOINTS = {
   COMPONENT_WORKFLOW_PARAMETERS: '/workflow-parameters',
   SECRET_REFERENCES: '/secret-references',
   COMPONENT: '/component',
-  BUILD_LOGS: '/build-logs',
   DEPLOYMENT_PIPELINE: '/deployment-pipeline',
   BUILDS: '/builds',
   COMPONENT_TRAITS: '/component-traits',
@@ -555,72 +551,8 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
   }
 
   // ============================================
-  // Build Logs
+  // Builds
   // ============================================
-
-  async getBuildLogs(params: BuildLogsParams): Promise<RuntimeLogsResponse> {
-    interface BuildLogsApiResponse {
-      success?: boolean;
-      data?: {
-        message?: string;
-      };
-      logs?: RuntimeLogsResponse['logs'];
-      totalCount?: number;
-      tookMs?: number;
-    }
-
-    const data = await this.apiFetch<BuildLogsApiResponse>(
-      API_ENDPOINTS.BUILD_LOGS,
-      {
-        params: {
-          componentName: params.componentName,
-          buildId: params.buildId,
-          buildUuid: params.buildUuid,
-          limit: (params.limit || 100).toString(),
-          sortOrder: params.sortOrder || 'desc',
-          projectName: params.projectName,
-          namespaceName: params.namespaceName,
-        },
-      },
-    );
-
-    if (
-      data.success &&
-      data.data?.message === 'observability-logs have not been configured'
-    ) {
-      throw new Error(
-        "Observability has not been configured so build logs aren't available",
-      );
-    }
-
-    return data as RuntimeLogsResponse;
-  }
-
-  async fetchBuildLogsForBuild(
-    build: ModelsBuild,
-  ): Promise<RuntimeLogsResponse> {
-    if (
-      !build.componentName ||
-      !build.name ||
-      !build.uuid ||
-      !build.projectName ||
-      !build.namespaceName
-    ) {
-      throw new Error(
-        'Component name, Build ID, UUID, Project name, or Namespace name not available',
-      );
-    }
-
-    return this.getBuildLogs({
-      componentName: build.componentName,
-      buildId: build.name,
-      buildUuid: build.uuid,
-      projectName: build.projectName,
-      namespaceName: build.namespaceName,
-      limit: 100,
-      sortOrder: 'desc',
-    });
-  }
 
   async fetchBuilds(
     componentName: string,

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -1,10 +1,6 @@
 import { createApiRef } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import type {
-  ModelsWorkload,
-  ModelsBuild,
-  RuntimeLogsResponse,
-} from '@openchoreo/backstage-plugin-common';
+import type { ModelsWorkload } from '@openchoreo/backstage-plugin-common';
 import type { Environment } from '../components/RuntimeLogs/types';
 
 // ============================================
@@ -249,17 +245,6 @@ export interface ComponentSummary {
   displayName?: string;
 }
 
-/** Build logs params */
-export interface BuildLogsParams {
-  componentName: string;
-  projectName: string;
-  namespaceName: string;
-  buildId: string;
-  buildUuid: string;
-  limit?: number;
-  sortOrder?: 'asc' | 'desc';
-}
-
 /** Component trait response */
 export interface ComponentTrait {
   kind?: 'Trait' | 'ClusterTrait';
@@ -467,14 +452,6 @@ export interface OpenChoreoClientApi {
 
   /** Get list of environments for a component */
   getEnvironments(entity: Entity): Promise<Environment[]>;
-
-  // === Build Logs ===
-
-  /** Fetch build logs */
-  getBuildLogs(params: BuildLogsParams): Promise<RuntimeLogsResponse>;
-
-  /** Fetch build logs for a specific build */
-  fetchBuildLogsForBuild(build: ModelsBuild): Promise<RuntimeLogsResponse>;
 
   /** Fetch builds for a component */
   fetchBuilds(

--- a/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
@@ -155,11 +155,12 @@ export function useLogsSummary() {
 
       // Count errors and warnings
       const logs: LogEntry[] = data.logs || [];
-      const errorCount = logs.filter(log => log.logLevel === 'ERROR').length;
-      const warningCount = logs.filter(log => log.logLevel === 'WARN').length;
+      const errorCount = logs.filter(log => log.level === 'ERROR').length;
+      const warningCount = logs.filter(log => log.level === 'WARN').length;
 
       // Get last activity time (most recent log)
-      const lastActivityTime = logs.length > 0 ? logs[0].timestamp : null;
+      const lastActivityTime =
+        logs.length > 0 ? logs[0].timestamp ?? null : null;
 
       setState(prev => ({
         ...prev,

--- a/plugins/openchoreo/src/components/RuntimeLogs/types.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/types.ts
@@ -1,22 +1,14 @@
-export interface LogEntry {
-  timestamp: string;
-  log: string;
-  logLevel: 'ERROR' | 'WARN' | 'INFO' | 'DEBUG';
-  componentId: string;
-  environmentId: string;
-  projectId: string;
-  version: string;
-  versionId: string;
-  namespace: string;
-  podId: string;
-  containerName: string;
-  labels: Record<string, string>;
-}
+import type { ObservabilityComponents } from '@openchoreo/openchoreo-client-node';
+
+/**
+ * A single component log entry as returned by POST /api/v1/logs/query.
+ */
+export type LogEntry = ObservabilityComponents['schemas']['ComponentLogEntry'];
 
 export interface LogsResponse {
   logs: LogEntry[];
-  totalCount: number;
-  tookMs: number;
+  total?: number;
+  tookMs?: number;
 }
 
 export interface Environment {


### PR DESCRIPTION
## Purpose

This pull request implements a significant refactor and unification of log querying across the OpenChoreo backend and CI plugins. The main focus is to migrate all log retrieval to the new `/api/v1/logs/query` endpoint, align type definitions with the new API schema, and remove legacy or redundant code. This results in more consistent log data structures, cleaner APIs, and easier future maintenance.

**Unified Log Querying and API Alignment**

- All log fetching (build logs, runtime logs, workflow logs) now uses the new `/api/v1/logs/query` endpoint instead of legacy endpoints, with appropriate changes to request bodies and `searchScope` usage. [[1]](diffhunk://#diff-886d8067ff7dc19a4eeb84c1dee91b95eb3035cc5b284e298fb5c3d2e7c9bb07L207-R209) [[2]](diffhunk://#diff-90aa6a3d20685397758551c0636078944be941d70d513ba1dc93e5de4d71f3faL248-R260) [[3]](diffhunk://#diff-eddc6b5d38b9f7d6a831b90996e4aa668aff407cc730b05600df5ea870cbda13L405-R418) [[4]](diffhunk://#diff-1c708eabcfb02781ea0f69810c820d605fe1da0196bcb6328f44b51d2eb50b02L93-R113)
- Log response handling and type definitions are updated to match the new schema: `logs`, `total`, and `tookMs` fields are now used everywhere, replacing legacy fields like `totalCount`. [[1]](diffhunk://#diff-90aa6a3d20685397758551c0636078944be941d70d513ba1dc93e5de4d71f3faL286-R284) [[2]](diffhunk://#diff-1c708eabcfb02781ea0f69810c820d605fe1da0196bcb6328f44b51d2eb50b02L132-R141) [[3]](diffhunk://#diff-eddc6b5d38b9f7d6a831b90996e4aa668aff407cc730b05600df5ea870cbda13L442-R442) [[4]](diffhunk://#diff-cf317a469c269118be025a7fba48701a51727bdaa36e6a85bc658e178c447a17L19-R33)

**Type System and Interface Updates**

- Legacy log types (`LogEntry`, `RuntimeLogsResponse`) are replaced with new types (`ComponentLogEntry`, `WorkflowLogEntry`, `LogsQueryResponse`) that mirror the `/api/v1/logs/query` response. Deprecated types are marked and maintained for backward compatibility. [[1]](diffhunk://#diff-3268b393886379cdb5d42fcc76a313a245d2a96db4b9c6dd014b5674fc7eabcaL9-R15) [[2]](diffhunk://#diff-28ade1a73f8e971a028ad477bc1a4bbd8f3b730ae32f1336865ca8869d535fcaL4-R21) [[3]](diffhunk://#diff-4ca069e61d4339c489ba21186788b222a9d0d486d9e97216176cc479b278f5ccL189-R222)
- The `RuntimeLogsService` and related interfaces are simplified: unnecessary fields (e.g., `componentId`, `environmentId`) are removed, and log level enums are narrowed to match the API. [[1]](diffhunk://#diff-3268b393886379cdb5d42fcc76a313a245d2a96db4b9c6dd014b5674fc7eabcaL150-R154) [[2]](diffhunk://#diff-1c708eabcfb02781ea0f69810c820d605fe1da0196bcb6328f44b51d2eb50b02L37-L38) [[3]](diffhunk://#diff-1c708eabcfb02781ea0f69810c820d605fe1da0196bcb6328f44b51d2eb50b02L49-R48) [[4]](diffhunk://#diff-1c708eabcfb02781ea0f69810c820d605fe1da0196bcb6328f44b51d2eb50b02L63-L65)

**Codebase Cleanup and Deprecation**

- Redundant or obsolete endpoints and methods for fetching build logs are removed from both the backend routers and the CI client API. [[1]](diffhunk://#diff-529828717f062ed082fc784aced07855df4e26c17da3464de7ae998c2b6b02caL536-L568) [[2]](diffhunk://#diff-fd5537f16e542d745e950e0aa16f3c2ba7537c405100356f889a95e1e40e9605L278-L312) [[3]](diffhunk://#diff-c2c0d74064f00b9f844bd7a57068dc76f7c64329c40ff13407b75898fbf2f2aaL125-L150) [[4]](diffhunk://#diff-d2845cf5ccfbe465d8c6dc84d9c160909ced4b43a44e3da2ae7ac9b722c357d8L62-L65)
- Imports and references to removed or deprecated types and methods are cleaned up throughout the codebase. [[1]](diffhunk://#diff-529828717f062ed082fc784aced07855df4e26c17da3464de7ae998c2b6b02caL5-R5) [[2]](diffhunk://#diff-d2845cf5ccfbe465d8c6dc84d9c160909ced4b43a44e3da2ae7ac9b722c357d8L5) [[3]](diffhunk://#diff-c2c0d74064f00b9f844bd7a57068dc76f7c64329c40ff13407b75898fbf2f2aaL6)

**Observability Service Schema Alignment**

- The observability backend's log response structure is updated to match the new unified schema, including a new `metadata` object and a switch from `logLevel` to `level`.
- Parameters in the `fetchRuntimeLogsByComponent` method are renamed for clarity and unused parameters are prefixed with underscores.

**Minor Consistency Improvements**

- Logging statements and error handling are updated to use the new parameter names and types, ensuring consistent developer experience and log output. [[1]](diffhunk://#diff-1c708eabcfb02781ea0f69810c820d605fe1da0196bcb6328f44b51d2eb50b02L93-R113) [[2]](diffhunk://#diff-1c708eabcfb02781ea0f69810c820d605fe1da0196bcb6328f44b51d2eb50b02L132-R141) F5c8cd86L121R121, F5c8cd86L121R121, [[3]](diffhunk://#diff-eddc6b5d38b9f7d6a831b90996e4aa668aff407cc730b05600df5ea870cbda13L513-R512)

These changes collectively modernize log handling, reduce technical debt, and pave the way for easier enhancements in the future.

Adding changes from https://github.com/openchoreo/openchoreo/pull/2294
Related: https://github.com/openchoreo/openchoreo/issues/1626

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
- Updated OpenChoreo Observer API to use a unified endpoint for log queries, replacing multiple specific endpoints.
- Enhanced API documentation and descriptions for clarity.
- Refactored client-side code to align with the new API structure, including changes to request parameters and response handling.
- Removed deprecated log retrieval methods and adjusted related components to utilize the new unified log query endpoint.

This change improves the consistency and usability of the logging functionality across the application.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified /api/v1/logs/query endpoint consolidates multiple log sources into a single, richer logs query with unified schemas for component and workflow logs.

* **Bug Fixes**
  * Improved null-safety for timestamps and log pagination.
  * Health checks simplified and no longer require authentication.

* **Refactor**
  * Observability responses and metadata streamlined for clearer component/workflow separation; deprecated build-log endpoints removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->