### PR TITLE
fix: correctly map role object fields in namespace role binding requests

### DIFF
--- a/plugins/openchoreo-backend/src/services/AuthzService/AuthzService.ts
+++ b/plugins/openchoreo-backend/src/services/AuthzService/AuthzService.ts
@@ -1051,11 +1051,14 @@ export class AuthzService {
             metadata: { name: binding.name },
             spec: {
               roleRef: {
-                kind: binding.roleNamespace ? 'AuthzRole' : 'AuthzClusterRole',
-                name: binding.role,
+                kind: binding.role?.namespace
+                  ? 'AuthzRole'
+                  : 'AuthzClusterRole',
+                name: binding.role?.name ?? binding.role,
               },
               entitlement: binding.entitlement,
               effect: binding.effect ?? 'allow',
+              ...(binding.targetPath && { targetPath: binding.targetPath }),
             },
           } as any,
         },
@@ -1114,11 +1117,14 @@ export class AuthzService {
             metadata: { name: binding.name ?? name },
             spec: {
               roleRef: {
-                kind: binding.roleNamespace ? 'AuthzRole' : 'AuthzClusterRole',
-                name: binding.role,
+                kind: binding.role?.namespace
+                  ? 'AuthzRole'
+                  : 'AuthzClusterRole',
+                name: binding.role?.name ?? binding.role,
               },
               entitlement: binding.entitlement,
               effect: binding.effect ?? 'allow',
+              ...(binding.targetPath && { targetPath: binding.targetPath }),
             },
           } as any,
         },


### PR DESCRIPTION
  The frontend sends `role` as an object `{ name, namespace }` but
  AuthzService was treating it as a string and checking the nonexistent
  `binding.roleNamespace` field. This caused `roleRef.name` to be sent as
  `[object Object]`, resulting in a 400 Bad Request from the backend.

  Also forward `targetPath` in the request body when present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authorization binding operations now accept both object-style and plain-string role references, resolving the correct binding type and role name from input.
  * Both cluster and namespace binding configurations now include an optional targetPath when provided.
  * Changes maintain backward compatibility with existing binding formats and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->