### PR TITLE
feat: switch API routing to OpenAPI-default (openchoreo #2324)

### DIFF
--- a/packages/openchoreo-client-node/docs/api-migration-guide.md
+++ b/packages/openchoreo-client-node/docs/api-migration-guide.md
@@ -199,7 +199,7 @@ getCondition(project, 'Ready'); // { type: 'Ready', status: 'True', ... }
 
 ## 7. Assumptions
 
-- Legacy and new API share the same base URL, differentiated by the `X-Use-OpenAPI` header
+- Legacy and new API share the same base URL; OpenAPI routing is now the default, legacy handlers require the `X-Use-Legacy-Routes` header
 - New API will have full CRUD for all resource types before 1.0 (component-types, traits, component-workflows currently WIP)
 - List endpoints return full resource descriptors (metadata + spec + status) -- no summary/lightweight list mode
 - The new API response is NOT wrapped in `{ success, data }` -- resources are returned directly

--- a/packages/openchoreo-client-node/src/factory.ts
+++ b/packages/openchoreo-client-node/src/factory.ts
@@ -13,9 +13,9 @@ import type { paths as ObservabilityPaths } from './generated/observability/type
 import type { paths as AIRCAAgentPaths } from './generated/ai-rca-agent/types';
 
 /**
- * Header name used to route requests to new API handlers on the OpenChoreo backend.
+ * Header name used to route requests to legacy API handlers on the OpenChoreo backend.
  */
-export const OPENCHOREO_API_VERSION_HEADER = 'X-Use-OpenAPI';
+export const OPENCHOREO_LEGACY_ROUTES_HEADER = 'X-Use-Legacy-Routes';
 import { isTracingEnabled, createTracingMiddleware } from './tracing';
 
 /**
@@ -130,14 +130,17 @@ export function createOpenChoreoLegacyApiClient(
     `Creating OpenChoreo Legacy API client with baseUrl: ${baseUrl}`,
   );
 
+  const headers: Record<string, string> = {
+    [OPENCHOREO_LEGACY_ROUTES_HEADER]: 'true',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
   const clientOptions: ClientOptions = {
     baseUrl: baseUrl,
     fetch: fetchApi,
-    headers: token
-      ? {
-          Authorization: `Bearer ${token}`,
-        }
-      : undefined,
+    headers,
   };
 
   const client = createClient<OpenChoreoLegacyPaths>(clientOptions);
@@ -155,7 +158,7 @@ export function createOpenChoreoLegacyApiClient(
  * Creates an OpenChoreo API client (new 1.0 API)
  *
  * Uses K8s-style resource descriptors (metadata/spec/status) and dedicated
- * per-resource CRUD endpoints. Attaches the API version routing header.
+ * per-resource CRUD endpoints. Routes to the default OpenAPI handlers.
  *
  * @param config - Configuration options for the client
  * @returns Configured OpenChoreo API client instance
@@ -168,17 +171,14 @@ export function createOpenChoreoApiClient(config: OpenChoreoClientConfig) {
 
   logger?.debug(`Creating OpenChoreo API client with baseUrl: ${baseUrl}`);
 
-  const headers: Record<string, string> = {
-    [OPENCHOREO_API_VERSION_HEADER]: 'true',
-  };
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
   const clientOptions: ClientOptions = {
     baseUrl,
     fetch: fetchApi,
-    headers,
+    headers: token
+      ? {
+          Authorization: `Bearer ${token}`,
+        }
+      : undefined,
   };
 
   const client = createClient<OpenChoreoPaths>(clientOptions);

--- a/packages/openchoreo-client-node/src/index.ts
+++ b/packages/openchoreo-client-node/src/index.ts
@@ -14,7 +14,7 @@ export {
   createOpenChoreoAIRCAAgentApiClient,
   createOpenChoreoClientFromConfig,
   createObservabilityClientWithUrl,
-  OPENCHOREO_API_VERSION_HEADER,
+  OPENCHOREO_LEGACY_ROUTES_HEADER,
   type OpenChoreoClientConfig,
   type OpenChoreoObservabilityClientConfig,
   type OpenChoreoAIRCAAgentClientConfig,


### PR DESCRIPTION
  Align with openchoreo PR #2324 which makes OpenAPI handlers the default.
  Remove the X-Use-OpenAPI header from the new API client and add
  X-Use-Legacy-Routes header to the legacy client instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API migration guide to clarify that OpenAPI handlers are now the default and legacy routes must be opted into via an explicit header; guidance on client behavior updated.

* **Bug Fixes**
  * Fixed routing logic so requests default to OpenAPI handlers and properly route to legacy handlers only when the explicit legacy-routing header is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->