### PR TITLE
fix(workflows): refactor observer api calls and add per-step filtering for workflows

### DIFF
--- a/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
+++ b/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
@@ -513,11 +513,16 @@ export class WorkflowService {
           log: entry.log,
         }));
 
-        this.logger.debug(
-          `Successfully fetched ${entries.length} workflow run logs from openchoreo-api`,
-        );
+        if (entries.length > 0) {
+          this.logger.debug(
+            `Successfully fetched ${entries.length} workflow run logs from openchoreo-api`,
+          );
+          return entries;
+        }
 
-        return entries;
+        this.logger.debug(
+          `Live logs empty for run ${runName}, falling back to observer`,
+        );
       }
 
       // Use observer API for older workflow runs
@@ -541,9 +546,11 @@ export class WorkflowService {
         `Sending workflow run logs request for component ${componentName} with run: ${runName}`,
       );
 
-      const startTime = new Date(
-        Date.now() - 30 * 24 * 60 * 60 * 1000,
-      ).toISOString();
+      const sinceMs =
+        typeof options.sinceSeconds === 'number' && options.sinceSeconds > 0
+          ? options.sinceSeconds * 1000
+          : 30 * 24 * 60 * 60 * 1000;
+      const startTime = new Date(Date.now() - sinceMs).toISOString();
       const endTime = new Date().toISOString();
 
       const { data, error, response } = await obsClient.POST(
@@ -557,6 +564,7 @@ export class WorkflowService {
             searchScope: {
               namespace: namespaceName,
               workflowRunName: runName,
+              ...(options.step ? { taskName: options.step } : {}),
             },
           },
         },
@@ -615,9 +623,9 @@ export class WorkflowService {
     }
 
     this.logger.debug(
-      `Fetching workflow run events for component: ${componentName}, run: ${runName} from ${
-        hasLiveObservability ? 'openchoreo-api' : 'observer-api'
-      }${step ? ` with step: ${step}` : ''}`,
+      `Fetching workflow run events for component: ${componentName}, run: ${runName}${
+        step ? ` with step: ${step}` : ''
+      }`,
     );
 
     try {
@@ -665,81 +673,10 @@ export class WorkflowService {
         this.logger.debug(
           `Successfully fetched ${entries.length} workflow run events from openchoreo-api`,
         );
-
         return entries;
       }
-
-      // Use observer API for older workflow runs
-      const { observerUrl } = await this.resolver.resolveForBuild(
-        namespaceName,
-        projectName,
-        token,
-      );
-
-      if (!observerUrl) {
-        throw new ObservabilityNotConfiguredError(componentName);
-      }
-
-      const obsClient = createObservabilityClientWithUrl(
-        observerUrl,
-        token,
-        this.logger,
-      );
-
-      this.logger.debug(
-        `Sending workflow run events request for component ${componentName} with run: ${runName}`,
-      );
-
-      const { data, error, response } = await obsClient.GET(
-        '/api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/workflow-runs/{runName}/events',
-        {
-          params: {
-            path: { namespaceName, projectName, componentName, runName },
-            query: {
-              ...(step ? { step } : {}),
-            },
-          },
-        },
-      );
-
-      if (error || !response.ok) {
-        if (response.status === 404) {
-          this.logger.info(
-            `Workflow run events endpoint not available (404). The observability service may not support workflow run events yet.`,
-          );
-          throw new ObservabilityNotConfiguredError(componentName);
-        }
-
-        this.logger.error(
-          `Failed to fetch workflow run events for component ${componentName}: ${response.status} ${response.statusText}`,
-        );
-        throw new Error(
-          `Failed to fetch workflow run events: ${response.status} ${response.statusText}`,
-        );
-      }
-
-      const entries: ComponentWorkflowRunEventEntry[] = (data || []).map(
-        (entry: any) => ({
-          timestamp: entry.timestamp,
-          type: entry.type,
-          reason: entry.reason,
-          message: entry.message,
-        }),
-      );
-
-      this.logger.debug(
-        `Successfully fetched ${entries.length} workflow run events from observer-api`,
-      );
-
-      return entries;
+      return [];
     } catch (error: unknown) {
-      if (error instanceof ObservabilityNotConfiguredError) {
-        this.logger.info(
-          `Observability not configured for component ${componentName}`,
-        );
-        throw error;
-      }
-
       this.logger.error(
         `Error fetching workflow run events for component ${componentName}:`,
         error as Error,

--- a/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
+++ b/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
@@ -532,6 +532,7 @@ export class GenericWorkflowService {
           searchScope: {
             namespace: namespaceName,
             workflowRunName: runName,
+            ...(task ? { taskName: task } : {}),
           },
         },
       });
@@ -672,110 +673,12 @@ export class GenericWorkflowService {
         `Successfully fetched ${entries.length} events for workflow run: ${runName}`,
       );
 
-      if (entries.length === 0) {
-        const observerResult = await this.fetchEventsFromObserver(
-          namespaceName,
-          runName,
-          task,
-          token,
-        );
-        if (observerResult !== null) return observerResult;
-      }
-
       return entries;
     } catch (error) {
       this.logger.error(
         `Failed to fetch events for workflow run ${runName} in namespace ${namespaceName}: ${error}`,
       );
       throw error;
-    }
-  }
-
-  /**
-   * Fallback: fetch events from the observer (OpenSearch) API for completed CI workflow runs.
-   * Returns null if the run is not a terminal CI run or if the observer is unavailable.
-   */
-  private async fetchEventsFromObserver(
-    namespaceName: string,
-    runName: string,
-    task?: string,
-    token?: string,
-  ): Promise<WorkflowRunEventEntry[] | null> {
-    try {
-      const client = createOpenChoreoApiClient({
-        baseUrl: this.baseUrl,
-        token,
-        logger: this.logger,
-      });
-
-      const {
-        data: run,
-        error,
-        response,
-      } = await client.GET(
-        '/api/v1/namespaces/{namespaceName}/workflowruns/{runName}',
-        { params: { path: { namespaceName, runName } } },
-      );
-
-      if (error || !response.ok || !run) return null;
-
-      const runStatus = deriveWorkflowRunStatus(run);
-      if (!TERMINAL_STATUSES.has(runStatus)) return null;
-
-      const projectName = (run as any).metadata?.labels?.[
-        CHOREO_LABELS.WORKFLOW_PROJECT
-      ];
-      const componentName = (run as any).metadata?.labels?.[
-        CHOREO_LABELS.WORKFLOW_COMPONENT
-      ];
-      if (!projectName || !componentName) return null;
-
-      const { observerUrl } = await this.resolver.resolveForBuild(
-        namespaceName,
-        projectName,
-        token,
-      );
-      if (!observerUrl) return null;
-
-      const obsClient = createObservabilityClientWithUrl(
-        observerUrl,
-        token,
-        this.logger,
-      );
-
-      const {
-        data: obsData,
-        error: obsError,
-        response: obsResponse,
-      } = await obsClient.GET(
-        '/api/v1/namespaces/{namespaceName}/projects/{projectName}/components/{componentName}/workflow-runs/{runName}/events',
-        {
-          params: {
-            path: { namespaceName, projectName, componentName, runName },
-            query: { ...(task ? { step: task } : {}) },
-          },
-        },
-      );
-
-      if (obsError || !obsResponse.ok || !Array.isArray(obsData)) return null;
-
-      const entries: WorkflowRunEventEntry[] = obsData.map((entry: any) => ({
-        timestamp: entry.timestamp,
-        type: entry.type,
-        reason: entry.reason,
-        message: entry.message,
-      }));
-
-      this.logger.debug(
-        `Observer fallback: fetched ${entries.length} events for workflow run: ${runName}`,
-      );
-
-      return entries;
-    } catch (err) {
-      this.logger.debug(
-        `Observer fallback for events of run ${runName} failed: ${err}`,
-      );
-      return null;
     }
   }
 }


### PR DESCRIPTION
## Purpose
- Adds `taskName` to observer log queries (`POST /api/v1/logs/query`) so logs are scoped to the requested step rather than returning all steps' logs merged together
- Removes dead observer events fallback code in both backends — the observer service has no events endpoint, so these code paths always resulted in a silent 404

## Related PR for observer
- https://github.com/openchoreo/openchoreo/pull/2342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log retrieval now returns live entries immediately; when none are found it falls through to the observer path. Event fetching no longer falls back to the observer for completed runs and returns consistent results or an empty set.
* **Refactor**
  * Observer queries now respect a provided "since" option and can optionally filter by task/step. Log messages adjusted to reflect the new control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->