### PR TITLE
feat: auto-refresh release tree and add manual refresh action

### DIFF
--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceTreeView.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceTreeView.tsx
@@ -1,5 +1,12 @@
 import { useState, useMemo, useEffect, type FC } from 'react';
-import { Box, Typography } from '@material-ui/core';
+import {
+  Box,
+  Typography,
+  IconButton,
+  Tooltip,
+  CircularProgress,
+} from '@material-ui/core';
+import RefreshIcon from '@material-ui/icons/Refresh';
 import { ResourceTreeEdge } from './ResourceTreeEdge';
 import { ResourceTreeNode } from './ResourceTreeNode';
 import { ResourceDetailPanel } from './ResourceDetailPanel';
@@ -15,6 +22,8 @@ interface ResourceTreeViewProps {
   releaseBindingData: Record<string, unknown> | null;
   namespaceName: string;
   releaseBindingName: string;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
 }
 
 export const ResourceTreeView: FC<ResourceTreeViewProps> = ({
@@ -23,6 +32,8 @@ export const ResourceTreeView: FC<ResourceTreeViewProps> = ({
   releaseBindingData,
   namespaceName,
   releaseBindingName,
+  onRefresh,
+  isRefreshing = false,
 }) => {
   const classes = useTreeStyles();
   const [selectedNode, setSelectedNode] = useState<LayoutNode | null>(null);
@@ -59,11 +70,33 @@ export const ResourceTreeView: FC<ResourceTreeViewProps> = ({
 
   return (
     <Box className={classes.treeContainer}>
-      <ReleaseStatusBar
-        releaseData={releaseData}
-        resourceTreeData={resourceTreeData}
-        releaseBindingData={releaseBindingData}
-      />
+      <Box className={classes.statusBarWrapper}>
+        <div className={classes.statusBarContent}>
+          <ReleaseStatusBar
+            releaseData={releaseData}
+            resourceTreeData={resourceTreeData}
+            releaseBindingData={releaseBindingData}
+          />
+        </div>
+        <div className={classes.statusBarAction}>
+          <Tooltip title="Refresh artifacts">
+            <span>
+              <IconButton
+                size="small"
+                onClick={onRefresh}
+                disabled={!onRefresh || isRefreshing}
+                aria-label="refresh artifacts"
+              >
+                {isRefreshing ? (
+                  <CircularProgress size={18} />
+                ) : (
+                  <RefreshIcon fontSize="small" />
+                )}
+              </IconButton>
+            </span>
+          </Tooltip>
+        </div>
+      </Box>
       <div className={classes.treeScrollArea}>
         <div
           className={classes.treeCanvas}

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeStyles.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeStyles.ts
@@ -9,6 +9,25 @@ export const useTreeStyles = makeStyles(theme => ({
     minHeight: 400,
     position: 'relative',
   },
+  statusBarWrapper: {
+    display: 'flex',
+    alignItems: 'stretch',
+    flexShrink: 0,
+  },
+  statusBarContent: {
+    flex: 1,
+    minWidth: 0,
+  },
+  statusBarAction: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing(0, 1),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    borderLeft: `1px solid ${theme.palette.divider}`,
+    backgroundColor: theme.palette.background.paper,
+    flexShrink: 0,
+  },
   statusBar: {
     display: 'flex',
     flexDirection: 'row',

--- a/plugins/openchoreo/src/components/Environments/ReleaseDetailsPage.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDetailsPage.tsx
@@ -6,8 +6,9 @@ import { Entity } from '@backstage/catalog-model';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { DetailPageLayout } from '@openchoreo/backstage-plugin-react';
 import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
+import { useEnvironmentPolling } from './hooks';
 import { ResourceTreeView } from './ReleaseDataRenderer/ResourceTreeView';
-import type { Environment } from './hooks/useEnvironmentData';
+import type { Environment } from './hooks';
 
 const useStyles = makeStyles(theme => ({
   loadingContainer: {
@@ -55,6 +56,7 @@ export const ReleaseDetailsPage = ({
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
   const [releaseData, setReleaseData] = useState<any>(null);
   const [resourceTreeData, setResourceTreeData] = useState<any>(null);
   const [releaseBindingData, setReleaseBindingData] = useState<Record<
@@ -67,61 +69,96 @@ export const ReleaseDetailsPage = ({
   const namespaceName =
     entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE] ?? '';
 
-  const loadReleaseData = useCallback(async () => {
-    if (!environmentName) return;
+  const loadReleaseData = useCallback(
+    async (showLoadingState = true) => {
+      if (!environmentName) return;
 
-    setLoading(true);
-    setError(null);
-
-    try {
-      // Fetch release data and release bindings in parallel
-      const [releaseResult, releaseBindingsResult] = await Promise.all([
-        client.fetchEnvironmentRelease(entity, environmentName),
-        client.fetchReleaseBindings(entity).catch(() => ({
-          success: false,
-          data: { items: [] },
-        })),
-      ]);
-      setReleaseData(releaseResult);
-
-      // Find the release binding matching this environment
-      // Handle both legacy format ({ success, data: { items } }) and new API format ({ items })
-      const bindingsResult = releaseBindingsResult as any;
-      const bindings: any[] =
-        bindingsResult?.data?.items ?? bindingsResult?.items ?? [];
-      const matchingBinding =
-        bindings.find(
-          (b: any) =>
-            (b.environment ?? b.spec?.environment) === environmentName,
-        ) ?? null;
-      setReleaseBindingData(matchingBinding);
-
-      // Fetch resource tree using the matched binding name
-      const bindingName =
-        matchingBinding?.name ??
-        (matchingBinding?.metadata as Record<string, unknown>)?.name;
-      if (bindingName && namespaceName) {
-        const resourceTreeResult = await client
-          .fetchResourceTree(namespaceName, bindingName as string)
-          .catch(() => ({ releases: [] }));
-        setResourceTreeData(resourceTreeResult);
-      } else {
-        setResourceTreeData({ releases: [] });
+      if (showLoadingState) {
+        setLoading(true);
+        setError(null);
       }
-    } catch (err: any) {
-      setError(err.message || 'Failed to load release details');
-    } finally {
-      setLoading(false);
-    }
-  }, [environmentName, namespaceName, entity, client]);
+
+      try {
+        // Fetch release data and release bindings in parallel
+        const [releaseResult, releaseBindingsResult] = await Promise.all([
+          client.fetchEnvironmentRelease(entity, environmentName),
+          client.fetchReleaseBindings(entity).catch(err => {
+            if (showLoadingState) {
+              return {
+                success: false,
+                data: { items: [] },
+              };
+            }
+            throw err;
+          }),
+        ]);
+
+        // Find the release binding matching this environment
+        // Handle both legacy format ({ success, data: { items } }) and new API format ({ items })
+        const bindingsResult = releaseBindingsResult as any;
+        const bindings: any[] =
+          bindingsResult?.data?.items ?? bindingsResult?.items ?? [];
+        const matchingBinding =
+          bindings.find(
+            (b: any) =>
+              (b.environment ?? b.spec?.environment) === environmentName,
+          ) ?? null;
+
+        // Fetch resource tree using the matched binding name
+        const bindingName =
+          matchingBinding?.name ??
+          (matchingBinding?.metadata as Record<string, unknown>)?.name;
+        let nextResourceTreeData: any = { releases: [] };
+
+        if (bindingName && namespaceName) {
+          nextResourceTreeData = await client
+            .fetchResourceTree(namespaceName, bindingName as string)
+            .catch(err => {
+              if (showLoadingState) {
+                return { releases: [] };
+              }
+              throw err;
+            });
+        }
+
+        setReleaseData(releaseResult);
+        setReleaseBindingData(matchingBinding);
+        setResourceTreeData(nextResourceTreeData);
+      } catch (err: any) {
+        if (showLoadingState) {
+          setError(err.message || 'Failed to load release details');
+        }
+      } finally {
+        if (showLoadingState) {
+          setLoading(false);
+        }
+      }
+    },
+    [environmentName, namespaceName, entity, client],
+  );
 
   useEffect(() => {
     loadReleaseData();
   }, [loadReleaseData]);
 
+  const shouldPollReleaseDetails = Boolean(environmentName);
+  const pollReleaseData = useCallback(() => {
+    void loadReleaseData(false);
+  }, [loadReleaseData]);
+  useEnvironmentPolling(shouldPollReleaseDetails, pollReleaseData);
+
   const handleRetry = () => {
     loadReleaseData();
   };
+
+  const handleManualRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await loadReleaseData(false);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [loadReleaseData]);
 
   const actions = error ? (
     <Button onClick={handleRetry} color="primary" variant="outlined">
@@ -166,6 +203,8 @@ export const ReleaseDetailsPage = ({
               ?.name ??
             ''
           }
+          onRefresh={handleManualRefresh}
+          isRefreshing={refreshing}
         />
       )}
 

--- a/plugins/openchoreo/src/components/Environments/components/EnvironmentCardContent.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/EnvironmentCardContent.tsx
@@ -102,7 +102,7 @@ export const EnvironmentCardContent = ({
               onClick={onOpenReleaseDetails}
               style={{ textTransform: 'none' }}
             >
-              View Release
+              View K8s Artifacts
             </Button>
           </Box>
         )}


### PR DESCRIPTION
## Purpose

- add periodic background refresh for Release Details data while page is open
- avoid full-page loading flicker during background polling
- add manual refresh button on the right side of the resource tree status bar with spinner state


https://github.com/user-attachments/assets/cac1843a-f9ab-4740-b108-e0afb830232c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a refresh button with loading spinner for manual release-data updates
  * Added automatic background polling to keep release details current when an environment is active

* **UI Updates**
  * Renamed "View Release" button to "View K8s Artifacts"
  * Status bar layout updated to separate content and action areas for the refresh control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->