### PR TITLE
feat: disable TechDocs sidebar link until production support is ready

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
 import ExtensionIcon from '@material-ui/icons/Extension';
-import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import LogoFull from './LogoFull';
@@ -127,7 +126,8 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
             icon={GroupIcon}
           />
           <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
-          <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
+          {/* TechDocs disabled until proper production support is implemented */}
+          {/* <SidebarItem icon={LibraryBooks} to="docs" text="Docs" /> */}
           <SidebarItem
             icon={CreateComponentIcon}
             to="create"


### PR DESCRIPTION
## Purpose

Disable this until we support techdocs properly. Customizers always can modify shell app to get it working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Docs navigation link from the global menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->