### PR TITLE
fix: show empty resource tree when ReleaseBinding has no releases yet

### DIFF
--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.tsx
@@ -55,7 +55,7 @@ function getBindingConditions(binding: Record<string, unknown>): any[] {
 }
 
 interface ReleaseBindingDetailTabsProps {
-  releaseData: ReleaseData;
+  releaseData: ReleaseData | null;
   releaseBindingData: Record<string, unknown> | null;
 }
 

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseStatusBar.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseStatusBar.tsx
@@ -11,14 +11,14 @@ import type {
   ResourceTreeNode,
 } from '../types';
 
-function getReadyCondition(releaseData: ReleaseData) {
-  const conditions = releaseData.data?.status?.conditions;
+function getReadyCondition(releaseData: ReleaseData | null) {
+  const conditions = releaseData?.data?.status?.conditions;
   if (!conditions) return undefined;
   return conditions.find(c => c.type === 'Ready');
 }
 
 function getOverallHealth(
-  releaseData: ReleaseData,
+  releaseData: ReleaseData | null,
   releaseBindingData?: Record<string, unknown> | null,
 ): { label: string; status: HealthStatus; reason?: string } {
   // Prefer ReleaseBinding status (matches tree root node logic)
@@ -138,7 +138,7 @@ function formatRelativeTime(timestamp: string): string {
 }
 
 interface ReleaseStatusBarProps {
-  releaseData: ReleaseData;
+  releaseData: ReleaseData | null;
   resourceTreeData: ResourceTreeData;
   releaseBindingData?: Record<string, unknown> | null;
 }
@@ -193,7 +193,11 @@ export const ReleaseStatusBar: FC<ReleaseStatusBarProps> = ({
         <Typography className={classes.statusBarLabel}>Resources</Typography>
         <div className={classes.statusBarValue}>
           <Typography variant="body2">
-            {resources.total} resource{resources.total !== 1 ? 's' : ''}
+            {resources.total === 0
+              ? 'No Resources'
+              : `${resources.total} resource${
+                  resources.total !== 1 ? 's' : ''
+                }`}
           </Typography>
         </div>
         {resources.breakdown && (

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.tsx
@@ -20,7 +20,7 @@ import type { ReleaseData } from '../types';
 interface ResourceDetailPanelProps {
   node: LayoutNode | null;
   onClose: () => void;
-  releaseData: ReleaseData;
+  releaseData: ReleaseData | null;
   releaseBindingData: Record<string, unknown> | null;
   namespaceName: string;
   releaseBindingName: string;

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceTreeView.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceTreeView.tsx
@@ -17,7 +17,7 @@ import type { LayoutNode } from './treeTypes';
 import type { ReleaseData, ResourceTreeData } from '../types';
 
 interface ResourceTreeViewProps {
-  releaseData: ReleaseData;
+  releaseData: ReleaseData | null;
   resourceTreeData: ResourceTreeData;
   releaseBindingData: Record<string, unknown> | null;
   namespaceName: string;

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.ts
@@ -50,12 +50,13 @@ function aggregateHealth(nodes: ResourceTreeNode[]): HealthStatus {
  * When resourceTreeData contains `releases`, intermediate Release nodes are created.
  */
 export function buildTreeNodes(
-  releaseData: ReleaseData,
+  releaseData: ReleaseData | null,
   resourceTreeData: ResourceTreeData,
   releaseBindingData?: Record<string, unknown> | null,
 ): TreeNode[] {
   const data = releaseData?.data;
-  if (!data) return [];
+  // If there is no release data but we have a release binding, build a root-only tree
+  if (!data && !releaseBindingData) return [];
 
   const nodes: TreeNode[] = [];
 
@@ -88,7 +89,7 @@ export function buildTreeNodes(
     }
   } else {
     // Fallback to release conditions if no binding data
-    const releaseConditions = data.status?.conditions ?? [];
+    const releaseConditions = data?.status?.conditions ?? [];
     const readyCondition = releaseConditions.find(c => c.type === 'Ready');
     if (readyCondition) {
       rootHealth = readyCondition.status === 'True' ? 'Healthy' : 'Degraded';
@@ -102,7 +103,7 @@ export function buildTreeNodes(
       ?.name as string) ??
     undefined;
   const rootName =
-    bindingName ?? data.spec?.owner?.componentName ?? 'ReleaseBinding';
+    bindingName ?? data?.spec?.owner?.componentName ?? 'ReleaseBinding';
 
   nodes.push({
     id: ROOT_NODE_ID,

--- a/plugins/openchoreo/src/components/Environments/ReleaseDetailsPage.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDetailsPage.tsx
@@ -191,10 +191,10 @@ export const ReleaseDetailsPage = ({
         </Box>
       )}
 
-      {!loading && !error && releaseData && (
+      {!loading && !error && (releaseData || releaseBindingData) && (
         <ResourceTreeView
           releaseData={releaseData}
-          resourceTreeData={resourceTreeData}
+          resourceTreeData={resourceTreeData ?? { releases: [] }}
           releaseBindingData={releaseBindingData}
           namespaceName={namespaceName}
           releaseBindingName={
@@ -208,7 +208,7 @@ export const ReleaseDetailsPage = ({
         />
       )}
 
-      {!loading && !error && !releaseData && (
+      {!loading && !error && !releaseData && !releaseBindingData && (
         <Box className={classes.emptyContainer}>
           <Typography variant="body2" color="textSecondary">
             No release data available for this environment


### PR DESCRIPTION
## Purpose

  - When a `ReleaseBinding` exists but hasn't produced any `Release` resources yet, the UI now renders the resource tree with only the root
  `ReleaseBinding` node instead of showing the misleading "No release data available for this environment" message
  - Status bar shows **No Resources** (instead of "0 resources") and **Health: Unknown** for the empty state
  - Makes `releaseData` nullable through the component tree (`ResourceTreeView`, `ReleaseStatusBar`, `ResourceDetailPanel`,
  `ReleaseBindingDetailTabs`, `treeLayoutUtils`) so the tree can render from `releaseBindingData` alone

## Before

https://github.com/user-attachments/assets/5ed90df1-ded8-497e-835b-5c4bf978fb34



## After

https://github.com/user-attachments/assets/f313105f-b876-4517-bdbe-d40dc37d3379



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors when release info is missing; UI remains stable.
  * Resources display now shows "No Resources" when none exist.

* **Improvements**
  * Release views render when either release data or binding data is available.
  * Empty-state messaging broadened to indicate no release data for the environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->