### PR TITLE
fix: avoid observer fallback for empty live logs on new workflow runs

### DIFF
--- a/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
+++ b/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
@@ -513,16 +513,12 @@ export class WorkflowService {
           log: entry.log,
         }));
 
-        if (entries.length > 0) {
-          this.logger.debug(
-            `Successfully fetched ${entries.length} workflow run logs from openchoreo-api`,
-          );
-          return entries;
-        }
-
         this.logger.debug(
-          `Live logs empty for run ${runName}, falling back to observer`,
+          entries.length > 0
+            ? `Successfully fetched ${entries.length} workflow run logs from openchoreo-api`
+            : `No live logs yet for run ${runName}`,
         );
+        return entries;
       }
 
       // Use observer API for older workflow runs


### PR DESCRIPTION
## Purpose
- Fix https://github.com/openchoreo/openchoreo/issues/2371

## Problem

  When a build is triggered, the OpenChoreo API returns no logs for the
  first few seconds. The backend was treating this empty response as a
  signal to fall back to the observer (OpenSearch) API. Since the
  observability plane is optional, this produced a 500 error:

  > Failed to get ObservabilityPlane 'default': 404 Not Found

  This affected both the component CI page and the generic workflows
  catalog page when viewing a freshly triggered run.

  ## Root Cause

  In `WorkflowService.fetchWorkflowRunLogs`, the live-log block only
  returned early if `entries.length > 0`. An empty response fell through
  to the observer fallback unconditionally.

  ## Fix

  When `hasLiveObservability=true`, always return the live result (even
  empty). The observer fallback is now only reached when
  `hasLiveObservability=false`, which the API sets for older/archived runs
  where live data is no longer available.

  The frontend already handles empty logs gracefully and re-polls every
  10s, so logs appear automatically once the build starts producing them.

  Note: `GenericWorkflowService` (workflows catalog page) already handled
  this correctly by checking run terminal status before touching the
  observer. Only `WorkflowService` (component CI page) had the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow run log retrieval behavior when live observability is enabled. The system no longer attempts fallback operations when fetching live logs, ensuring consistent log retrieval regardless of whether live logs are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

