### PR TITLE
fix: cap time range for workflow run logs to comply with observer limits

### DIFF
--- a/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
+++ b/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
@@ -542,10 +542,15 @@ export class WorkflowService {
         `Sending workflow run logs request for component ${componentName} with run: ${runName}`,
       );
 
-      const sinceMs =
+      // The observer rejects queries where the time range exceeds 30 days.
+      // Cap the window at 29 days to stay safely within that limit regardless
+      // of clock skew or boundary-comparison behaviour on the observer side.
+      const maxAllowedMs = 29 * 24 * 60 * 60 * 1000;
+      const requestedMs =
         typeof options.sinceSeconds === 'number' && options.sinceSeconds > 0
           ? options.sinceSeconds * 1000
-          : 30 * 24 * 60 * 60 * 1000;
+          : maxAllowedMs;
+      const sinceMs = Math.min(requestedMs, maxAllowedMs);
       const startTime = new Date(Date.now() - sinceMs).toISOString();
       const endTime = new Date().toISOString();
 


### PR DESCRIPTION
## Purpose
This pull request introduces a safeguard to the workflow log retrieval logic in `WorkflowService`. The main change ensures that the time range for log queries never exceeds 29 days, preventing potential errors from the observer service, which rejects queries over 30 days.

Log retrieval window restriction:

* Updated the calculation of the `sinceMs` variable in `WorkflowService.ts` to cap the log query window at 29 days (in milliseconds), regardless of user input, to avoid exceeding the observer's 30-day limit and to account for possible clock skew or boundary issues.

Resolves intermittent error of recieving below error
<img width="1279" height="468" alt="image" src="https://github.com/user-attachments/assets/cc570bb7-5b00-47ad-a6a9-c457ed7a0e77" />

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

Updated the time range calculation in WorkflowService to ensure that the maximum allowed duration for log requests does not exceed 29 days, preventing potential rejections from the observer due to exceeding the 30-day limit.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the maximum time window for retrieving workflow logs from 30 to 29 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->