### PR TITLE
fix: handle workload creation when no existing workload exists

### DIFF
--- a/plugins/openchoreo-backend/src/services/WorkloadService/WorkloadInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/WorkloadService/WorkloadInfoService.ts
@@ -111,36 +111,63 @@ export class WorkloadInfoService implements WorkloadService {
       }
 
       const existingWorkload = listData.items[0];
-      if (!existingWorkload) {
-        throw new Error(
-          `No existing workload found for component: ${componentName}`,
+
+      if (existingWorkload) {
+        // Update existing workload
+        const workloadName = existingWorkload.metadata.name;
+        if (!workloadName) {
+          throw new Error(
+            `Workload for component ${componentName} has no name in metadata`,
+          );
+        }
+
+        const { data, error, response } = await client.PUT(
+          '/api/v1/namespaces/{namespaceName}/workloads/{workloadName}',
+          {
+            params: {
+              path: { namespaceName, workloadName },
+            },
+            body: {
+              ...existingWorkload,
+              spec: workloadSpec as { [key: string]: unknown },
+            },
+          },
         );
+
+        if (error || !response.ok) {
+          throw new Error(
+            `Failed to update workload: ${response.status} ${response.statusText}`,
+          );
+        }
+
+        return data.spec;
       }
 
-      const workloadName = existingWorkload.metadata.name;
-      if (!workloadName) {
-        throw new Error(
-          `Workload for component ${componentName} has no name in metadata`,
-        );
-      }
-
-      // Update the workload with the new spec
-      const { data, error, response } = await client.PUT(
-        '/api/v1/namespaces/{namespaceName}/workloads/{workloadName}',
+      // Create new workload
+      const { data, error, response } = await client.POST(
+        '/api/v1/namespaces/{namespaceName}/workloads',
         {
           params: {
-            path: { namespaceName, workloadName },
+            path: { namespaceName },
           },
           body: {
-            ...existingWorkload,
-            spec: workloadSpec as { [key: string]: unknown },
+            metadata: {
+              name: `${componentName}-workload`,
+            },
+            spec: {
+              ...(workloadSpec as { [key: string]: unknown }),
+              owner: {
+                projectName,
+                componentName,
+              },
+            },
           },
         },
       );
 
       if (error || !response.ok) {
         throw new Error(
-          `Failed to update workload: ${response.status} ${response.statusText}`,
+          `Failed to create workload: ${response.status} ${response.statusText}`,
         );
       }
 


### PR DESCRIPTION
  applyWorkload previously threw an error when no workload existed for a
  component. Now it falls through to POST a new workload instead of only
  supporting PUT updates, enabling the Configure & Deploy form to work
  for pre-built image components without an existing workload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workload management now properly handles both creation of new workloads and updates to existing ones
  * Enhanced error messaging to distinguish between workload creation and update operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->