### PR TITLE
feat: use lastSpecUpdateTime for deployed timestamp in environment cards

### DIFF
--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -339,7 +339,7 @@ export class EnvironmentInfoService implements EnvironmentService {
         | 'NotReady'
         | 'Failed'
         | undefined;
-      lastDeployed = binding.createdAt;
+      lastDeployed = binding.lastSpecUpdateTime ?? binding.createdAt;
       releaseName = binding.releaseName;
 
       if (binding.endpoints && binding.endpoints.length > 0) {

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -96,6 +96,8 @@ export function transformReleaseBinding(
       | ReleaseBindingResponse['workloadOverrides']
       | undefined,
     createdAt: getCreatedAt(binding) ?? '',
+    lastSpecUpdateTime:
+      (binding.status as any)?.lastSpecUpdateTime ?? undefined,
     status: deriveBindingStatus(binding),
     endpoints: (() => {
       const raw = (binding.status as any)?.endpoints;

--- a/plugins/openchoreo-common/src/types/bff-types.ts
+++ b/plugins/openchoreo-common/src/types/bff-types.ts
@@ -529,6 +529,8 @@ export interface ReleaseBindingResponse {
   workloadOverrides?: WorkloadOverrides;
   /** Format: date-time */
   createdAt: string;
+  /** Format: date-time – last time the spec was updated (from status.lastSpecUpdateTime) */
+  lastSpecUpdateTime?: string;
   status?: string;
   endpoints?: ReleaseBindingEndpoint[];
 }


### PR DESCRIPTION
## Purpose

Use the new lastSpecUpdateTime field from the ReleaseBinding status instead of creationTimestamp to show when a deployment was last updated. Falls back to createdAt if lastSpecUpdateTime is not available.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deployments now track and display specification update timestamps, showing when configurations were last modified for improved visibility into deployment history and change tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->