### PR TITLE
feat: remove auth providers section from settings

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -85,7 +85,6 @@ import {
   UserSettingsPage,
   SettingsLayout,
   UserSettingsGeneral,
-  UserSettingsAuthProviders,
 } from '@backstage/plugin-user-settings';
 import CategoryIcon from '@material-ui/icons/Category';
 import ExtensionIcon from '@material-ui/icons/Extension';
@@ -94,7 +93,6 @@ import SettingsApplicationsIcon from '@material-ui/icons/SettingsApplications';
 import { UnifiedThemeProvider } from '@backstage/theme';
 import { VisitListener } from '@backstage/plugin-home';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { OpenChoreoProviderSettings } from './components/settings/OpenChoreoProviderSettings';
 import { DependencyGraphZoomOverrides } from './components/graph/DependencyGraphZoomOverrides';
 
 /**
@@ -285,11 +283,6 @@ const routes = (
       <SettingsLayout>
         <SettingsLayout.Route path="general" title="General">
           <UserSettingsGeneral />
-        </SettingsLayout.Route>
-        <SettingsLayout.Route path="auth-providers" title="Auth Providers">
-          <UserSettingsAuthProviders
-            providerSettings={<OpenChoreoProviderSettings />}
-          />
         </SettingsLayout.Route>
         <SettingsLayout.Route path="access-control" title="Access Control">
           <AccessControlContent />


### PR DESCRIPTION
Users who will use other auth providers for plugin integrations such as github, azure, etc., can always enable this back when modifying backstage portal.

<img width="1728" height="869" alt="image" src="https://github.com/user-attachments/assets/57e6b3d9-d42f-4edb-9558-fe19149725e8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed Auth Providers section from user settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->