### PR TITLE
feat: add incident indicators to environment cards

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
@@ -315,6 +315,98 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  # Incidents query endpoint
+  /api/v1alpha1/incidents/query:
+    post:
+      tags:
+        - Incidents
+      summary: Query incidents
+      description: Query incidents from the observer service
+      operationId: queryIncidents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentsQueryRequest'
+      responses:
+        '200':
+          description: Incidents queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentsQueryResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # Triggered alerts query endpoint
+  /api/v1alpha1/alerts/query:
+    post:
+      tags:
+        - Alerts
+      summary: Query alerts
+      description: Query alerts from the observer service
+      operationId: queryAlerts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlertsQueryRequest'
+      responses:
+        '200':
+          description: Alerts queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlertsQueryResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     # Request schemas for logs
@@ -584,7 +676,7 @@ components:
           minimum: 1
           maximum: 1000
           description: The maximum number of items to return
-        sort:
+        sortOrder:
           type: string
           description: The sort order of the query
           enum:
@@ -712,6 +804,264 @@ components:
               value:
                 type: string
                 description: The value of the attribute
+
+    # Request schema for alerts query
+    AlertsQueryRequest:
+      type: object
+      properties:
+        startTime:
+          type: string
+          description: The start time of the query
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query
+          format: date-time
+        limit:
+          type: integer
+          description: The maximum number of items to return
+          default: 100
+          minimum: 1
+          maximum: 1000
+        sortOrder:
+          type: string
+          description: The sort order of the query
+          enum:
+            - asc
+            - desc
+          default: desc
+        searchScope:
+          $ref: '#/components/schemas/ComponentSearchScope'
+      required: [startTime, endTime, searchScope]
+
+    # Response schema for alerts query
+    AlertsQueryResponse:
+      type: object
+      properties:
+        alerts:
+          type: array
+          description: The list of alerts
+          items:
+            type: object
+            properties:
+              timestamp:
+                type: string
+                description: The timestamp of the alert
+                format: date-time
+              alertId:
+                type: string
+                description: The alert ID
+              alertValue:
+                type: string
+                description: The value of the alert
+              notificationChannels:
+                type: array
+                description: The notification channels of the alert. Empty if failed to notify.
+                items:
+                  type: string
+                  description: The name of the notification channel
+              metadata:
+                type: object
+                properties:
+                  alertRule:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: The name of the alert rule
+                      description:
+                        type: string
+                        description: The description of the alert rule
+                      severity:
+                        type: string
+                        description: The severity of the alert rule
+                        enum:
+                          - info
+                          - warning
+                          - critical
+                      source:
+                        type: object
+                        description: The source configuration of the alert rule
+                        properties:
+                          type:
+                            type: string
+                            description: The type of the alert source
+                            enum:
+                              - log
+                              - metric
+                          query:
+                            type: string
+                            description: The query used for log-based alerts
+                          metric:
+                            type: string
+                            description: The metric used for metric-based alerts
+                      condition:
+                        type: object
+                        description: The condition configuration of the alert rule
+                        properties:
+                          operator:
+                            type: string
+                            description: The comparison operator used for evaluation
+                            enum:
+                              - gt
+                              - lt
+                              - gte
+                              - lte
+                              - eq
+                              - neq
+                          threshold:
+                            type: number
+                            description: The threshold value that triggers the alert
+                          window:
+                            type: string
+                            description: The time window for aggregation (e.g. "5m", "1h")
+                          interval:
+                            type: string
+                            description: The evaluation interval (e.g. "1m", "5m")
+                  labels:
+                    type: object
+                    properties:
+                      componentName:
+                        type: string
+                        description: The name of the component
+                      environmentName:
+                        type: string
+                        description: The name of the environment
+                      projectName:
+                        type: string
+                        description: The name of the project
+                      namespaceName:
+                        type: string
+                        description: The name of the namespace
+                      componentUid:
+                        type: string
+                        description: The UID of the component
+                        format: uuid
+                      environmentUid:
+                        type: string
+                        description: The UID of the environment
+                        format: uuid
+                      projectUid:
+                        type: string
+                        description: The UID of the project
+                        format: uuid
+        total:
+          type: integer
+          description: The total number of alerts
+        tookMs:
+          type: integer
+          description: The time taken to query the alerts in milliseconds
+
+    # Request schema for incidents query
+    IncidentsQueryRequest:
+      type: object
+      properties:
+        startTime:
+          type: string
+          description: The start time of the query
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query
+          format: date-time
+        limit:
+          type: integer
+          description: The maximum number of items to return
+          default: 100
+          minimum: 1
+          maximum: 1000
+        sortOrder:
+          type: string
+          description: The sort order of the query
+          enum:
+            - asc
+            - desc
+          default: desc
+        searchScope:
+          $ref: '#/components/schemas/ComponentSearchScope'
+      required: [startTime, endTime, searchScope]
+
+    # Response schema for incidents query
+    IncidentsQueryResponse:
+      type: object
+      properties:
+        incidents:
+          type: array
+          description: The list of incidents
+          items:
+            type: object
+            properties:
+              timestamp:
+                type: string
+                description: The timestamp of the incident
+                format: date-time
+              alertId:
+                type: string
+                description: The ID of the alert that triggered the incident
+              incidentId:
+                type: string
+                description: The ID of the incident
+              incidentTriggerAiRca:
+                type: boolean
+                description: Whether AI RCA was triggered for the incident
+              status:
+                type: string
+                description: The status of the incident
+                enum:
+                  - triggered
+                  - acknowledged
+                  - resolved
+              triggeredAt:
+                type: string
+                description: The timestamp when the incident was triggered
+                format: date-time
+              acknowledgedAt:
+                type: string
+                description: The timestamp when the incident was acknowledged
+                format: date-time
+              resolvedAt:
+                type: string
+                description: The timestamp when the incident was resolved
+                format: date-time
+              notes:
+                type: string
+                description: Notes associated with the incident
+              description:
+                type: string
+                description: The description of the incident
+              labels:
+                type: object
+                properties:
+                  componentName:
+                    type: string
+                    description: The name of the component
+                  environmentName:
+                    type: string
+                    description: The name of the environment
+                  projectName:
+                    type: string
+                    description: The name of the project
+                  namespaceName:
+                    type: string
+                    description: The name of the namespace
+                  componentUid:
+                    type: string
+                    description: The UID of the component
+                    format: uuid
+                  environmentUid:
+                    type: string
+                    description: The UID of the environment
+                    format: uuid
+                  projectUid:
+                    type: string
+                    description: The UID of the project
+                    format: uuid
+        total:
+          type: integer
+          description: The total number of incidents
+        tookMs:
+          type: integer
+          description: The time taken to query the incidents in milliseconds
 
     ErrorResponse:
       type: object

--- a/packages/openchoreo-client-node/src/generated/observability/types.ts
+++ b/packages/openchoreo-client-node/src/generated/observability/types.ts
@@ -124,6 +124,46 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1alpha1/incidents/query': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Query incidents
+     * @description Query incidents from the observer service
+     */
+    post: operations['queryIncidents'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1alpha1/alerts/query': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Query alerts
+     * @description Query alerts from the observer service
+     */
+    post: operations['queryAlerts'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -303,7 +343,7 @@ export interface components {
        * @default desc
        * @enum {string}
        */
-      sort: 'asc' | 'desc';
+      sortOrder: 'asc' | 'desc';
       searchScope: components['schemas']['ComponentSearchScope'];
     };
     TracesQueryResponse: {
@@ -390,6 +430,207 @@ export interface components {
         /** @description The value of the attribute */
         value?: string;
       }[];
+    };
+    AlertsQueryRequest: {
+      /**
+       * Format: date-time
+       * @description The start time of the query
+       */
+      startTime: string;
+      /**
+       * Format: date-time
+       * @description The end time of the query
+       */
+      endTime: string;
+      /**
+       * @description The maximum number of items to return
+       * @default 100
+       */
+      limit: number;
+      /**
+       * @description The sort order of the query
+       * @default desc
+       * @enum {string}
+       */
+      sortOrder: 'asc' | 'desc';
+      searchScope: components['schemas']['ComponentSearchScope'];
+    };
+    AlertsQueryResponse: {
+      /** @description The list of alerts */
+      alerts?: {
+        /**
+         * Format: date-time
+         * @description The timestamp of the alert
+         */
+        timestamp?: string;
+        /** @description The alert ID */
+        alertId?: string;
+        /** @description The value of the alert */
+        alertValue?: string;
+        /** @description The notification channels of the alert. Empty if failed to notify. */
+        notificationChannels?: string[];
+        metadata?: {
+          alertRule?: {
+            /** @description The name of the alert rule */
+            name?: string;
+            /** @description The description of the alert rule */
+            description?: string;
+            /**
+             * @description The severity of the alert rule
+             * @enum {string}
+             */
+            severity?: 'info' | 'warning' | 'critical';
+            /** @description The source configuration of the alert rule */
+            source?: {
+              /**
+               * @description The type of the alert source
+               * @enum {string}
+               */
+              type?: 'log' | 'metric';
+              /** @description The query used for log-based alerts */
+              query?: string;
+              /** @description The metric used for metric-based alerts */
+              metric?: string;
+            };
+            /** @description The condition configuration of the alert rule */
+            condition?: {
+              /**
+               * @description The comparison operator used for evaluation
+               * @enum {string}
+               */
+              operator?: 'gt' | 'lt' | 'gte' | 'lte' | 'eq' | 'neq';
+              /** @description The threshold value that triggers the alert */
+              threshold?: number;
+              /** @description The time window for aggregation (e.g. "5m", "1h") */
+              window?: string;
+              /** @description The evaluation interval (e.g. "1m", "5m") */
+              interval?: string;
+            };
+          };
+          labels?: {
+            /** @description The name of the component */
+            componentName?: string;
+            /** @description The name of the environment */
+            environmentName?: string;
+            /** @description The name of the project */
+            projectName?: string;
+            /** @description The name of the namespace */
+            namespaceName?: string;
+            /**
+             * Format: uuid
+             * @description The UID of the component
+             */
+            componentUid?: string;
+            /**
+             * Format: uuid
+             * @description The UID of the environment
+             */
+            environmentUid?: string;
+            /**
+             * Format: uuid
+             * @description The UID of the project
+             */
+            projectUid?: string;
+          };
+        };
+      }[];
+      /** @description The total number of alerts */
+      total?: number;
+      /** @description The time taken to query the alerts in milliseconds */
+      tookMs?: number;
+    };
+    IncidentsQueryRequest: {
+      /**
+       * Format: date-time
+       * @description The start time of the query
+       */
+      startTime: string;
+      /**
+       * Format: date-time
+       * @description The end time of the query
+       */
+      endTime: string;
+      /**
+       * @description The maximum number of items to return
+       * @default 100
+       */
+      limit: number;
+      /**
+       * @description The sort order of the query
+       * @default desc
+       * @enum {string}
+       */
+      sortOrder: 'asc' | 'desc';
+      searchScope: components['schemas']['ComponentSearchScope'];
+    };
+    IncidentsQueryResponse: {
+      /** @description The list of incidents */
+      incidents?: {
+        /**
+         * Format: date-time
+         * @description The timestamp of the incident
+         */
+        timestamp?: string;
+        /** @description The ID of the alert that triggered the incident */
+        alertId?: string;
+        /** @description The ID of the incident */
+        incidentId?: string;
+        /** @description Whether AI RCA was triggered for the incident */
+        incidentTriggerAiRca?: boolean;
+        /**
+         * @description The status of the incident
+         * @enum {string}
+         */
+        status?: 'triggered' | 'acknowledged' | 'resolved';
+        /**
+         * Format: date-time
+         * @description The timestamp when the incident was triggered
+         */
+        triggeredAt?: string;
+        /**
+         * Format: date-time
+         * @description The timestamp when the incident was acknowledged
+         */
+        acknowledgedAt?: string;
+        /**
+         * Format: date-time
+         * @description The timestamp when the incident was resolved
+         */
+        resolvedAt?: string;
+        /** @description Notes associated with the incident */
+        notes?: string;
+        /** @description The description of the incident */
+        description?: string;
+        labels?: {
+          /** @description The name of the component */
+          componentName?: string;
+          /** @description The name of the environment */
+          environmentName?: string;
+          /** @description The name of the project */
+          projectName?: string;
+          /** @description The name of the namespace */
+          namespaceName?: string;
+          /**
+           * Format: uuid
+           * @description The UID of the component
+           */
+          componentUid?: string;
+          /**
+           * Format: uuid
+           * @description The UID of the environment
+           */
+          environmentUid?: string;
+          /**
+           * Format: uuid
+           * @description The UID of the project
+           */
+          projectUid?: string;
+        };
+      }[];
+      /** @description The total number of incidents */
+      total?: number;
+      /** @description The time taken to query the incidents in milliseconds */
+      tookMs?: number;
     };
     ErrorResponse: {
       /**
@@ -719,6 +960,126 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['TraceSpanDetailsResponse'];
+        };
+      };
+      /** @description Invalid request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  queryIncidents: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['IncidentsQueryRequest'];
+      };
+    };
+    responses: {
+      /** @description Incidents queried successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['IncidentsQueryResponse'];
+        };
+      };
+      /** @description Invalid request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ErrorResponse'];
+        };
+      };
+    };
+  };
+  queryAlerts: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AlertsQueryRequest'];
+      };
+    };
+    responses: {
+      /** @description Alerts queried successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AlertsQueryResponse'];
         };
       };
       /** @description Invalid request */

--- a/plugins/openchoreo-observability-backend/src/services/ObservabilityService.ts
+++ b/plugins/openchoreo-observability-backend/src/services/ObservabilityService.ts
@@ -514,7 +514,7 @@ export class ObservabilityService {
    * @param options.limit - The maximum number of traces to return (default 100)
    * @param options.startTime - The start time of the query (ISO 8601)
    * @param options.endTime - The end time of the query (ISO 8601)
-   * @param options.sort - Sort order for traces (asc/desc, default desc)
+   * @param options.sortOrder - Sort order for traces (asc/desc, default desc)
    * @param userToken - Optional user token for authentication
    * @returns Promise with traces data
    */
@@ -527,7 +527,7 @@ export class ObservabilityService {
       limit?: number;
       startTime?: string;
       endTime?: string;
-      sort?: 'asc' | 'desc';
+      sortOrder?: 'asc' | 'desc';
     },
     userToken?: string,
   ): Promise<{
@@ -568,7 +568,7 @@ export class ObservabilityService {
             startTime: options.startTime,
             endTime: options.endTime,
             limit: options?.limit ?? 100,
-            sort: options?.sort ?? 'desc',
+            sortOrder: options?.sortOrder ?? 'desc',
             searchScope: {
               namespace: namespaceName,
               project: projectName,
@@ -675,7 +675,7 @@ export class ObservabilityService {
             startTime: options.startTime,
             endTime: options.endTime,
             limit: 1000,
-            sort: 'asc',
+            sortOrder: 'asc',
             searchScope: {
               namespace: namespaceName,
               project: projectName,

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
@@ -54,7 +54,7 @@ export interface ObservabilityApi {
       limit?: number;
       startTime?: string;
       endTime?: string;
-      sort?: 'asc' | 'desc';
+      sortOrder?: 'asc' | 'desc';
     },
   ): Promise<{
     traces: Trace[];
@@ -105,6 +105,29 @@ export interface ObservabilityApi {
     environmentName: string,
     namespaceName: string,
   ): Promise<RCAReportDetailed>;
+
+  getIncidents(
+    namespaceName: string,
+    projectName: string,
+    environmentName: string,
+    componentName: string,
+    options?: {
+      startTime?: string;
+      endTime?: string;
+      limit?: number;
+      sortOrder?: 'asc' | 'desc';
+    },
+  ): Promise<{
+    incidents: Array<{
+      incidentId: string;
+      alertId: string;
+      status: 'triggered' | 'acknowledged' | 'resolved';
+      description?: string;
+      triggeredAt?: string;
+      resolvedAt?: string;
+    }>;
+    total: number;
+  }>;
 }
 
 export const observabilityApiRef = createApiRef<ObservabilityApi>({
@@ -225,7 +248,7 @@ export class ObservabilityClient implements ObservabilityApi {
       limit?: number;
       startTime?: string;
       endTime?: string;
-      sort?: 'asc' | 'desc';
+      sortOrder?: 'asc' | 'desc';
     },
   ): Promise<{
     traces: Trace[];
@@ -247,7 +270,7 @@ export class ObservabilityClient implements ObservabilityApi {
             options?.startTime ?? new Date(Date.now() - 3600000).toISOString(),
           endTime: options?.endTime ?? new Date().toISOString(),
           limit: options?.limit ?? 100,
-          sort: options?.sort ?? 'desc',
+          sortOrder: options?.sortOrder ?? 'desc',
           searchScope: {
             namespace: namespaceName,
             project: projectName,
@@ -318,7 +341,7 @@ export class ObservabilityClient implements ObservabilityApi {
             options?.startTime ?? new Date(Date.now() - 3600000).toISOString(),
           endTime: options?.endTime ?? new Date().toISOString(),
           limit: 1000,
-          sort: 'asc',
+          sortOrder: 'asc',
           searchScope: {
             namespace: namespaceName,
             project: projectName,
@@ -490,6 +513,81 @@ export class ObservabilityClient implements ObservabilityApi {
 
     const data = await response.json();
     return data;
+  }
+
+  async getIncidents(
+    namespaceName: string,
+    projectName: string,
+    environmentName: string,
+    componentName: string,
+    options?: {
+      startTime?: string;
+      endTime?: string;
+      limit?: number;
+      sortOrder?: 'asc' | 'desc';
+    },
+  ): Promise<{
+    incidents: Array<{
+      incidentId: string;
+      alertId: string;
+      status: 'triggered' | 'acknowledged' | 'resolved';
+      description?: string;
+      triggeredAt?: string;
+      resolvedAt?: string;
+    }>;
+    total: number;
+  }> {
+    const { observerUrl } = await this.urlCache.resolveUrls(
+      namespaceName,
+      environmentName,
+    );
+
+    const response = await this.fetchApi.fetch(
+      `${observerUrl}/api/v1alpha1/incidents/query`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...DIRECT_HEADER },
+        body: JSON.stringify({
+          startTime:
+            options?.startTime ?? new Date(Date.now() - 3600000).toISOString(),
+          endTime: options?.endTime ?? new Date().toISOString(),
+          limit: options?.limit ?? 100,
+          sortOrder: options?.sortOrder ?? 'desc',
+          searchScope: {
+            namespace: namespaceName,
+            project: projectName,
+            component: componentName,
+            environment: environmentName,
+          },
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const error = await this.parseError(response);
+      if (error.includes('Observability is not configured for component')) {
+        throw new Error('Observability is not enabled for this component');
+      }
+      throw new Error(
+        error || `Failed to fetch incidents: ${response.statusText}`,
+      );
+    }
+
+    const data = await response.json();
+    const validStatuses = ['triggered', 'acknowledged', 'resolved'];
+    return {
+      incidents: (data.incidents ?? [])
+        .filter((i: any) => validStatuses.includes(i.status))
+        .map((i: any) => ({
+          incidentId: i.incidentId ?? '',
+          alertId: i.alertId ?? '',
+          status: i.status,
+          description: i.description,
+          triggeredAt: i.triggeredAt,
+          resolvedAt: i.resolvedAt,
+        })),
+      total: data.total ?? 0,
+    };
   }
 
   async getRuntimeLogs(

--- a/plugins/openchoreo-observability/src/hooks/useTraces.ts
+++ b/plugins/openchoreo-observability/src/hooks/useTraces.ts
@@ -59,7 +59,7 @@ export function useTraces(filters: Filters, entity: Entity) {
           limit: 100,
           startTime,
           endTime,
-          sort: 'desc',
+          sortOrder: 'desc',
         },
       );
 

--- a/plugins/openchoreo/src/components/Environments/EnvironmentsList.tsx
+++ b/plugins/openchoreo/src/components/Environments/EnvironmentsList.tsx
@@ -12,6 +12,7 @@ import type { Environment } from './hooks';
 import type { PendingAction } from './types';
 import { NotificationBanner, SetupCard, EnvironmentCard } from './components';
 import { useEnvironmentsContext } from './EnvironmentsContext';
+import { useIncidentsSummary } from './hooks/useIncidentsSummary';
 
 /**
  * List view for the Environments page.
@@ -41,6 +42,9 @@ export const EnvironmentsList = () => {
   const refreshTracker = useItemActionTracker<string>();
   const promotionTracker = useItemActionTracker<string>();
   const suspendTracker = useItemActionTracker<string>();
+
+  // Incidents summary per environment
+  const incidentsSummaries = useIncidentsSummary(displayEnvironments);
 
   // Notifications
   const notification = useNotification();
@@ -154,6 +158,9 @@ export const EnvironmentsList = () => {
                   .catch(err =>
                     notification.showError(`Error suspending: ${err}`),
                   )
+              }
+              activeIncidentCount={
+                incidentsSummaries.get(env.name)?.activeCount
               }
             />
           </Grid>

--- a/plugins/openchoreo/src/components/Environments/components/EnvironmentCard.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/EnvironmentCard.tsx
@@ -25,6 +25,7 @@ export const EnvironmentCard = ({
   onOpenReleaseDetails,
   onPromote,
   onSuspend,
+  activeIncidentCount,
 }: EnvironmentCardProps) => {
   const classes = useEnvironmentCardStyles();
 
@@ -51,6 +52,8 @@ export const EnvironmentCard = ({
               releaseName={deployment.releaseName}
               endpoints={endpoints}
               onOpenReleaseDetails={onOpenReleaseDetails}
+              activeIncidentCount={activeIncidentCount}
+              environmentName={environmentName}
             />
 
             <EnvironmentActions

--- a/plugins/openchoreo/src/components/Environments/components/EnvironmentCardContent.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/EnvironmentCardContent.tsx
@@ -15,6 +15,7 @@ import { formatRelativeTime } from '@openchoreo/backstage-plugin-react';
 import { useEnvironmentCardStyles } from '../styles';
 import { EnvironmentCardContentProps } from '../types';
 import { InvokeUrlsDialog } from './InvokeUrlsDialog';
+import { IncidentsBanner } from './IncidentsBanner';
 
 /**
  * Content section of an environment card showing deployment details
@@ -26,6 +27,8 @@ export const EnvironmentCardContent = ({
   releaseName,
   endpoints,
   onOpenReleaseDetails,
+  activeIncidentCount,
+  environmentName,
 }: EnvironmentCardContentProps) => {
   const classes = useEnvironmentCardStyles();
 
@@ -82,6 +85,16 @@ export const EnvironmentCardContent = ({
           </Box>
         )}
       </Box>
+
+      {status &&
+        activeIncidentCount !== undefined &&
+        activeIncidentCount > 0 &&
+        environmentName && (
+          <IncidentsBanner
+            count={activeIncidentCount}
+            environmentName={environmentName}
+          />
+        )}
 
       {image && (
         <Box mt={2}>

--- a/plugins/openchoreo/src/components/Environments/components/IncidentsBanner.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/IncidentsBanner.tsx
@@ -1,0 +1,82 @@
+import { Box, Link, Tooltip, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import WarningIcon from '@material-ui/icons/Warning';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { buildEntityPath } from '@openchoreo/backstage-plugin-react';
+
+const useStyles = makeStyles(theme => ({
+  banner: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: theme.palette.warning.light,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(1, 1.5),
+    marginTop: theme.spacing(2),
+  },
+  left: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  icon: {
+    color: theme.palette.warning.dark,
+    fontSize: '1.2rem',
+  },
+  text: {
+    color: theme.palette.warning.dark,
+    fontSize: '0.875rem',
+  },
+  viewLink: {
+    color: theme.palette.warning.dark,
+    fontSize: '0.8rem',
+    textDecoration: 'none',
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+}));
+
+interface IncidentsBannerProps {
+  count: number;
+  environmentName: string;
+}
+
+export const IncidentsBanner = ({
+  count,
+  environmentName,
+}: IncidentsBannerProps) => {
+  const classes = useStyles();
+  const { entity } = useEntity();
+
+  if (count <= 0) return null;
+
+  const label =
+    count === 1 ? '1 Incident detected' : `${count} Incidents detected`;
+  const tooltip = `${count} incident${
+    count === 1 ? '' : 's'
+  } detected during last hour`;
+  const viewUrl = `${buildEntityPath(
+    entity,
+  )}/incidents?env=${encodeURIComponent(environmentName.toLowerCase())}`;
+
+  return (
+    <Tooltip title={tooltip} arrow placement="top">
+      <Box className={classes.banner}>
+        <Box className={classes.left}>
+          <WarningIcon className={classes.icon} />
+          <Typography className={classes.text}>{label}</Typography>
+        </Box>
+        <Link
+          href={viewUrl}
+          className={classes.viewLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={e => e.stopPropagation()}
+        >
+          View
+        </Link>
+      </Box>
+    </Tooltip>
+  );
+};

--- a/plugins/openchoreo/src/components/Environments/components/index.ts
+++ b/plugins/openchoreo/src/components/Environments/components/index.ts
@@ -6,3 +6,4 @@ export { EnvironmentCardHeader } from './EnvironmentCardHeader';
 export { EnvironmentCardContent } from './EnvironmentCardContent';
 export { EnvironmentActions } from './EnvironmentActions';
 export { InvokeUrlsDialog } from './InvokeUrlsDialog';
+export { IncidentsBanner } from './IncidentsBanner';

--- a/plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { useApi, createApiRef } from '@backstage/core-plugin-api';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import type { Environment } from './useEnvironmentData';
+
+interface ObservabilityIncidentsApi {
+  getIncidents(
+    namespaceName: string,
+    projectName: string,
+    environmentName: string,
+    componentName: string,
+    options?: {
+      startTime?: string;
+      endTime?: string;
+      limit?: number;
+      sortOrder?: 'asc' | 'desc';
+    },
+  ): Promise<{
+    incidents: Array<{
+      incidentId: string;
+      alertId: string;
+      status: 'triggered' | 'acknowledged' | 'resolved';
+      description?: string;
+      triggeredAt?: string;
+      resolvedAt?: string;
+    }>;
+    total: number;
+  }>;
+}
+
+const observabilityApiRef = createApiRef<ObservabilityIncidentsApi>({
+  id: 'plugin.openchoreo-observability.service',
+});
+
+export interface IncidentsSummary {
+  activeCount: number;
+  loading: boolean;
+}
+
+export function useIncidentsSummary(
+  environments: Environment[],
+): Map<string, IncidentsSummary> {
+  const { entity } = useEntity();
+  const observabilityApi = useApi(observabilityApiRef);
+  const [summaries, setSummaries] = useState<Map<string, IncidentsSummary>>(
+    new Map(),
+  );
+  const requestIdRef = useRef(0);
+
+  const componentName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.COMPONENT];
+  const projectName = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT];
+  const namespaceName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
+
+  const fetchIncidents = useCallback(async () => {
+    const currentRequestId = ++requestIdRef.current;
+
+    if (!componentName || !projectName || !namespaceName) {
+      setSummaries(new Map());
+      return;
+    }
+
+    if (environments.length === 0) {
+      setSummaries(new Map());
+      return;
+    }
+
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 3600000);
+
+    // Set loading state
+    const loading = new Map<string, IncidentsSummary>();
+    for (const env of environments) {
+      loading.set(env.name, { activeCount: 0, loading: true });
+    }
+    setSummaries(loading);
+
+    // Fetch in parallel
+    const results = await Promise.allSettled(
+      environments.map(async env => {
+        const result = await observabilityApi.getIncidents(
+          namespaceName,
+          projectName,
+          env.resourceName ?? env.name,
+          componentName,
+          {
+            startTime: oneHourAgo.toISOString(),
+            endTime: now.toISOString(),
+            limit: 100,
+          },
+        );
+
+        const activeCount = result.incidents.filter(
+          i => i.status === 'triggered' || i.status === 'acknowledged',
+        ).length;
+
+        return { envName: env.name, activeCount };
+      }),
+    );
+
+    // Ignore stale responses from superseded fetches
+    if (currentRequestId !== requestIdRef.current) {
+      return;
+    }
+
+    const final = new Map<string, IncidentsSummary>();
+    for (let i = 0; i < environments.length; i++) {
+      const env = environments[i];
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        final.set(env.name, {
+          activeCount: result.value.activeCount,
+          loading: false,
+        });
+      } else {
+        // Silently treat errors as no incidents (observability might not be configured)
+        final.set(env.name, { activeCount: 0, loading: false });
+      }
+    }
+    setSummaries(final);
+  }, [
+    observabilityApi,
+    componentName,
+    projectName,
+    namespaceName,
+    environments,
+  ]);
+
+  useEffect(() => {
+    fetchIncidents();
+  }, [fetchIncidents]);
+
+  return summaries;
+}

--- a/plugins/openchoreo/src/components/Environments/types.ts
+++ b/plugins/openchoreo/src/components/Environments/types.ts
@@ -92,6 +92,8 @@ export interface EnvironmentCardContentProps {
   releaseName?: string;
   endpoints: EndpointInfo[];
   onOpenReleaseDetails: () => void;
+  activeIncidentCount?: number;
+  environmentName?: string;
 }
 
 /**
@@ -143,4 +145,5 @@ export interface EnvironmentCardProps {
   onOpenReleaseDetails: () => void;
   onPromote: (targetEnvName: string) => Promise<void>;
   onSuspend: () => Promise<void>;
+  activeIncidentCount?: number;
 }


### PR DESCRIPTION
## Summary
- Adds `getIncidents` method to the observability API client to query incidents from the observer service (`POST /api/v1alpha1/incidents/query`)
- Introduces an incidents banner on environment cards that shows active incident count (triggered/acknowledged) from the last hour
- Banner includes a "View" link that navigates to the incidents page for the specific environment
- Incident counts are fetched in parallel for all environments using a new `useIncidentsSummary` hook
- Banner is only shown when the environment has an active deployment (not in "not deployed" state)

<img width="1916" height="991" alt="image" src="https://github.com/user-attachments/assets/a55a68b2-4fa3-4147-b678-93f96c9a7083" />

Related: https://github.com/openchoreo/openchoreo/issues/2450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment cards now show active incident counts and display a dismissible warning banner with a "View" link.
  * Observability now supports querying incidents and alerts, enabling per-environment incident summaries.

* **Chores**
  * Traces query option renamed from "sort" to "sortOrder" across public APIs and hooks (update callers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->