### PR TITLE
fix: improve release binding status handling and conditions display

### DIFF
--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -2,6 +2,7 @@ import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
 import type {
   ReleaseBindingResponse,
   ReleaseBindingEndpoint,
+  ReleaseBindingCondition,
 } from '@openchoreo/backstage-plugin-common';
 import { getName, getNamespace, getCreatedAt } from './common';
 
@@ -108,6 +109,20 @@ export function transformReleaseBinding(
       return raw.filter(
         (e): e is ReleaseBindingEndpoint =>
           e !== null && typeof e === 'object' && typeof e.name === 'string',
+      );
+    })(),
+    conditions: (() => {
+      const raw = binding.status?.conditions;
+      if (!Array.isArray(raw)) return undefined;
+      return raw.map(
+        (c: any): ReleaseBindingCondition => ({
+          type: c.type,
+          status: c.status,
+          reason: c.reason,
+          message: c.message,
+          lastTransitionTime: c.lastTransitionTime,
+          observedGeneration: c.observedGeneration,
+        }),
       );
     })(),
   };

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -115,6 +115,7 @@ export type {
   ReleaseBindingEndpointURLDetails,
   ReleaseBindingEndpoint,
   ReleaseBindingResponse,
+  ReleaseBindingCondition,
   WorkloadOverrides,
   ContainerOverride,
   ComponentReleaseResponse,

--- a/plugins/openchoreo-common/src/types/bff-types.ts
+++ b/plugins/openchoreo-common/src/types/bff-types.ts
@@ -541,6 +541,17 @@ export interface ReleaseBindingResponse {
   lastSpecUpdateTime?: string;
   status?: string;
   endpoints?: ReleaseBindingEndpoint[];
+  conditions?: ReleaseBindingCondition[];
+}
+
+export interface ReleaseBindingCondition {
+  type: string;
+  status: string;
+  reason?: string;
+  message?: string;
+  /** Format: date-time */
+  lastTransitionTime?: string;
+  observedGeneration?: number;
 }
 
 export interface WorkloadOverrides {

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.tsx
@@ -47,7 +47,9 @@ function getBindingStatus(
 }
 
 function getBindingConditions(binding: Record<string, unknown>): any[] {
-  // New API: binding.status.conditions
+  // Flat format: binding.conditions (transformed by backend)
+  if (Array.isArray(binding.conditions)) return binding.conditions;
+  // K8s format: binding.status.conditions
   const status = binding.status as Record<string, unknown> | undefined;
   if (status && Array.isArray(status.conditions)) return status.conditions;
   return [];


### PR DESCRIPTION
## Summary                                        
  - Treat `ResourceApplyFailed` as a failure reason when deriving release binding status, alongside the existing `ResourcesDegraded`
   reason                                                                                                                           
  - Pass through status conditions from the K8s ReleaseBinding response to the frontend so the conditions table renders in the      
  resource tree detail panel 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced release binding status reporting with detailed condition information, providing better visibility into binding states
  * Introduced specific failure reasons (ResourcesDegraded, ResourceApplyFailed) for improved error diagnostics and troubleshooting capabilities
  * Improved status evaluation accuracy through generation-aware filtering of conditions, ensuring only relevant conditions affect status determination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->