### PR TITLE
refactor: remove isPlatformEngineer flag and simplify useUserGroups to useUserInfo

### DIFF
--- a/packages/app/src/components/Home/HomePage.tsx
+++ b/packages/app/src/components/Home/HomePage.tsx
@@ -7,7 +7,7 @@ import { HomePageSearchBar } from '@backstage/plugin-search';
 import { SearchContextProvider } from '@backstage/plugin-search-react';
 import { Grid, Typography, Box } from '@material-ui/core';
 import { useStyles } from './styles';
-import { useUserGroups } from '../../hooks';
+import { useUserInfo } from '../../hooks';
 import { useNamespacePermission } from '@openchoreo/backstage-plugin-react';
 import { HomePagePlatformDetailsCard } from '@openchoreo/backstage-plugin-platform-engineer-core';
 
@@ -16,7 +16,7 @@ import { HomePagePlatformDetailsCard } from '@openchoreo/backstage-plugin-platfo
  */
 export const HomePage = () => {
   const classes = useStyles();
-  const { userName, loading } = useUserGroups();
+  const { userName, loading } = useUserInfo();
   const { canView: canViewPlatformDetails } = useNamespacePermission();
 
   if (loading) {

--- a/packages/app/src/components/catalog/ChoreoEntityKindPicker.tsx
+++ b/packages/app/src/components/catalog/ChoreoEntityKindPicker.tsx
@@ -12,7 +12,6 @@ import {
   useEntityList,
   catalogApiRef,
 } from '@backstage/plugin-catalog-react';
-import { useUserGroups } from '../../hooks';
 
 // Mapping of internal kind names to OpenChoreo display names
 const kindDisplayNames: Record<string, string> = {
@@ -43,7 +42,6 @@ const kindDisplayNames: Record<string, string> = {
 
 interface KindCategory {
   label: string;
-  platformOnly?: boolean;
   kinds: string[];
 }
 
@@ -54,7 +52,6 @@ const kindCategories: KindCategory[] = [
   },
   {
     label: 'Platform Resources',
-    platformOnly: true,
     kinds: [
       'dataplane',
       'clusterdataplane',
@@ -68,7 +65,6 @@ const kindCategories: KindCategory[] = [
   },
   {
     label: 'Platform Configuration',
-    platformOnly: true,
     kinds: [
       'clustercomponenttype',
       'componenttype',
@@ -269,10 +265,6 @@ export const ChoreoEntityKindPicker = (props: ChoreoEntityKindPickerProps) => {
       initialFilter: initialFilter,
     });
 
-  // Get user groups to check if user is a platform engineer
-  const { userGroups } = useUserGroups();
-  const isPlatformEngineer = userGroups.includes('platformengineer');
-
   useEffect(() => {
     if (error) {
       alertApi.post({
@@ -319,9 +311,6 @@ export const ChoreoEntityKindPicker = (props: ChoreoEntityKindPickerProps) => {
     }
 
     for (const category of kindCategories) {
-      // Skip platform-only categories for non-platform engineers
-      if (category.platformOnly && !isPlatformEngineer) continue;
-
       // Filter to only kinds that exist in the catalog
       const visibleKinds = category.kinds.filter(k => availableKinds.has(k));
 
@@ -354,7 +343,7 @@ export const ChoreoEntityKindPicker = (props: ChoreoEntityKindPickerProps) => {
     }
 
     return items;
-  }, [availableKinds, isPlatformEngineer, error, classes, app]);
+  }, [availableKinds, error, classes, app]);
 
   if (error) return null;
 

--- a/packages/app/src/hooks/index.ts
+++ b/packages/app/src/hooks/index.ts
@@ -1,4 +1,4 @@
-export { useUserGroups } from './useUserGroups';
+export { useUserInfo } from './useUserInfo';
 
 // Feature flags hooks and types are now in @openchoreo/backstage-plugin-react
 // Import from: import { useOpenChoreoFeatures, FeatureGate } from '@openchoreo/backstage-plugin-react';

--- a/packages/app/src/hooks/useUserInfo.ts
+++ b/packages/app/src/hooks/useUserInfo.ts
@@ -5,23 +5,9 @@ import {
   errorApiRef,
 } from '@backstage/core-plugin-api';
 
-/**
- * Hook to fetch the user's group memberships
- *
- * @returns An object containing:
- *  - userGroups: Array of group names the user belongs to
- *  - userName: The user's name
- *  - loading: Boolean indicating if the data is still loading
- *  - error: Error object if the fetch failed
- *
- * @example
- * const { userGroups, loading } = useUserGroups();
- * const isPlatformEngineer = userGroups.includes('platformengineer');
- */
-export const useUserGroups = () => {
+export const useUserInfo = () => {
   const identityApi = useApi(identityApiRef);
   const errorApi = useApi(errorApiRef);
-  const [userGroups, setUserGroups] = useState<string[]>([]);
   const [userName, setUserName] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>();
@@ -30,12 +16,6 @@ export const useUserGroups = () => {
     const loadUserInfo = async () => {
       try {
         const identity = await identityApi.getBackstageIdentity();
-        const ownershipRefs = identity.ownershipEntityRefs || [];
-        // Extract group names from refs like "group:default/admins"
-        const groups = ownershipRefs
-          .filter(ref => ref.startsWith('group:'))
-          .map(ref => ref.split('/')[1]);
-        setUserGroups(groups);
         setUserName(identity.userEntityRef.split('/')[1]);
       } catch (err) {
         const errorObj =
@@ -50,5 +30,5 @@ export const useUserGroups = () => {
     loadUserInfo();
   }, [identityApi, errorApi]);
 
-  return { userGroups, userName, loading, error };
+  return { userName, loading, error };
 };


### PR DESCRIPTION
## Purpose
- Removes the `isPlatformEngineer` flag from `ChoreoEntityKindPicker` — all users now see all kind categories without any group-based filtering
- Removes the `platformOnly` field from the `KindCategory` interface and category definitions since it is no longer used
- Renames `useUserGroups` → `useUserInfo` and strips `userGroups` from the return value, keeping only `userName`, `loading`, and `error`
- Updates all call sites: `HomePage.tsx`, `ChoreoEntityKindPicker.tsx`, and `hooks/index.ts`
- Fix https://github.com/openchoreo/openchoreo/issues/2545