### PR TITLE
feat: add permission filtering for infrastructure and platform entity kinds

### DIFF
--- a/plugins/openchoreo-common/src/permissions.ts
+++ b/plugins/openchoreo-common/src/permissions.ts
@@ -413,12 +413,31 @@ export const CATALOG_PERMISSION_TO_ACTION: Record<string, string> = {
  *
  * - Component: Maps to OpenChoreo components
  * - System: Maps to OpenChoreo projects
- * - Domain: Maps to OpenChoreo organizations
+ * - Domain: Maps to OpenChoreo namespaces
+ * - Dataplane, BuildPlane, ObservabilityPlane, DeploymentPipeline: Namespace-scoped infrastructure
+ * - ClusterDataplane, ClusterBuildPlane, ClusterObservabilityPlane: Cluster-scoped infrastructure
+ * - ComponentType, TraitType, Workflow, ComponentWorkflow, Environment: Namespace-scoped platform resources
+ * - ClusterComponentType, ClusterTraitType, ClusterWorkflow: Cluster-scoped platform resources
  */
 export const OPENCHOREO_MANAGED_ENTITY_KINDS = [
   'Component',
   'System',
   'Domain',
+  'Dataplane',
+  'BuildPlane',
+  'ObservabilityPlane',
+  'DeploymentPipeline',
+  'ClusterDataplane',
+  'ClusterBuildPlane',
+  'ClusterObservabilityPlane',
+  'ComponentType',
+  'ClusterComponentType',
+  'TraitType',
+  'ClusterTraitType',
+  'Workflow',
+  'ClusterWorkflow',
+  'ComponentWorkflow',
+  'Environment',
 ];
 
 /**
@@ -429,7 +448,11 @@ export const OPENCHOREO_MANAGED_ENTITY_KINDS = [
  * Each kind maps to a different resource type in OpenChoreo:
  * - Component → component:* actions
  * - System → project:* actions
- * - Domain → organization:* actions
+ * - Domain → namespace:* actions
+ * - Dataplane/BuildPlane/ObservabilityPlane/DeploymentPipeline → respective :view actions
+ * - ClusterDataplane/ClusterBuildPlane/ClusterObservabilityPlane → respective cluster:view actions
+ * - ComponentType/TraitType/Workflow/ComponentWorkflow/Environment → respective :view actions
+ * - ClusterComponentType/ClusterTraitType/ClusterWorkflow → respective cluster:view actions
  */
 export const CATALOG_KIND_TO_ACTION: Record<string, Record<string, string>> = {
   component: {
@@ -442,5 +465,50 @@ export const CATALOG_KIND_TO_ACTION: Record<string, Record<string, string>> = {
   },
   domain: {
     'catalog.entity.read': 'namespace:view',
+  },
+  dataplane: {
+    'catalog.entity.read': 'dataplane:view',
+  },
+  buildplane: {
+    'catalog.entity.read': 'buildplane:view',
+  },
+  observabilityplane: {
+    'catalog.entity.read': 'observabilityplane:view',
+  },
+  deploymentpipeline: {
+    'catalog.entity.read': 'deploymentpipeline:view',
+  },
+  clusterdataplane: {
+    'catalog.entity.read': 'clusterdataplane:view',
+  },
+  clusterbuildplane: {
+    'catalog.entity.read': 'clusterbuildplane:view',
+  },
+  clusterobservabilityplane: {
+    'catalog.entity.read': 'clusterobservabilityplane:view',
+  },
+  componenttype: {
+    'catalog.entity.read': 'componenttype:view',
+  },
+  clustercomponenttype: {
+    'catalog.entity.read': 'clustercomponenttype:view',
+  },
+  traittype: {
+    'catalog.entity.read': 'trait:view',
+  },
+  clustertraittype: {
+    'catalog.entity.read': 'clustertrait:view',
+  },
+  workflow: {
+    'catalog.entity.read': 'workflow:view',
+  },
+  clusterworkflow: {
+    'catalog.entity.read': 'clusterworkflow:view',
+  },
+  componentworkflow: {
+    'catalog.entity.read': 'workflow:view',
+  },
+  environment: {
+    'catalog.entity.read': 'environment:view',
   },
 };

--- a/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCatalogEntityCapability.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCatalogEntityCapability.ts
@@ -87,8 +87,49 @@ function parseCapabilityPath(path: string): {
 
 /**
  * Entity level type for path specificity checking.
+ * - domain/namespace-scoped: namespace-level only (no project/component paths)
+ * - system: project-level (no component paths)
+ * - component: any level
+ * - cluster-scoped: only global wildcard "*" path
  */
-type EntityLevel = 'domain' | 'system' | 'component';
+type EntityLevel =
+  | 'domain'
+  | 'system'
+  | 'component'
+  | 'namespace-scoped'
+  | 'cluster-scoped';
+
+/** Maps each managed entity kind to its entity level for path specificity. */
+const KIND_TO_ENTITY_LEVEL: Record<string, EntityLevel> = {
+  domain: 'domain',
+  system: 'system',
+  component: 'component',
+  dataplane: 'namespace-scoped',
+  buildplane: 'namespace-scoped',
+  observabilityplane: 'namespace-scoped',
+  deploymentpipeline: 'namespace-scoped',
+  componenttype: 'namespace-scoped',
+  traittype: 'namespace-scoped',
+  workflow: 'namespace-scoped',
+  componentworkflow: 'namespace-scoped',
+  environment: 'namespace-scoped',
+  clusterdataplane: 'cluster-scoped',
+  clusterbuildplane: 'cluster-scoped',
+  clusterobservabilityplane: 'cluster-scoped',
+  clustercomponenttype: 'cluster-scoped',
+  clustertraittype: 'cluster-scoped',
+  clusterworkflow: 'cluster-scoped',
+};
+
+/** Entity kinds that are cluster-scoped (no namespace annotation). */
+const CLUSTER_SCOPED_KINDS = new Set([
+  'clusterdataplane',
+  'clusterbuildplane',
+  'clusterobservabilityplane',
+  'clustercomponenttype',
+  'clustertraittype',
+  'clusterworkflow',
+]);
 
 /**
  * Checks if a capability path matches the given scope.
@@ -109,11 +150,17 @@ function matchesScope(
     return true;
   }
 
+  // Cluster-scoped entities only match the global wildcard "*"
+  // Since path !== '*' at this point, cluster-scoped never matches non-wildcard paths
+  if (entityLevel === 'cluster-scoped') {
+    return false;
+  }
+
   const parsed = parseCapabilityPath(path);
 
   // Check path specificity - reject paths more specific than entity level
-  // Domain entities: path must NOT have project or component
-  if (entityLevel === 'domain') {
+  // Domain and namespace-scoped entities: path must NOT have project or component
+  if (entityLevel === 'domain' || entityLevel === 'namespace-scoped') {
     if (parsed.project || parsed.component) {
       return false; // Path is more specific than entity level
     }
@@ -171,9 +218,15 @@ function isPathValidForLevel(path: string, entityLevel: EntityLevel): boolean {
     return true;
   }
 
+  // Cluster-scoped entities only accept the global wildcard
+  if (entityLevel === 'cluster-scoped') {
+    return false;
+  }
+
   const parsed = parseCapabilityPath(path);
 
-  if (entityLevel === 'domain') {
+  // Domain and namespace-scoped: reject project/component-specific paths
+  if (entityLevel === 'domain' || entityLevel === 'namespace-scoped') {
     return !parsed.project && !parsed.component;
   }
 
@@ -217,27 +270,37 @@ export const matchesCatalogEntityCapability = createCatalogPermissionRule({
 
     // Get the capability config for this entity kind
     const kindCapability = kindCapabilities[entityKind];
+    const entityLevel = KIND_TO_ENTITY_LEVEL[entityKind] ?? 'component';
 
-    // Extract scope from entity annotations based on entity kind
-    // Different entity kinds use different annotations:
-    // - Domain: only organization
-    // - System: organization + project-id
-    // - Component: organization + project + component
+    // Handle cluster-scoped entities (no namespace annotation)
+    if (entityLevel === 'cluster-scoped') {
+      if (!kindCapability) {
+        return false;
+      }
+      const { allowedPaths, deniedPaths } = kindCapability;
+      // For cluster-scoped, only '*' path is meaningful
+      if (deniedPaths.some(p => p === '*')) {
+        return false;
+      }
+      if (allowedPaths.some(p => p === '*')) {
+        return true;
+      }
+      return false;
+    }
+
+    // Extract scope from entity annotations based on entity level
     let scope: { ns?: string; project?: string; component?: string };
 
-    if (entityKind === 'domain') {
-      // Domain only has organization
+    if (entityLevel === 'domain' || entityLevel === 'namespace-scoped') {
       scope = {
         ns: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE],
       };
-    } else if (entityKind === 'system') {
-      // System has organization and project-id
+    } else if (entityLevel === 'system') {
       scope = {
         ns: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE],
         project: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT_ID],
       };
     } else {
-      // Component has organization, project, and component
       scope = {
         ns: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE],
         project: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT],
@@ -256,9 +319,6 @@ export const matchesCatalogEntityCapability = createCatalogPermissionRule({
     }
 
     const { allowedPaths, deniedPaths } = kindCapability;
-
-    // Determine entity level for path specificity checking
-    const entityLevel = entityKind as EntityLevel;
 
     // Check if explicitly denied at this scope
     for (const deniedPath of deniedPaths) {
@@ -305,7 +365,7 @@ export const matchesCatalogEntityCapability = createCatalogPermissionRule({
     for (const kind of kinds) {
       const kindLower = kind.toLowerCase();
       const capability = kindCapabilities[kindLower];
-      const entityLevel = kindLower as EntityLevel;
+      const entityLevel = KIND_TO_ENTITY_LEVEL[kindLower] ?? 'component';
 
       const singleKindFilter: EntitiesSearchFilter = {
         key: 'kind',
@@ -313,14 +373,30 @@ export const matchesCatalogEntityCapability = createCatalogPermissionRule({
       };
 
       if (!capability) {
+        if (CLUSTER_SCOPED_KINDS.has(kindLower)) {
+          // Cluster-scoped without capability: exclude entirely
+          // (not added to kindFilters, so excluded by otherKindsFilter)
+          continue;
+        }
         // No capability defined for this kind - only allow non-OpenChoreo entities
-        // (those without openchoreo.io/organization annotation)
+        // (those without openchoreo.io/namespace annotation)
         kindFilters.push({
           allOf: [singleKindFilter, { not: noOrgAnnotationFilter }] as [
             PermissionCriteria<EntitiesSearchFilter>,
             ...PermissionCriteria<EntitiesSearchFilter>[],
           ],
         });
+        continue;
+      }
+
+      // Handle cluster-scoped kinds
+      if (CLUSTER_SCOPED_KINDS.has(kindLower)) {
+        const hasWildcard = capability.allowedPaths.some(p => p === '*');
+        if (hasWildcard) {
+          // Allow all entities of this cluster-scoped kind
+          kindFilters.push(singleKindFilter);
+        }
+        // If no wildcard, kind is excluded entirely
         continue;
       }
 


### PR DESCRIPTION
  Add 15 custom entity kinds to catalog permission filtering so they are
  no longer visible to users without the appropriate capabilities.

  Namespace-scoped (filtered by openchoreo.io/namespace annotation):
  Dataplane, BuildPlane, ObservabilityPlane, DeploymentPipeline,
  ComponentType, TraitType, Workflow, ComponentWorkflow, Environment

  Cluster-scoped (filtered by wildcard capability check):
  ClusterDataplane, ClusterBuildPlane, ClusterObservabilityPlane,
  ClusterComponentType, ClusterTraitType, ClusterWorkflow

Related to https://github.com/openchoreo/openchoreo/issues/2436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple new entity types in the catalog and permissions system: Dataplane, BuildPlane, ObservabilityPlane, DeploymentPipeline, Workflow variants, ComponentType, TraitType, and Environment.
  * Enhanced permission and access control configurations for both cluster-scoped and namespace-scoped resources with updated capability mappings.
  * Improved domain and organizational scoping mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->