### PR TITLE
fix: fetch project-specific deployment pipeline instead of first in namespace

### DIFF
--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
@@ -114,6 +114,16 @@ const k8sReleaseBinding = {
   },
 };
 
+const k8sProject = {
+  metadata: { name: 'my-project', namespace: 'test-ns' },
+  spec: { deploymentPipelineRef: { name: 'default-pipeline' } },
+};
+
+const k8sProjectNoPipeline = {
+  metadata: { name: 'my-project', namespace: 'test-ns' },
+  spec: {},
+};
+
 const k8sPipeline = {
   metadata: {
     name: 'default-pipeline',
@@ -176,8 +186,10 @@ describe('EnvironmentInfoService', () => {
       );
       // 2. release bindings
       mockGET.mockResolvedValueOnce(okResponse({ items: [k8sReleaseBinding] }));
-      // 3. deployment pipelines
-      mockGET.mockResolvedValueOnce(okResponse({ items: [k8sPipeline] }));
+      // 3. project (to get deploymentPipelineRef)
+      mockGET.mockResolvedValueOnce(okResponse(k8sProject));
+      // 4. deployment pipeline by name
+      mockGET.mockResolvedValueOnce(okResponse(k8sPipeline));
 
       const service = createService();
       const result = await service.fetchDeploymentInfo(
@@ -203,8 +215,10 @@ describe('EnvironmentInfoService', () => {
       );
       // bindings fail
       mockGET.mockResolvedValueOnce(errorResponse());
-      // pipeline
-      mockGET.mockResolvedValueOnce(okResponse({ items: [k8sPipeline] }));
+      // project
+      mockGET.mockResolvedValueOnce(okResponse(k8sProject));
+      // pipeline by name
+      mockGET.mockResolvedValueOnce(okResponse(k8sPipeline));
 
       const service = createService();
       const result = await service.fetchDeploymentInfo(
@@ -224,7 +238,8 @@ describe('EnvironmentInfoService', () => {
     it('returns empty array when no environments found', async () => {
       mockGET.mockResolvedValueOnce(okResponse({ items: [], pagination: {} }));
       mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
-      mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
+      // project with no pipeline ref
+      mockGET.mockResolvedValueOnce(okResponse(k8sProjectNoPipeline));
 
       const service = createService();
       const result = await service.fetchDeploymentInfo(
@@ -244,12 +259,13 @@ describe('EnvironmentInfoService', () => {
     it('calls promote endpoint then refetches deployment info', async () => {
       // POST promote
       mockPOST.mockResolvedValueOnce(okResponse({}));
-      // Then fetchDeploymentInfo internally calls 3 GETs:
+      // Then fetchDeploymentInfo internally calls 4 GETs:
       mockGET.mockResolvedValueOnce(
         okResponse({ items: [k8sEnvironment], pagination: {} }),
       );
       mockGET.mockResolvedValueOnce(okResponse({ items: [k8sReleaseBinding] }));
-      mockGET.mockResolvedValueOnce(okResponse({ items: [k8sPipeline] }));
+      mockGET.mockResolvedValueOnce(okResponse(k8sProject));
+      mockGET.mockResolvedValueOnce(okResponse(k8sPipeline));
 
       const service = createService();
       const result = await service.promoteComponent(
@@ -297,7 +313,8 @@ describe('EnvironmentInfoService', () => {
         okResponse({ items: [k8sEnvironment], pagination: {} }),
       );
       mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
-      mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
+      // project with no pipeline ref
+      mockGET.mockResolvedValueOnce(okResponse(k8sProjectNoPipeline));
 
       const service = createService();
       const result = await service.deleteReleaseBinding(
@@ -322,7 +339,8 @@ describe('EnvironmentInfoService', () => {
         okResponse({ items: [k8sEnvironment], pagination: {} }),
       );
       mockGET.mockResolvedValueOnce(okResponse({ items: [k8sReleaseBinding] }));
-      mockGET.mockResolvedValueOnce(okResponse({ items: [k8sPipeline] }));
+      mockGET.mockResolvedValueOnce(okResponse(k8sProject));
+      mockGET.mockResolvedValueOnce(okResponse(k8sPipeline));
 
       const service = createService();
       const result = await service.deployRelease(
@@ -443,10 +461,10 @@ describe('EnvironmentInfoService', () => {
       );
       // bindings (none)
       mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
-      // pipeline with dev -> staging -> prod
-      mockGET.mockResolvedValueOnce(
-        okResponse({ items: [pipelineDevStagingProd] }),
-      );
+      // project
+      mockGET.mockResolvedValueOnce(okResponse(k8sProject));
+      // pipeline by name
+      mockGET.mockResolvedValueOnce(okResponse(pipelineDevStagingProd));
 
       const service = createService();
       const result = await service.fetchDeploymentInfo(
@@ -469,9 +487,8 @@ describe('EnvironmentInfoService', () => {
         okResponse({ items: allEnvs, pagination: {} }),
       );
       mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
-      mockGET.mockResolvedValueOnce(
-        okResponse({ items: [pipelineDevStagingProd] }),
-      );
+      mockGET.mockResolvedValueOnce(okResponse(k8sProject));
+      mockGET.mockResolvedValueOnce(okResponse(pipelineDevStagingProd));
 
       const service = createService();
       const result = await service.fetchDeploymentInfo(
@@ -493,8 +510,8 @@ describe('EnvironmentInfoService', () => {
         okResponse({ items: allEnvs, pagination: {} }),
       );
       mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
-      // no pipeline
-      mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
+      // project with no pipeline ref
+      mockGET.mockResolvedValueOnce(okResponse(k8sProjectNoPipeline));
 
       const service = createService();
       const result = await service.fetchDeploymentInfo(
@@ -518,7 +535,8 @@ describe('EnvironmentInfoService', () => {
         okResponse({ items: allEnvs, pagination: {} }),
       );
       mockGET.mockResolvedValueOnce(okResponse({ items: [] }));
-      mockGET.mockResolvedValueOnce(okResponse({ items: [emptyPipeline] }));
+      mockGET.mockResolvedValueOnce(okResponse(k8sProject));
+      mockGET.mockResolvedValueOnce(okResponse(emptyPipeline));
 
       const service = createService();
       const result = await service.fetchDeploymentInfo(

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -144,24 +144,50 @@ export class EnvironmentInfoService implements EnvironmentService {
         'bindings',
       );
 
-      // Fetch deployment pipelines filtered by project
+      // Fetch project-specific deployment pipeline
       const pipelinePromise = createTimedPromise(
         (async () => {
-          const { data, error, response } = await client.GET(
-            '/api/v1/namespaces/{namespaceName}/deploymentpipelines',
+          // First, fetch the project to get its pipeline reference
+          const {
+            data: project,
+            error: projectError,
+            response: projectResponse,
+          } = await client.GET(
+            '/api/v1/namespaces/{namespaceName}/projects/{projectName}',
             {
               params: {
-                path: { namespaceName: request.namespaceName },
-                query: {},
+                path: {
+                  namespaceName: request.namespaceName,
+                  projectName: request.projectName,
+                },
+              },
+            },
+          );
+          if (
+            projectError ||
+            !projectResponse.ok ||
+            !project?.spec?.deploymentPipelineRef?.name
+          ) {
+            return null;
+          }
+
+          // Then fetch the specific deployment pipeline by name
+          const pipelineName = project.spec.deploymentPipelineRef.name;
+          const { data, error, response } = await client.GET(
+            '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
+            {
+              params: {
+                path: {
+                  namespaceName: request.namespaceName,
+                  deploymentPipelineName: pipelineName,
+                },
               },
             },
           );
           if (error || !response.ok) {
             return null;
           }
-          // Take the first pipeline for this project
-          const pipeline = data.items?.[0];
-          return pipeline ? transformDeploymentPipeline(pipeline) : null;
+          return transformDeploymentPipeline(data!);
         })(),
         'pipeline',
       );


### PR DESCRIPTION
  The deploy endpoint was fetching all deployment pipelines in the namespace
  and blindly picking the first one, causing incorrect environments to be
  returned when multiple projects share a namespace.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite for environment service to validate deployment pipeline resolution behavior.

* **Refactor**
  * Improved internal mechanism for resolving deployment pipelines within environments, ensuring more accurate and reliable pipeline identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->