### PR TITLE
feat: add permission checks for Workflow and ClusterWorkflow scaffolder cards

### DIFF
--- a/packages/app/src/components/scaffolder/CustomTemplateListPage.tsx
+++ b/packages/app/src/components/scaffolder/CustomTemplateListPage.tsx
@@ -47,6 +47,8 @@ import {
   useClusterTraitCreatePermission,
   useClusterComponentTypePermission,
   useComponentWorkflowPermission,
+  useWorkflowPermission,
+  useClusterWorkflowPermission,
   useNamespacePermission,
 } from '@openchoreo/backstage-plugin-react';
 import { ScaffolderStarredFilter } from './ScaffolderStarredFilter';
@@ -131,6 +133,8 @@ const TemplateListContent = (props: TemplateListPageProps) => {
   const clusterTraitPerm = useClusterTraitCreatePermission();
   const clusterComponentTypePerm = useClusterComponentTypePermission();
   const componentWorkflowPerm = useComponentWorkflowPermission();
+  const workflowPerm = useWorkflowPermission();
+  const clusterWorkflowPerm = useClusterWorkflowPermission();
   const namespacePerm = useNamespacePermission();
 
   // Map template spec.type to whether the card should be disabled
@@ -158,6 +162,10 @@ const TemplateListContent = (props: TemplateListPageProps) => {
           return (
             !componentWorkflowPerm.loading && !componentWorkflowPerm.canCreate
           );
+        case 'Workflow':
+          return !workflowPerm.loading && !workflowPerm.canCreate;
+        case 'ClusterWorkflow':
+          return !clusterWorkflowPerm.loading && !clusterWorkflowPerm.canCreate;
         case 'Namespace':
           return !namespacePerm.loading && !namespacePerm.canCreate;
         default:
@@ -173,6 +181,8 @@ const TemplateListContent = (props: TemplateListPageProps) => {
       componentTypePerm,
       clusterComponentTypePerm,
       componentWorkflowPerm,
+      workflowPerm,
+      clusterWorkflowPerm,
       namespacePerm,
     ],
   );

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -53,6 +53,8 @@ export {
   openchoreoComponentTypeCreatePermission,
   openchoreoClusterComponentTypeCreatePermission,
   openchoreoClusterTraitCreatePermission,
+  openchoreoWorkflowCreatePermission,
+  openchoreoClusterWorkflowCreatePermission,
   openchoreoComponentWorkflowCreatePermission,
   openchoreoComponentTypeUpdatePermission,
   openchoreoComponentTypeDeletePermission,

--- a/plugins/openchoreo-common/src/permissions.ts
+++ b/plugins/openchoreo-common/src/permissions.ts
@@ -159,6 +159,24 @@ export const openchoreoClusterTraitCreatePermission = createPermission({
 });
 
 /**
+ * Permission to create a new workflow.
+ * Requires organization context.
+ */
+export const openchoreoWorkflowCreatePermission = createPermission({
+  name: 'openchoreo.workflow.create',
+  attributes: { action: 'create' },
+});
+
+/**
+ * Permission to create a new cluster workflow.
+ * Cluster-scoped permission (no namespace context required).
+ */
+export const openchoreoClusterWorkflowCreatePermission = createPermission({
+  name: 'openchoreo.clusterworkflow.create',
+  attributes: { action: 'create' },
+});
+
+/**
  * Permission to create a new component workflow.
  * Requires organization context.
  */
@@ -645,6 +663,8 @@ export const openchoreoPermissions = [
   openchoreoComponentTypeCreatePermission,
   openchoreoClusterComponentTypeCreatePermission,
   openchoreoClusterTraitCreatePermission,
+  openchoreoWorkflowCreatePermission,
+  openchoreoClusterWorkflowCreatePermission,
   openchoreoComponentWorkflowCreatePermission,
   // Update & Delete permissions for resource definition kinds
   openchoreoComponentTypeUpdatePermission,
@@ -715,6 +735,8 @@ export const OPENCHOREO_PERMISSION_TO_ACTION: Record<string, string> = {
   'openchoreo.traits.view': 'trait:view',
   'openchoreo.trait.create': 'trait:create',
   'openchoreo.componenttype.create': 'componenttype:create',
+  'openchoreo.workflow.create': 'workflow:create',
+  'openchoreo.clusterworkflow.create': 'clusterworkflow:create',
   'openchoreo.componentworkflow.create': 'workflow:create',
   'openchoreo.clustercomponenttype.create': 'clustercomponenttype:create',
   'openchoreo.clustertrait.create': 'clustertrait:create',

--- a/plugins/openchoreo-react/src/hooks/useClusterWorkflowPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterWorkflowPermission.ts
@@ -1,0 +1,35 @@
+import { usePermission } from '@backstage/plugin-permission-react';
+import { openchoreoClusterWorkflowCreatePermission } from '@openchoreo/backstage-plugin-common';
+
+/**
+ * Result of the useClusterWorkflowPermission hook.
+ */
+export interface UseClusterWorkflowPermissionResult {
+  /** Whether the user has permission to create a cluster workflow */
+  canCreate: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+  /** Tooltip message for create permission denied (empty string when allowed/loading) */
+  createDeniedTooltip: string;
+}
+
+/**
+ * Hook for checking if the current user has permission to create cluster workflows.
+ *
+ * This is a cluster-scoped permission (no namespace context required).
+ */
+export const useClusterWorkflowPermission =
+  (): UseClusterWorkflowPermissionResult => {
+    const { allowed: canCreate, loading } = usePermission({
+      permission: openchoreoClusterWorkflowCreatePermission,
+    });
+
+    return {
+      canCreate,
+      loading,
+      createDeniedTooltip:
+        !canCreate && !loading
+          ? 'You do not have permission to create a cluster workflow'
+          : '',
+    };
+  };

--- a/plugins/openchoreo-react/src/hooks/useWorkflowPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useWorkflowPermission.ts
@@ -1,0 +1,34 @@
+import { usePermission } from '@backstage/plugin-permission-react';
+import { openchoreoWorkflowCreatePermission } from '@openchoreo/backstage-plugin-common';
+
+/**
+ * Result of the useWorkflowPermission hook.
+ */
+export interface UseWorkflowPermissionResult {
+  /** Whether the user has permission to create a workflow */
+  canCreate: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+  /** Tooltip message for create permission denied (empty string when allowed/loading) */
+  createDeniedTooltip: string;
+}
+
+/**
+ * Hook for checking if the current user has permission to create workflows.
+ *
+ * This is an org-level permission (no resource context required).
+ */
+export const useWorkflowPermission = (): UseWorkflowPermissionResult => {
+  const { allowed: canCreate, loading } = usePermission({
+    permission: openchoreoWorkflowCreatePermission,
+  });
+
+  return {
+    canCreate,
+    loading,
+    createDeniedTooltip:
+      !canCreate && !loading
+        ? 'You do not have permission to create a workflow'
+        : '',
+  };
+};

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -263,6 +263,14 @@ export {
   type UseComponentWorkflowPermissionResult,
 } from './hooks/useComponentWorkflowPermission';
 export {
+  useWorkflowPermission,
+  type UseWorkflowPermissionResult,
+} from './hooks/useWorkflowPermission';
+export {
+  useClusterWorkflowPermission,
+  type UseClusterWorkflowPermissionResult,
+} from './hooks/useClusterWorkflowPermission';
+export {
   useClusterTraitCreatePermission,
   type UseClusterTraitCreatePermissionResult,
 } from './hooks/useClusterTraitCreatePermission';

--- a/plugins/permission-backend-module-openchoreo-policy/src/policy/OpenChoreoPermissionPolicy.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/policy/OpenChoreoPermissionPolicy.ts
@@ -347,9 +347,14 @@ export class OpenChoreoPermissionPolicy implements PermissionPolicy {
   /**
    * Handles scaffolder.task.create permission.
    *
+   * `scaffolder.task.create` is a basic permission with no resource type and
+   * no template context — Backstage fires it before the template is selected,
+   * so we cannot know which resource the user intends to create. This check
+   * acts as a gate for "can this user use the scaffolder at all?". Actual
+   * resource-level permissions (e.g. component:create, workflow:create) are
+   * enforced separately when the template's actions execute.
+   *
    * Allows if user has ANY create capability for scaffolder resource types.
-   * This is a global check - we cannot filter by scope at this point
-   * since the template hasn't been executed yet.
    */
   private async handleScaffolderTaskCreate(
     user?: PolicyQueryUser,
@@ -377,6 +382,7 @@ export class OpenChoreoPermissionPolicy implements PermissionPolicy {
         'trait:create',
         'componenttype:create',
         'workflow:create',
+        'clusterworkflow:create',
         'namespace:create',
       ];
 


### PR DESCRIPTION
  Define openchoreo.workflow.create and openchoreo.clusterworkflow.create
  permissions with corresponding action mappings, add useWorkflowPermission
  and useClusterWorkflowPermission hooks, and wire them into the scaffolder
  page so cards are disabled when the user lacks the capability. Also clarify
  the handleScaffolderTaskCreate comment explaining why any create capability
  is sufficient at that stage.

<img width="1728" height="902" alt="Screenshot 2026-03-11 at 09 59 55" src="https://github.com/user-attachments/assets/679669b6-589d-49d0-a72b-764c4ce0f71a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now respects workflow and cluster-workflow create permissions: templates of those types are disabled when users lack create access.
  * New permission-aware hooks exposed for use in the UI to surface denied-create tooltips.

* **Chores**
  * Permission system extended to include workflow and cluster-workflow create actions and mapping to scaffolder create checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->