### PR TITLE
feat: improve incident indicators and cross-tab navigation

### DIFF
--- a/plugins/openchoreo-observability/src/components/Incidents/IncidentsFilter.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/IncidentsFilter.tsx
@@ -54,19 +54,31 @@ export const IncidentsFilter: FC<IncidentsFilterProps> = ({
   };
 
   const handleEnvironmentChange = (event: ChangeEvent<{ value: unknown }>) => {
-    onFiltersChange({ environmentId: event.target.value as string });
+    onFiltersChange({
+      environmentId: event.target.value as string,
+      searchQuery: '',
+    });
   };
 
   const handleTimeRangeChange = (event: ChangeEvent<{ value: unknown }>) => {
-    onFiltersChange({ timeRange: event.target.value as string });
+    onFiltersChange({
+      timeRange: event.target.value as string,
+      searchQuery: '',
+    });
   };
 
   const handleComponentChange = (event: ChangeEvent<{ value: unknown }>) => {
-    onFiltersChange({ componentIds: event.target.value as string[] });
+    onFiltersChange({
+      componentIds: event.target.value as string[],
+      searchQuery: '',
+    });
   };
 
   const handleStatusChange = (event: ChangeEvent<{ value: unknown }>) => {
-    onFiltersChange({ status: event.target.value as string[] });
+    onFiltersChange({
+      status: event.target.value as string[],
+      searchQuery: '',
+    });
   };
 
   return (

--- a/plugins/openchoreo-observability/src/components/Incidents/ObservabilityProjectIncidentsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/ObservabilityProjectIncidentsPage.tsx
@@ -155,12 +155,24 @@ const ObservabilityProjectIncidentsContent = () => {
     return result;
   }, [incidents, filters.status, filters.searchQuery]);
 
-  // Open the RCA Reports tab of this project entity in a new browser tab
-  const handleViewRCA = useCallback(() => {
-    const catalogNs = entity.metadata.namespace || 'default';
-    const url = `/catalog/${catalogNs}/system/${projectName}/rca-reports`;
-    window.open(url, '_blank', 'noopener,noreferrer');
-  }, [entity, projectName]);
+  // Open the RCA Reports tab of this project entity in a new browser tab,
+  // pre-filtered by environment, time range, and alert ID.
+  const handleViewRCA = useCallback(
+    (incident: IncidentSummary) => {
+      const catalogNs = entity.metadata.namespace || 'default';
+      const params = new URLSearchParams({
+        ...(filters.environmentId ? { env: filters.environmentId } : {}),
+        ...(filters.timeRange ? { timeRange: filters.timeRange } : {}),
+        ...(incident.alertId ? { q: incident.alertId } : {}),
+      });
+      const query = params.toString();
+      const url = `/catalog/${catalogNs}/system/${projectName}/rca-reports${
+        query ? `?${query}` : ''
+      }`;
+      window.open(url, '_blank', 'noopener,noreferrer');
+    },
+    [entity, projectName, filters.environmentId, filters.timeRange],
+  );
 
   const handleAcknowledge = useCallback(
     async (incident: IncidentSummary) => {

--- a/plugins/openchoreo-observability/src/components/RCA/RCAFilters.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAFilters.tsx
@@ -1,12 +1,14 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useState, useEffect } from 'react';
 import {
   FormControl,
   InputLabel,
   Select,
   MenuItem,
   Grid,
+  TextField,
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
+import { useDebounce } from 'react-use';
 import {
   Filters,
   TIME_RANGE_OPTIONS,
@@ -30,27 +32,63 @@ export const RCAFilters = ({
   environmentsLoading,
   disabled = false,
 }: RCAFiltersProps) => {
+  const [searchInput, setSearchInput] = useState(filters.searchQuery || '');
+
+  useEffect(() => {
+    setSearchInput(filters.searchQuery || '');
+  }, [filters.searchQuery]);
+
+  const DEFAULT_DEBOUNCE_MS = 1000;
+  useDebounce(
+    () => {
+      onFiltersChange({ searchQuery: searchInput });
+    },
+    DEFAULT_DEBOUNCE_MS,
+    [searchInput],
+  );
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(event.target.value);
+  };
+
   const handleEnvironmentChange = (event: ChangeEvent<{ value: unknown }>) => {
     const selectedEnvironment = environments.find(
       env => env.uid === (event.target.value as string),
     );
     if (selectedEnvironment) {
-      onFiltersChange({ environment: selectedEnvironment });
+      onFiltersChange({ environment: selectedEnvironment, searchQuery: '' });
     }
   };
 
   const handleTimeRangeChange = (event: ChangeEvent<{ value: unknown }>) => {
-    onFiltersChange({ timeRange: event.target.value as string });
+    onFiltersChange({
+      timeRange: event.target.value as string,
+      searchQuery: '',
+    });
   };
 
   const handleStatusChange = (event: ChangeEvent<{ value: unknown }>) => {
     const value = event.target.value as string;
-    onFiltersChange({ rcaStatus: value ? (value as RCAStatus) : undefined });
+    onFiltersChange({
+      rcaStatus: value ? (value as RCAStatus) : undefined,
+      searchQuery: '',
+    });
   };
 
   return (
     <Grid container spacing={3}>
-      <Grid item xs={12} md={4}>
+      <Grid item xs={12} md={3}>
+        <TextField
+          fullWidth
+          placeholder="Search RCA reports..."
+          variant="outlined"
+          value={searchInput}
+          onChange={handleSearchChange}
+          disabled={disabled}
+        />
+      </Grid>
+
+      <Grid item xs={12} md={3}>
         <FormControl
           fullWidth
           disabled={disabled || environmentsLoading}
@@ -76,7 +114,7 @@ export const RCAFilters = ({
         </FormControl>
       </Grid>
 
-      <Grid item xs={12} md={4}>
+      <Grid item xs={12} md={3}>
         <FormControl fullWidth disabled={disabled} variant="outlined">
           <InputLabel id="status-label">Status</InputLabel>
           <Select
@@ -95,7 +133,7 @@ export const RCAFilters = ({
         </FormControl>
       </Grid>
 
-      <Grid item xs={12} md={4}>
+      <Grid item xs={12} md={3}>
         <FormControl fullWidth disabled={disabled} variant="outlined">
           <InputLabel id="time-range-label">Time Range</InputLabel>
           <Select

--- a/plugins/openchoreo-observability/src/components/RCA/RCAPage.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { Box, Typography, Button } from '@material-ui/core';
 import { RCAFilters } from './RCAFilters';
@@ -6,8 +6,9 @@ import { RCAActions } from './RCAActions';
 import { RCATable } from './RCATable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import type { RCAReportSummary } from '../../types';
 import {
-  useFilters,
+  useUrlFilters,
   useGetEnvironmentsByNamespace,
   useRCAReports,
 } from '../../hooks';
@@ -32,22 +33,26 @@ const RCAListContent = () => {
     loading: environmentsLoading,
     error: environmentsError,
   } = useGetEnvironmentsByNamespace(namespace);
-  const { filters, updateFilters } = useFilters();
+  const { filters, updateFilters } = useUrlFilters({ environments });
 
   const {
     reports,
     loading: reportsLoading,
     error: reportsError,
     refresh,
-    totalCount,
   } = useRCAReports(filters, entity);
 
-  // Auto-select first environment when environments are loaded
-  useEffect(() => {
-    if (environments.length > 0 && !filters.environment) {
-      updateFilters({ environment: environments[0] });
-    }
-  }, [environments, filters.environment, updateFilters]);
+  const filteredReports = useMemo((): RCAReportSummary[] => {
+    if (!filters.searchQuery) return reports;
+    const q = filters.searchQuery.toLowerCase();
+    return reports.filter(
+      r =>
+        (r.alertId || '').toLowerCase().includes(q) ||
+        (r.reportId || '').toLowerCase().includes(q) ||
+        (r.summary || '').toLowerCase().includes(q) ||
+        (r.status || '').toLowerCase().includes(q),
+    );
+  }, [reports, filters.searchQuery]);
 
   const handleFiltersChange = useCallback(
     (newFilters: Partial<typeof filters>) => {
@@ -115,11 +120,11 @@ const RCAListContent = () => {
           <RCAActions
             disabled={reportsLoading}
             onRefresh={handleRefresh}
-            totalCount={totalCount}
+            totalCount={filteredReports.length}
           />
 
           <EntityLinkContext.Provider value={namespaceValue}>
-            <RCATable reports={reports} loading={reportsLoading} />
+            <RCATable reports={filteredReports} loading={reportsLoading} />
           </EntityLinkContext.Provider>
         </>
       )}

--- a/plugins/openchoreo/src/components/Environments/EnvironmentsList.tsx
+++ b/plugins/openchoreo/src/components/Environments/EnvironmentsList.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Grid } from '@material-ui/core';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
@@ -51,7 +51,11 @@ export const EnvironmentsList = () => {
   const suspendTracker = useItemActionTracker<string>();
 
   // Incidents summary per environment
-  const incidentsSummaries = useIncidentsSummary(displayEnvironments);
+  const deployedEnvironments = useMemo(
+    () => displayEnvironments.filter(env => env.deployment.status === 'Ready'),
+    [displayEnvironments],
+  );
+  const incidentsSummaries = useIncidentsSummary(deployedEnvironments);
 
   // Notifications
   const notification = useNotification();

--- a/plugins/openchoreo/src/components/Environments/components/IncidentsBanner.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/IncidentsBanner.tsx
@@ -2,7 +2,7 @@ import { Box, Link, Tooltip, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import WarningIcon from '@material-ui/icons/Warning';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { buildEntityPath } from '@openchoreo/backstage-plugin-react';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 
 const useStyles = makeStyles(theme => ({
   banner: {
@@ -56,9 +56,15 @@ export const IncidentsBanner = ({
   const tooltip = `${count} incident${
     count === 1 ? '' : 's'
   } detected during last hour`;
-  const viewUrl = `${buildEntityPath(
-    entity,
-  )}/incidents?env=${encodeURIComponent(environmentName.toLowerCase())}`;
+  const namespace = entity.metadata.namespace || 'default';
+  const projectName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT] ?? '';
+  const params = new URLSearchParams({
+    env: environmentName.toLowerCase(),
+    timeRange: '1h',
+    status: 'active',
+  });
+  const viewUrl = `/catalog/${namespace}/system/${projectName}/incidents?${params.toString()}`;
 
   return (
     <Tooltip title={tooltip} arrow placement="top">

--- a/plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts
@@ -20,7 +20,7 @@ interface ObservabilityIncidentsApi {
     incidents: Array<{
       incidentId: string;
       alertId: string;
-      status: 'triggered' | 'acknowledged' | 'resolved';
+      status: 'active' | 'acknowledged' | 'resolved';
       description?: string;
       triggeredAt?: string;
       resolvedAt?: string;
@@ -93,7 +93,7 @@ export function useIncidentsSummary(
         );
 
         const activeCount = result.incidents.filter(
-          i => i.status === 'triggered' || i.status === 'acknowledged',
+          i => i.status === 'active',
         ).length;
 
         return { envName: env.name, activeCount };


### PR DESCRIPTION
## Summary
- Show incident indicator only for active status in deploy page
- Navigate to project (system) entity instead of component for incidents
- Pass env, timeRange, and status filters to incidents view URL
- Skip incident fetching for undeployed environments
- Add search filter to RCA reports page with client-side filtering
- Navigate from incidents to RCA with env, timeRange, and alertId prefilled
- Switch RCA page to URL-synced filters (useUrlFilters) for deep linking
- Stabilize useRCAReports dependency to prevent infinite fetch loop

## Test plan
- [x] Verify incident indicator only appears for active incidents on deploy page
- [x] Verify clicking incident navigates to project-level incidents view with correct filters
- [x] Verify RCA page filters sync with URL parameters
- [x] Verify search filter works on RCA reports page
- [x] Verify no infinite fetch loops in RCA reports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search capability for RCA reports with debounced input
  * RCA reports page now pre-fills filters based on selected incident context

* **Improvements**
  * Incident summaries now reflect only deployed environments
  * Search resets when other filters are applied
  * Updated incident status terminology for consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->