### PR TITLE
feat: add deselect-all toggle to kind and project filters

### DIFF
--- a/packages/app/src/components/platformOverview/PlatformOverviewPage.tsx
+++ b/packages/app/src/components/platformOverview/PlatformOverviewPage.tsx
@@ -229,14 +229,13 @@ export function PlatformOverviewPage() {
       if (next.has(key)) {
         next.delete(key);
       } else {
-        if (selectedProjects.length <= 1) return;
         next.add(key);
       }
       setParams({
         excludedProjects: next.size > 0 ? [...next].join(',') : undefined,
       });
     },
-    [excludedSet, selectedProjects.length, setParams],
+    [excludedSet, setParams],
   );
 
   const showProjectFilter =
@@ -394,9 +393,16 @@ export function PlatformOverviewPage() {
         <MenuList dense>
           <MenuItem
             className={classes.menuItem}
-            disabled={selectedProjects.length === projects.length}
             onClick={() => {
-              setParams({ excludedProjects: undefined });
+              if (selectedProjects.length === projects.length) {
+                // Deselect all
+                setParams({
+                  excludedProjects: projects.map(p => projectKey(p)).join(','),
+                });
+              } else {
+                // Select all
+                setParams({ excludedProjects: undefined });
+              }
               setProjectAnchor(null);
             }}
           >
@@ -419,19 +425,16 @@ export function PlatformOverviewPage() {
           {projects.map(p => {
             const key = projectKey(p);
             const isSelected = !excludedSet.has(key);
-            const isLastSelected = isSelected && selectedProjects.length <= 1;
             return (
               <MenuItem
                 key={key}
                 className={classes.menuItem}
-                disabled={isLastSelected}
                 onClick={() => handleProjectToggle(p)}
               >
                 <ListItemIcon>
                   <Checkbox
                     className={classes.checkbox}
                     checked={isSelected}
-                    disabled={isLastSelected}
                     color="primary"
                     size="small"
                     disableRipple

--- a/plugins/openchoreo-react/src/components/GraphKindFilter/GraphKindFilter.tsx
+++ b/plugins/openchoreo-react/src/components/GraphKindFilter/GraphKindFilter.tsx
@@ -129,14 +129,19 @@ export function GraphKindFilter({
 
   const handlePresetClick = (presetId: string) => {
     const preset = presets.find(p => p.id === presetId);
-    if (preset) {
+    if (!preset) return;
+    const state = getPresetState(preset.kinds);
+    if (state === 'checked') {
+      // Deselect: remove this preset's kinds from the selection
+      const remaining = selectedKinds.filter(k => !preset.kinds.includes(k));
+      onKindsChange(remaining);
+    } else {
       onKindsChange([...preset.kinds]);
     }
   };
 
   const handleKindToggle = (kind: string) => {
     if (selectedSet.has(kind)) {
-      if (selectedSet.size <= 1) return;
       onKindsChange(selectedKinds.filter(k => k !== kind));
     } else {
       onKindsChange([...selectedKinds, kind]);
@@ -190,7 +195,6 @@ export function GraphKindFilter({
         <MenuList dense>
           {visibleKinds.map((kind, index) => {
             const isSelected = selectedSet.has(kind.id);
-            const isLastSelected = isSelected && selectedSet.size <= 1;
             const color =
               ENTITY_KIND_COLORS[kind.id.toLowerCase()] ?? DEFAULT_NODE_COLOR;
             const showDivider =
@@ -202,14 +206,12 @@ export function GraphKindFilter({
                 {showDivider && <Divider />}
                 <MenuItem
                   className={classes.menuItem}
-                  disabled={isLastSelected}
                   onClick={() => handleKindToggle(kind.id)}
                 >
                   <ListItemIcon>
                     <Checkbox
                       className={classes.checkbox}
                       checked={isSelected}
-                      disabled={isLastSelected}
                       color="primary"
                       size="small"
                       disableRipple

--- a/plugins/openchoreo-react/src/components/PlatformOverviewGraphView/PlatformOverviewGraphView.tsx
+++ b/plugins/openchoreo-react/src/components/PlatformOverviewGraphView/PlatformOverviewGraphView.tsx
@@ -244,7 +244,7 @@ export function PlatformOverviewGraphView({
 
   const loading = refsLoading || graphLoading;
   const error = refsError || graphError;
-  const showGraph = !loading && !error && entityCount > 0;
+  const showGraph = !loading && !error && entityCount > 0 && nodes.length > 0;
 
   // Stable key to detect graph content changes (e.g. project filter)
   const graphContentKey = useMemo(

--- a/plugins/openchoreo-react/src/hooks/useAllEntitiesOfKinds.ts
+++ b/plugins/openchoreo-react/src/hooks/useAllEntitiesOfKinds.ts
@@ -17,6 +17,13 @@ export function useAllEntitiesOfKinds(kinds: string[], namespaces?: string[]) {
   );
 
   const fetchEntities = useCallback(async () => {
+    if (kinds.length === 0) {
+      setEntityRefs([]);
+      setEntityCount(0);
+      setLoading(false);
+      setError(undefined);
+      return;
+    }
     try {
       setLoading(true);
       setError(undefined);

--- a/plugins/openchoreo-react/src/hooks/useEntityGraphData.ts
+++ b/plugins/openchoreo-react/src/hooks/useEntityGraphData.ts
@@ -99,7 +99,10 @@ export function useEntityGraphData(
   );
 
   const projectRefsKey = useMemo(
-    () => projectRefs?.slice().sort().join(',') ?? '',
+    () =>
+      projectRefs === undefined
+        ? undefined
+        : projectRefs.slice().sort().join(','),
     [projectRefs],
   );
 
@@ -238,13 +241,12 @@ export function useEntityGraphData(
 
   // Apply project reachability filter client-side (no re-fetch)
   const filtered = useMemo(() => {
-    if (
-      !projectRefs ||
-      projectRefs.length === 0 ||
-      !allProjectRefs ||
-      fullGraph.nodes.length === 0
-    ) {
+    if (!projectRefs || !allProjectRefs || fullGraph.nodes.length === 0) {
       return fullGraph;
+    }
+    // Empty projectRefs = all projects deselected → show nothing
+    if (projectRefs.length === 0) {
+      return { nodes: [], edges: [] };
     }
     const nodeIdSet = new Set(fullGraph.nodes.map(n => n.id));
     const validRoots = projectRefs.filter(ref => nodeIdSet.has(ref));


### PR DESCRIPTION
  Make the "All" checkbox in both Kind and Project filter popovers act as
  a toggle — clicking it when all items are selected now deselects
  everything. Remove the min-1 selection constraint so users can clear
  filters entirely; the graph shows a "No entities found" empty state.

  - Short-circuit useAllEntitiesOfKinds when kinds is empty to avoid unnecessary API calls
  - Handle empty projectRefs in useEntityGraphData to return an empty graph instead of the full unfiltered graph
  - Fix projectRefsKey so undefined and [] produce distinct memo keys, ensuring reactive updates when toggling between all/none
  - Check nodes.length in showGraph so empty filtered results trigger the empty state UI instead of rendering a blank SVG


https://github.com/user-attachments/assets/08a1c016-bf8e-4394-ada8-2a64cbbb8fd6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project filtering flexibility—now allows deselecting all projects and removing selection guards.
  * Enhanced graph kind filter behavior to support toggling any item, including deselecting all kinds.
  * Fixed graph rendering to display only when data nodes are available.

* **Performance**
  * Optimized data fetching by skipping unnecessary API calls when no kinds are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->