### PR TITLE
feat: refactor RCA quick fixes to singular change field and file card UI

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-ai-rca-agent.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-ai-rca-agent.yaml
@@ -248,10 +248,10 @@ paths:
     put:
       tags:
         - RCA Reports
-      summary: Update report state (mark actions as applied)
+      summary: Update action statuses
       description: |
-        Marks the specified remediation actions as `applied` in the stored report.
-        Called by the frontend after successfully applying fixes client-side.
+        Updates the status of specific remediation actions in the stored report.
+        Accepts indices to mark as `applied` or `dismissed`.
       operationId: updateReport
       parameters:
         - name: report_id
@@ -267,7 +267,7 @@ paths:
               $ref: '#/components/schemas/ReportUpdateRequest'
       responses:
         '200':
-          description: Report updated successfully
+          description: Actions updated successfully
           content:
             application/json:
               schema:
@@ -859,13 +859,11 @@ components:
           properties:
             status:
               type: string
-              enum: [suggested, revised, applied]
+              enum: [suggested, revised, applied, dismissed]
               default: suggested
-            changes:
-              type: array
-              default: []
-              items:
-                $ref: '#/components/schemas/ResourceChange'
+            change:
+              nullable: true
+              $ref: '#/components/schemas/ResourceChange'
 
     ResourceChange:
       type: object
@@ -873,23 +871,19 @@ components:
       properties:
         release_binding:
           type: string
-          description: Name of the ReleaseBinding to modify
         env:
           type: array
           default: []
-          description: Environment variable changes, identified by key name
           items:
             $ref: '#/components/schemas/EnvVarChange'
         files:
           type: array
           default: []
-          description: File mount changes, identified by key name
           items:
             $ref: '#/components/schemas/FileChange'
         fields:
           type: array
           default: []
-          description: Field-level changes for non-array paths (trait overrides, componentType overrides)
           items:
             $ref: '#/components/schemas/FieldChange'
 
@@ -899,24 +893,19 @@ components:
       properties:
         key:
           type: string
-          description: 'Environment variable name (e.g. POSTGRES_DSN)'
         value:
           type: string
-          description: New value for the environment variable
 
     FileChange:
       type: object
-      required: [key]
+      required: [key, mount_path, value]
       properties:
         key:
           type: string
-          description: 'File key (e.g. config.yaml)'
-        value:
-          type: string
-          description: New file content
         mount_path:
           type: string
-          description: 'New mount path (e.g. /app/)'
+        value:
+          type: string
 
     FieldChange:
       type: object
@@ -924,25 +913,25 @@ components:
       properties:
         json_pointer:
           type: string
-          description: 'RFC 6901 JSON Pointer for non-array fields. Example: /spec/traitEnvironmentConfigs/my-trait/enabled'
         value:
-          description: Value to set at the JSON Pointer location
           oneOf:
             - type: string
             - type: number
             - type: boolean
-            - type: object
-            - type: array
 
     ReportUpdateRequest:
       type: object
-      required: [appliedIndices]
       properties:
         appliedIndices:
           type: array
+          default: []
           items:
             type: integer
-          description: Indices of the recommended actions to mark as applied
+        dismissedIndices:
+          type: array
+          default: []
+          items:
+            type: integer
 
   securitySchemes:
     bearerAuth:

--- a/packages/openchoreo-client-node/src/generated/ai-rca-agent/types.ts
+++ b/packages/openchoreo-client-node/src/generated/ai-rca-agent/types.ts
@@ -80,9 +80,9 @@ export interface paths {
     /** Get RCA report by report ID */
     get: operations['getRCAReport'];
     /**
-     * Update report state (mark actions as applied)
-     * @description Marks the specified remediation actions as `applied` in the stored report.
-     *     Called by the frontend after successfully applying fixes client-side.
+     * Update action statuses
+     * @description Updates the status of specific remediation actions in the stored report.
+     *     Accepts indices to mark as `applied` or `dismissed`.
      *
      */
     put: operations['updateReport'];
@@ -373,52 +373,36 @@ export interface components {
        * @default suggested
        * @enum {string}
        */
-      status: 'suggested' | 'revised' | 'applied';
-      /** @default [] */
-      changes: components['schemas']['ResourceChange'][];
+      status: 'suggested' | 'revised' | 'applied' | 'dismissed';
+      change?: components['schemas']['ResourceChange'];
     };
     ResourceChange: {
-      /** @description Name of the ReleaseBinding to modify */
       release_binding: string;
-      /**
-       * @description Environment variable changes, identified by key name
-       * @default []
-       */
+      /** @default [] */
       env: components['schemas']['EnvVarChange'][];
-      /**
-       * @description File mount changes, identified by key name
-       * @default []
-       */
+      /** @default [] */
       files: components['schemas']['FileChange'][];
-      /**
-       * @description Field-level changes for non-array paths (trait overrides, componentType overrides)
-       * @default []
-       */
+      /** @default [] */
       fields: components['schemas']['FieldChange'][];
     };
     EnvVarChange: {
-      /** @description Environment variable name (e.g. POSTGRES_DSN) */
       key: string;
-      /** @description New value for the environment variable */
       value: string;
     };
     FileChange: {
-      /** @description File key (e.g. config.yaml) */
       key: string;
-      /** @description New file content */
-      value?: string;
-      /** @description New mount path (e.g. /app/) */
-      mount_path?: string;
+      mount_path: string;
+      value: string;
     };
     FieldChange: {
-      /** @description RFC 6901 JSON Pointer for non-array fields. Example: /spec/traitEnvironmentConfigs/my-trait/enabled */
       json_pointer: string;
-      /** @description Value to set at the JSON Pointer location */
-      value: string | number | boolean | Record<string, never> | unknown[];
+      value: string | number | boolean;
     };
     ReportUpdateRequest: {
-      /** @description Indices of the recommended actions to mark as applied */
+      /** @default [] */
       appliedIndices: number[];
+      /** @default [] */
+      dismissedIndices: number[];
     };
   };
   responses: never;
@@ -663,7 +647,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Report updated successfully */
+      /** @description Actions updated successfully */
       200: {
         headers: {
           [name: string]: unknown;

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -56,6 +56,7 @@ export {
   openchoreoMetricsViewPermission,
   openchoreoTracesViewPermission,
   openchoreoRcaViewPermission,
+  openchoreoRcaUpdatePermission,
   openchoreoTraitsViewPermission,
   openchoreoTraitCreatePermission,
   openchoreoComponentTypeCreatePermission,

--- a/plugins/openchoreo-common/src/permissions.ts
+++ b/plugins/openchoreo-common/src/permissions.ts
@@ -689,6 +689,16 @@ export const openchoreoRcaViewPermission = createPermission({
 });
 
 /**
+ * Permission to update RCA reports for a project (apply/dismiss fixes).
+ * Resource-based: requires the specific project context.
+ */
+export const openchoreoRcaUpdatePermission = createPermission({
+  name: 'openchoreo.rca.update',
+  attributes: { action: 'update' },
+  resourceType: OPENCHOREO_RESOURCE_TYPE_PROJECT,
+});
+
+/**
  * Permission to view traits for a component.
  * Resource-based: requires the specific component context.
  */
@@ -738,6 +748,7 @@ export const openchoreoPermissions = [
   openchoreoMetricsViewPermission,
   openchoreoTracesViewPermission,
   openchoreoRcaViewPermission,
+  openchoreoRcaUpdatePermission,
   openchoreoTraitsViewPermission,
   openchoreoTraitCreatePermission,
   openchoreoComponentTypeCreatePermission,
@@ -820,6 +831,7 @@ export const OPENCHOREO_PERMISSION_TO_ACTION: Record<string, string> = {
   'openchoreo.metrics.view': 'metrics:view',
   'openchoreo.traces.view': 'traces:view',
   'openchoreo.rca.view': 'rcareport:view',
+  'openchoreo.rca.update': 'rcareport:update',
   'openchoreo.traits.view': 'trait:view',
   'openchoreo.trait.create': 'trait:create',
   'openchoreo.componenttype.create': 'componenttype:create',

--- a/plugins/openchoreo-observability/src/api/RCAAgentApi.ts
+++ b/plugins/openchoreo-observability/src/api/RCAAgentApi.ts
@@ -36,10 +36,10 @@ export interface RCAAgentApi {
     signal?: AbortSignal,
   ): Promise<void>;
 
-  markActionsApplied(
+  updateActionStatuses(
     reportId: string,
     routing: ChatRoutingContext,
-    appliedIndices: number[],
+    update: { appliedIndices?: number[]; dismissedIndices?: number[] },
   ): Promise<void>;
 }
 
@@ -142,10 +142,10 @@ export class RCAAgentClient implements RCAAgentApi {
     }
   }
 
-  async markActionsApplied(
+  async updateActionStatuses(
     reportId: string,
     routing: ChatRoutingContext,
-    appliedIndices: number[],
+    update: { appliedIndices?: number[]; dismissedIndices?: number[] },
   ): Promise<void> {
     const { rcaAgentUrl } = await this.urlCache.resolveUrls(
       routing.namespaceName,
@@ -160,7 +160,7 @@ export class RCAAgentClient implements RCAAgentApi {
       `${rcaAgentUrl}/api/v1/rca-agent/reports/${encodeURIComponent(reportId)}`,
       {
         method: 'PUT',
-        body: JSON.stringify({ appliedIndices }),
+        body: JSON.stringify(update),
         headers: {
           'Content-Type': 'application/json',
           'x-openchoreo-direct': 'true',

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/RCAReportView.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/RCAReportView.tsx
@@ -20,7 +20,7 @@ import { IncidentOverviewSection } from './sections/IncidentOverviewSection';
 import { AssessmentSection } from './sections/AssessmentSection';
 import { ChatPanelSection } from './sections/ChatPanelSection';
 import { QuickFixesPanelSection } from './sections/QuickFixesPanelSection';
-import { patchAppliedKey } from './sections/PatchTabContent';
+import { allActionsResolved } from './sections/PatchTabContent';
 import { useRCAReportStyles } from './styles';
 import { EntityLinkContext } from './EntityLinkContext';
 import type { AIRCAAgentComponents } from '@openchoreo/backstage-plugin-common';
@@ -63,7 +63,12 @@ export const RCAReportView = ({
     const actions = recs?.recommended_actions;
     if (actions) {
       actions.forEach((action, idx) => {
-        if (action.status === 'revised' && action.changes?.length > 0) {
+        if (
+          (action.status === 'revised' ||
+            action.status === 'applied' ||
+            action.status === 'dismissed') &&
+          action.change
+        ) {
           result.push({ index: idx, action });
         }
       });
@@ -76,13 +81,7 @@ export const RCAReportView = ({
   const [activePanel, setActivePanel] = useState<'chat' | 'fixes' | null>(
     () => {
       if (!hasRevised) return null;
-      try {
-        if (localStorage.getItem(patchAppliedKey(reportId)) === 'true') {
-          return null;
-        }
-      } catch {
-        // ignore
-      }
+      if (allActionsResolved(revisedActions)) return null;
       return 'fixes';
     },
   );

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/PatchTabContent.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/PatchTabContent.tsx
@@ -5,11 +5,14 @@ import {
   Button,
   TextField,
   LinearProgress,
+  Tooltip,
 } from '@material-ui/core';
 import BuildIcon from '@material-ui/icons/Build';
 import CheckIcon from '@material-ui/icons/Check';
+import CloseIcon from '@material-ui/icons/Close';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import { useApi, fetchApiRef } from '@backstage/core-plugin-api';
+import { useRcaUpdatePermission } from '@openchoreo/backstage-plugin-react';
 import { useRCAReportStyles } from '../styles';
 import { FormattedText } from '../FormattedText';
 import type {
@@ -29,7 +32,7 @@ interface ChatContext {
   backendBaseUrl?: string;
 }
 
-type ActionStatus = 'idle' | 'applying' | 'success' | 'failed';
+type ActionStatus = 'idle' | 'applying' | 'success' | 'failed' | 'dismissed';
 
 interface ActionState {
   status: ActionStatus;
@@ -44,9 +47,17 @@ interface PatchTabContentProps {
   revisedActions: { index: number; action: RecommendedAction }[];
 }
 
-/** localStorage key for tracking applied state per report */
-export function patchAppliedKey(reportId: string): string {
-  return `rca-patch-applied:${reportId}`;
+/** Check whether all actions in the set are resolved (applied or dismissed) */
+export function allActionsResolved(
+  actions: { action: RecommendedAction }[],
+): boolean {
+  return (
+    actions.length > 0 &&
+    actions.every(
+      ({ action }) =>
+        action.status === 'applied' || action.status === 'dismissed',
+    )
+  );
 }
 
 const ALLOWED_OVERRIDE_CATEGORIES = new Set([
@@ -66,6 +77,13 @@ function applyJsonPointer(doc: any, pointer: string, value: any): void {
   }
   let current = doc;
   for (const key of keys.slice(0, -1)) {
+    if (
+      current[key] === null ||
+      current[key] === undefined ||
+      typeof current[key] !== 'object'
+    ) {
+      current[key] = {};
+    }
     current = current[key];
   }
   const last = keys.at(-1)!;
@@ -80,7 +98,6 @@ function applyEnvChange(doc: any, key: string, value: string): void {
     existing.value = value;
   } else {
     env.push({ key, value });
-    // Ensure the path exists
     doc.spec ??= {};
     doc.spec.workloadOverrides ??= {};
     doc.spec.workloadOverrides.container ??= {};
@@ -91,63 +108,153 @@ function applyEnvChange(doc: any, key: string, value: string): void {
 function applyFileChange(
   doc: any,
   key: string,
-  value?: string,
-  mountPath?: string,
+  mountPath: string,
+  value: string,
 ): void {
-  const files: { key: string; value?: string; mountPath?: string }[] =
+  const files: { key: string; value: string; mountPath: string }[] =
     doc.spec?.workloadOverrides?.container?.files ?? [];
-  const existing = files.find(f => f.key === key);
+  const existing = files.find(f => f.key === key && f.mountPath === mountPath);
   if (existing) {
-    if (value !== undefined) existing.value = value;
-    if (mountPath !== undefined) existing.mountPath = mountPath;
+    existing.value = value;
   } else {
-    const entry: { key: string; value?: string; mountPath?: string } = { key };
-    if (value !== undefined) entry.value = value;
-    if (mountPath !== undefined) entry.mountPath = mountPath;
-    files.push(entry);
-    doc.spec ??= {};
-    doc.spec.workloadOverrides ??= {};
-    doc.spec.workloadOverrides.container ??= {};
-    doc.spec.workloadOverrides.container.files = files;
+    throw new Error(
+      `File mount '${key}' at '${mountPath}' not found in binding`,
+    );
   }
 }
 
-/** A unified editable item extracted from env, files, or fields. */
-interface PatchItem {
-  type: 'env' | 'file' | 'field';
+type PrimitiveValue = string | number | boolean;
+
+interface EditableField {
   label: string;
-  value: string;
+  value: PrimitiveValue;
+  fieldIdx: number;
 }
 
-function extractPatchItems(rc: ResourceChange): PatchItem[] {
-  const items: PatchItem[] = [];
+interface FileField {
+  fileKey: string;
+  mountPath: string;
+  content: { value: string; fieldIdx: number };
+}
+
+interface FieldNode {
+  label: string | null; // null = leaf (render the field)
+  field?: EditableField; // present only for leaves
+  children?: FieldNode[];
+}
+
+interface PatchSection {
+  title: string;
+  envVars?: EditableField[];
+  files?: FileField[];
+  fieldTree?: FieldNode[];
+}
+
+function buildFieldTree(fields: EditableField[]): FieldNode[] {
+  // Group by first segment of label
+  const prefixMap = new Map<string, EditableField[]>();
+  const leaves: FieldNode[] = [];
+
+  for (const f of fields) {
+    const dot = f.label.indexOf('.');
+    if (dot > 0) {
+      const prefix = f.label.slice(0, dot);
+      const list = prefixMap.get(prefix) ?? [];
+      list.push({ ...f, label: f.label.slice(dot + 1) });
+      prefixMap.set(prefix, list);
+    } else {
+      leaves.push({ label: null, field: f });
+    }
+  }
+
+  const nodes: FieldNode[] = [...leaves];
+
+  for (const [prefix, children] of prefixMap) {
+    if (children.length === 1) {
+      // Only 1 child — don't nest, restore the full label
+      nodes.push({
+        label: null,
+        field: { ...children[0], label: `${prefix}.${children[0].label}` },
+      });
+    } else {
+      // 2+ children — recurse
+      nodes.push({ label: prefix, children: buildFieldTree(children) });
+    }
+  }
+
+  return nodes;
+}
+
+function extractPatchSections(rc: ResourceChange): PatchSection[] {
+  const sections: PatchSection[] = [];
+  let fieldIdx = 0;
+
+  // Workload overrides: env vars and files
+  const envVars: EditableField[] = [];
+  const files: FileField[] = [];
+
   for (const e of (rc.env ?? []) as EnvVarChange[]) {
-    items.push({ type: 'env', label: `env: ${e.key}`, value: e.value });
+    envVars.push({ label: e.key, value: e.value, fieldIdx: fieldIdx++ });
   }
   for (const f of (rc.files ?? []) as FileChange[]) {
-    if (f.value !== undefined) {
-      items.push({ type: 'file', label: `file: ${f.key}`, value: f.value });
-    }
-    if (f.mount_path !== undefined) {
-      items.push({
-        type: 'file',
-        label: `file: ${f.key} (mountPath)`,
-        value: f.mount_path,
+    files.push({
+      fileKey: f.key,
+      mountPath: f.mount_path,
+      content: { value: f.value, fieldIdx: fieldIdx++ },
+    });
+  }
+
+  if (envVars.length > 0 || files.length > 0) {
+    sections.push({
+      title: 'Workload Overrides',
+      envVars: envVars.length > 0 ? envVars : undefined,
+      files: files.length > 0 ? files : undefined,
+    });
+  }
+
+  // Group field changes by section (componentType vs trait instances)
+  const componentTypeFields: EditableField[] = [];
+  const traitFieldsMap = new Map<string, EditableField[]>();
+
+  for (const f of (rc.fields ?? []) as FieldChange[]) {
+    const parts = f.json_pointer.replace(/^\/spec\//, '').split('/');
+    const section = parts[0];
+    const label = parts
+      .slice(section === 'traitEnvironmentConfigs' ? 2 : 1)
+      .join('.');
+
+    if (section === 'traitEnvironmentConfigs' && parts.length >= 2) {
+      const traitName = parts[1];
+      const list = traitFieldsMap.get(traitName) ?? [];
+      list.push({ label, value: f.value, fieldIdx: fieldIdx++ });
+      traitFieldsMap.set(traitName, list);
+    } else {
+      componentTypeFields.push({
+        label,
+        value: f.value,
+        fieldIdx: fieldIdx++,
       });
     }
   }
-  for (const f of (rc.fields ?? []) as FieldChange[]) {
-    items.push({
-      type: 'field',
-      label: f.json_pointer
-        .replace(/^\/spec\/[^/]+\//, '')
-        .split('/')
-        .join('.'),
-      value: String(f.value),
+
+  if (componentTypeFields.length > 0) {
+    sections.push({
+      title: 'Component Overrides',
+      fieldTree: buildFieldTree(componentTypeFields),
     });
   }
-  return items;
+
+  for (const [traitName, traitFields] of traitFieldsMap) {
+    sections.push({
+      title: `Trait: ${traitName}`,
+      fieldTree: buildFieldTree(traitFields),
+    });
+  }
+
+  return sections;
 }
+
+const monoInputStyle = { fontFamily: 'monospace', fontSize: '0.8rem' } as const;
 
 export const PatchTabContent = ({
   reportId,
@@ -156,29 +263,28 @@ export const PatchTabContent = ({
 }: PatchTabContentProps) => {
   const classes = useRCAReportStyles();
   const fetchApi = useApi(fetchApiRef);
-  const storageKey = patchAppliedKey(reportId);
+  const {
+    canUpdateRca,
+    loading: permissionLoading,
+    deniedTooltip,
+  } = useRcaUpdatePermission();
 
-  const wasApplied = (() => {
-    try {
-      return localStorage.getItem(storageKey) === 'true';
-    } catch {
-      return false;
-    }
-  })();
+  const allResolved = allActionsResolved(revisedActions);
 
-  const [phase, setPhase] = useState<Phase>(wasApplied ? 'done' : 'idle');
+  const [phase, setPhase] = useState<Phase>(allResolved ? 'done' : 'idle');
   const [actionStates, setActionStates] = useState<Map<number, ActionState>>(
     () => {
-      if (!wasApplied) return new Map();
+      if (!allResolved) return new Map();
       const m = new Map<number, ActionState>();
-      for (const { index } of revisedActions) {
-        m.set(index, { status: 'success' });
+      for (const { index, action } of revisedActions) {
+        m.set(index, {
+          status: action.status === 'dismissed' ? 'dismissed' : 'success',
+        });
       }
       return m;
     },
   );
   const [error, setError] = useState('');
-
   // Editable values keyed by "actionIndex-resourceChangeIndex-fieldIndex"
   const [editedValues, setEditedValues] = useState<Map<string, string>>(
     new Map(),
@@ -189,9 +295,29 @@ export const PatchTabContent = ({
     rcIdx: number,
     fieldIdx: number,
     original: string | number | boolean | Record<string, never> | unknown[],
-  ) => {
+  ): string => {
     const key = `${actionIdx}-${rcIdx}-${fieldIdx}`;
     return editedValues.get(key) ?? String(original);
+  };
+
+  /** Return the edited value coerced back to the original primitive type, or the original if unedited. */
+  const getPatchValue = (
+    actionIdx: number,
+    rcIdx: number,
+    fieldIdx: number,
+    original: PrimitiveValue,
+  ): PrimitiveValue => {
+    const key = `${actionIdx}-${rcIdx}-${fieldIdx}`;
+    const edited = editedValues.get(key);
+    if (edited === undefined) return original;
+    if (typeof original === 'number') {
+      const n = Number(edited);
+      return Number.isNaN(n) ? edited : n;
+    }
+    if (typeof original === 'boolean') {
+      return edited === 'true';
+    }
+    return edited;
   };
 
   const setEditedValue = (
@@ -236,14 +362,12 @@ export const PatchTabContent = ({
         }
         const bindingPatches = new Map<string, BindingPatch[]>();
         for (const { index: actionIndex, action } of actions) {
-          (action.changes as ResourceChange[]).forEach(
-            (resourceChange, rcIdx) => {
-              const name = resourceChange.release_binding;
-              const patches = bindingPatches.get(name) ?? [];
-              patches.push({ actionIndex, rcIdx, resourceChange });
-              bindingPatches.set(name, patches);
-            },
-          );
+          const resourceChange = action.change as ResourceChange;
+          if (!resourceChange) continue;
+          const name = resourceChange.release_binding;
+          const patches = bindingPatches.get(name) ?? [];
+          patches.push({ actionIndex, rcIdx: 0, resourceChange });
+          bindingPatches.set(name, patches);
         }
 
         // Apply patches per binding: GET once → apply all changes → PUT once
@@ -291,33 +415,26 @@ export const PatchTabContent = ({
                 itemIdx++;
               }
 
-              // Apply file changes
+              // Apply file changes (key + mount_path identify the mount, only value is editable)
               for (const f of (resourceChange.files ?? []) as FileChange[]) {
-                const editedValue =
-                  f.value !== undefined
-                    ? getEditedValue(actionIndex, rcIdx, itemIdx++, f.value)
-                    : undefined;
-                const editedMount =
-                  f.mount_path !== undefined
-                    ? getEditedValue(
-                        actionIndex,
-                        rcIdx,
-                        itemIdx++,
-                        f.mount_path,
-                      )
-                    : undefined;
-                applyFileChange(updated, f.key, editedValue, editedMount);
+                const editedValue = getEditedValue(
+                  actionIndex,
+                  rcIdx,
+                  itemIdx++,
+                  f.value,
+                );
+                applyFileChange(updated, f.key, f.mount_path, editedValue);
               }
 
               // Apply field changes (JSON Pointers for trait/componentType overrides)
               for (const f of (resourceChange.fields ?? []) as FieldChange[]) {
-                const editedVal = getEditedValue(
+                const patchVal = getPatchValue(
                   actionIndex,
                   rcIdx,
                   itemIdx,
                   f.value,
                 );
-                applyJsonPointer(updated, f.json_pointer, editedVal);
+                applyJsonPointer(updated, f.json_pointer, patchVal);
                 itemIdx++;
               }
             }
@@ -371,13 +488,13 @@ export const PatchTabContent = ({
         // Mark applied actions in the RCA agent backend
         if (successIndices.length > 0) {
           try {
-            await chatContext.rcaAgentApi.markActionsApplied(
+            await chatContext.rcaAgentApi.updateActionStatuses(
               reportId,
               {
                 namespaceName: chatContext.namespaceName,
                 environmentName: chatContext.environmentName,
               },
-              successIndices,
+              { appliedIndices: successIndices },
             );
           } catch {
             // Non-fatal: the fix was applied, state update failed
@@ -386,17 +503,6 @@ export const PatchTabContent = ({
 
         setActionStates(resultStates);
         setPhase(successIndices.length > 0 ? 'done' : 'error');
-
-        if (
-          successIndices.length > 0 &&
-          successIndices.length === actions.length
-        ) {
-          try {
-            localStorage.setItem(storageKey, 'true');
-          } catch {
-            // ignore
-          }
-        }
       } catch (err) {
         const msg =
           err instanceof Error ? err.message : 'Failed to apply fixes';
@@ -410,7 +516,7 @@ export const PatchTabContent = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [chatContext, reportId, fetchApi, storageKey, editedValues],
+    [chatContext, reportId, fetchApi, editedValues],
   );
 
   const handleApplySingle = useCallback(
@@ -420,10 +526,42 @@ export const PatchTabContent = ({
     [applyFixes],
   );
 
-  const renderActionButton = (index: number, action: RecommendedAction) => {
-    const state = actionStates.get(index);
+  const handleDismiss = useCallback(
+    async (index: number) => {
+      setActionStates(prev => {
+        const next = new Map(prev);
+        next.set(index, { status: 'applying' });
+        return next;
+      });
+      try {
+        await chatContext.rcaAgentApi.updateActionStatuses(
+          reportId,
+          {
+            namespaceName: chatContext.namespaceName,
+            environmentName: chatContext.environmentName,
+          },
+          { dismissedIndices: [index] },
+        );
+        setActionStates(prev => {
+          const next = new Map(prev);
+          next.set(index, { status: 'dismissed' });
+          return next;
+        });
+      } catch {
+        setActionStates(prev => {
+          const next = new Map(prev);
+          next.set(index, { status: 'failed', details: 'Failed to dismiss' });
+          return next;
+        });
+      }
+    },
+    [chatContext, reportId],
+  );
 
-    if (state?.status === 'applying') {
+  const renderActionButtons = (index: number, action: RecommendedAction) => {
+    const localStatus = actionStates.get(index)?.status;
+
+    if (localStatus === 'applying') {
       return (
         <Button variant="outlined" size="small" disabled>
           Applying...
@@ -431,20 +569,28 @@ export const PatchTabContent = ({
       );
     }
 
-    if (state?.status === 'success') {
+    if (localStatus === 'success' || action.status === 'applied') {
       return (
         <Button
           variant="outlined"
           size="small"
           disabled
-          startIcon={<CheckIcon style={{ color: '#4caf50' }} />}
+          startIcon={<CheckIcon />}
         >
           Applied
         </Button>
       );
     }
 
-    if (state?.status === 'failed') {
+    if (localStatus === 'dismissed' || action.status === 'dismissed') {
+      return (
+        <Button variant="outlined" size="small" disabled>
+          Dismissed
+        </Button>
+      );
+    }
+
+    if (localStatus === 'failed') {
       return (
         <Button
           variant="outlined"
@@ -458,17 +604,38 @@ export const PatchTabContent = ({
       );
     }
 
+    const busy = phase === 'running';
+    const disableActions = busy || permissionLoading || !canUpdateRca;
     return (
-      <Button
-        variant="outlined"
-        color="primary"
-        size="small"
-        startIcon={<BuildIcon />}
-        onClick={() => handleApplySingle(index, action)}
-        disabled={phase !== 'idle'}
-      >
-        Apply Fix
-      </Button>
+      <Box display="flex" style={{ gap: 8 }}>
+        <Tooltip title={deniedTooltip}>
+          <span>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<CloseIcon />}
+              onClick={() => handleDismiss(index)}
+              disabled={disableActions}
+            >
+              Dismiss
+            </Button>
+          </span>
+        </Tooltip>
+        <Tooltip title={deniedTooltip}>
+          <span>
+            <Button
+              variant="outlined"
+              color="primary"
+              size="small"
+              startIcon={<BuildIcon />}
+              onClick={() => handleApplySingle(index, action)}
+              disabled={disableActions}
+            >
+              Apply Fix
+            </Button>
+          </span>
+        </Tooltip>
+      </Box>
     );
   };
 
@@ -483,51 +650,213 @@ export const PatchTabContent = ({
     );
   }
 
-  const isRunning =
-    phase === 'running' || phase === 'done' || phase === 'error';
+  const isRunning = phase === 'running';
+
+  const renderFieldNodes = (
+    nodes: FieldNode[],
+    actionIdx: number,
+    disabled: boolean,
+    depth = 0,
+  ): React.ReactNode =>
+    nodes.map((node, nIdx) => {
+      if (node.field) {
+        const f = node.field;
+        return (
+          <TextField
+            key={`${actionIdx}-field-${f.fieldIdx}`}
+            fullWidth
+            variant="outlined"
+            size="small"
+            label={f.label}
+            value={getEditedValue(actionIdx, 0, f.fieldIdx, f.value)}
+            onChange={e =>
+              setEditedValue(actionIdx, 0, f.fieldIdx, e.target.value)
+            }
+            disabled={disabled}
+            InputProps={{ style: monoInputStyle }}
+            InputLabelProps={{ shrink: true }}
+          />
+        );
+      }
+      return (
+        <Box
+          key={`${actionIdx}-grp-${depth}-${nIdx}`}
+          display="flex"
+          flexDirection="column"
+          style={{ gap: 10 }}
+        >
+          <Typography variant="caption" color="textSecondary">
+            {node.label}
+          </Typography>
+          {node.children &&
+            renderFieldNodes(node.children, actionIdx, disabled, depth + 1)}
+        </Box>
+      );
+    });
 
   return (
     <Box>
-      {revisedActions.map(({ index, action }) => (
-        <Box key={index} className={classes.patchActionCard}>
-          <Typography
-            component="div"
-            className={classes.patchActionDescription}
-          >
-            <FormattedText text={action.description} />
-          </Typography>
+      {revisedActions.map(({ index, action }) => {
+        const rc = action.change as ResourceChange | undefined;
+        const sections = rc ? extractPatchSections(rc) : [];
+        const state = actionStates.get(index)?.status;
+        const disabled =
+          isRunning ||
+          action.status === 'applied' ||
+          action.status === 'dismissed' ||
+          state === 'success' ||
+          state === 'dismissed';
+        return (
+          <Box key={index} className={classes.patchActionCard}>
+            {rc && (
+              <Typography className={classes.patchBindingName}>
+                {rc.release_binding}
+              </Typography>
+            )}
+            <Typography
+              component="div"
+              className={classes.patchActionDescription}
+            >
+              <FormattedText text={action.description} disableMarkdown />
+            </Typography>
 
-          {(action.changes as ResourceChange[]).map((resourceChange, rcIdx) =>
-            extractPatchItems(resourceChange).map((item, itemIdx) => (
-              <TextField
-                key={`${index}-${rcIdx}-${itemIdx}`}
-                fullWidth
-                variant="outlined"
-                size="small"
-                label={item.label}
-                value={getEditedValue(index, rcIdx, itemIdx, item.value)}
-                onChange={e =>
-                  setEditedValue(index, rcIdx, itemIdx, e.target.value)
-                }
-                disabled={isRunning}
-                InputProps={{
-                  style: { fontFamily: 'monospace', fontSize: '0.8rem' },
-                }}
-                InputLabelProps={{ shrink: true }}
-              />
-            )),
-          )}
+            {sections.length > 0 && (
+              <Box display="flex" flexDirection="column" style={{ gap: 16 }}>
+                {sections.map((section, sIdx) => (
+                  <Box
+                    key={`${index}-s-${sIdx}`}
+                    display="flex"
+                    flexDirection="column"
+                    style={{ gap: 10 }}
+                  >
+                    <Typography
+                      variant="caption"
+                      style={{
+                        fontSize: '0.65rem',
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}
+                      color="textSecondary"
+                    >
+                      {section.title}
+                    </Typography>
 
-          {actionStates.get(index)?.status === 'applying' && (
-            <LinearProgress style={{ borderRadius: 2 }} />
-          )}
+                    {section.envVars && (
+                      <Box
+                        display="flex"
+                        flexDirection="column"
+                        style={{ gap: 8 }}
+                      >
+                        <Typography
+                          variant="caption"
+                          style={{ fontSize: '0.6rem' }}
+                          color="textSecondary"
+                        >
+                          Environment Variables
+                        </Typography>
+                        {section.envVars.map(ev => (
+                          <TextField
+                            key={`${index}-env-${ev.fieldIdx}`}
+                            fullWidth
+                            variant="outlined"
+                            size="small"
+                            label={ev.label}
+                            value={getEditedValue(
+                              index,
+                              0,
+                              ev.fieldIdx,
+                              ev.value,
+                            )}
+                            onChange={e =>
+                              setEditedValue(
+                                index,
+                                0,
+                                ev.fieldIdx,
+                                e.target.value,
+                              )
+                            }
+                            disabled={disabled}
+                            InputProps={{ style: monoInputStyle }}
+                            InputLabelProps={{ shrink: true }}
+                          />
+                        ))}
+                      </Box>
+                    )}
 
-          <Box className={classes.patchActionFooter}>
-            <Box />
-            {renderActionButton(index, action)}
+                    {section.files && (
+                      <Box
+                        display="flex"
+                        flexDirection="column"
+                        style={{ gap: 8 }}
+                      >
+                        <Typography
+                          variant="caption"
+                          style={{ fontSize: '0.6rem' }}
+                          color="textSecondary"
+                        >
+                          Files
+                        </Typography>
+                        {section.files.map(file => (
+                          <TextField
+                            key={`${index}-file-${file.content.fieldIdx}`}
+                            fullWidth
+                            variant="outlined"
+                            size="small"
+                            label={`${file.mountPath.replace(/\/?$/, '/')}${
+                              file.fileKey
+                            }`}
+                            value={getEditedValue(
+                              index,
+                              0,
+                              file.content.fieldIdx,
+                              file.content.value,
+                            )}
+                            onChange={e =>
+                              setEditedValue(
+                                index,
+                                0,
+                                file.content.fieldIdx,
+                                e.target.value,
+                              )
+                            }
+                            disabled={disabled}
+                            multiline
+                            minRows={3}
+                            maxRows={12}
+                            InputProps={{ style: monoInputStyle }}
+                            InputLabelProps={{
+                              shrink: true,
+                              style: {
+                                maxWidth: '100%',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                              },
+                            }}
+                          />
+                        ))}
+                      </Box>
+                    )}
+
+                    {section.fieldTree &&
+                      renderFieldNodes(section.fieldTree, index, disabled)}
+                  </Box>
+                ))}
+              </Box>
+            )}
+
+            {actionStates.get(index)?.status === 'applying' && (
+              <LinearProgress style={{ borderRadius: 2 }} />
+            )}
+
+            <Box className={classes.patchActionFooter}>
+              <Box />
+              {renderActionButtons(index, action)}
+            </Box>
           </Box>
-        </Box>
-      ))}
+        );
+      })}
 
       {phase === 'error' && (
         <Box display="flex" alignItems="center" mt={1} p={1} style={{ gap: 8 }}>

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/styles.ts
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/styles.ts
@@ -440,7 +440,7 @@ export const useRCAReportStyles = makeStyles(theme => ({
   },
   patchActionDescription: {
     fontWeight: 500,
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: theme.typography.caption.fontSize,
     color: theme.palette.text.primary,
     lineHeight: 1.4,
   },
@@ -454,5 +454,11 @@ export const useRCAReportStyles = makeStyles(theme => ({
     fontSize: theme.typography.caption.fontSize,
     color: theme.palette.text.secondary,
     fontStyle: 'italic',
+  },
+  patchBindingName: {
+    fontSize: theme.typography.caption.fontSize,
+    color: theme.palette.primary.main,
+    fontWeight: 500,
+    letterSpacing: '0.3px',
   },
 }));

--- a/plugins/openchoreo-react/src/hooks/useRcaUpdatePermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useRcaUpdatePermission.ts
@@ -1,0 +1,38 @@
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { usePermission } from '@backstage/plugin-permission-react';
+import { openchoreoRcaUpdatePermission } from '@openchoreo/backstage-plugin-common';
+
+/**
+ * Result of the useRcaUpdatePermission hook.
+ */
+export interface UseRcaUpdatePermissionResult {
+  /** Whether the user has permission to update RCA reports (apply/dismiss fixes) */
+  canUpdateRca: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+  /** Tooltip message to show when permission is denied (empty string when allowed/loading) */
+  deniedTooltip: string;
+  /** The permission name identifier */
+  permissionName: string;
+}
+
+export const useRcaUpdatePermission = (): UseRcaUpdatePermissionResult => {
+  const { entity } = useEntity();
+  const { allowed, loading } = usePermission({
+    permission: openchoreoRcaUpdatePermission,
+    resourceRef: stringifyEntityRef(entity),
+  });
+
+  const deniedTooltip =
+    !allowed && !loading
+      ? 'You do not have permission to update RCA reports.'
+      : '';
+
+  return {
+    canUpdateRca: allowed,
+    loading,
+    deniedTooltip,
+    permissionName: openchoreoRcaUpdatePermission.name,
+  };
+};

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -215,6 +215,10 @@ export {
   type UseRcaPermissionResult,
 } from './hooks/useRcaPermission';
 export {
+  useRcaUpdatePermission,
+  type UseRcaUpdatePermissionResult,
+} from './hooks/useRcaUpdatePermission';
+export {
   useTraitsPermission,
   type UseTraitsPermissionResult,
 } from './hooks/useTraitsPermission';


### PR DESCRIPTION
## Summary
- Refactor `RecommendedAction` from `changes` array to singular `change` field to match updated OpenAPI spec
- Replace localStorage-based patch tracking with status-driven `allActionsApplied` check
- Group file patches into card UI with editable key, content, and mount path fields
- Add intermediate object creation in `applyJsonPointer` for robustness
- Update OpenAPI example from `traitOverrides` to `traitEnvironmentConfigs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add "Dismiss" for recommended fixes; reports can now mark actions as applied or dismissed (API supports appliedIndices and dismissedIndices).
  * Expose a new permission to allow updating RCA reports.

* **Improvements**
  * Reorganized patch UI into binding-based sections with improved rendering for files, env vars, and nested fields; file mount path shown.
  * Enhanced action statuses and visuals (idle, applying, success, failed, dismissed); permission-aware controls.

* **Bug Fixes**
  * Strengthened error handling and simplified progress logic for patch operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->