### PR TITLE
feat: replace workflow-scope annotation with workflow-type label and extentions

### DIFF
--- a/packages/app/src/scaffolder/ClusterWorkflowYamlEditor/ClusterWorkflowYamlEditorExtension.tsx
+++ b/packages/app/src/scaffolder/ClusterWorkflowYamlEditor/ClusterWorkflowYamlEditorExtension.tsx
@@ -11,6 +11,7 @@ const DEFAULT_CLUSTER_WORKFLOW_TEMPLATE = {
   metadata: {
     name: '',
     annotations: {} as Record<string, string>,
+    labels: {} as Record<string, string>,
   },
   spec: {
     schema: {
@@ -51,8 +52,7 @@ function generateInitialYaml(formData: Record<string, unknown>): string {
     template.metadata.annotations['openchoreo.dev/description'] = description;
   }
   if (isComponentWorkflow) {
-    template.metadata.annotations['openchoreo.dev/workflow-scope'] =
-      'component';
+    template.metadata.labels['openchoreo.dev/workflow-type'] = 'component';
   }
 
   return YAML.stringify(template, { indent: 2 });
@@ -70,7 +70,7 @@ export const ClusterWorkflowYamlEditorExtension = ({
   const isComponentWorkflow =
     formContext?.formData?.is_component_workflow === true;
 
-  // Generate initial YAML or sync workflow-scope annotation on mount.
+  // Generate initial YAML or sync workflow-type label on mount.
   // This runs each time the step mounts (e.g., navigating back and forth between steps).
   useEffect(() => {
     if (!formContext?.formData) {
@@ -84,26 +84,24 @@ export const ClusterWorkflowYamlEditorExtension = ({
       return;
     }
 
-    // Existing YAML — sync the workflow-scope annotation with the toggle
+    // Existing YAML — sync the workflow-type label with the toggle
     try {
       const parsed = YAML.parse(formData);
       if (!parsed?.metadata) {
         return;
       }
-      if (!parsed.metadata.annotations) {
-        parsed.metadata.annotations = {};
+      if (!parsed.metadata.labels) {
+        parsed.metadata.labels = {};
       }
 
-      const hasAnnotation =
-        parsed.metadata.annotations['openchoreo.dev/workflow-scope'] ===
-        'component';
+      const hasLabel =
+        parsed.metadata.labels['openchoreo.dev/workflow-type'] === 'component';
 
-      if (isComponentWorkflow && !hasAnnotation) {
-        parsed.metadata.annotations['openchoreo.dev/workflow-scope'] =
-          'component';
+      if (isComponentWorkflow && !hasLabel) {
+        parsed.metadata.labels['openchoreo.dev/workflow-type'] = 'component';
         onChange(YAML.stringify(parsed, { indent: 2 }));
-      } else if (!isComponentWorkflow && hasAnnotation) {
-        delete parsed.metadata.annotations['openchoreo.dev/workflow-scope'];
+      } else if (!isComponentWorkflow && hasLabel) {
+        delete parsed.metadata.labels['openchoreo.dev/workflow-type'];
         onChange(YAML.stringify(parsed, { indent: 2 }));
       }
     } catch {

--- a/packages/app/src/scaffolder/ComponentWorkflowYamlEditor/ComponentWorkflowYamlEditorExtension.tsx
+++ b/packages/app/src/scaffolder/ComponentWorkflowYamlEditor/ComponentWorkflowYamlEditorExtension.tsx
@@ -12,6 +12,7 @@ const DEFAULT_WORKFLOW_TEMPLATE = {
     name: '',
     namespace: '',
     annotations: {} as Record<string, string>,
+    labels: {} as Record<string, string>,
   },
   spec: {
     schema: {
@@ -57,8 +58,7 @@ function generateInitialYaml(formData: Record<string, unknown>): string {
     template.metadata.annotations['openchoreo.dev/description'] = description;
   }
   if (isComponentWorkflow) {
-    template.metadata.annotations['openchoreo.dev/workflow-scope'] =
-      'component';
+    template.metadata.labels['openchoreo.dev/workflow-type'] = 'component';
   }
 
   return YAML.stringify(template, { indent: 2 });
@@ -76,7 +76,7 @@ export const ComponentWorkflowYamlEditorExtension = ({
   const isComponentWorkflow =
     formContext?.formData?.is_component_workflow === true;
 
-  // Generate initial YAML or sync workflow-scope annotation on mount.
+  // Generate initial YAML or sync workflow-type label on mount.
   // This runs each time the step mounts (e.g., navigating back and forth between steps).
   useEffect(() => {
     if (!formContext?.formData) {
@@ -89,26 +89,24 @@ export const ComponentWorkflowYamlEditorExtension = ({
       return;
     }
 
-    // Existing YAML — sync the workflow-scope annotation with the toggle
+    // Existing YAML — sync the workflow-type label with the toggle
     try {
       const parsed = YAML.parse(formData);
       if (!parsed?.metadata) {
         return;
       }
-      if (!parsed.metadata.annotations) {
-        parsed.metadata.annotations = {};
+      if (!parsed.metadata.labels) {
+        parsed.metadata.labels = {};
       }
 
-      const hasAnnotation =
-        parsed.metadata.annotations['openchoreo.dev/workflow-scope'] ===
-        'component';
+      const hasLabel =
+        parsed.metadata.labels['openchoreo.dev/workflow-type'] === 'component';
 
-      if (isComponentWorkflow && !hasAnnotation) {
-        parsed.metadata.annotations['openchoreo.dev/workflow-scope'] =
-          'component';
+      if (isComponentWorkflow && !hasLabel) {
+        parsed.metadata.labels['openchoreo.dev/workflow-type'] = 'component';
         onChange(YAML.stringify(parsed, { indent: 2 }));
-      } else if (!isComponentWorkflow && hasAnnotation) {
-        delete parsed.metadata.annotations['openchoreo.dev/workflow-scope'];
+      } else if (!isComponentWorkflow && hasLabel) {
+        delete parsed.metadata.labels['openchoreo.dev/workflow-type'];
         onChange(YAML.stringify(parsed, { indent: 2 }));
       }
     } catch {

--- a/plugins/catalog-backend-module-openchoreo/src/index.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/index.ts
@@ -31,6 +31,7 @@ export {
   translateClusterComponentTypeToEntity,
   translateClusterTraitToEntity,
   translateClusterWorkflowToEntity,
+  extractWorkflowParameters,
   type ComponentEntityTranslationConfig,
   type EntityTranslationConfig,
   type ProjectEntityTranslationConfig,

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -19,7 +19,6 @@ import {
   isReady,
   isCreated,
   type OpenChoreoComponents,
-  getAnnotation,
 } from '@openchoreo/openchoreo-client-node';
 import type {
   NamespaceResponse,
@@ -102,6 +101,7 @@ import {
   translateClusterTraitToEntity as translateClusterTrait,
   translateClusterWorkflowToEntity as translateClusterWF,
   translateWorkflowToEntity as translateWF,
+  extractWorkflowParameters,
 } from '../utils/entityTranslation';
 
 /**
@@ -1741,15 +1741,14 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     cwf: NewClusterWorkflow,
   ): ClusterWorkflowEntityV1alpha1 {
     const isCI =
-      cwf.metadata?.annotations?.['openchoreo.dev/workflow-scope'] ===
-      'component';
+      cwf.metadata?.labels?.['openchoreo.dev/workflow-type'] === 'component';
     return translateClusterWF(
       {
         name: getName(cwf)!,
         displayName: getDisplayName(cwf),
         description: getDescription(cwf),
         createdAt: getCreatedAt(cwf),
-        parameters: getAnnotation(cwf, CHOREO_ANNOTATIONS.WORKFLOW_PARAMETERS),
+        parameters: extractWorkflowParameters((cwf as any).spec),
         type: isCI ? 'CI' : 'Generic',
         deletionTimestamp: getDeletionTimestamp(cwf),
       },
@@ -1989,15 +1988,14 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     namespaceName: string,
   ): WorkflowEntityV1alpha1 {
     const isCI =
-      wf.metadata?.annotations?.['openchoreo.dev/workflow-scope'] ===
-      'component';
+      wf.metadata?.labels?.['openchoreo.dev/workflow-type'] === 'component';
     return translateWF(
       {
         name: getName(wf)!,
         displayName: getDisplayName(wf),
         description: getDescription(wf),
         createdAt: getCreatedAt(wf),
-        parameters: getAnnotation(wf, CHOREO_ANNOTATIONS.WORKFLOW_PARAMETERS),
+        parameters: extractWorkflowParameters((wf as any).spec),
         type: isCI ? 'CI' : 'Generic',
         deletionTimestamp: getDeletionTimestamp(wf),
       },

--- a/plugins/catalog-backend-module-openchoreo/src/utils/entityTranslation.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/utils/entityTranslation.ts
@@ -21,6 +21,55 @@ type ModelsComponent = ComponentResponse;
 type AllowedTraitRef = { kind?: string; name: string };
 type AllowedWorkflowRef = { kind?: string; name: string };
 
+const COMPONENT_REPOSITORY_EXTENSIONS: Record<string, string> = {
+  'x-openchoreo-component-parameter-repository-url': 'repoUrl',
+  'x-openchoreo-component-parameter-repository-branch': 'branch',
+  'x-openchoreo-component-parameter-repository-commit': 'commit',
+  'x-openchoreo-component-parameter-repository-app-path': 'appPath',
+  'x-openchoreo-component-parameter-repository-secret-ref': 'secretRef',
+};
+
+function walkSchemaForExtensions(
+  properties: Record<string, any>,
+  prefix: string,
+  mapping: Record<string, string>,
+): void {
+  for (const [propName, propSchema] of Object.entries(properties)) {
+    if (!propSchema || typeof propSchema !== 'object') continue;
+    const currentPath = `${prefix}.${propName}`;
+    for (const [ext, key] of Object.entries(COMPONENT_REPOSITORY_EXTENSIONS)) {
+      if (propSchema[ext] === true) {
+        mapping[key] = currentPath;
+      }
+    }
+    if (propSchema.properties) {
+      walkSchemaForExtensions(propSchema.properties, currentPath, mapping);
+    }
+  }
+}
+
+/**
+ * Extracts workflow parameter path mappings from a workflow spec's schema extensions.
+ * The new API uses x-openchoreo-component-parameter-repository-* extensions on schema
+ * properties instead of the openchoreo.dev/component-workflow-parameters annotation.
+ *
+ * Returns the annotation-compatible string format (e.g., "repoUrl: parameters.repository.url")
+ * so existing consumers continue to work without changes.
+ */
+export function extractWorkflowParameters(spec: any): string | undefined {
+  const schemaSection = spec?.parameters || spec?.schema?.parameters;
+  const schema = schemaSection?.openAPIV3Schema || schemaSection?.ocSchema;
+  if (!schema?.properties) return undefined;
+
+  const mapping: Record<string, string> = {};
+  walkSchemaForExtensions(schema.properties, 'parameters', mapping);
+
+  if (Object.keys(mapping).length === 0) return undefined;
+  return Object.entries(mapping)
+    .map(([key, path]) => `${key}: ${path}`)
+    .join('\n');
+}
+
 const normalizeAllowedTraits = (
   traits: Array<string | AllowedTraitRef> | undefined,
   defaultKind: 'Trait' | 'ClusterTrait',

--- a/plugins/openchoreo-common/src/constants.ts
+++ b/plugins/openchoreo-common/src/constants.ts
@@ -50,6 +50,7 @@ export const CHOREO_LABELS = {
   MANAGED: 'openchoreo.io/managed',
   WORKFLOW_PROJECT: 'openchoreo.dev/project',
   WORKFLOW_COMPONENT: 'openchoreo.dev/component',
+  WORKFLOW_TYPE: 'openchoreo.dev/workflow-type',
 } as const;
 
 /**

--- a/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
+++ b/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
@@ -130,8 +130,7 @@ export class GenericWorkflowService {
       const items: Workflow[] = ((data as any)?.items || []).map((wf: any) => {
         const name: string = wf.metadata?.name ?? '';
         const isCI =
-          wf.metadata?.annotations?.['openchoreo.dev/workflow-scope'] ===
-          'component';
+          wf.metadata?.labels?.[CHOREO_LABELS.WORKFLOW_TYPE] === 'component';
         return {
           name,
           displayName:

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/clusterWorkflow.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/clusterWorkflow.ts
@@ -9,6 +9,7 @@ import YAML from 'yaml';
 import {
   type ImmediateCatalogService,
   translateClusterWorkflowToEntity,
+  extractWorkflowParameters,
 } from '@openchoreo/backstage-plugin-catalog-backend-module';
 
 export const createClusterWorkflowDefinitionAction = (
@@ -137,9 +138,9 @@ export const createClusterWorkflowDefinitionAction = (
             string,
             string
           >;
+          const labels = (yamlMetadata?.labels || {}) as Record<string, string>;
 
-          const isCI =
-            annotations['openchoreo.dev/workflow-scope'] === 'component';
+          const isCI = labels['openchoreo.dev/workflow-type'] === 'component';
 
           const entity = translateClusterWorkflowToEntity(
             {
@@ -147,8 +148,7 @@ export const createClusterWorkflowDefinitionAction = (
               displayName: annotations['openchoreo.dev/display-name'],
               description: annotations['openchoreo.dev/description'],
               createdAt: new Date().toISOString(),
-              parameters:
-                annotations['openchoreo.dev/component-workflow-parameters'],
+              parameters: extractWorkflowParameters(resourceObj.spec),
               type: isCI ? 'CI' : 'Generic',
             },
             {


### PR DESCRIPTION
## Purpose
- Fix https://github.com/openchoreo/openchoreo/issues/2462
- Aligns Backstage plugins with [openchoreo/openchoreo#2616](https://github.com/openchoreo/openchoreo/pull/2616), which replaces annotation-based component
  workflow classification with K8s-native labels and schema extensions.

### What changed in the OpenChoreo API

- `openchoreo.dev/workflow-scope: "component"` annotation → `openchoreo.dev/workflow-type: "component"` **label**
- `openchoreo.dev/component-workflow-parameters` annotation (YAML key-value paths) → `x-openchoreo-component-parameter-repository-*: true` extensions on `spec.schema.parameters` properties

### Changes in this PR

- **`constants.ts`**: Added `WORKFLOW_TYPE` to `CHOREO_LABELS`
- **`entityTranslation.ts`**: Added `extractWorkflowParameters(spec)` — recursively scans `spec.parameters.openAPIV3Schema`/`ocSchema` for `x-openchoreo-component-parameter-repository-*` extensions and rebuilds the legacy annotation-format mapping string, keeping existing consumers (`GitSourceField`, `BuildWorkflowParameters`, `Workflows.tsx`) working without changes
- **`OpenChoreoEntityProvider.ts`**: `isCI` detection uses `metadata.labels` instead of `metadata.annotations`; `parameters` field uses `extractWorkflowParameters(spec)` instead of reading the removed annotation
- **`GenericWorkflowService.ts`**: `isCI` detection uses label
- **`clusterWorkflow.ts`** (scaffolder): `isCI` uses label; `parameters` extracted from `spec.schema` extensions
- **`ClusterWorkflowYamlEditorExtension.tsx`** / **`ComponentWorkflowYamlEditorExtension.tsx`**: YAML template generation and toggle-sync now write/read `metadata.labels['openchoreo.dev/workflow-type']` instead of the removed annotation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched workflow classification from annotations to a dedicated workflow-type label for consistent behavior across UI and backend.
  * Editors now read/write the workflow-type label and ensure metadata.labels exist when toggling component mode.
* **New Features**
  * Workflow parameters are now extracted from workflow specifications (schema extensions) instead of legacy annotations.
  * Added a stable constant for the workflow-type label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->