### PR TITLE
refactor!: rename secretRef to secretKeyRef across plugins

### DIFF
--- a/packages/app/src/scaffolder/WorkloadDetailsField/WorkloadDetailsField.tsx
+++ b/packages/app/src/scaffolder/WorkloadDetailsField/WorkloadDetailsField.tsx
@@ -80,7 +80,7 @@ configurations:
     # Reference a secret
     - key: DB_PASSWORD
       valueFrom:
-        secretRef:
+        secretKeyRef:
           name: db-credentials
           key: password
 
@@ -707,7 +707,7 @@ export const WorkloadDetailsField = ({
         return {
           ...ev,
           value: undefined,
-          valueFrom: { secretRef: { name: '', key: '' } },
+          valueFrom: { secretKeyRef: { name: '', key: '' } },
         };
       });
       setEnvVars(newEnvVars);
@@ -812,7 +812,7 @@ export const WorkloadDetailsField = ({
         return {
           ...fm,
           value: undefined,
-          valueFrom: { secretRef: { name: '', key: '' } },
+          valueFrom: { secretKeyRef: { name: '', key: '' } },
         };
       });
       setFileMounts(newFileMounts);
@@ -1473,7 +1473,7 @@ export const workloadDetailsFieldValidation = (
   // Validate env var keys are non-empty when values exist
   if (value.envVars) {
     value.envVars.forEach((ev, index) => {
-      const hasValue = ev.value || ev.valueFrom?.secretRef?.name;
+      const hasValue = ev.value || ev.valueFrom?.secretKeyRef?.name;
       if (hasValue && !ev.key) {
         validation.addError(
           `Environment Variable #${
@@ -1487,7 +1487,7 @@ export const workloadDetailsFieldValidation = (
   // Validate file mount keys and mount paths
   if (value.fileMounts) {
     value.fileMounts.forEach((fm, index) => {
-      const hasValue = fm.value || fm.valueFrom?.secretRef?.name;
+      const hasValue = fm.value || fm.valueFrom?.secretKeyRef?.name;
       if ((hasValue || fm.mountPath) && !fm.key) {
         validation.addError(`File Mount #${index + 1}: Filename is required`);
       }

--- a/packages/openchoreo-client-node/openapi/openchoreo-api-legacy.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api-legacy.yaml
@@ -1321,7 +1321,7 @@ components:
     EnvVarValueFrom:
       type: object
       properties:
-        secretRef:
+        secretKeyRef:
           $ref: '#/components/schemas/SecretKeyRef'
 
     SecretKeyRef:

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -6033,7 +6033,7 @@ components:
       type: object
       description: Reference to a secret or inline value
       properties:
-        secretRef:
+        secretKeyRef:
           $ref: '#/components/schemas/SecretKeyReference'
         value:
           type: string
@@ -7978,7 +7978,7 @@ components:
       type: object
       description: Value source reference
       properties:
-        secretRef:
+        secretKeyRef:
           type: object
           description: Secret reference
           properties:

--- a/packages/openchoreo-client-node/src/generated/openchoreo-legacy/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo-legacy/types.ts
@@ -1910,7 +1910,7 @@ export interface components {
       valueFrom?: components['schemas']['EnvVarValueFrom'];
     };
     EnvVarValueFrom: {
-      secretRef?: components['schemas']['SecretKeyRef'];
+      secretKeyRef?: components['schemas']['SecretKeyRef'];
     };
     SecretKeyRef: {
       name: string;

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -2725,7 +2725,7 @@ export interface components {
     };
     /** @description Reference to a secret or inline value */
     ValueFrom: {
-      secretRef?: components['schemas']['SecretKeyReference'];
+      secretKeyRef?: components['schemas']['SecretKeyReference'];
       /** @description Inline value (optional fallback) */
       value?: string;
     };
@@ -4006,7 +4006,7 @@ export interface components {
     /** @description Value source reference */
     EnvVarValueFrom: {
       /** @description Secret reference */
-      secretRef?: {
+      secretKeyRef?: {
         /** @description Secret name */
         name?: string;
         /** @description Secret key */

--- a/plugins/openchoreo-common/src/types/bff-types.ts
+++ b/plugins/openchoreo-common/src/types/bff-types.ts
@@ -704,7 +704,7 @@ export interface FileVar {
 }
 
 export interface EnvVarValueFrom {
-  secretRef?: SecretKeyRef;
+  secretKeyRef?: SecretKeyRef;
 }
 
 export interface SecretKeyRef {

--- a/plugins/openchoreo-react/src/components/EnvVarEditor/EnvVarEditor.tsx
+++ b/plugins/openchoreo-react/src/components/EnvVarEditor/EnvVarEditor.tsx
@@ -166,20 +166,20 @@ export const EnvVarEditor: FC<EnvVarEditorProps> = ({
       onChange('valueFrom', undefined);
     } else {
       onChange('value', undefined);
-      onChange('valueFrom', { secretRef: { name: '', key: '' } });
+      onChange('valueFrom', { secretKeyRef: { name: '', key: '' } });
     }
   };
 
   const handleSecretNameChange = (name: string) => {
-    onChange('valueFrom', { secretRef: { name, key: '' } });
+    onChange('valueFrom', { secretKeyRef: { name, key: '' } });
     if (name && envVar.value) {
       onChange('value', undefined);
     }
   };
 
   const handleSecretKeyChange = (key: string) => {
-    const currentName = envVar.valueFrom?.secretRef?.name || '';
-    onChange('valueFrom', { secretRef: { name: currentName, key } });
+    const currentName = envVar.valueFrom?.secretKeyRef?.name || '';
+    onChange('valueFrom', { secretKeyRef: { name: currentName, key } });
     if (key && envVar.value) {
       onChange('value', undefined);
     }
@@ -194,8 +194,8 @@ export const EnvVarEditor: FC<EnvVarEditorProps> = ({
 
   // Format value for display (both current and base)
   const formatDisplayValue = (ev: EnvVar, m: 'plain' | 'secret') => {
-    if (m === 'secret' && ev.valueFrom?.secretRef) {
-      const { name, key } = ev.valueFrom.secretRef;
+    if (m === 'secret' && ev.valueFrom?.secretKeyRef) {
+      const { name, key } = ev.valueFrom.secretKeyRef;
       return `Secret: ${name}/${key}`;
     }
     // Mask sensitive values
@@ -213,7 +213,7 @@ export const EnvVarEditor: FC<EnvVarEditorProps> = ({
   const getDisplayValue = () => formatDisplayValue(envVar, mode);
 
   // Determine base value mode
-  const baseValueMode: 'plain' | 'secret' = baseValue?.valueFrom?.secretRef
+  const baseValueMode: 'plain' | 'secret' = baseValue?.valueFrom?.secretKeyRef
     ? 'secret'
     : 'plain';
 
@@ -317,8 +317,8 @@ export const EnvVarEditor: FC<EnvVarEditorProps> = ({
       </Grid>
       <Grid item xs={8}>
         <SecretSelector
-          secretName={envVar.valueFrom?.secretRef?.name || ''}
-          secretKey={envVar.valueFrom?.secretRef?.key || ''}
+          secretName={envVar.valueFrom?.secretKeyRef?.name || ''}
+          secretKey={envVar.valueFrom?.secretKeyRef?.key || ''}
           secrets={secrets}
           onSecretNameChange={handleSecretNameChange}
           onSecretKeyChange={handleSecretKeyChange}

--- a/plugins/openchoreo-react/src/components/FileVarEditor/FileVarEditor.tsx
+++ b/plugins/openchoreo-react/src/components/FileVarEditor/FileVarEditor.tsx
@@ -284,20 +284,20 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
       onChange('valueFrom', undefined);
     } else {
       onChange('value', undefined);
-      onChange('valueFrom', { secretRef: { name: '', key: '' } });
+      onChange('valueFrom', { secretKeyRef: { name: '', key: '' } });
     }
   };
 
   const handleSecretNameChange = (name: string) => {
-    onChange('valueFrom', { secretRef: { name, key: '' } });
+    onChange('valueFrom', { secretKeyRef: { name, key: '' } });
     if (name && fileVar.value) {
       onChange('value', undefined);
     }
   };
 
   const handleSecretKeyChange = (key: string) => {
-    const currentName = fileVar.valueFrom?.secretRef?.name || '';
-    onChange('valueFrom', { secretRef: { name: currentName, key } });
+    const currentName = fileVar.valueFrom?.secretKeyRef?.name || '';
+    onChange('valueFrom', { secretKeyRef: { name: currentName, key } });
     if (key && fileVar.value) {
       onChange('value', undefined);
     }
@@ -341,8 +341,8 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
 
   // Format base value for display
   const formatBaseValue = (fv: FileVar): string => {
-    if (fv.valueFrom?.secretRef) {
-      const { name, key } = fv.valueFrom.secretRef;
+    if (fv.valueFrom?.secretKeyRef) {
+      const { name, key } = fv.valueFrom.secretKeyRef;
       return `Secret: ${name}/${key}`;
     }
     if (fv.value && fv.value.length > 0) {
@@ -377,10 +377,10 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
                   → {fileVar.mountPath || '(no path)'}
                 </Typography>
               </Box>
-              {isSecret && fileVar.valueFrom?.secretRef && (
+              {isSecret && fileVar.valueFrom?.secretKeyRef && (
                 <Typography className={classes.secretRef}>
-                  Secret: {fileVar.valueFrom.secretRef.name}/
-                  {fileVar.valueFrom.secretRef.key}
+                  Secret: {fileVar.valueFrom.secretKeyRef.name}/
+                  {fileVar.valueFrom.secretKeyRef.key}
                 </Typography>
               )}
             </Box>
@@ -544,8 +544,8 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
         <Box className={classes.editContent}>
           {isSecret ? (
             <SecretSelector
-              secretName={fileVar.valueFrom?.secretRef?.name || ''}
-              secretKey={fileVar.valueFrom?.secretRef?.key || ''}
+              secretName={fileVar.valueFrom?.secretKeyRef?.name || ''}
+              secretKey={fileVar.valueFrom?.secretKeyRef?.key || ''}
               secrets={secrets}
               onSecretNameChange={handleSecretNameChange}
               onSecretKeyChange={handleSecretKeyChange}

--- a/plugins/openchoreo-react/src/components/OverrideEnvVarList/OverrideEnvVarList.tsx
+++ b/plugins/openchoreo-react/src/components/OverrideEnvVarList/OverrideEnvVarList.tsx
@@ -130,7 +130,7 @@ export const OverrideEnvVarList: FC<OverrideEnvVarListProps> = ({
         editBuffer.setBuffer({
           ...editBuffer.editBuffer,
           value: undefined,
-          valueFrom: { secretRef: { name: '', key: '' } },
+          valueFrom: { secretKeyRef: { name: '', key: '' } },
         });
       }
     } else {
@@ -196,7 +196,7 @@ export const OverrideEnvVarList: FC<OverrideEnvVarListProps> = ({
 
   // Render an inherited (read-only) env var row using EnvVarEditor
   const renderInheritedRow = (item: EnvVarWithStatus) => {
-    const baseMode = item.envVar.valueFrom?.secretRef ? 'secret' : 'plain';
+    const baseMode = item.envVar.valueFrom?.secretKeyRef ? 'secret' : 'plain';
     return (
       <Box
         key={`inherited-${item.envVar.key}`}

--- a/plugins/openchoreo-react/src/components/OverrideFileVarList/OverrideFileVarList.tsx
+++ b/plugins/openchoreo-react/src/components/OverrideFileVarList/OverrideFileVarList.tsx
@@ -133,7 +133,7 @@ export const OverrideFileVarList: FC<OverrideFileVarListProps> = ({
         editBuffer.setBuffer({
           ...editBuffer.editBuffer,
           value: undefined,
-          valueFrom: { secretRef: { name: '', key: '' } },
+          valueFrom: { secretKeyRef: { name: '', key: '' } },
         });
       }
     } else {
@@ -200,7 +200,7 @@ export const OverrideFileVarList: FC<OverrideFileVarListProps> = ({
 
   // Render an inherited (read-only) file var row using FileVarEditor
   const renderInheritedRow = (item: FileVarWithStatus, index: number) => {
-    const baseMode = item.fileVar.valueFrom?.secretRef ? 'secret' : 'plain';
+    const baseMode = item.fileVar.valueFrom?.secretKeyRef ? 'secret' : 'plain';
     return (
       <Box
         key={`inherited-${item.fileVar.key}`}

--- a/plugins/openchoreo-react/src/components/StandardEnvVarList/StandardEnvVarList.tsx
+++ b/plugins/openchoreo-react/src/components/StandardEnvVarList/StandardEnvVarList.tsx
@@ -100,7 +100,7 @@ export const StandardEnvVarList: FC<StandardEnvVarListProps> = ({
         editBuffer.setBuffer({
           ...editBuffer.editBuffer,
           value: undefined,
-          valueFrom: { secretRef: { name: '', key: '' } },
+          valueFrom: { secretKeyRef: { name: '', key: '' } },
         });
       }
     } else {

--- a/plugins/openchoreo-react/src/components/StandardFileVarList/StandardFileVarList.tsx
+++ b/plugins/openchoreo-react/src/components/StandardFileVarList/StandardFileVarList.tsx
@@ -100,7 +100,7 @@ export const StandardFileVarList: FC<StandardFileVarListProps> = ({
         editBuffer.setBuffer({
           ...editBuffer.editBuffer,
           value: undefined,
-          valueFrom: { secretRef: { name: '', key: '' } },
+          valueFrom: { secretKeyRef: { name: '', key: '' } },
         });
       }
     } else {

--- a/plugins/openchoreo-react/src/hooks/useEnvVarEditBuffer.ts
+++ b/plugins/openchoreo-react/src/hooks/useEnvVarEditBuffer.ts
@@ -62,7 +62,7 @@ export interface UseEnvVarEditBufferResult {
  */
 function isEnvVarEmpty(envVar: EnvVar | undefined | null): boolean {
   if (!envVar) return true;
-  return !envVar.key && !envVar.value && !envVar.valueFrom?.secretRef?.name;
+  return !envVar.key && !envVar.value && !envVar.valueFrom?.secretKeyRef?.name;
 }
 
 /**

--- a/plugins/openchoreo-react/src/hooks/useFileVarEditBuffer.ts
+++ b/plugins/openchoreo-react/src/hooks/useFileVarEditBuffer.ts
@@ -66,7 +66,7 @@ function isFileVarEmpty(fileVar: FileVar | undefined | null): boolean {
     !fileVar.key &&
     !fileVar.mountPath &&
     !fileVar.value &&
-    !fileVar.valueFrom?.secretRef?.name
+    !fileVar.valueFrom?.secretKeyRef?.name
   );
 }
 

--- a/plugins/openchoreo-react/src/hooks/useModeState.ts
+++ b/plugins/openchoreo-react/src/hooks/useModeState.ts
@@ -26,7 +26,7 @@ export interface UseModeStateOptions {
  *
  * This hook tracks which items are in 'plain' or 'secret' mode using a key-based state map.
  * It handles:
- * - Getting mode from existing data (if it has valueFrom.secretRef, it's secret mode)
+ * - Getting mode from existing data (if it has valueFrom.secretKeyRef, it's secret mode)
  * - Setting mode for UI state
  * - Cleaning up state when items are removed
  * - Shifting indices when items are removed from the middle
@@ -63,12 +63,12 @@ export function useModeState(options: UseModeStateOptions): UseModeStateResult {
         if (container) {
           if (type === 'env') {
             const envVar = container.env?.[index];
-            if (envVar?.valueFrom?.secretRef) {
+            if (envVar?.valueFrom?.secretKeyRef) {
               return 'secret';
             }
           } else if (type === 'file') {
             const fileVar = (container as any).files?.[index];
-            if (fileVar?.valueFrom?.secretRef) {
+            if (fileVar?.valueFrom?.secretKeyRef) {
               return 'secret';
             }
           }

--- a/plugins/openchoreo-react/src/utils/envVarUtils.ts
+++ b/plugins/openchoreo-react/src/utils/envVarUtils.ts
@@ -99,8 +99,8 @@ export function getBaseEnvVarsForContainer(
  * @returns Display string for the value
  */
 export function formatEnvVarValue(envVar: EnvVar): string {
-  if (envVar.valueFrom?.secretRef) {
-    const { name, key } = envVar.valueFrom.secretRef;
+  if (envVar.valueFrom?.secretKeyRef) {
+    const { name, key } = envVar.valueFrom.secretKeyRef;
     return `Secret: ${name}/${key}`;
   }
   if (envVar.value !== undefined) {

--- a/plugins/openchoreo-react/src/utils/fileVarUtils.ts
+++ b/plugins/openchoreo-react/src/utils/fileVarUtils.ts
@@ -101,8 +101,8 @@ export function getBaseFileVarsForContainer(
  * @returns Display string for the value
  */
 export function formatFileVarValue(fileVar: FileVar): string {
-  if (fileVar.valueFrom?.secretRef) {
-    const { name, key } = fileVar.valueFrom.secretRef;
+  if (fileVar.valueFrom?.secretKeyRef) {
+    const { name, key } = fileVar.valueFrom.secretKeyRef;
     return `Secret: ${name}/${key}`;
   }
   if (fileVar.value !== undefined && fileVar.value.length > 0) {

--- a/plugins/openchoreo/src/components/Environments/Workload/WorkloadEditor/ContainerContent.tsx
+++ b/plugins/openchoreo/src/components/Environments/Workload/WorkloadEditor/ContainerContent.tsx
@@ -176,7 +176,7 @@ export function ContainerContent({
       } else {
         onEnvVarChange(index, 'value', undefined as any);
         onEnvVarChange(index, 'valueFrom', {
-          secretRef: { name: '', key: '' },
+          secretKeyRef: { name: '', key: '' },
         } as any);
       }
     }
@@ -196,7 +196,7 @@ export function ContainerContent({
       } else {
         onFileVarChange(index, 'value', undefined as any);
         onFileVarChange(index, 'valueFrom', {
-          secretRef: { name: '', key: '' },
+          secretKeyRef: { name: '', key: '' },
         } as any);
       }
     }

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.ts
@@ -217,13 +217,13 @@ export interface WorkloadResourceInput {
   envVars?: Array<{
     key: string;
     value?: string;
-    valueFrom?: { secretRef?: { name: string; key: string } };
+    valueFrom?: { secretKeyRef?: { name: string; key: string } };
   }>;
   fileMounts?: Array<{
     key: string;
     mountPath: string;
     value?: string;
-    valueFrom?: { secretRef?: { name: string; key: string } };
+    valueFrom?: { secretKeyRef?: { name: string; key: string } };
   }>;
 }
 


### PR DESCRIPTION
## Summary

fixes - https://github.com/openchoreo/openchoreo/issues/2647

- Renames `secretRef` to `secretKeyRef` across OpenAPI specs, generated types, common types, React components, hooks, utils, and scaffolder to align with the CRD field rename in choreov3 (openchoreo/choreov3#2642)

## Test plan
- [x] TypeScript compilation passes (`yarn tsc --noEmit`)
- [ ] Verify env var and file mount secret reference flows work in the UI
- [ ] Verify scaffolder workload details field works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified secret reference naming across environment and file variable editors, validation, YAML examples, and API schemas — the UI and examples now use the updated "secret key" reference format for selecting and displaying secrets; behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->