### PR TITLE
feat: reorder API page cards and remove duplicate namespace filter

### DIFF
--- a/packages/app/src/components/catalog/CustomApiExplorerPage.tsx
+++ b/packages/app/src/components/catalog/CustomApiExplorerPage.tsx
@@ -10,7 +10,6 @@ import {
   EntityKindPicker,
   EntityListProvider,
   EntityLifecyclePicker,
-  EntityNamespacePicker,
   EntityProcessingStatusPicker,
   EntityTagPicker,
 } from '@backstage/plugin-catalog-react';
@@ -48,9 +47,6 @@ export const CustomApiExplorerPage = () => {
             {/* Filters at the top (desktop) */}
             <Box className={classes.filterSection}>
               <Grid container spacing={2} alignItems="center">
-                <Grid item sm={12} md={4} lg={3}>
-                  <EntityNamespacePicker />
-                </Grid>
                 <Grid item className={classes.advancedFiltersGridItem}>
                   <button
                     className={classes.advancedFiltersToggle}
@@ -100,9 +96,6 @@ export const CustomApiExplorerPage = () => {
             >
               <Box className={classes.filterDrawerContent}>
                 <Box className={classes.filterGrid}>
-                  <Box className={classes.filterItem}>
-                    <EntityNamespacePicker />
-                  </Box>
                   <Box className={classes.filterItem}>
                     <StarredFilter />
                   </Box>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -484,6 +484,14 @@ const apiPage = (
     <EntityLayout.Route path="/" title="Overview">
       <Grid container spacing={3}>
         {entityWarningContent}
+        <Grid container item md={12}>
+          <Grid item md={6}>
+            <EntityProvidingComponentsCard />
+          </Grid>
+          <Grid item md={6}>
+            <EntityConsumingComponentsCard />
+          </Grid>
+        </Grid>
         <Grid item md={6}>
           <EntityAboutCard />
         </Grid>
@@ -493,17 +501,6 @@ const apiPage = (
             height={400}
             renderNode={CustomGraphNode}
           />
-        </Grid>
-        <Grid item md={4} xs={12}>
-          <EntityLinksCard />
-        </Grid>
-        <Grid container item md={12}>
-          <Grid item md={6}>
-            <EntityProvidingComponentsCard />
-          </Grid>
-          <Grid item md={6}>
-            <EntityConsumingComponentsCard />
-          </Grid>
         </Grid>
       </Grid>
     </EntityLayout.Route>


### PR DESCRIPTION
  Move Providers/Consumers cards to top and About/Relations to bottom on
  API entity page, remove unused Links card. Remove duplicate
  EntityNamespacePicker from API listing page (already in table header).


Before: 
<img width="1728" height="869" alt="Screenshot 2026-03-13 at 03 32 49" src="https://github.com/user-attachments/assets/0ed30ac5-40e7-4c88-94b8-59adaae249bc" />
<img width="1728" height="869" alt="Screenshot 2026-03-13 at 03 32 58" src="https://github.com/user-attachments/assets/ffffa4e3-be95-43d6-aea4-5131a777aa1d" />

After:
<img width="1728" height="869" alt="Screenshot 2026-03-13 at 03 33 51" src="https://github.com/user-attachments/assets/c7592e25-a329-4b63-a00a-839b29cf9950" />
<img width="1728" height="869" alt="Screenshot 2026-03-13 at 03 34 01" src="https://github.com/user-attachments/assets/fc288c8f-dd26-4a88-be9d-94c7913aa41f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed** namespace filtering option from API explorer and mobile filter interface
* **Reorganized** API page layout to display component provisioning and consumption information more prominently in the main overview section, improving visibility of component relationships

<!-- end of auto-generated comment: release notes by coderabbit.ai -->