### PR TITLE
feat: make catalog listing external icon open in new tab

### DIFF
--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -4,6 +4,7 @@ import {
   Chip,
   CircularProgress,
   IconButton,
+  Tooltip,
   Typography,
 } from '@material-ui/core';
 import { TablePagination } from '@material-ui/core';
@@ -420,11 +421,20 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
                 >
                   <FavoriteEntity entity={entity} />
                   {!markedForDeletion && (
-                    <EntityRefLink entityRef={entity} defaultKind={entity.kind}>
-                      <IconButton size="small">
+                    <Tooltip title="Open in new tab">
+                      <IconButton
+                        component="a"
+                        href={entityRoute({
+                          kind: entity.kind.toLocaleLowerCase('en-US'),
+                          namespace: entity.metadata.namespace || 'default',
+                          name: entity.metadata.name,
+                        })}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
                         <OpenInNewIcon fontSize="small" />
                       </IconButton>
-                    </EntityRefLink>
+                    </Tooltip>
                   )}
                 </Box>
               </Box>


### PR DESCRIPTION
  Add tooltip and change the OpenInNew icon button to open the entity
  page in a new browser tab instead of same-tab navigation, which is
  now redundant since the entire row is clickable.


https://github.com/user-attachments/assets/1b26e515-c026-403b-972e-a10ab7a52554



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* Added a tooltip to the "Open in New Tab" action button in the catalog interface to provide additional guidance to users about the functionality
* Enhanced the navigation experience when opening catalog entities by implementing direct anchor links with proper security attributes for new tab operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->