### PR TITLE
fix: extract workflow parameters and type

### DIFF
--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/componentWorkflow.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/componentWorkflow.ts
@@ -9,6 +9,7 @@ import YAML from 'yaml';
 import {
   type ImmediateCatalogService,
   translateWorkflowToEntity,
+  extractWorkflowParameters,
 } from '@openchoreo/backstage-plugin-catalog-backend-module';
 
 export const createComponentWorkflowDefinitionAction = (
@@ -153,6 +154,9 @@ export const createComponentWorkflowDefinitionAction = (
             string,
             string
           >;
+          const labels = (yamlMetadata?.labels || {}) as Record<string, string>;
+
+          const isCI = labels['openchoreo.dev/workflow-type'] === 'component';
 
           const entity = translateWorkflowToEntity(
             {
@@ -160,6 +164,8 @@ export const createComponentWorkflowDefinitionAction = (
               displayName: annotations['openchoreo.dev/display-name'],
               description: annotations['openchoreo.dev/description'],
               createdAt: new Date().toISOString(),
+              parameters: extractWorkflowParameters(resourceObj.spec),
+              type: isCI ? 'CI' : 'Generic',
             },
             namespaceName,
             {


### PR DESCRIPTION
 ## Summary
- Imports `extractWorkflowParameters` in `componentWorkflow.ts` to match `clusterWorkflow.ts`
- Extracts `labels` from YAML metadata and derives `type` from `openchoreo.dev/workflow-type` label
- Passes `parameters: extractWorkflowParameters(resourceObj.spec)` and `type` to `translateWorkflowToEntity` during the immediate catalog insert

## Purpose
PR #2616 moved workflow parameter metadata from a raw OpenChoreo annotation (`openchoreo.dev/component-workflow-parameters`) to schema extensions (`x-openchoreo-component-parameter-repository-*`). The extraction logic `extractWorkflowParameters` was already applied in:
- `OpenChoreoEntityProvider.ts` (scheduled sync path)
- `clusterWorkflow.ts` (immediate insert for ClusterWorkflow)

But `componentWorkflow.ts` (immediate insert for namespace-scoped Workflow) was missed, so those entities landed in the catalog without the `WORKFLOW_PARAMETERS` annotation or correct `type` until the next sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows now support enhanced parameter extraction and configuration from specifications, enabling more detailed and flexible workflow definitions.
  * Implemented automatic workflow type classification based on configuration metadata, allowing workflows to be identified as CI (Continuous Integration) or Generic for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->