### PR TITLE
fix: trigger in app navigation for links in CompactEntityHeader component

### DIFF
--- a/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
+++ b/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
@@ -665,8 +665,25 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
             let nameNode: ReactNode;
 
             if (node.path) {
+              const namePath = node.path;
               nameNode = (
-                <a href={node.path} className={classes.breadcrumbNameLink}>
+                <a
+                  href={namePath}
+                  className={classes.breadcrumbNameLink}
+                  onClick={event => {
+                    // Allow new tab behaviors (middle-click, ctrl/meta+click)
+                    if (
+                      event.button !== 0 ||
+                      event.metaKey ||
+                      event.ctrlKey ||
+                      event.shiftKey
+                    ) {
+                      return;
+                    }
+                    event.preventDefault();
+                    navigate(namePath);
+                  }}
+                >
                   {node.value}
                 </a>
               );
@@ -690,6 +707,18 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
                 <a
                   href={kindCatalogPath}
                   className={classes.breadcrumbKindLink}
+                  onClick={event => {
+                    if (
+                      event.button !== 0 ||
+                      event.metaKey ||
+                      event.ctrlKey ||
+                      event.shiftKey
+                    ) {
+                      return;
+                    }
+                    event.preventDefault();
+                    navigate(kindCatalogPath);
+                  }}
                 >
                   {levelLabel}
                 </a>


### PR DESCRIPTION
## Purpose

This PR fixes navigation of link from Entity Header. 
Previously links in the Header component triggered full page reloads. This PR fixes this


https://github.com/user-attachments/assets/fe5471de-70fa-48f3-94fc-51483ae9e8f3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Breadcrumb links now use in-app navigation for standard left-clicks, providing seamless navigation within the application while preserving the ability to open links in new tabs using middle-click or modifier keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->