### PR TITLE
fix(platform-overview): restore cluster-scoped kinds when cluster scope is toggled back on

### DIFF
--- a/packages/app/src/components/platformOverview/PlatformOverviewPage.tsx
+++ b/packages/app/src/components/platformOverview/PlatformOverviewPage.tsx
@@ -186,6 +186,7 @@ export function PlatformOverviewPage() {
     const scopeChanged = currentScope !== prevScopeRef.current;
     const systemDeselected = prevSystemKindRef.current && !systemKindSelected;
     const clusterTurnedOff = prevClusterRef.current && !clusterSelected;
+    const clusterTurnedOn = !prevClusterRef.current && clusterSelected;
     prevScopeRef.current = currentScope;
     prevSystemKindRef.current = systemKindSelected;
     prevClusterRef.current = clusterSelected;
@@ -201,6 +202,18 @@ export function PlatformOverviewPage() {
       );
       if (cleaned.length > 0 && cleaned.length < selectedKinds.length) {
         setParams({ kinds: cleaned.join(',') }, { replace: true });
+      }
+    }
+
+    // When cluster scope is turned on, re-add cluster-scoped kinds to the URL
+    if (clusterTurnedOn) {
+      const currentSet = new Set(selectedKinds);
+      const missing = CLUSTER_SCOPED_KINDS.filter(k => !currentSet.has(k));
+      if (missing.length > 0) {
+        setParams(
+          { kinds: [...selectedKinds, ...missing].join(',') },
+          { replace: true },
+        );
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
  When toggling cluster scope OFF, the useEffect correctly removed
  cluster-scoped kinds (clusterdataplane, clusterworkflowplane,
  clusterobservabilityplane, clusterworkflow) from the URL kinds
  parameter. However, toggling cluster scope back ON did not re-add
  them, leaving the user with a partial view missing all cluster
  resources.

  Added a symmetric clusterTurnedOn branch that detects the OFF→ON
  transition and re-adds any missing CLUSTER_SCOPED_KINDS to the URL,
  with Set-based deduplication to avoid duplicates if some kinds were
  manually re-added before toggling

Before:


https://github.com/user-attachments/assets/696376b1-cafb-4e7a-a819-10e758b04a56

After:


https://github.com/user-attachments/assets/b02213a1-30ac-4e47-934c-102aa0e75b62




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* When enabling cluster scope, the application now automatically includes all required cluster-scoped kinds in the view, ensuring consistent synchronization with cluster scope deactivation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->