### PR TITLE
feat(scaffolder): add skeleton loaders to create page during template loading

### DIFF
--- a/packages/app/src/components/scaffolder/CustomTemplateListPage.tsx
+++ b/packages/app/src/components/scaffolder/CustomTemplateListPage.tsx
@@ -58,6 +58,7 @@ import { ScaffolderTagPicker } from './ScaffolderTagPicker';
 import { ScaffolderSearchBar } from './ScaffolderSearchBar';
 import { ScaffolderNamespacePicker } from './ScaffolderNamespacePicker';
 import { CustomTemplateCard } from './CustomTemplateCard';
+import { TemplateCardSkeletons } from './TemplateCardSkeleton';
 import { useStyles } from './styles';
 
 const APPLICATION_TYPES = ['System (Project)'];
@@ -196,7 +197,7 @@ const TemplateListContent = (props: TemplateListPageProps) => {
   );
 
   // Get all template entities from the catalog (filtered by search/category/tag/starred)
-  const { entities } = useEntityList();
+  const { entities, loading } = useEntityList();
   const templates = entities as TemplateEntityV1beta3[];
 
   const applicationTemplates = useMemo(
@@ -398,7 +399,11 @@ const TemplateListContent = (props: TemplateListPageProps) => {
           Application Resources
         </Typography>
         <Grid container spacing={3}>
-          {renderTemplateCards(applicationTemplates)}
+          {loading ? (
+            <TemplateCardSkeletons count={2} />
+          ) : (
+            renderTemplateCards(applicationTemplates)
+          )}
           {/* Component — navigation card, no single backing template */}
           <Grid item xs={12} sm={6} md={3}>
             {componentDisabled ? (
@@ -414,13 +419,17 @@ const TemplateListContent = (props: TemplateListPageProps) => {
         </Grid>
 
         {/* Platform Resources */}
-        {platformTemplates.length > 0 && (
+        {(loading || platformTemplates.length > 0) && (
           <>
             <Typography className={classes.sectionSubtitle}>
               Platform Resources
             </Typography>
             <Grid container spacing={3}>
-              {renderTemplateCards(platformTemplates)}
+              {loading ? (
+                <TemplateCardSkeletons count={3} />
+              ) : (
+                renderTemplateCards(platformTemplates)
+              )}
             </Grid>
           </>
         )}

--- a/packages/app/src/components/scaffolder/TemplateCardSkeleton.tsx
+++ b/packages/app/src/components/scaffolder/TemplateCardSkeleton.tsx
@@ -1,0 +1,31 @@
+import { Box, Grid } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+import { useStyles } from './styles';
+
+export const TemplateCardSkeleton = () => {
+  const classes = useStyles();
+
+  return (
+    <Box
+      className={`${classes.cardBase} ${classes.resourceCard} ${classes.skeletonCard}`}
+    >
+      <Skeleton variant="circle" width={36} height={36} />
+      <Skeleton variant="text" width={100} style={{ marginTop: 12 }} />
+      <Skeleton variant="text" width={160} style={{ marginTop: 4 }} />
+    </Box>
+  );
+};
+
+export const TemplateCardSkeletons = ({ count }: { count: number }) => {
+  const skeletons = Array.from({ length: count }, (_, i) => i);
+
+  return (
+    <>
+      {skeletons.map(i => (
+        <Grid item xs={12} sm={6} md={3} key={`skeleton-${i}`}>
+          <TemplateCardSkeleton />
+        </Grid>
+      ))}
+    </>
+  );
+};

--- a/packages/app/src/components/scaffolder/styles.ts
+++ b/packages/app/src/components/scaffolder/styles.ts
@@ -121,6 +121,16 @@ export const useStyles = makeStyles(theme => ({
       transform: 'translateY(-2px)',
     },
   },
+  // Non-interactive skeleton placeholder card
+  skeletonCard: {
+    cursor: 'default',
+    '&:hover': {
+      borderColor: '#f3f4f6',
+      boxShadow:
+        'rgba(0, 0, 0, 0.05) 0px 1px 3px 0px, rgba(0, 0, 0, 0.03) 0px 1px 2px 0px',
+      transform: 'none',
+    },
+  },
   // Centered icon + label card layout
   resourceCard: {
     alignItems: 'center',


### PR DESCRIPTION
  The gap: When a user navigates to /create, the Component navigation card renders immediately (it's
  hardcoded), but the Application Resources and Platform Resources template cards depend on
  useEntityList() which fetches from the catalog asynchronously. During that fetch there are zero
  loading indicators — the page renders with just the lone Component card and empty whitespace where
  template cards will eventually appear. This makes the page look broken or incomplete, especially on
  slower connections. Users have no way to tell if the page is still loading or if there genuinely are
  no templates available.

  The skeletons fill that gap by showing placeholder cards in the exact same layout as the real ones,
  giving immediate visual feedback that content is on its way.

Before: 

https://github.com/user-attachments/assets/def76e3e-ded5-45eb-b9d6-6f6951d05f22

After:


https://github.com/user-attachments/assets/84108b4e-543c-4f03-9546-797fa4735437



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added skeleton placeholder cards that display while application and platform templates load, providing better visual feedback during data fetching and enhancing the overall loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->