### PR TITLE
fix: use Ready condition as single source of truth for deployment status

### DIFF
--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -378,8 +378,6 @@ export class EnvironmentInfoService implements EnvironmentService {
     let releaseName: string | undefined;
 
     if (binding) {
-      // Use OpenChoreo status directly without mapping
-      // OpenChoreo returns: "Ready", "NotReady", or "Failed"
       deploymentStatus = binding.status as
         | 'Ready'
         | 'NotReady'
@@ -404,6 +402,8 @@ export class EnvironmentInfoService implements EnvironmentService {
       dataPlaneRef: envData.dataPlaneRef?.name,
       deployment: {
         status: deploymentStatus,
+        statusReason: binding?.statusReason,
+        statusMessage: binding?.statusMessage,
         lastDeployed,
         image,
         releaseName,

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
@@ -1,0 +1,243 @@
+import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
+import {
+  deriveBindingStatus,
+  deriveBindingStatusDetailed,
+} from './release-binding';
+
+type ReleaseBinding = OpenChoreoComponents['schemas']['ReleaseBinding'];
+
+function makeBinding(
+  conditions: Array<{
+    type: string;
+    status: string;
+    reason?: string;
+    message?: string;
+    observedGeneration?: number;
+  }>,
+  generation?: number,
+): ReleaseBinding {
+  return {
+    metadata: { generation } as any,
+    status: { conditions: conditions as any },
+  } as ReleaseBinding;
+}
+
+describe('deriveBindingStatus', () => {
+  it('returns NotReady when there are no conditions', () => {
+    const binding = makeBinding([]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns NotReady when Ready condition is absent', () => {
+    const binding = makeBinding([
+      { type: 'ReleaseSynced', status: 'True' },
+      { type: 'ResourcesReady', status: 'True' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns Ready when Ready condition is True', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'True', reason: 'Ready' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('Ready');
+  });
+
+  it('returns NotReady for ResourcesProgressing reason', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'ResourcesProgressing',
+        message: 'Deployment rollout in progress',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns NotReady for JobRunning reason', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'False', reason: 'JobRunning' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns NotReady for ConnectionsPending reason', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'False', reason: 'ConnectionsPending' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns NotReady for ResourcesUnknown reason', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'False', reason: 'ResourcesUnknown' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns NotReady for ResourcesUndeployed reason (intentional undeploy)', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'False', reason: 'ResourcesUndeployed' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns Failed for ResourcesDegraded reason', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'ResourcesDegraded',
+        message: 'Primary workload is degraded',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('Failed');
+  });
+
+  it('returns Failed for ResourceApplyFailed reason', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'False', reason: 'ResourceApplyFailed' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('Failed');
+  });
+
+  it('returns Failed for RenderingFailed reason', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'RenderingFailed',
+        message: 'Failed to render resources: component type validation failed',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('Failed');
+  });
+
+  it('returns Failed for ComponentNotFound reason', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'False', reason: 'ComponentNotFound' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('Failed');
+  });
+
+  it('returns Failed for JobFailed reason', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'False', reason: 'JobFailed' },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('Failed');
+  });
+
+  it('returns Failed for InvalidReleaseConfiguration reason', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'InvalidReleaseConfiguration',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('Failed');
+  });
+
+  it('returns Failed for unknown/unrecognized reasons (default to error)', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'SomeNewUnknownReason',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('Failed');
+  });
+
+  it('filters conditions by observedGeneration', () => {
+    // Ready condition has a stale generation - should be filtered out
+    const binding = makeBinding(
+      [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Ready',
+          observedGeneration: 1,
+        },
+      ],
+      2, // current generation is 2
+    );
+    // The Ready condition is for gen 1 but current is gen 2, so filtered out
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('includes conditions with missing observedGeneration', () => {
+    const binding = makeBinding(
+      [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Ready',
+          // no observedGeneration - treated as matching
+        },
+      ],
+      2,
+    );
+    expect(deriveBindingStatus(binding)).toBe('Ready');
+  });
+});
+
+describe('deriveBindingStatusDetailed', () => {
+  it('returns reason and message for Failed status', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'RenderingFailed',
+        message: 'component type validation failed: invalid field X',
+      },
+    ]);
+    const result = deriveBindingStatusDetailed(binding);
+    expect(result).toEqual({
+      status: 'Failed',
+      reason: 'RenderingFailed',
+      message: 'component type validation failed: invalid field X',
+    });
+  });
+
+  it('returns reason and message for Ready status', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'True',
+        reason: 'Ready',
+        message: 'All resources healthy',
+      },
+    ]);
+    const result = deriveBindingStatusDetailed(binding);
+    expect(result).toEqual({
+      status: 'Ready',
+      reason: 'Ready',
+      message: 'All resources healthy',
+    });
+  });
+
+  it('returns reason and message for NotReady progressing status', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'ResourcesProgressing',
+        message: 'Deployment rollout in progress',
+      },
+    ]);
+    const result = deriveBindingStatusDetailed(binding);
+    expect(result).toEqual({
+      status: 'NotReady',
+      reason: 'ResourcesProgressing',
+      message: 'Deployment rollout in progress',
+    });
+  });
+
+  it('returns status without reason/message for empty conditions', () => {
+    const binding = makeBinding([]);
+    const result = deriveBindingStatusDetailed(binding);
+    expect(result).toEqual({ status: 'NotReady' });
+  });
+});

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -8,31 +8,52 @@ import { getName, getNamespace, getCreatedAt } from './common';
 
 type NewReleaseBinding = OpenChoreoComponents['schemas']['ReleaseBinding'];
 
-const EXPECTED_CONDITION_TYPES = [
-  'ReleaseSynced',
-  'ResourcesReady',
-  'Ready',
+/** Reasons on the Ready condition that indicate transient progress, not an error. */
+const PROGRESSING_REASONS = [
+  'ResourcesProgressing',
+  'JobRunning',
+  'ConnectionsPending',
+  'ResourcesUnknown',
 ] as const;
 
+/** Reasons that represent an intentional non-deployed state, not an error. */
+const NON_ERROR_REASONS = ['ResourcesUndeployed'] as const;
+
+export interface DerivedBindingStatus {
+  status: 'Ready' | 'NotReady' | 'Failed';
+  reason?: string;
+  message?: string;
+}
+
 /**
- * Derives a binding status string from K8s conditions.
+ * Derives a binding status from the Ready condition on the ReleaseBinding.
  *
- * Improvements over Go-side determineReleaseBindingStatus:
- *   1. Missing observedGeneration is treated as a match (included in filter)
- *   2. All three expected condition types must be present with status "True" for Ready
- *   3. Any False condition → Failed (if ResourcesDegraded) or NotReady (otherwise)
+ * The Ready condition is now always present (fixed in openchoreo#2697) and is
+ * the single source of truth. Its reason distinguishes transient progress
+ * (→ NotReady) from actual errors (→ Failed).
  */
 export function deriveBindingStatus(
   binding: NewReleaseBinding,
 ): 'Ready' | 'NotReady' | 'Failed' | undefined {
+  return deriveBindingStatusDetailed(binding)?.status;
+}
+
+/**
+ * Like deriveBindingStatus but also returns the Ready condition's reason and
+ * message so callers can surface actionable details.
+ */
+export function deriveBindingStatusDetailed(
+  binding: NewReleaseBinding,
+): DerivedBindingStatus | undefined {
   const conditions = (binding.status?.conditions ?? []) as Array<{
     type: string;
     status: string;
     reason?: string;
+    message?: string;
     observedGeneration?: number;
   }>;
 
-  if (conditions.length === 0) return 'NotReady';
+  if (conditions.length === 0) return { status: 'NotReady' };
 
   const generation = (binding as any).metadata?.generation as
     | number
@@ -49,35 +70,50 @@ export function deriveBindingStatus(
       )
     : conditions;
 
-  // Need at least the 3 expected condition types for a conclusive status
-  if (conditionsForGeneration.length < EXPECTED_CONDITION_TYPES.length) {
-    return 'NotReady';
+  // Use the Ready condition as the single source of truth
+  const readyCond = conditionsForGeneration.find(c => c.type === 'Ready');
+  if (!readyCond) return { status: 'NotReady' }; // Not yet reconciled
+
+  if (readyCond.status === 'True') {
+    return {
+      status: 'Ready',
+      reason: readyCond.reason,
+      message: readyCond.message,
+    };
   }
 
-  // Any condition with a failure reason → Failed
-  const FAILURE_REASONS = ['ResourcesDegraded', 'ResourceApplyFailed'] as const;
+  // Ready=False: distinguish progressing from errors
   if (
-    conditionsForGeneration.some(
-      c =>
-        c.status === 'False' &&
-        FAILURE_REASONS.includes(c.reason as (typeof FAILURE_REASONS)[number]),
+    PROGRESSING_REASONS.includes(
+      readyCond.reason as (typeof PROGRESSING_REASONS)[number],
     )
   ) {
-    return 'Failed';
+    return {
+      status: 'NotReady',
+      reason: readyCond.reason,
+      message: readyCond.message,
+    };
   }
 
-  // Any other False condition → NotReady (don't rely on a hardcoded reason allowlist)
-  if (conditionsForGeneration.some(c => c.status === 'False')) {
-    return 'NotReady';
+  // Intentional undeploy — not an error
+  if (
+    NON_ERROR_REASONS.includes(
+      readyCond.reason as (typeof NON_ERROR_REASONS)[number],
+    )
+  ) {
+    return {
+      status: 'NotReady',
+      reason: readyCond.reason,
+      message: readyCond.message,
+    };
   }
 
-  // All three expected types must be present with status "True"
-  const allExpectedTrue = EXPECTED_CONDITION_TYPES.every(type => {
-    const cond = conditionsForGeneration.find(c => c.type === type);
-    return cond?.status === 'True';
-  });
-
-  return allExpectedTrue ? 'Ready' : 'NotReady';
+  // Everything else is a failure
+  return {
+    status: 'Failed',
+    reason: readyCond.reason,
+    message: readyCond.message,
+  };
 }
 
 /**
@@ -87,6 +123,8 @@ export function deriveBindingStatus(
 export function transformReleaseBinding(
   binding: NewReleaseBinding,
 ): ReleaseBindingResponse {
+  const derived = deriveBindingStatusDetailed(binding);
+
   return {
     name: getName(binding) ?? '',
     componentName: binding.spec?.owner?.componentName ?? '',
@@ -103,7 +141,9 @@ export function transformReleaseBinding(
     createdAt: getCreatedAt(binding) ?? '',
     lastSpecUpdateTime:
       (binding.status as any)?.lastSpecUpdateTime ?? undefined,
-    status: deriveBindingStatus(binding),
+    status: derived?.status,
+    statusReason: derived?.reason,
+    statusMessage: derived?.message,
     endpoints: (() => {
       const raw = (binding.status as any)?.endpoints;
       if (!Array.isArray(raw)) return undefined;

--- a/plugins/openchoreo-backend/src/types.ts
+++ b/plugins/openchoreo-backend/src/types.ts
@@ -63,6 +63,8 @@ export interface Environment {
   dataPlaneRef?: string;
   deployment: {
     status?: 'Ready' | 'NotReady' | 'Failed' | undefined;
+    statusReason?: string;
+    statusMessage?: string;
     lastDeployed?: string;
     image?: string;
     releaseName?: string;

--- a/plugins/openchoreo-common/src/types/bff-types.ts
+++ b/plugins/openchoreo-common/src/types/bff-types.ts
@@ -543,6 +543,10 @@ export interface ReleaseBindingResponse {
   /** Format: date-time – last time the spec was updated (from status.lastSpecUpdateTime) */
   lastSpecUpdateTime?: string;
   status?: string;
+  /** The Ready condition's reason (e.g. ResourcesDegraded, RenderingFailed) */
+  statusReason?: string;
+  /** The Ready condition's human-readable message with actionable details */
+  statusMessage?: string;
   endpoints?: ReleaseBindingEndpoint[];
   conditions?: ReleaseBindingCondition[];
 }

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -43,6 +43,8 @@ export interface ReleaseBinding {
   workloadOverrides?: unknown;
   endpoints?: { url: string }[];
   status?: string;
+  statusReason?: string;
+  statusMessage?: string;
 }
 
 /** Release bindings response */

--- a/plugins/openchoreo/src/components/Environments/OverviewCard/useDeploymentStatus.ts
+++ b/plugins/openchoreo/src/components/Environments/OverviewCard/useDeploymentStatus.ts
@@ -64,12 +64,14 @@ export function useDeploymentStatus() {
     fetchData();
   }, [fetchData]);
 
-  // Poll if any environment has NotReady status
+  // Poll if any environment has NotReady or Failed status (failed deployments may recover)
   useEffect(() => {
-    const hasNotReady = state.environments.some(
-      env => env.deployment?.status === 'NotReady',
+    const shouldPoll = state.environments.some(
+      env =>
+        env.deployment?.status === 'NotReady' ||
+        env.deployment?.status === 'Failed',
     );
-    if (!hasNotReady) return undefined;
+    if (!shouldPoll) return undefined;
 
     const intervalId = setInterval(() => {
       fetchData();

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseStatusBar.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseStatusBar.tsx
@@ -12,16 +12,19 @@ import type {
 
 function getOverallHealth(
   releaseBindingData?: Record<string, unknown> | null,
-): { label: string; status: HealthStatus; reason?: string } {
+): { label: string; status: HealthStatus; reason?: string; message?: string } {
   if (releaseBindingData) {
     if (typeof releaseBindingData.status === 'string') {
       const flatStatus = releaseBindingData.status;
+      const reason = releaseBindingData.statusReason as string | undefined;
+      const message = releaseBindingData.statusMessage as string | undefined;
+
       if (flatStatus === 'Ready')
-        return { label: 'Healthy', status: 'Healthy' };
+        return { label: 'Healthy', status: 'Healthy', reason, message };
       if (flatStatus === 'Failed')
-        return { label: 'Degraded', status: 'Degraded' };
+        return { label: 'Degraded', status: 'Degraded', reason, message };
       if (flatStatus === 'NotReady')
-        return { label: 'Progressing', status: 'Progressing' };
+        return { label: 'Progressing', status: 'Progressing', reason, message };
     } else {
       const bindingStatus = releaseBindingData.status as
         | Record<string, unknown>
@@ -35,11 +38,12 @@ function getOverallHealth(
       if (readyCondition) {
         const condStatus = (readyCondition as any).status;
         const reason = (readyCondition as any).reason as string | undefined;
+        const message = (readyCondition as any).message as string | undefined;
         if (condStatus === 'True')
-          return { label: 'Healthy', status: 'Healthy', reason };
+          return { label: 'Healthy', status: 'Healthy', reason, message };
         if (condStatus === 'False')
-          return { label: 'Degraded', status: 'Degraded', reason };
-        return { label: 'Progressing', status: 'Progressing', reason };
+          return { label: 'Degraded', status: 'Degraded', reason, message };
+        return { label: 'Progressing', status: 'Progressing', reason, message };
       }
     }
   }
@@ -163,6 +167,11 @@ export const ReleaseStatusBar: FC<ReleaseStatusBarProps> = ({
         {health.reason && (
           <Typography className={classes.statusBarDetail}>
             Reason: {health.reason}
+          </Typography>
+        )}
+        {health.message && (
+          <Typography className={classes.statusBarDetail}>
+            {health.message}
           </Typography>
         )}
       </div>

--- a/plugins/openchoreo/src/components/Environments/components/EnvironmentCard.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/EnvironmentCard.tsx
@@ -48,6 +48,8 @@ export const EnvironmentCard = ({
       <>
         <EnvironmentCardContent
           status={deployment.status}
+          statusReason={deployment.statusReason}
+          statusMessage={deployment.statusMessage}
           lastDeployed={deployment.lastDeployed}
           image={deployment.image}
           releaseName={deployment.releaseName}

--- a/plugins/openchoreo/src/components/Environments/components/EnvironmentCardContent.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/EnvironmentCardContent.tsx
@@ -22,6 +22,8 @@ import { IncidentsBanner } from './IncidentsBanner';
  */
 export const EnvironmentCardContent = ({
   status,
+  statusReason,
+  statusMessage,
   lastDeployed,
   image,
   releaseName,
@@ -58,17 +60,28 @@ export const EnvironmentCardContent = ({
           >
             Deployment Status:
           </Typography>
-          <StatusBadge
-            status={
-              status === 'Ready'
-                ? 'active'
-                : status === 'NotReady'
-                ? 'pending'
-                : status === 'Failed'
-                ? 'failed'
-                : 'not-deployed'
+          <Tooltip
+            title={
+              statusReason && statusMessage
+                ? `${statusReason}: ${statusMessage}`
+                : statusReason ?? statusMessage ?? ''
             }
-          />
+            disableHoverListener={!statusReason && !statusMessage}
+          >
+            <span>
+              <StatusBadge
+                status={
+                  status === 'Ready'
+                    ? 'active'
+                    : status === 'NotReady'
+                    ? 'pending'
+                    : status === 'Failed'
+                    ? 'failed'
+                    : 'not-deployed'
+                }
+              />
+            </span>
+          </Tooltip>
         </Box>
         {releaseName && (
           <Box mt={1.5}>

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentData.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentData.ts
@@ -28,6 +28,8 @@ export interface Environment {
   dataPlaneRef?: string;
   deployment: {
     status?: 'Ready' | 'NotReady' | 'Failed';
+    statusReason?: string;
+    statusMessage?: string;
     lastDeployed?: string;
     image?: string;
     releaseName?: string;

--- a/plugins/openchoreo/src/components/Environments/types.ts
+++ b/plugins/openchoreo/src/components/Environments/types.ts
@@ -87,6 +87,8 @@ export interface EnvironmentCardHeaderProps {
  */
 export interface EnvironmentCardContentProps {
   status?: 'Ready' | 'NotReady' | 'Failed';
+  statusReason?: string;
+  statusMessage?: string;
   lastDeployed?: string;
   image?: string;
   releaseName?: string;
@@ -129,6 +131,8 @@ export interface EnvironmentCardProps {
   bindingsPermissionLoading?: boolean;
   deployment: {
     status?: 'Ready' | 'NotReady' | 'Failed';
+    statusReason?: string;
+    statusMessage?: string;
     lastDeployed?: string;
     image?: string;
     releaseName?: string;

--- a/plugins/openchoreo/src/components/Projects/ProjectComponentsCard/DeploymentStatusCell.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectComponentsCard/DeploymentStatusCell.tsx
@@ -23,6 +23,8 @@ export const DeploymentStatusCell = ({
         const deployment = component.deploymentStatus?.[env.name.toLowerCase()];
         const isDeployed = deployment?.isDeployed || false;
         const status = deployment?.status;
+        const statusReason = deployment?.statusReason;
+        const statusMessage = deployment?.statusMessage;
 
         // Determine status icon and color
         let StatusIcon = null;
@@ -30,21 +32,35 @@ export const DeploymentStatusCell = ({
         let iconClass = '';
 
         if (isDeployed) {
+          let reasonDetail: string | undefined;
+          if (statusReason && statusMessage) {
+            reasonDetail = `${statusReason}: ${statusMessage}`;
+          } else if (statusReason) {
+            reasonDetail = statusReason;
+          }
+
           if (status === 'Ready') {
             StatusIcon = CheckCircleIcon;
             iconClass = classes.statusIconReady;
-            tooltipSuffix = 'Deployed (Ready)';
+            tooltipSuffix = reasonDetail
+              ? `Deployed (Ready — ${reasonDetail})`
+              : 'Deployed (Ready)';
           } else if (status === 'Failed') {
             StatusIcon = ErrorIcon;
             iconClass = classes.statusIconError;
-            tooltipSuffix = `Deployed (${status})`;
+            tooltipSuffix = reasonDetail
+              ? `Deployed (Failed — ${reasonDetail})`
+              : 'Deployed (Failed)';
           } else if (status === 'NotReady') {
             StatusIcon = WarningIcon;
             iconClass = classes.statusIconWarning;
-            tooltipSuffix = `Deployed (${status})`;
+            tooltipSuffix = reasonDetail
+              ? `Deployed (NotReady — ${reasonDetail})`
+              : 'Deployed (NotReady)';
           } else {
             StatusIcon = StatusPending;
-            tooltipSuffix = status ? `Deployed (${status})` : 'Deployed';
+            const label = status ? `Deployed (${status})` : 'Deployed';
+            tooltipSuffix = reasonDetail ? `${label} — ${reasonDetail}` : label;
           }
         }
 

--- a/plugins/openchoreo/src/components/Projects/hooks/useComponentsWithDeployment.ts
+++ b/plugins/openchoreo/src/components/Projects/hooks/useComponentsWithDeployment.ts
@@ -9,6 +9,8 @@ import { openChoreoClientApiRef } from '../../../api/OpenChoreoClientApi';
 export interface EnvironmentDeploymentStatus {
   isDeployed: boolean;
   status?: string; // Actual status from ReleaseBinding: Ready, NotReady, Failed, etc.
+  statusReason?: string;
+  statusMessage?: string;
 }
 
 export type ComponentDeploymentStatus = Record<
@@ -94,6 +96,8 @@ export function useComponentsWithDeployment(
                     deploymentStatus[envName] = {
                       isDeployed: true,
                       status: binding.status,
+                      statusReason: binding.statusReason,
+                      statusMessage: binding.statusMessage,
                     };
                   }
                 });


### PR DESCRIPTION
## Purpose

### Summary

- Refactor `deriveBindingStatus()` to use the `Ready` condition as the single source of truth, instead of requiring all 3 sub-conditions to be
present
- Distinguish transient progress (`ResourcesProgressing`, `JobRunning`, `ConnectionsPending`, `ResourcesUnknown`) from actual errors — only progress
  reasons map to `NotReady` (orange); all other `Ready=False` reasons now correctly map to `Failed` (red)
- Fix polling in `useDeploymentStatus` to also poll on `Failed` status, so recovered deployments update without manual refresh
- Surface the `Ready` condition's `reason` and `message` in UI tooltips on environment cards, deployment status cells, and the release status bar
- Add `statusReason` and `statusMessage` fields throughout the data pipeline (`ReleaseBindingResponse` → `Environment.deployment` → frontend
components)
- Add 20 unit tests for `deriveBindingStatus` and `deriveBindingStatusDetailed` covering all status derivation scenarios

Closes openchoreo/openchoreo#2699
Related: openchoreo/openchoreo#2697

Related backend change: https://github.com/openchoreo/openchoreo/pull/2698


**Before:**


https://github.com/user-attachments/assets/8ead9ecf-4e9b-4beb-a474-d849427fa776

**After:**


https://github.com/user-attachments/assets/3af2f6f5-e90b-4f6e-9958-2155135facbb





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment status now includes a reason and human-readable message surfaced in tooltips, health panels, and deployment lists.

* **Improvements**
  * Polling/monitoring continues for NotReady and Failed deployments.
  * Status reason/message propagated across environment and project views for clearer diagnostics.

* **Tests**
  * Added unit tests covering status derivation, reason/message propagation, and observed-generation filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->