### PR TITLE
feat: show more CR YAML fields in Definition Tab editor

### DIFF
--- a/plugins/openchoreo/src/components/ResourceDefinition/utils.ts
+++ b/plugins/openchoreo/src/components/ResourceDefinition/utils.ts
@@ -101,13 +101,7 @@ export function isClusterScopedKind(kind: string): boolean {
 /**
  * Server-managed fields that should be stripped from CRD before displaying
  */
-const SERVER_MANAGED_FIELDS = [
-  'managedFields',
-  'resourceVersion',
-  'uid',
-  'creationTimestamp',
-  'generation',
-];
+const SERVER_MANAGED_FIELDS = ['resourceVersion', 'managedFields'];
 
 /**
  * Cleans a CRD for editing by removing server-managed fields
@@ -125,9 +119,6 @@ export function cleanCrdForEditing(
     }
     cleaned.metadata = metadata;
   }
-
-  // Remove status (should not be edited by users)
-  delete cleaned.status;
 
   return cleaned;
 }


### PR DESCRIPTION
  Reduce the set of fields stripped by cleanCrdForEditing() so users can
  see uid, creationTimestamp, generation, and the status block in the YAML
  editor.

  Previously all of these were hidden to keep the editor minimal, but they
  provide useful context (e.g. resource age, current status) and hiding
  them made it harder to understand the full resource state. The backend
  already ignores status on save and uses a fetch-merge-update pattern for
  resourceVersion, so showing these fields is safe.

  resourceVersion and managedFields remain hidden: resourceVersion because
  sending a stale value causes update conflicts, and managedFields because
  it's extremely verbose noise (50+ lines of field manager metadata).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource definitions now retain status information and preserve additional metadata fields during editing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->