### PR TITLE
fix(permissions): UI does not reflect project-level deny policy overriding namespace-level allow

### DIFF
--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -29,6 +29,8 @@ export {
   openchoreoComponentUpdatePermission,
   openchoreoWorkloadUpdatePermission,
   openchoreoProjectCreatePermission,
+  openchoreoComponentCreateScopedPermission,
+  openchoreoProjectCreateScopedPermission,
   openchoreoProjectReadPermission,
   openchoreoNamespaceReadPermission,
   openchoreoNamespaceCreatePermission,

--- a/plugins/openchoreo-common/src/permissions.ts
+++ b/plugins/openchoreo-common/src/permissions.ts
@@ -87,6 +87,28 @@ export const openchoreoProjectCreatePermission = createPermission({
 });
 
 /**
+ * Scoped permission to create a component within a specific project/namespace.
+ * Resource-based: evaluates deny paths against entity scope.
+ * Use on project pages where entity context is available.
+ */
+export const openchoreoComponentCreateScopedPermission = createPermission({
+  name: 'openchoreo.component.create.scoped',
+  attributes: { action: 'create' },
+  resourceType: OPENCHOREO_RESOURCE_TYPE_NAMESPACED_RESOURCE,
+});
+
+/**
+ * Scoped permission to create a project within a specific namespace.
+ * Resource-based: evaluates deny paths against entity scope.
+ * Use on namespace pages where entity context is available.
+ */
+export const openchoreoProjectCreateScopedPermission = createPermission({
+  name: 'openchoreo.project.create.scoped',
+  attributes: { action: 'create' },
+  resourceType: OPENCHOREO_RESOURCE_TYPE_NAMESPACED_RESOURCE,
+});
+
+/**
  * Permission to read/view a project.
  * Resource-based: requires the specific project context.
  */
@@ -809,6 +831,9 @@ export const openchoreoPermissions = [
   openchoreoClusterObservabilityplaneDeletePermission,
   openchoreoClusterWorkflowUpdatePermission,
   openchoreoClusterWorkflowDeletePermission,
+  // Scoped create permissions (for entity-context pages)
+  openchoreoComponentCreateScopedPermission,
+  openchoreoProjectCreateScopedPermission,
 ];
 
 /**
@@ -825,6 +850,8 @@ export const OPENCHOREO_PERMISSION_TO_ACTION: Record<string, string> = {
   'openchoreo.component.viewbuilds': 'workflowrun:view',
   'openchoreo.releasebinding.create': 'releasebinding:create',
   'openchoreo.project.create': 'project:create',
+  'openchoreo.component.create.scoped': 'component:create',
+  'openchoreo.project.create.scoped': 'project:create',
   'openchoreo.project.read': 'project:view',
   'openchoreo.namespace.read': 'namespace:view',
   'openchoreo.namespace.create': 'namespace:create',

--- a/plugins/openchoreo-react/src/hooks/useScopedComponentCreatePermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useScopedComponentCreatePermission.ts
@@ -1,0 +1,45 @@
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { usePermission } from '@backstage/plugin-permission-react';
+import { openchoreoComponentCreateScopedPermission } from '@openchoreo/backstage-plugin-common';
+
+/**
+ * Result of the useScopedComponentCreatePermission hook.
+ */
+export interface UseScopedComponentCreatePermissionResult {
+  /** Whether the user has permission to create a component in this scope */
+  canCreate: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+  /** Tooltip message for create permission denied (empty string when allowed/loading) */
+  createDeniedTooltip: string;
+}
+
+/**
+ * Hook for checking if the current user has permission to create components
+ * within the scope of the current entity (project/namespace).
+ *
+ * Unlike `useComponentCreatePermission` (basic/global), this hook is
+ * resource-based and evaluates deny paths against the entity's scope.
+ * Use this on project pages where a project-level deny policy should
+ * disable the "Create Component" button.
+ *
+ * Must be used within an EntityProvider context.
+ */
+export const useScopedComponentCreatePermission =
+  (): UseScopedComponentCreatePermissionResult => {
+    const { entity } = useEntity();
+    const { allowed: canCreate, loading } = usePermission({
+      permission: openchoreoComponentCreateScopedPermission,
+      resourceRef: stringifyEntityRef(entity),
+    });
+
+    return {
+      canCreate,
+      loading,
+      createDeniedTooltip:
+        !canCreate && !loading
+          ? 'You do not have permission to create a component in this project'
+          : '',
+    };
+  };

--- a/plugins/openchoreo-react/src/hooks/useScopedProjectCreatePermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useScopedProjectCreatePermission.ts
@@ -1,0 +1,45 @@
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { usePermission } from '@backstage/plugin-permission-react';
+import { openchoreoProjectCreateScopedPermission } from '@openchoreo/backstage-plugin-common';
+
+/**
+ * Result of the useScopedProjectCreatePermission hook.
+ */
+export interface UseScopedProjectCreatePermissionResult {
+  /** Whether the user has permission to create a project in this scope */
+  canCreate: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+  /** Tooltip message for create permission denied (empty string when allowed/loading) */
+  createDeniedTooltip: string;
+}
+
+/**
+ * Hook for checking if the current user has permission to create projects
+ * within the scope of the current entity (namespace).
+ *
+ * Unlike `useProjectPermission` (basic/global), this hook is resource-based
+ * and evaluates deny paths against the entity's scope. Use this on namespace
+ * pages where a namespace-level deny policy should disable the
+ * "Create Project" button.
+ *
+ * Must be used within an EntityProvider context.
+ */
+export const useScopedProjectCreatePermission =
+  (): UseScopedProjectCreatePermissionResult => {
+    const { entity } = useEntity();
+    const { allowed: canCreate, loading } = usePermission({
+      permission: openchoreoProjectCreateScopedPermission,
+      resourceRef: stringifyEntityRef(entity),
+    });
+
+    return {
+      canCreate,
+      loading,
+      createDeniedTooltip:
+        !canCreate && !loading
+          ? 'You do not have permission to create a project in this namespace'
+          : '',
+    };
+  };

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -311,6 +311,14 @@ export {
   type UseResourceDefinitionPermissionResult,
 } from './hooks/useResourceDefinitionPermission';
 export {
+  useScopedComponentCreatePermission,
+  type UseScopedComponentCreatePermissionResult,
+} from './hooks/useScopedComponentCreatePermission';
+export {
+  useScopedProjectCreatePermission,
+  type UseScopedProjectCreatePermissionResult,
+} from './hooks/useScopedProjectCreatePermission';
+export {
   useAsyncOperation,
   type AsyncStatus,
   type AsyncState,

--- a/plugins/openchoreo/src/components/HomePage/QuickActionsSection/QuickActions.tsx
+++ b/plugins/openchoreo/src/components/HomePage/QuickActionsSection/QuickActions.tsx
@@ -4,19 +4,29 @@ import {
   CardActionArea,
   CardContent,
   Grid,
+  Tooltip,
   Typography,
 } from '@material-ui/core';
 import LaunchIcon from '@material-ui/icons/Launch';
 import { Link } from 'react-router-dom';
+import { useComponentCreatePermission } from '@openchoreo/backstage-plugin-react';
 import { useStyles } from './styles';
 
 export const QuickActionsSection: React.FC = () => {
   const classes = useStyles();
+  const { canCreate, loading: createPermLoading } =
+    useComponentCreatePermission();
+
   const quickActions = [
     {
       title: 'Create Component',
       description: 'Start a new service',
       link: '/create/templates/default/create-openchoreo-component',
+      disabled: !canCreate && !createPermLoading,
+      tooltip:
+        !canCreate && !createPermLoading
+          ? 'You do not have permission to create a component'
+          : '',
     },
     {
       title: 'View My Projects',
@@ -41,32 +51,38 @@ export const QuickActionsSection: React.FC = () => {
       <Grid container spacing={2} className={classes.quickActionsContainer}>
         {quickActions.map((action, index) => (
           <Grid item xs={12} sm={6} md={6} key={index}>
-            <Card className={classes.quickActionCard}>
-              <CardActionArea
-                className={classes.quickActionCardAction}
-                component={Link}
-                to={action.link}
-                disableRipple
+            <Tooltip title={action.tooltip ?? ''}>
+              <Card
+                className={classes.quickActionCard}
+                style={action.disabled ? { opacity: 0.5 } : undefined}
               >
-                <CardContent className={classes.quickActionCardContent}>
-                  <Box className={classes.quickActionHeader}>
-                    <Typography
-                      variant="h5"
-                      className={classes.quickActionTitle}
-                    >
-                      {action.title}
+                <CardActionArea
+                  className={classes.quickActionCardAction}
+                  component={action.disabled ? 'div' : Link}
+                  {...(action.disabled ? {} : { to: action.link })}
+                  disabled={action.disabled}
+                  disableRipple
+                >
+                  <CardContent className={classes.quickActionCardContent}>
+                    <Box className={classes.quickActionHeader}>
+                      <Typography
+                        variant="h5"
+                        className={classes.quickActionTitle}
+                      >
+                        {action.title}
+                      </Typography>
+                      <LaunchIcon
+                        fontSize="small"
+                        className={classes.quickActionIcon}
+                      />
+                    </Box>
+                    <Typography variant="body2" color="textSecondary">
+                      {action.description}
                     </Typography>
-                    <LaunchIcon
-                      fontSize="small"
-                      className={classes.quickActionIcon}
-                    />
-                  </Box>
-                  <Typography variant="body2" color="textSecondary">
-                    {action.description}
-                  </Typography>
-                </CardContent>
-              </CardActionArea>
-            </Card>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Tooltip>
           </Grid>
         ))}
       </Grid>

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.tsx
@@ -5,7 +5,7 @@ import { useEntity, useRelatedEntities } from '@backstage/plugin-catalog-react';
 import { Box, Button, Tooltip, Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import { useNavigate } from 'react-router-dom';
-import { useProjectPermission } from '@openchoreo/backstage-plugin-react';
+import { useScopedProjectCreatePermission } from '@openchoreo/backstage-plugin-react';
 import { shouldNavigateOnRowClick } from '../../../utils/shouldNavigateOnRowClick';
 import { useNamespaceProjectsCardStyles } from './styles';
 
@@ -22,7 +22,7 @@ export const NamespaceProjectsCard = () => {
     canCreate,
     loading: permLoading,
     createDeniedTooltip,
-  } = useProjectPermission();
+  } = useScopedProjectCreatePermission();
   const navigate = useNavigate();
 
   const columns: TableColumn<Entity>[] = [

--- a/plugins/openchoreo/src/components/Projects/ProjectComponentsCard/ProjectComponentsCard.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectComponentsCard/ProjectComponentsCard.tsx
@@ -10,6 +10,7 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import {
   useCreateComponentPath,
   useReleaseBindingPermission,
+  useScopedComponentCreatePermission,
 } from '@openchoreo/backstage-plugin-react';
 import {
   useComponentsWithDeployment,
@@ -39,6 +40,11 @@ export const ProjectComponentsCard = () => {
     useCreateComponentPath(entity);
   const { canViewBindings, loading: bindingsPermissionLoading } =
     useReleaseBindingPermission();
+  const {
+    canCreate,
+    loading: createPermLoading,
+    createDeniedTooltip,
+  } = useScopedComponentCreatePermission();
 
   // Filter and sort environments based on deployment pipeline
   const pipelineEnvironments = useMemo(() => {
@@ -138,7 +144,13 @@ export const ProjectComponentsCard = () => {
     },
   ];
 
-  if (loading || envsLoading || pipelineLoading || bindingsPermissionLoading) {
+  if (
+    loading ||
+    envsLoading ||
+    pipelineLoading ||
+    bindingsPermissionLoading ||
+    createPermLoading
+  ) {
     return (
       <Box p={3}>
         <Typography variant="body1" color="textSecondary" align="center">
@@ -186,18 +198,23 @@ export const ProjectComponentsCard = () => {
         ]}
         components={{
           Action: ({ action }: any) => (
-            <Button
-              variant="contained"
-              color="primary"
-              size="small"
-              startIcon={<AddIcon />}
-              className={classes.createComponentButton}
-              onClick={(event: React.MouseEvent) =>
-                action.onClick(event, undefined)
-              }
-            >
-              Create Component
-            </Button>
+            <Tooltip title={createDeniedTooltip}>
+              <span>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  startIcon={<AddIcon />}
+                  className={classes.createComponentButton}
+                  disabled={!canCreate || createPermLoading}
+                  onClick={(event: React.MouseEvent) =>
+                    action.onClick(event, undefined)
+                  }
+                >
+                  Create Component
+                </Button>
+              </span>
+            </Tooltip>
           ),
         }}
       />

--- a/plugins/permission-backend-module-openchoreo-policy/src/policy/OpenChoreoPermissionPolicy.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/policy/OpenChoreoPermissionPolicy.ts
@@ -179,9 +179,36 @@ export class OpenChoreoPermissionPolicy implements PermissionPolicy {
       }
 
       // For basic permissions (non-resource), check if action has any allowed paths
+      // Also verify that not every allowed path is covered by a deny path
       const actionCapability =
         capabilities.capabilities?.[action] ?? capabilities.capabilities?.['*'];
-      const isAllowed = (actionCapability?.allowed?.length ?? 0) > 0;
+      const allowedPaths =
+        actionCapability?.allowed
+          ?.map(a => a.path)
+          .filter((p): p is string => !!p) ?? [];
+      const deniedPaths =
+        actionCapability?.denied
+          ?.map(d => d.path)
+          .filter((p): p is string => !!p) ?? [];
+
+      let isAllowed = allowedPaths.length > 0;
+
+      // Safety net: if there are deny paths, check that at least one allowed path
+      // is not fully covered by a deny path. A deny of '*' covers everything.
+      if (isAllowed && deniedPaths.length > 0) {
+        const hasGlobalDeny = deniedPaths.includes('*');
+        if (hasGlobalDeny) {
+          isAllowed = false;
+        } else {
+          // Check if every allowed path is covered by a deny path
+          const allCovered = allowedPaths.every(ap =>
+            deniedPaths.some(dp => ap === dp || ap.startsWith(`${dp}/`)),
+          );
+          if (allCovered) {
+            isAllowed = false;
+          }
+        }
+      }
 
       this.logger.debug(`${permission.name}: ${isAllowed ? 'ALLOW' : 'DENY'}`);
 

--- a/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCapability.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCapability.ts
@@ -201,7 +201,11 @@ export const matchesCapability = createPermissionRule({
     // TODO: need to handle annotation change from org to namespace
     const namespace =
       entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
-    const project = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT];
+    // System entities use PROJECT_ID annotation, others use PROJECT
+    const project =
+      entity.kind.toLowerCase() === 'system'
+        ? entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT_ID]
+        : entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT];
     const component =
       entity.metadata.annotations?.[CHOREO_ANNOTATIONS.COMPONENT];
 


### PR DESCRIPTION
  When a user has a namespace-level developer binding (e.g., component:create
  allowed on ns/my-ns/*) and a project-level deny policy is added (denied on
  ns/my-ns/project/my-project/*), the backend correctly denies the action but
  the UI keeps the "Create" button enabled. The user only sees an error after
  clicking.

  Three root causes:
  1. ProjectComponentsCard "Create Component" button had no permission check
  2. NamespaceProjectsCard used a basic (non-resource) permission hook that ignores deny paths (only checks allowed.length > 0)
  3. matchesCapability rule used wrong annotation (PROJECT instead of PROJECT_ID) for System entities, causing scope mismatch

  Changes:
  - Add scoped resource-based create permissions (component.create.scoped, project.create.scoped) that leverage the CONDITIONAL flow to evaluate deny paths against entity scope
  - Fix matchesCapability to use PROJECT_ID annotation for System entities, matching matchesCatalogEntityCapability behavior
  - Add deny-path safety net to basic permissions path in the policy so globally-denied users see disabled buttons on global pages too
  - Add permission check to ProjectComponentsCard and QuickActions
  - Switch NamespaceProjectsCard to scoped permission hook


https://github.com/user-attachments/assets/e7dd4937-4275-4817-aaaf-a079cdf22b6a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added namespace-scoped permissions for component and project creation, enabling fine-grained access control within namespaces.
  * Create Component and Create Project actions now evaluate namespace-level permissions with contextual denial tooltips when access is restricted.

* **Bug Fixes**
  * Improved permission policy logic to correctly evaluate deny paths and prevent unintended access in namespace-scoped permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->