### PR TITLE
fix(catalog): add missing deploymentpipeline template to production config

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -123,6 +123,10 @@ catalog:
       rules:
         - allow: [Template]
     - type: file
+      target: /app/templates/create-openchoreo-deploymentpipeline/template.yaml
+      rules:
+        - allow: [Template]
+    - type: file
       target: /app/templates/create-openchoreo-clustercomponenttype/template.yaml
       rules:
         - allow: [Template]


### PR DESCRIPTION
  The create-openchoreo-deploymentpipeline template was only registered in
  app-config.yaml (dev) but not in app-config.production.yaml, causing it
  to be absent from the scaffolder UI in production deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new deployment pipeline template to the catalog, expanding available deployment options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->