### PR TITLE
fix: default Platform Overview scope to first available namespace

### DIFF
--- a/packages/app/src/components/platformOverview/PlatformOverviewPage.tsx
+++ b/packages/app/src/components/platformOverview/PlatformOverviewPage.tsx
@@ -151,11 +151,21 @@ export function PlatformOverviewPage() {
     if (availableNamespaces.length === 0) return;
     scopeInitialised.current = true;
 
-    const hasValidNamespace = selectedNamespaces.some(ns =>
+    const filteredValid = selectedNamespaces.filter(ns =>
       availableNamespaces.includes(ns),
     );
-    if (hasValidNamespace) return;
 
+    if (filteredValid.length > 0) {
+      // Some namespaces are valid — only update if stale ones were removed
+      if (filteredValid.length === selectedNamespaces.length) return;
+      const newScopes = clusterSelected
+        ? [CLUSTER_NAMESPACE, ...filteredValid]
+        : filteredValid;
+      setParams({ scope: newScopes.join(',') }, { replace: true });
+      return;
+    }
+
+    // No valid namespaces — fall back to preferred
     const preferred = availableNamespaces.includes('default')
       ? 'default'
       : availableNamespaces[0];


### PR DESCRIPTION
  The Platform Overview page hardcoded its default scope to the "default"
  namespace. When a user only had access to non-default namespaces, the
  page rendered nothing because entities were queried against a namespace
  the user couldn't access.

  Change DEFAULT_SCOPE to cluster-only (no namespace assumption), expose
  loading state from useNamespaces(), and add a one-shot effect that
  corrects the scope to the first available namespace once the async
  namespace fetch completes. Prefers "default" if available, otherwise
  falls back to the first namespace in the list. Uses replace:true to
  avoid polluting browser history.


Before:

https://github.com/user-attachments/assets/39f7eef4-e48c-4dde-a43e-7a65357016b4

After:

https://github.com/user-attachments/assets/b20f35c7-8bc3-4fb1-82e4-073d96b667dd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed namespace scope synchronization so the URL stays aligned with loaded namespaces.
  * Prevented selecting unavailable namespaces by automatically falling back to the preferred namespace (default if present, else first available).

* **New Features**
  * Show a loading indicator while namespace data is retrieved and initialize namespace list correctly.
  * Simplified scope handling to use a single cluster-namespace format for clarity and consistent URL updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->