### PR TITLE
fix: resolve catalog table column misalignment between header and data rows

### DIFF
--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -374,7 +374,9 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
 
                 {/* Type column */}
                 {showType && (
-                  <Box className={classes.hiddenOnMobile}>
+                  <Box
+                    className={`${classes.columnCell} ${classes.hiddenOnMobile}`}
+                  >
                     {componentType ? (
                       <Chip
                         label={componentType}

--- a/packages/app/src/components/catalog/styles.ts
+++ b/packages/app/src/components/catalog/styles.ts
@@ -234,6 +234,8 @@ export const useCardListStyles = makeStyles(theme => {
       textTransform: 'uppercase' as const,
       color: theme.palette.text.secondary,
       letterSpacing: '0.05em',
+      minWidth: 0,
+      overflow: 'hidden',
     },
 
     // Entity row
@@ -266,11 +268,13 @@ export const useCardListStyles = makeStyles(theme => {
     },
     nameCell: {
       minWidth: 0,
+      overflow: 'hidden',
     },
     actionsCell: {
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(0.5),
+      minWidth: 0,
       '& > :first-child': {
         marginLeft: -8,
       },
@@ -281,12 +285,14 @@ export const useCardListStyles = makeStyles(theme => {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap' as const,
+      minWidth: 0,
     },
     linkCell: {
       fontSize: '0.8rem',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap' as const,
+      minWidth: 0,
       '& a': {
         color: theme.palette.primary.main,
         textDecoration: 'none',
@@ -300,6 +306,7 @@ export const useCardListStyles = makeStyles(theme => {
       alignItems: 'center',
       gap: 4,
       overflow: 'hidden',
+      minWidth: 0,
       '& svg': {
         fontSize: '1rem',
         color: theme.palette.text.secondary,
@@ -349,6 +356,7 @@ export const useCardListStyles = makeStyles(theme => {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap' as const,
+      minWidth: 0,
     },
     paginationContainer: {
       display: 'flex',
@@ -380,6 +388,8 @@ export const useCardListStyles = makeStyles(theme => {
       gap: 4,
       fontSize: '0.75rem',
       whiteSpace: 'nowrap' as const,
+      minWidth: 0,
+      overflow: 'hidden',
     },
     agentDot: {
       width: 8,


### PR DESCRIPTION

  CSS Grid items default to `min-width: auto`, which allows grid tracks to
  expand beyond their `fr`-proportional allocation when cell content is wider
  than the allocated space. The header row contains short labels ("Name",
  "Namespace") that never exceed their allocation, while entity rows contain
  longer values (names, descriptions, project names) that push columns wider.
  This caused columns like NAMESPACE, PROJECT, and TYPE to shift 20-50px
  between the header and data rows.

  Fix by adding `minWidth: 0` and `overflow: hidden` to all direct grid
  child styles, ensuring cells respect their `fr` proportions regardless of
  content length.

Before: 

<img width="1727" height="866" alt="Screenshot 2026-03-14 at 20 47 01" src="https://github.com/user-attachments/assets/6f654570-98d6-4310-b62a-ee4b50ffd69e" />
<img width="1727" height="866" alt="Screenshot 2026-03-14 at 20 34 05" src="https://github.com/user-attachments/assets/74c2de74-317a-4272-8e31-853bfeb61c1b" />


After:
<img width="1727" height="866" alt="Screenshot 2026-03-14 at 20 46 03" src="https://github.com/user-attachments/assets/bf6f7299-4c0a-4e0e-8c05-f2ae3607e390" />
