### PR TITLE
feat: add "Cluster" role type chip in namespace role binding views

### DIFF
--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/BindingDetailDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/BindingDetailDialog.tsx
@@ -14,6 +14,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import BlockIcon from '@material-ui/icons/Block';
 import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
+import { useSharedStyles } from './styles';
 
 const useStyles = makeStyles(theme => ({
   summaryCard: {
@@ -107,6 +108,7 @@ const useStyles = makeStyles(theme => ({
 export interface BindingDetailMapping {
   role: string;
   scope: string;
+  isClusterRole?: boolean;
 }
 
 export interface BindingDetail {
@@ -131,6 +133,7 @@ export const BindingDetailDialog = ({
   scopeLabel,
 }: BindingDetailDialogProps) => {
   const classes = useStyles();
+  const sharedClasses = useSharedStyles();
 
   if (!binding) return null;
 
@@ -220,7 +223,17 @@ export const BindingDetailDialog = ({
               {binding.roleMappings.map((rm, idx) => (
                 <Box key={idx} className={classes.mappingRow}>
                   <Box className={classes.mappingRoleColumn}>
-                    <Typography variant="body2">{rm.role}</Typography>
+                    <Typography variant="body2">
+                      {rm.role}
+                      {rm.isClusterRole && (
+                        <Chip
+                          label="Cluster"
+                          size="small"
+                          variant="outlined"
+                          className={sharedClasses.clusterRoleChip}
+                        />
+                      )}
+                    </Typography>
                   </Box>
                   <Box className={classes.mappingScopeColumn}>{rm.scope}</Box>
                 </Box>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
@@ -238,6 +238,7 @@ export const NamespaceRoleBindingsContent = ({
       roleMappings: (binding.roleMappings || []).map(rm => ({
         role: rm.role?.name || '\u2014',
         scope: formatNsMappingScope(rm.scope, binding.namespace),
+        isClusterRole: !rm.role?.namespace,
       })),
     });
   };

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/styles.ts
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/styles.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useSharedStyles = makeStyles(() => ({
+  clusterRoleChip: {
+    marginLeft: 6,
+    fontSize: '0.65rem',
+    height: 18,
+  },
+}));

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/ReviewStep.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/ReviewStep.tsx
@@ -6,7 +6,8 @@ import { NotificationBanner } from '@openchoreo/backstage-plugin-react';
 import { WizardStepProps, WizardRoleMapping } from './types';
 import { getEntitlementClaim } from '../../hooks';
 import { BindingType } from '../MappingDialog';
-import { SCOPE_CLUSTER } from '../../constants';
+import { SCOPE_CLUSTER, SCOPE_NAMESPACE } from '../../constants';
+import { useSharedStyles } from '../styles';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -160,6 +161,7 @@ export const ReviewStep = ({
   namespace,
 }: ReviewStepProps) => {
   const classes = useStyles();
+  const sharedClasses = useSharedStyles();
 
   const selectedUserTypeInfo = userTypes.find(
     ut => ut.type === state.subjectType,
@@ -245,7 +247,19 @@ export const ReviewStep = ({
             {state.roleMappings.map((rm, idx) => (
               <Box key={idx} className={classes.mappingRow}>
                 <Box className={classes.mappingRoleColumn}>
-                  <Typography variant="body2">{rm.role}</Typography>
+                  <Typography variant="body2">
+                    {rm.role}
+                    {bindingType === SCOPE_NAMESPACE &&
+                      !rm.roleNamespace &&
+                      rm.role && (
+                        <Chip
+                          label="Cluster"
+                          size="small"
+                          variant="outlined"
+                          className={sharedClasses.clusterRoleChip}
+                        />
+                      )}
+                  </Typography>
                 </Box>
                 <Box className={classes.mappingScopeColumn}>
                   {buildScopePath(rm, bindingType, namespace)}

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/RoleMappingsStep.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/RoleMappingsStep.tsx
@@ -9,6 +9,7 @@ import {
   Select,
   MenuItem,
   CircularProgress,
+  Chip,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
@@ -21,6 +22,7 @@ import { Tooltip } from '@material-ui/core';
 import { WizardStepProps, WizardRoleMapping } from './types';
 import { BindingType } from '../MappingDialog';
 import { SCOPE_CLUSTER, SCOPE_NAMESPACE } from '../../constants';
+import { useSharedStyles } from '../styles';
 import { useNamespaces, useProjects, useComponents } from '../../hooks';
 
 const useStyles = makeStyles(theme => ({
@@ -328,6 +330,7 @@ export const RoleMappingsStep = ({
   namespace,
 }: RoleMappingsStepProps) => {
   const classes = useStyles();
+  const sharedClasses = useSharedStyles();
 
   const { namespaces, loading: namespacesLoading } = useNamespaces();
 
@@ -634,6 +637,16 @@ export const RoleMappingsStep = ({
               <Box className={classes.roleColumn}>
                 <Typography className={classes.confirmedText}>
                   {mapping.role || '\u2014'}
+                  {bindingType === SCOPE_NAMESPACE &&
+                    !mapping.roleNamespace &&
+                    mapping.role && (
+                      <Chip
+                        label="Cluster"
+                        size="small"
+                        variant="outlined"
+                        className={sharedClasses.clusterRoleChip}
+                      />
+                    )}
                 </Typography>
               </Box>
               <Box className={classes.scopeColumn}>


### PR DESCRIPTION
## Purpose

In the role mappings view, when selecting a role for namespace bindings, the view pages does not indicate the role type (cluster role vs. namespace role). When both a cluster role and a namespace role share the same name (e.g., "view"), users cannot distinguish between them in the selector, leading to confusion and potential misconfiguration.
## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
  - Adds a "Cluster" chip next to cluster-scoped roles in namespace role binding views to distinguish them from
  namespace roles
  - Chip appears in the binding detail dialog (row click preview), wizard confirmed rows, and wizard review step
  - Shared chip style defined in MappingsTab/styles.ts via useSharedStyles hook

Related: https://github.com/openchoreo/openchoreo/issues/2702

### UX
### Pset 1
before
<img width="1512" height="768" alt="Screenshot 2026-03-16 at 2 47 23 PM" src="https://github.com/user-attachments/assets/ab06e93a-315d-479f-bb46-3cb076046cff" />
After
<img width="1512" height="768" alt="Screenshot 2026-03-16 at 3 14 30 PM" src="https://github.com/user-attachments/assets/fa2ea6d7-4b0b-4fff-8467-6d1bac402085" />

### set 2 (update and create)
Before
<img width="1512" height="768" alt="Screenshot 2026-03-16 at 2 47 33 PM" src="https://github.com/user-attachments/assets/1940b457-8ca9-4c32-85fc-dee839e59725" />
After
<img width="1512" height="768" alt="Screenshot 2026-03-16 at 3 15 55 PM" src="https://github.com/user-attachments/assets/09a7fbff-0e33-4f77-a3f0-70f39e35844c" />

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators (cluster badges) to distinguish cluster-level roles from namespace-scoped roles across the access control interface, providing clearer role mapping identification in role binding details and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->