### PR TITLE
fix: match cell diagram canvas background to platform overview dot pattern

### DIFF
--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { Progress } from '@backstage/core-components';
 import Box from '@material-ui/core/Box';
+import { makeStyles } from '@material-ui/core/styles';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useApi } from '@backstage/core-plugin-api';
 import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
@@ -12,7 +13,31 @@ const CellView = lazy(() =>
   })),
 );
 
+const useStyles = makeStyles(theme => ({
+  cellDiagramWrapper: {
+    height: 'calc(100vh - 146px)',
+    width: 'calc(100% + 48px)',
+    margin: '-24px -24px -24px -24px',
+    // Single dot pattern layer matching Platform Overview
+    backgroundImage:
+      theme.palette.type === 'dark'
+        ? 'radial-gradient(circle, rgba(255,255,255,0.06) 1px, transparent 1px)'
+        : 'radial-gradient(circle, rgba(0,0,0,0.05) 1px, transparent 1px)',
+    backgroundSize: '20px 20px',
+    // Strip library dot pattern from all descendant divs (no node uses backgroundImage)
+    '& div': {
+      backgroundImage: 'none !important',
+    },
+    // Clear container-level white backgrounds only (depths 1-3)
+    // These are Container (Diagram.js), Container/PromptScreen (ProjectDiagram.js), DiagramContainer
+    '& > div, & > div > div, & > div > div > div': {
+      backgroundColor: 'transparent !important',
+    },
+  },
+}));
+
 export const CellDiagram = () => {
+  const classes = useStyles();
   const { entity } = useEntity();
   const [cellDiagramData, setCellDiagramData] = useState<Project>();
   const client = useApi(openChoreoClientApiRef);
@@ -31,13 +56,7 @@ export const CellDiagram = () => {
   }, [entity, client]);
 
   return (
-    <Box
-      sx={{
-        height: 'calc(100vh - 146px)',
-        width: 'calc(100% + 48px)',
-        margin: '-24px -24px -24px -24px',
-      }}
-    >
+    <Box className={classes.cellDiagramWrapper}>
       <Suspense fallback={<Progress />}>
         <CellView project={cellDiagramData} />
       </Suspense>


### PR DESCRIPTION

Platform Overview Background:

<img width="1727" height="870" alt="Screenshot 2026-03-16 at 15 36 39" src="https://github.com/user-attachments/assets/4d5d1ca4-fe02-451d-9c0d-bc1dcc5eb311" />

Cell Diagram: Before

<img width="1727" height="870" alt="Screenshot 2026-03-16 at 15 36 32" src="https://github.com/user-attachments/assets/4c8820cd-1a69-4026-963e-309f04585002" />

Cell Diagram: After

<img width="1727" height="870" alt="Screenshot 2026-03-16 at 15 36 47" src="https://github.com/user-attachments/assets/cc2bd15a-0f11-4ed5-9f42-01dea4489bc2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced CellDiagram component styling with improved Material-UI styling patterns and refined background visuals, including dot patterns and transparency adjustments for better alignment with the Platform Overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->