### PR TITLE
fix: update default role templates

### DIFF
--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
@@ -11,6 +11,7 @@ import {
   Chip,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { Alert } from '@material-ui/lab';
 import { useActions, ClusterRole, NamespaceRole } from '../hooks';
 import {
   SCOPE_CLUSTER,
@@ -54,28 +55,199 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const ROLE_TEMPLATES = {
+  admin: {
+    name: 'admin',
+    label: 'Admin',
+    actions: ['*'],
+  },
+  platformEngineer: {
+    name: 'platform-engineer',
+    label: 'Platform Engineer',
+    actions: [
+      'namespace:view',
+      'namespace:create',
+      'namespace:update',
+      'namespace:delete',
+      'project:view',
+      'project:create',
+      'project:update',
+      'project:delete',
+      'component:view',
+      'component:create',
+      'component:update',
+      'component:delete',
+      'componentrelease:view',
+      'componentrelease:create',
+      'releasebinding:view',
+      'releasebinding:create',
+      'releasebinding:update',
+      'releasebinding:delete',
+      'environment:view',
+      'environment:create',
+      'environment:update',
+      'environment:delete',
+      'dataplane:view',
+      'dataplane:create',
+      'dataplane:update',
+      'dataplane:delete',
+      'workflowplane:view',
+      'workflowplane:create',
+      'workflowplane:update',
+      'workflowplane:delete',
+      'observabilityplane:view',
+      'observabilityplane:create',
+      'observabilityplane:update',
+      'observabilityplane:delete',
+      'componenttype:view',
+      'componenttype:create',
+      'componenttype:update',
+      'componenttype:delete',
+      'trait:view',
+      'trait:create',
+      'trait:update',
+      'trait:delete',
+      'workflow:view',
+      'workflow:create',
+      'workflow:update',
+      'workflow:delete',
+      'workflowrun:view',
+      'workflowrun:create',
+      'deploymentpipeline:view',
+      'deploymentpipeline:create',
+      'deploymentpipeline:update',
+      'deploymentpipeline:delete',
+      'secretreference:view',
+      'secretreference:create',
+      'secretreference:update',
+      'secretreference:delete',
+      'workload:view',
+      'workload:create',
+      'workload:update',
+      'workload:delete',
+      'logs:view',
+      'metrics:view',
+      'traces:view',
+      'alerts:view',
+      'incidents:view',
+      'rcareport:view',
+      'rcareport:update',
+      'observabilityalertsnotificationchannel:view',
+      'observabilityalertsnotificationchannel:create',
+      'observabilityalertsnotificationchannel:update',
+      'observabilityalertsnotificationchannel:delete',
+      'clusterdataplane:view',
+      'clusterdataplane:create',
+      'clusterdataplane:update',
+      'clusterdataplane:delete',
+      'clusterworkflowplane:view',
+      'clusterworkflowplane:create',
+      'clusterworkflowplane:update',
+      'clusterworkflowplane:delete',
+      'clusterobservabilityplane:view',
+      'clusterobservabilityplane:create',
+      'clusterobservabilityplane:update',
+      'clusterobservabilityplane:delete',
+      'clustercomponenttype:view',
+      'clustercomponenttype:create',
+      'clustercomponenttype:update',
+      'clustercomponenttype:delete',
+      'clustertrait:view',
+      'clustertrait:create',
+      'clustertrait:update',
+      'clustertrait:delete',
+      'clusterworkflow:view',
+      'clusterworkflow:create',
+      'clusterworkflow:update',
+      'clusterworkflow:delete',
+    ],
+  },
   developer: {
     name: 'developer',
     label: 'Developer',
     actions: [
+      'clusterdataplane:view',
+      'clusterworkflowplane:view',
+      'clusterobservabilityplane:view',
+      'clustercomponenttype:view',
+      'clustertrait:view',
+      'clusterworkflow:view',
+      'namespace:view',
+      'environment:view',
+      'deploymentpipeline:view',
+      'dataplane:view',
+      'workflowplane:view',
+      'observabilityplane:view',
+      'componenttype:view',
+      'trait:view',
+      'workflow:view',
+      'project:view',
       'component:view',
       'component:create',
       'component:update',
+      'component:delete',
+      'componentrelease:view',
+      'componentrelease:create',
+      'releasebinding:view',
       'releasebinding:create',
-      'namespace:view',
-      'environment:view',
-      'project:view',
+      'releasebinding:update',
+      'workflowrun:view',
+      'workflowrun:create',
+      'secretreference:view',
+      'secretreference:create',
+      'secretreference:update',
+      'secretreference:delete',
+      'workload:view',
+      'workload:create',
+      'workload:update',
+      'workload:delete',
+      'logs:view',
+      'metrics:view',
+      'traces:view',
+      'alerts:view',
+      'rcareport:view',
     ],
   },
-  viewer: {
-    name: 'viewer',
-    label: 'Viewer',
-    actions: ['component:view', 'project:view', 'namespace:view'],
-  },
-  admin: {
-    name: 'admin',
-    label: 'Admin (All)',
-    actions: ['*'],
+  sre: {
+    name: 'sre',
+    label: 'SRE',
+    actions: [
+      'clusterdataplane:view',
+      'clusterworkflowplane:view',
+      'clusterobservabilityplane:view',
+      'clustercomponenttype:view',
+      'clustertrait:view',
+      'clusterworkflow:view',
+      'namespace:view',
+      'environment:view',
+      'deploymentpipeline:view',
+      'dataplane:view',
+      'workflowplane:view',
+      'observabilityplane:view',
+      'componenttype:view',
+      'trait:view',
+      'workflow:view',
+      'project:view',
+      'component:view',
+      'componentrelease:view',
+      'componentrelease:create',
+      'releasebinding:view',
+      'releasebinding:create',
+      'releasebinding:update',
+      'workflowrun:view',
+      'workflowrun:create',
+      'workload:view',
+      'workload:create',
+      'secretreference:view',
+      'secretreference:update',
+      'logs:view',
+      'metrics:view',
+      'traces:view',
+      'alerts:view',
+      'incidents:view',
+      'incidents:update',
+      'rcareport:view',
+      'rcareport:update',
+    ],
   },
 };
 
@@ -204,6 +376,15 @@ export const RoleDialog = ({
           </Typography>
         </DialogTitle>
         <DialogContent>
+          {error && (
+            <Alert
+              severity="error"
+              style={{ marginBottom: 16 }}
+              onClose={() => setError(null)}
+            >
+              {error}
+            </Alert>
+          )}
           <Box className={classes.templateSection}>
             <Typography variant="subtitle2" gutterBottom>
               Quick Start Templates
@@ -267,12 +448,6 @@ export const RoleDialog = ({
               </Typography>
             )}
           </Box>
-
-          {error && (
-            <Typography color="error" variant="body2">
-              {error}
-            </Typography>
-          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose} disabled={saving}>


### PR DESCRIPTION
Related to https://github.com/openchoreo/openchoreo/issues/2743

This pull request updates the `RoleDialog` component in the access control section to enhance role management and error feedback. The main changes include expanding the predefined role templates with more granular permissions and improving the user experience for error display.

**Role templates and permissions:**
- Added new role templates: `platformEngineer` and `sre`, each with detailed and specific action permissions for more flexible access control. The `admin` template is now more clearly defined, and the `developer` template has expanded permissions. The old `viewer` template was removed.

**Error handling and user feedback:**
- Replaced the plain text error message with a styled `Alert` component from `@material-ui/lab` for better visibility and user experience. [[1]](diffhunk://#diff-75f66f8f133f0c7278006920314fe95c3a03bc4a49513efffb48c22db6a7f695R14) [[2]](diffhunk://#diff-75f66f8f133f0c7278006920314fe95c3a03bc4a49513efffb48c22db6a7f695R379-R387) [[3]](diffhunk://#diff-75f66f8f133f0c7278006920314fe95c3a03bc4a49513efffb48c22db6a7f695L271-L275)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four role templates: Admin, Platform Engineer, SRE, and Developer to simplify role creation.
  * Error messages in the Role dialog now appear as a dismissible alert for clearer feedback.

* **Improvements**
  * Expanded and refined role template options with broader action coverage for finer-grained role configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->