### PR TITLE
fix: use component release workload in environment overrides

### DIFF
--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -779,6 +779,30 @@ export async function createRouter({
     });
   });
 
+  router.get('/component-release', async (req, res) => {
+    const { namespaceName, releaseName } = req.query;
+
+    if (!namespaceName || !releaseName) {
+      throw new InputError(
+        'namespaceName and releaseName are required query parameters',
+      );
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    const release = await environmentInfoService.fetchComponentRelease(
+      {
+        namespaceName: namespaceName as string,
+        releaseName: releaseName as string,
+      },
+      userToken,
+    );
+    res.json({
+      success: true,
+      data: release,
+    });
+  });
+
   router.get('/release-bindings', async (req, res) => {
     const { componentName, projectName, namespaceName } = req.query;
 

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -1061,6 +1061,61 @@ export class EnvironmentInfoService implements EnvironmentService {
   }
 
   /**
+   * Fetches a specific component release by name.
+   *
+   * @param {Object} request - The request parameters
+   * @param {string} request.namespaceName - Name of the namespace
+   * @param {string} request.releaseName - Name of the component release
+   * @returns {Promise<any>} Component release details including frozen workload spec
+   */
+  async fetchComponentRelease(
+    request: {
+      namespaceName: string;
+      releaseName: string;
+    },
+    token?: string,
+  ) {
+    const startTime = Date.now();
+    this.logger.debug(`Fetching component release ${request.releaseName}`);
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      const { data, error, response } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/componentreleases/{componentReleaseName}',
+        {
+          params: {
+            path: {
+              namespaceName: request.namespaceName,
+              componentReleaseName: request.releaseName,
+            },
+          },
+        },
+      );
+
+      assertApiResponse({ data, error, response }, 'fetch component release');
+
+      const totalTime = Date.now() - startTime;
+      this.logger.debug(
+        `Component release fetched for ${request.releaseName}: Total: ${totalTime}ms`,
+      );
+
+      return data;
+    } catch (error: unknown) {
+      const totalTime = Date.now() - startTime;
+      this.logger.error(
+        `Error fetching component release ${request.releaseName} (${totalTime}ms):`,
+        error as Error,
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Fetches all release bindings for a specific component.
    *
    * @param {Object} request - The request parameters

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -227,6 +227,9 @@ export type ModelsWorkload = WorkloadResponse;
 export type WorkloadResource = OpenChoreoComponents['schemas']['Workload'];
 /** Spec portion of a WorkloadResource */
 export type WorkloadSpec = NonNullable<WorkloadResource['spec']>;
+/** ComponentRelease resource type from the OpenAPI spec */
+export type ComponentRelease =
+  OpenChoreoComponents['schemas']['ComponentRelease'];
 export type ModelsCompleteComponent = ComponentResponse;
 export type WorkflowRunStatusResponse = ComponentWorkflowRunStatusResponse;
 

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -9,6 +9,7 @@ import { CLUSTER_SCOPED_RESOURCE_KINDS } from './OpenChoreoClientApi';
 import type {
   OpenChoreoClientApi,
   ActionInfo,
+  ComponentReleaseResponse,
   CreateReleaseResponse,
   SchemaResponse,
   ReleaseBindingsResponse,
@@ -52,6 +53,7 @@ const API_ENDPOINTS = {
   DASHBOARD_BINDINGS_COUNT: '/dashboard/bindings-count',
   CREATE_RELEASE: '/create-release',
   DEPLOY_RELEASE: '/deploy-release',
+  COMPONENT_RELEASE: '/component-release',
   COMPONENT_RELEASE_SCHEMA: '/component-release-schema',
   RELEASE_BINDINGS: '/release-bindings',
   UPDATE_RELEASE_BINDING: '/update-release-binding',
@@ -305,6 +307,23 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
       params: entityMetadataToParams(metadata),
       body: { releaseName },
     });
+  }
+
+  async fetchComponentRelease(
+    entity: Entity,
+    releaseName: string,
+  ): Promise<ComponentReleaseResponse> {
+    const metadata = extractEntityMetadata(entity);
+
+    return this.apiFetch<ComponentReleaseResponse>(
+      API_ENDPOINTS.COMPONENT_RELEASE,
+      {
+        params: {
+          namespaceName: metadata.namespace,
+          releaseName,
+        },
+      },
+    );
   }
 
   async fetchComponentReleaseSchema(

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -1,6 +1,9 @@
 import { createApiRef } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import type { WorkloadResource } from '@openchoreo/backstage-plugin-common';
+import type {
+  WorkloadResource,
+  ComponentRelease,
+} from '@openchoreo/backstage-plugin-common';
 import type { Environment } from '../components/RuntimeLogs/types';
 
 // ============================================
@@ -70,6 +73,12 @@ export interface SchemaResponse {
   success: boolean;
   message: string;
   data?: ComponentSchemaResponse;
+}
+
+/** Component release response */
+export interface ComponentReleaseResponse {
+  success: boolean;
+  data?: ComponentRelease;
 }
 
 /** Workflow schema response */
@@ -389,6 +398,12 @@ export interface OpenChoreoClientApi {
 
   /** Deploy a release to its target environment */
   deployRelease(entity: Entity, releaseName: string): Promise<any>;
+
+  /** Fetch a specific component release (includes frozen workload spec) */
+  fetchComponentRelease(
+    entity: Entity,
+    releaseName: string,
+  ): Promise<ComponentReleaseResponse>;
 
   /** Fetch the schema for a component release (for overrides UI) */
   fetchComponentReleaseSchema(

--- a/plugins/openchoreo/src/components/Environments/hooks/useOverridesData.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useOverridesData.ts
@@ -278,13 +278,13 @@ export function useOverridesData(
           const hasActualWorkload = hasActualWorkloadData(workloadOverrides);
           setHasActualWorkloadOverrides(hasActualWorkload);
 
-          // Fetch base workload info for reference display (non-blocking — may not exist yet)
-          const workloadResource = await client
-            .fetchWorkloadInfo(entity)
-            .catch(() => null);
-          // Extract spec for form/display use — fetchWorkloadInfo returns the full K8s resource
-          const workloadInfo = (workloadResource?.spec ??
-            workloadResource) as ModelsWorkload | null;
+          // Fetch base workload from component release (snapshotted workload at release time)
+          const releaseResponse = await client.fetchComponentRelease(
+            entity,
+            releaseName!,
+          );
+          const workloadInfo = (releaseResponse?.data?.spec?.workload ??
+            null) as ModelsWorkload | null;
           setBaseWorkloadData(workloadInfo);
 
           // If no workload overrides exist, populate container structure from base workload
@@ -310,13 +310,13 @@ export function useOverridesData(
           setTraitFormDataMap({});
           setInitialTraitFormDataMap({});
 
-          // Fetch base workload info for reference display (non-blocking — may not exist yet)
-          const workloadResource = await client
-            .fetchWorkloadInfo(entity)
-            .catch(() => null);
-          // Extract spec for form/display use — fetchWorkloadInfo returns the full K8s resource
-          const workloadInfo = (workloadResource?.spec ??
-            workloadResource) as ModelsWorkload | null;
+          // Fetch base workload from component release (snapshotted workload at release time)
+          const releaseResponse = await client.fetchComponentRelease(
+            entity,
+            releaseName!,
+          );
+          const workloadInfo = (releaseResponse?.data?.spec?.workload ??
+            null) as ModelsWorkload | null;
           setBaseWorkloadData(workloadInfo);
 
           // Populate container structure from base workload


### PR DESCRIPTION
## Summary
- Added `fetchComponentRelease` backend service method and `/component-release` route to fetch a specific component release
- Added corresponding frontend API client method and `ComponentRelease` type alias in `openchoreo-common`
- Updated `useOverridesData` to source base workload data from the component release's snapshotted `spec.workload` instead of the latest workload

Resolves https://github.com/openchoreo/openchoreo/issues/2793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query and retrieve specific component release details by namespace and release name.
  * Retrieve release binding information for components.

* **Refactor**
  * Workload data retrieval now uses release-based fetching, affecting how base workload info is sourced and displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->