### PR TITLE
ci: switch Docker build cache to GitHub Actions cache

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -153,5 +153,5 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.GIT_SHA_SHORT }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-dev
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-dev
-          cache-to: type=inline
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Switch Docker build cache from `type=inline` (registry-based) to `type=gha,mode=max` (GitHub Actions cache)
- `type=inline` only caches the final stage layers
- `type=gha,mode=max` caches all intermediate build stages, significantly reducing multi-arch build times

## Test plan
- [x] Verified cold cache build completes successfully (25m 28s — expected slower due to cache upload)
- [x] Verified warm cache build completes successfully (2m 7s — down from ~20 min)

Ref: openchoreo/openchoreo#2811