### PR TITLE
feat: resolve entity ownership from backstage.io/owner CR annotations

### DIFF
--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.test.ts
@@ -760,4 +760,142 @@ describe('OpenChoreoEntityProvider', () => {
       expect(findEntities(entities, 'API')).toHaveLength(0);
     });
   });
+
+  describe('ownership annotation resolution', () => {
+    function setupOwnershipMocks(opts: {
+      projectAnnotations?: Record<string, string>;
+      componentAnnotations?: Record<string, string>;
+    }) {
+      const project = {
+        metadata: {
+          ...k8sMeta('my-project'),
+          annotations: {
+            ...k8sMeta('my-project').annotations,
+            ...opts.projectAnnotations,
+          },
+        },
+        spec: {
+          deploymentPipelineRef: {
+            kind: 'DeploymentPipeline',
+            name: 'default-pipeline',
+          },
+        },
+        status: { conditions: [readyCondition] },
+      };
+
+      const component = {
+        metadata: {
+          ...k8sMeta('api-service'),
+          annotations: {
+            ...k8sMeta('api-service').annotations,
+            ...opts.componentAnnotations,
+          },
+        },
+        spec: {
+          componentType: { kind: 'ComponentType', name: 'Service' },
+          owner: { projectName: 'my-project' },
+        },
+        status: { conditions: [readyCondition] },
+      };
+
+      setupPathBasedMocks({
+        '/api/v1/namespaces/{namespaceName}/projects': okData({
+          items: [project],
+        }),
+        '/api/v1/namespaces/{namespaceName}/components': okData({
+          items: [component],
+        }),
+        '/api/v1/namespaces/{namespaceName}/deploymentpipelines': okData({
+          items: [k8sPipeline],
+        }),
+        '/api/v1/namespaces': okData({ items: [k8sNamespace] }),
+      });
+    }
+
+    it('uses project backstage.io/owner annotation for System entity', async () => {
+      setupOwnershipMocks({
+        projectAnnotations: {
+          'backstage.io/owner': 'group:default/platform-team',
+        },
+      });
+
+      const entities = await runProvider();
+      const system = findEntities(entities, 'System')[0];
+      expect((system.spec as any).owner).toBe('group:default/platform-team');
+    });
+
+    it('falls back to defaultOwner when project has no ownership annotation', async () => {
+      setupOwnershipMocks({});
+
+      const entities = await runProvider();
+      const system = findEntities(entities, 'System')[0];
+      expect((system.spec as any).owner).toBe('group:default/test-owner');
+    });
+
+    it('uses component backstage.io/owner annotation for Component entity', async () => {
+      setupOwnershipMocks({
+        componentAnnotations: {
+          'backstage.io/owner': 'group:default/team-alpha',
+        },
+      });
+
+      const entities = await runProvider();
+      const comp = findEntities(entities, 'Component').find(
+        c => c.metadata.name === 'api-service',
+      );
+      expect((comp?.spec as any).owner).toBe('group:default/team-alpha');
+    });
+
+    it('inherits project owner when component has no annotation', async () => {
+      setupOwnershipMocks({
+        projectAnnotations: { 'backstage.io/owner': 'group:default/team-beta' },
+      });
+
+      const entities = await runProvider();
+      const comp = findEntities(entities, 'Component').find(
+        c => c.metadata.name === 'api-service',
+      );
+      expect((comp?.spec as any).owner).toBe('group:default/team-beta');
+    });
+
+    it('falls back to defaultOwner when neither component nor project has annotation', async () => {
+      setupOwnershipMocks({});
+
+      const entities = await runProvider();
+      const comp = findEntities(entities, 'Component').find(
+        c => c.metadata.name === 'api-service',
+      );
+      expect((comp?.spec as any).owner).toBe('group:default/test-owner');
+    });
+
+    it('component annotation takes precedence over project annotation', async () => {
+      setupOwnershipMocks({
+        projectAnnotations: {
+          'backstage.io/owner': 'group:default/project-team',
+        },
+        componentAnnotations: {
+          'backstage.io/owner': 'group:default/component-team',
+        },
+      });
+
+      const entities = await runProvider();
+      const comp = findEntities(entities, 'Component').find(
+        c => c.metadata.name === 'api-service',
+      );
+      expect((comp?.spec as any).owner).toBe('group:default/component-team');
+    });
+
+    it('ignores empty or whitespace-only annotation values', async () => {
+      setupOwnershipMocks({
+        projectAnnotations: { 'backstage.io/owner': '   ' },
+        componentAnnotations: { 'backstage.io/owner': '' },
+      });
+
+      const entities = await runProvider();
+      const comp = findEntities(entities, 'Component').find(
+        c => c.metadata.name === 'api-service',
+      );
+      expect((comp?.spec as any).owner).toBe('group:default/test-owner');
+    });
+  });
 });

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -18,6 +18,7 @@ import {
   getDescription,
   isReady,
   isCreated,
+  getAnnotation,
   type OpenChoreoComponents,
 } from '@openchoreo/openchoreo-client-node';
 import type {
@@ -161,6 +162,32 @@ export class OpenChoreoEntityProvider implements EntityProvider {
 
   getProviderName(): string {
     return 'OpenChoreoEntityProvider';
+  }
+
+  /**
+   * Resolves the owner for a Project (System) entity from the backstage.io/owner annotation.
+   * Falls back to this.defaultOwner if no annotation is present.
+   */
+  private resolveProjectOwner(project: NewProject): string {
+    return (
+      getAnnotation(project, CHOREO_ANNOTATIONS.BACKSTAGE_OWNER)?.trim() ||
+      this.defaultOwner
+    );
+  }
+
+  /**
+   * Resolves the owner for a Component entity.
+   * Priority: component annotation > project annotation > defaultOwner.
+   */
+  private resolveComponentOwner(
+    component: NewComponent,
+    project: NewProject,
+  ): string {
+    return (
+      getAnnotation(component, CHOREO_ANNOTATIONS.BACKSTAGE_OWNER)?.trim() ||
+      getAnnotation(project, CHOREO_ANNOTATIONS.BACKSTAGE_OWNER)?.trim() ||
+      this.defaultOwner
+    );
   }
 
   async connect(connection: EntityProviderConnection): Promise<void> {
@@ -480,6 +507,9 @@ export class OpenChoreoEntityProvider implements EntityProvider {
           // Pass 1: Collect workload data for all components in this namespace
           // Pass 2: Create entities with cross-component dependency resolution
 
+          // Build project lookup map for ownership resolution in pass 2
+          const projectMap = new Map(projects.map(p => [getName(p)!, p]));
+
           const componentWorkloadMap = new Map<string, ComponentWorkloadData>();
 
           // Pass 1 — Collect workload data
@@ -607,10 +637,18 @@ export class OpenChoreoEntityProvider implements EntityProvider {
               }
             }
 
+            // Resolve ownership: component annotation > project annotation > defaultOwner
+            const project = projectMap.get(projectName)!;
+            const resolvedOwner = this.resolveComponentOwner(
+              component,
+              project,
+            );
+
             const componentEntity = this.translateNewComponentToEntity(
               component,
               nsName,
               projectName,
+              resolvedOwner,
               providesApis,
               consumesApis.length > 0 ? consumesApis : undefined,
             );
@@ -623,6 +661,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                 schemaEndpoints,
                 nsName,
                 projectName,
+                resolvedOwner,
               );
               allEntities.push(...apiEntities);
             }
@@ -1589,7 +1628,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       namespaceName,
       {
         locationKey: this.getProviderName(),
-        defaultOwner: this.defaultOwner,
+        defaultOwner: this.resolveProjectOwner(project),
       },
     );
   }
@@ -1601,6 +1640,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     component: NewComponent,
     namespaceName: string,
     projectName: string,
+    owner: string,
     providesApis?: string[],
     consumesApis?: string[],
   ): Entity {
@@ -1636,7 +1676,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       namespaceName,
       projectName,
       {
-        defaultOwner: this.defaultOwner,
+        defaultOwner: owner,
         componentTypeUtils: this.componentTypeUtils,
         locationKey: `provider:${this.getProviderName()}`,
       },
@@ -2065,6 +2105,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     endpoints: Record<string, WorkloadEndpoint>,
     namespaceName: string,
     projectName: string,
+    owner: string,
   ): Entity[] {
     const apiEntities: Entity[] = [];
 
@@ -2103,7 +2144,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         spec: {
           type: this.mapSchemaTypeToBackstageApiType(endpoint.schema?.type),
           lifecycle: 'production',
-          owner: this.defaultOwner,
+          owner,
           system: projectName,
           definition: this.createApiDefinitionFromWorkloadEndpoint(endpoint),
         },

--- a/plugins/openchoreo-common/src/constants.ts
+++ b/plugins/openchoreo-common/src/constants.ts
@@ -44,6 +44,8 @@ export const CHOREO_ANNOTATIONS = {
   WORKFLOW_PLANE_REF_KIND: 'openchoreo.io/workflow-plane-ref-kind',
   // Workflow parameters schema
   WORKFLOW_PARAMETERS: 'openchoreo.dev/component-workflow-parameters',
+  // Backstage ownership annotation (read from OpenChoreo CR annotations during catalog sync)
+  BACKSTAGE_OWNER: 'backstage.io/owner',
 } as const;
 
 export const CHOREO_LABELS = {


### PR DESCRIPTION
  Support three-tier ownership fallback during catalog sync:
  component annotation → project annotation → configured default.

  API entities inherit their parent component's resolved owner.
  No OpenChoreo backend changes required.

Fixes: https://github.com/openchoreo/openchoreo/issues/2812

**Demo:**

**Project has ownership annotation:**

<img width="672" height="510" alt="image" src="https://github.com/user-attachments/assets/21bacf16-e458-415d-b84e-3024fc1d5ef9" />



**Two components in the project: One inherits owner from project. One defines owner in its definition.**

https://github.com/user-attachments/assets/e40054c7-55f2-454f-914f-01bfd9f12cdb



**Provided APIs from component inherits owner from component**

https://github.com/user-attachments/assets/f6537f6f-ba40-47c1-81ff-3bfe7ace8e13



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ownership annotation resolution on projects and components
  * Component ownership annotations take precedence over project annotations
  * Ownership is now properly propagated throughout the entity creation pipeline
  * Empty or whitespace-only ownership values are ignored with fallback to defaults

* **Tests**
  * Expanded test coverage for ownership annotation resolution with multiple precedence and fallback scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->