### PR TITLE
fix: prevent orphaned catalog entities from scaffolder

### DIFF
--- a/plugins/catalog-backend-module-openchoreo/src/module.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/module.ts
@@ -41,8 +41,8 @@ import {
 import { openChoreoTokenServiceRef } from '@openchoreo/openchoreo-auth';
 import { matchesCatalogEntityCapability } from '@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy';
 
-// Singleton instance of the ScaffolderEntityProvider
-// This will be shared across the module and the service
+// Singleton instances shared between the catalog module and the ImmediateCatalogService factory
+let entityProviderInstance: OpenChoreoEntityProvider | undefined;
 let scaffolderProviderInstance: ScaffolderEntityProvider | undefined;
 
 // Singleton promise for the AnnotationStore
@@ -143,17 +143,15 @@ export const catalogModuleOpenchoreo = createBackendModule({
         catalog.addProcessor(new ClusterWorkflowEntityProcessor());
 
         // Register the scheduled OpenChoreo entity provider
-        catalog.addEntityProvider(
-          new OpenChoreoEntityProvider(
-            taskRunner,
-            logger,
-            config,
-            tokenService,
-          ),
+        entityProviderInstance = new OpenChoreoEntityProvider(
+          taskRunner,
+          logger,
+          config,
+          tokenService,
         );
+        catalog.addEntityProvider(entityProviderInstance);
 
-        // Create and register the ScaffolderEntityProvider for immediate insertions
-        // Pass 'OpenChoreoEntityProvider' so it uses the same location key bucket
+        // Register the ScaffolderEntityProvider for immediate entity insertions
         if (!scaffolderProviderInstance) {
           scaffolderProviderInstance = new ScaffolderEntityProvider(
             logger,
@@ -161,6 +159,11 @@ export const catalogModuleOpenchoreo = createBackendModule({
           );
         }
         catalog.addEntityProvider(scaffolderProviderInstance);
+
+        // Wire cross-provider reference so full sync can clean up stale scaffolder entities
+        entityProviderInstance.setScaffolderProvider(
+          scaffolderProviderInstance,
+        );
 
         // Register OpenChoreo permission rule for catalog entities
         // This allows catalog.entity.* permissions to be checked against OpenChoreo capabilities
@@ -172,7 +175,7 @@ export const catalogModuleOpenchoreo = createBackendModule({
 
 /**
  * Factory for the ImmediateCatalogService.
- * This creates and provides the service instance that can be used by other modules.
+ * Delegates to ScaffolderEntityProvider for immediate delta mutations.
  */
 export const immediateCatalogServiceFactory = createServiceFactory({
   service: immediateCatalogServiceRef,
@@ -180,7 +183,6 @@ export const immediateCatalogServiceFactory = createServiceFactory({
     logger: coreServices.logger,
   },
   async factory({ logger }): Promise<ImmediateCatalogService> {
-    // Ensure singleton instance exists
     if (!scaffolderProviderInstance) {
       scaffolderProviderInstance = new ScaffolderEntityProvider(
         logger,

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -2,7 +2,7 @@ import {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -188,6 +188,18 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       getAnnotation(project, CHOREO_ANNOTATIONS.BACKSTAGE_OWNER)?.trim() ||
       this.defaultOwner
     );
+  }
+
+  private scaffolderProvider?: import('./ScaffolderEntityProvider').ScaffolderEntityProvider;
+
+  /**
+   * Sets a reference to the ScaffolderEntityProvider so that the full sync
+   * can clean up stale scaffolder-inserted entities.
+   */
+  setScaffolderProvider(
+    provider: import('./ScaffolderEntityProvider').ScaffolderEntityProvider,
+  ): void {
+    this.scaffolderProvider = provider;
   }
 
   async connect(connection: EntityProviderConnection): Promise<void> {
@@ -1213,6 +1225,14 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       });
 
       this.logEntityCounts(allEntities, domainEntities.length);
+
+      // Clean up stale scaffolder-inserted entities that no longer exist in the API
+      if (this.scaffolderProvider) {
+        const validEntityRefs = new Set(
+          allEntities.map(e => stringifyEntityRef(e)),
+        );
+        await this.scaffolderProvider.removeStaleEntities(validEntityRefs);
+      }
     } catch (error) {
       this.logger.error(`Failed to run OpenChoreoEntityProvider: ${error}`);
     }

--- a/plugins/catalog-backend-module-openchoreo/src/provider/ScaffolderEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/ScaffolderEntityProvider.ts
@@ -2,7 +2,7 @@ import {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 /**
@@ -18,6 +18,8 @@ export class ScaffolderEntityProvider implements EntityProvider {
   private connection?: EntityProviderConnection;
   private readonly logger: LoggerService;
   private readonly mainProviderName: string;
+  /** Tracks entity refs inserted by the scaffolder for stale entity cleanup. */
+  private readonly insertedRefs = new Set<string>();
 
   constructor(
     logger: LoggerService,
@@ -74,8 +76,11 @@ export class ScaffolderEntityProvider implements EntityProvider {
         removed: [],
       });
 
+      const entityRef = stringifyEntityRef(entity);
+      this.insertedRefs.add(entityRef);
+
       this.logger.info(
-        `Successfully inserted entity: ${entity.metadata.name} (locationKey: ${locationKey})`,
+        `Successfully inserted entity: ${entityRef} (locationKey: ${locationKey})`,
       );
     } catch (error) {
       this.logger.error(
@@ -121,6 +126,50 @@ export class ScaffolderEntityProvider implements EntityProvider {
     } catch (error) {
       this.logger.error(`Failed to remove entity ${entityRef}: ${error}`);
       throw error;
+    }
+  }
+
+  /**
+   * Removes scaffolder-inserted entities that are no longer in the current
+   * set of valid entity refs (i.e., entities that exist in the OpenChoreo API).
+   * Called by OpenChoreoEntityProvider after each full sync to clean up
+   * stale entities that were scaffolded but have since been deleted.
+   */
+  async removeStaleEntities(validEntityRefs: Set<string>): Promise<void> {
+    if (!this.connection || this.insertedRefs.size === 0) {
+      return;
+    }
+
+    const staleRefs = [...this.insertedRefs].filter(
+      ref => !validEntityRefs.has(ref),
+    );
+
+    if (staleRefs.length === 0) {
+      return;
+    }
+
+    this.logger.info(
+      `Cleaning up ${
+        staleRefs.length
+      } stale scaffolder entities: ${staleRefs.join(', ')}`,
+    );
+
+    const locationKey = `provider:${this.mainProviderName}`;
+
+    try {
+      await this.connection.applyMutation({
+        type: 'delta',
+        added: [],
+        removed: staleRefs.map(entityRef => ({ entityRef, locationKey })),
+      });
+
+      for (const ref of staleRefs) {
+        this.insertedRefs.delete(ref);
+      }
+    } catch (error) {
+      this.logger.error(
+        `Failed to clean up stale scaffolder entities: ${error}`,
+      );
     }
   }
 }


### PR DESCRIPTION
ScaffolderEntityProvider uses a different sourceKey than
OpenChoreoEntityProvider. Backstage's full mutation only removes
entities tracked under its own sourceKey, so scaffolder-inserted
entities that are deleted before the next full sync could never
be cleaned up.

Add cross-provider cleanup: after each full sync,
OpenChoreoEntityProvider calls ScaffolderEntityProvider's new
removeStaleEntities() method, which tracks inserted entity refs
and removes any that no longer exist in the API response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog backend entity lifecycle management by automatically tracking and removing stale entities that are no longer referenced in the system.

* **New Features**
  * Enhanced scaffolder integration with improved cleanup mechanisms to ensure orphaned entities are properly removed during catalog synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->