### PR TITLE
feat: add deletion-marked visual indicators to catalog graph nodes

### DIFF
--- a/plugins/openchoreo-react/src/components/CustomGraphNode/CustomGraphNode.tsx
+++ b/plugins/openchoreo-react/src/components/CustomGraphNode/CustomGraphNode.tsx
@@ -16,9 +16,11 @@ import { SvgIconTypeMap } from '@material-ui/core/SvgIcon/SvgIcon';
 import { DEFAULT_NAMESPACE, Entity } from '@backstage/catalog-model';
 import { EntityNodeData } from '@backstage/plugin-catalog-graph';
 import {
+  DELETION_WARNING_COLOR,
   getNodeColor,
   getNodeKindLabel,
   getNodeTintFill,
+  isNodeMarkedForDeletion,
 } from '../../utils/graphUtils';
 
 // Inline EntityIcon component to avoid import issues
@@ -120,24 +122,54 @@ export function CustomGraphNode({
   const paddedWidth = Math.max(contentWidth, minWidthForBadge);
   const paddedHeight = height + padding * 2;
 
+  // Check if entity is marked for deletion
+  const isDeleting = isNodeMarkedForDeletion(entityObj);
+
   // Get the base display title and kind label
   const baseTitle = entityRefPresentationSnapshot.primaryTitle ?? id;
-  const kindLabel = getNodeKindLabel(entity.kind);
+  const kindLabel = isDeleting ? 'Deleting' : getNodeKindLabel(entity.kind);
 
   // Get kind-based color and tint fill
   const nodeColor = getNodeColor(entity.kind);
   const tintFill = getNodeTintFill(nodeColor, isDark);
-  const borderColor = `${nodeColor}B3`; // accent color at 70% opacity
+  const borderColor = isDeleting
+    ? `${DELETION_WARNING_COLOR}B3`
+    : `${nodeColor}B3`; // accent color at 70% opacity
 
-  // Sanitize entity ref for use as a unique clipPath ID
-  const clipId = `accent-clip-${id.replace(/[^a-zA-Z0-9]/g, '-')}`;
+  // Sanitize entity ref for use as a unique SVG ID
+  const sanitizedId = id.replace(/[^a-zA-Z0-9]/g, '-');
+  const clipId = `accent-clip-${sanitizedId}`;
+  const stripePatternId = `deletion-stripe-${sanitizedId}`;
 
   return (
-    <g onClick={onClick} className={clsx(onClick && classes.clickable)}>
+    <g
+      onClick={onClick}
+      className={clsx(onClick && classes.clickable)}
+      opacity={isDeleting ? 0.6 : undefined}
+    >
       <defs>
         <clipPath id={clipId}>
           <rect width={paddedWidth} height={paddedHeight} rx={10} />
         </clipPath>
+        {isDeleting && (
+          <pattern
+            id={stripePatternId}
+            width="6"
+            height="6"
+            patternUnits="userSpaceOnUse"
+            patternTransform="rotate(45)"
+          >
+            <line
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="6"
+              stroke={DELETION_WARNING_COLOR}
+              strokeWidth="1.5"
+              strokeOpacity="0.15"
+            />
+          </pattern>
+        )}
       </defs>
       {/* Main body */}
       <rect
@@ -150,13 +182,24 @@ export function CustomGraphNode({
         height={paddedHeight}
         rx={10}
         strokeWidth={1.5}
+        strokeDasharray={isDeleting ? '6 3' : undefined}
         filter="url(#node-shadow)"
       />
+      {/* Diagonal stripe overlay for deletion-marked nodes */}
+      {isDeleting && (
+        <rect
+          width={paddedWidth}
+          height={paddedHeight}
+          rx={10}
+          fill={`url(#${stripePatternId})`}
+          pointerEvents="none"
+        />
+      )}
       {/* Left accent stripe — clipped to the node's rounded shape */}
       <rect
         width={accentWidth}
         height={paddedHeight}
-        fill={nodeColor}
+        fill={isDeleting ? DELETION_WARNING_COLOR : nodeColor}
         clipPath={`url(#${clipId})`}
       />
       {hasKindIcon && (
@@ -211,6 +254,9 @@ export function CustomGraphNode({
                 textAnchor="start"
                 dominantBaseline="central"
                 className={classes.kindBadgeText}
+                style={
+                  isDeleting ? { fill: DELETION_WARNING_COLOR } : undefined
+                }
               >
                 {kindLabel}
               </text>
@@ -227,7 +273,10 @@ export function CustomGraphNode({
       >
         {baseTitle}
       </text>
-      <title>{entityRefPresentationSnapshot.entityRef}</title>
+      <title>
+        {entityRefPresentationSnapshot.entityRef}
+        {isDeleting ? ' (Marked for Deletion)' : ''}
+      </title>
     </g>
   );
 }

--- a/plugins/openchoreo-react/src/components/GraphLegend/GraphLegend.tsx
+++ b/plugins/openchoreo-react/src/components/GraphLegend/GraphLegend.tsx
@@ -2,6 +2,7 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Chip from '@material-ui/core/Chip';
 import {
+  DELETION_WARNING_COLOR,
   ENTITY_KIND_COLORS,
   DEFAULT_NODE_COLOR,
   getNodeTintFill,
@@ -60,14 +61,19 @@ const KIND_LABELS: Record<string, string> = {
 
 export type GraphLegendProps = {
   kinds: string[];
+  showDeletionIndicator?: boolean;
 };
 
-export function GraphLegend({ kinds }: GraphLegendProps) {
+export function GraphLegend({
+  kinds,
+  showDeletionIndicator = true,
+}: GraphLegendProps) {
   return (
     <Box className={useStyles().root}>
       {kinds.map(kind => (
         <LegendChip key={kind} kind={kind} />
       ))}
+      {showDeletionIndicator && <DeletionLegendChip />}
     </Box>
   );
 }
@@ -88,6 +94,26 @@ function LegendChip({ kind }: { kind: string }) {
         backgroundColor: getNodeTintFill(color, isDark),
         border: `1px solid ${color}B3`,
         ['--dot-color' as string]: color,
+      }}
+    />
+  );
+}
+
+function DeletionLegendChip() {
+  const classes = useStyles();
+  const theme = useTheme();
+  const isDark = theme.palette.type === 'dark';
+
+  return (
+    <Chip
+      size="small"
+      label="Marked for Deletion"
+      className={classes.chip}
+      style={{
+        backgroundColor: getNodeTintFill(DELETION_WARNING_COLOR, isDark),
+        border: `1px dashed ${DELETION_WARNING_COLOR}B3`,
+        opacity: 0.6,
+        ['--dot-color' as string]: DELETION_WARNING_COLOR,
       }}
     />
   );

--- a/plugins/openchoreo-react/src/utils/graphUtils.ts
+++ b/plugins/openchoreo-react/src/utils/graphUtils.ts
@@ -2,6 +2,7 @@
  * Graph utilities for custom entity node rendering in the catalog graph.
  * Provides kind-based coloring and label prefixes for better entity differentiation.
  */
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 
 /**
  * Entity kind to color mapping using theme palette colors.
@@ -161,4 +162,17 @@ export function getNodeDisplayLabel(
   }
 
   return name;
+}
+
+/** Warning color used for deletion indicators on graph nodes. */
+export const DELETION_WARNING_COLOR = '#f59e0b';
+
+/**
+ * Checks whether an entity is marked for deletion by looking for
+ * the deletion-timestamp annotation.
+ */
+export function isNodeMarkedForDeletion(entity: {
+  metadata: { annotations?: Record<string, string> };
+}): boolean {
+  return !!entity.metadata.annotations?.[CHOREO_ANNOTATIONS.DELETION_TIMESTAMP];
 }


### PR DESCRIPTION
  Nodes marked for deletion now display with dashed borders, diagonal
  stripe overlay, reduced opacity, and a warning-colored accent. The
  graph legend includes a new "Marked for Deletion" chip.

<img width="1723" height="866" alt="image" src="https://github.com/user-attachments/assets/58413a0b-65bb-468c-a9e9-a11b816a8cf7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nodes marked for deletion now show a clear visual state: "Deleting" label, deletion-colored border/accent, reduced opacity, diagonal stripe overlay, and an updated tooltip indicating "Marked for Deletion".
  * Graph legend now includes a "Marked for Deletion" chip to explain the deletion visual and help identify affected nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->