### PR TITLE
fix: use display names consistently in breadcrumbs and fix deployment error icon

### DIFF
--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -1655,6 +1655,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     return translateComponent(
       {
         name: componentName,
+        displayName: getDisplayName(component),
         uid: getUid(component),
         type: componentType,
         componentType:

--- a/plugins/catalog-backend-module-openchoreo/src/utils/entityTranslation.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/utils/entityTranslation.ts
@@ -173,7 +173,7 @@ export function translateComponentToEntity(
     kind: 'Component',
     metadata: {
       name: component.name,
-      title: component.name,
+      title: component.displayName || component.name,
       namespace: namespaceName,
       ...(component.description && { description: component.description }),
       tags: config.componentTypeUtils.generateTags(component.type || 'unknown'),

--- a/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
+++ b/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import useAsync from 'react-use/esm/useAsync';
 import Box from '@material-ui/core/Box';
 import MaterialBreadcrumbs from '@material-ui/core/Breadcrumbs';
 import Chip from '@material-ui/core/Chip';
@@ -380,6 +381,19 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
     isCurrent: boolean;
   };
 
+  // Fetch display titles for parent/ancestor entities (we only have refs)
+  const { value: ancestorTitle } = useAsync(async () => {
+    if (!ancestorEntity?.targetRef) return undefined;
+    const ent = await catalogApi.getEntityByRef(ancestorEntity.targetRef);
+    return ent?.metadata.title;
+  }, [ancestorEntity?.targetRef]);
+
+  const { value: parentTitle } = useAsync(async () => {
+    if (!parentEntity?.targetRef) return undefined;
+    const ent = await catalogApi.getEntityByRef(parentEntity.targetRef);
+    return ent?.metadata.title;
+  }, [parentEntity?.targetRef]);
+
   const breadcrumbNodes = useMemo<BreadcrumbNode[]>(() => {
     const nodes: BreadcrumbNode[] = [];
 
@@ -418,6 +432,7 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
         makeNode(
           `ancestor-${ancestorEntity.targetRef}`,
           ancestorEntity.targetRef,
+          { valueOverride: ancestorTitle ?? undefined },
         ),
       );
     }
@@ -426,6 +441,7 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
       nodes.push(
         makeNode(`parent-${parentEntity.targetRef}`, parentEntity.targetRef, {
           relationType: ancestorEntity?.type,
+          valueOverride: parentTitle ?? undefined,
         }),
       );
     }
@@ -440,7 +456,15 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
     );
 
     return nodes;
-  }, [ancestorEntity, parentEntity, entity, entityName, kindDisplayNames]);
+  }, [
+    ancestorEntity,
+    parentEntity,
+    entity,
+    entityName,
+    kindDisplayNames,
+    ancestorTitle,
+    parentTitle,
+  ]);
 
   const getMenuTitleForNodeIndex = useCallback(
     (targetNodeIndex: number) => {

--- a/plugins/openchoreo/src/components/Projects/ProjectComponentsCard/DeploymentStatusCell.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectComponentsCard/DeploymentStatusCell.tsx
@@ -1,7 +1,7 @@
 import { Box, Chip, Tooltip, Typography } from '@material-ui/core';
 import { StatusPending } from '@backstage/core-components';
 import CheckCircleIcon from '@material-ui/icons/CheckCircleOutlined';
-import ErrorIcon from '@material-ui/icons/ErrorOutlined';
+import ErrorIcon from '@material-ui/icons/ErrorOutline';
 import WarningIcon from '@material-ui/icons/ReportProblemOutlined';
 import CloudOffIcon from '@material-ui/icons/CloudOff';
 import { ComponentWithDeployment, type Environment } from '../hooks';


### PR DESCRIPTION
## Summary
- Pass component `displayName` through entity translation so `metadata.title` reflects the CR's `openchoreo.dev/display-name` annotation, matching how projects and namespaces already work
- Fetch parent/ancestor entity titles in breadcrumb navigation so all levels show display names with fallback to entity name
- Use `ErrorOutline` icon in deployment status to match the build column's Backstage `StatusError` icon

Before
<img width="2576" height="200" alt="image" src="https://github.com/user-attachments/assets/dcb55815-edf0-4bec-b3d4-ffb759fefe17" />

---

<img width="665" height="240" alt="image" src="https://github.com/user-attachments/assets/2cda0a2e-5911-440d-b204-b42fc1d0c355" />


After
<img width="2576" height="200" alt="image" src="https://github.com/user-attachments/assets/a36c96b9-0780-4e17-a3b9-c91240708e68" />

---

<img width="728" height="90" alt="image" src="https://github.com/user-attachments/assets/a6ef2e90-c0d8-481f-9242-4affa7009b7b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced breadcrumb navigation to display ancestor and parent entity titles, providing clearer navigation context.
  * Component display names are now properly utilized throughout the catalog interface.
  * Refined visual styling of the error indicator in deployment status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->