### PR TITLE
feat: add optional endpoint basepath in endpoint editor

### DIFF
--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
@@ -2,6 +2,7 @@ import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
 import {
   deriveBindingStatus,
   deriveBindingStatusDetailed,
+  transformReleaseBinding,
 } from './release-binding';
 
 type ReleaseBinding = OpenChoreoComponents['schemas']['ReleaseBinding'];
@@ -270,5 +271,54 @@ describe('deriveBindingStatusDetailed', () => {
     const binding = makeBinding([]);
     const result = deriveBindingStatusDetailed(binding);
     expect(result).toEqual({ status: 'NotReady' });
+  });
+});
+
+describe('transformReleaseBinding endpoint https prioritization', () => {
+  const http = { host: 'api.example.com', port: 80, scheme: 'http' };
+  const https = { host: 'api.example.com', port: 443, scheme: 'https' };
+
+  function makeBindingWithEndpoints(endpoints: unknown[]): ReleaseBinding {
+    return {
+      status: { conditions: [], endpoints },
+    } as unknown as ReleaseBinding;
+  }
+
+  it('orders https before http in externalURLs', () => {
+    const result = transformReleaseBinding(
+      makeBindingWithEndpoints([
+        { name: 'ep', externalURLs: { plain: http, secure: https } },
+      ]),
+    );
+    const urls = Object.values(result.endpoints![0].externalURLs!);
+    expect(urls[0].scheme).toBe('https');
+    expect(urls[1].scheme).toBe('http');
+  });
+
+  it('orders https before http in internalURLs', () => {
+    const result = transformReleaseBinding(
+      makeBindingWithEndpoints([
+        { name: 'ep', internalURLs: { plain: http, secure: https } },
+      ]),
+    );
+    const urls = Object.values(result.endpoints![0].internalURLs!);
+    expect(urls[0].scheme).toBe('https');
+  });
+
+  it('preserves order when only http is present', () => {
+    const result = transformReleaseBinding(
+      makeBindingWithEndpoints([
+        { name: 'ep', externalURLs: { a: http, b: { ...http, port: 8080 } } },
+      ]),
+    );
+    const urls = Object.values(result.endpoints![0].externalURLs!);
+    expect(urls.map(u => u.port)).toEqual([80, 8080]);
+  });
+
+  it('leaves endpoints without URL maps untouched', () => {
+    const result = transformReleaseBinding(
+      makeBindingWithEndpoints([{ name: 'ep' }]),
+    );
+    expect(result.endpoints![0]).toEqual({ name: 'ep' });
   });
 });

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -2,6 +2,7 @@ import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
 import type {
   ReleaseBindingResponse,
   ReleaseBindingEndpoint,
+  ReleaseBindingEndpointURLDetails,
   ReleaseBindingCondition,
 } from '@openchoreo/backstage-plugin-common';
 import { getName, getNamespace, getCreatedAt } from './common';
@@ -142,6 +143,48 @@ export function deriveBindingStatusDetailed(
 }
 
 /**
+ * Reorders a URL map so that HTTPS entries come first.
+ *
+ * The frontend selects an endpoint's primary URL with `Object.values(urls)[0]`
+ * — the first entry in iteration order — and is otherwise scheme-blind. When an
+ * endpoint exposes both an http and an https URL we want the secure one to win,
+ * so we surface https entries first here while keeping the relative order of
+ * everything else stable. Object iteration order follows insertion order for the
+ * string keys used here, so rebuilding the record is enough to influence the
+ * frontend's choice without any frontend change.
+ */
+function prioritizeHttpsUrls(
+  urls: Record<string, ReleaseBindingEndpointURLDetails>,
+): Record<string, ReleaseBindingEndpointURLDetails> {
+  const isHttps = (d: ReleaseBindingEndpointURLDetails | undefined) =>
+    d?.scheme?.toLowerCase() === 'https';
+  const entries = Object.entries(urls);
+  const ordered = [
+    ...entries.filter(([, d]) => isHttps(d)),
+    ...entries.filter(([, d]) => !isHttps(d)),
+  ];
+  return Object.fromEntries(ordered);
+}
+
+/**
+ * Returns a copy of the endpoint with its external/internal URL maps reordered
+ * so https URLs take precedence over http when both are present.
+ */
+function prioritizeEndpointHttps(
+  endpoint: ReleaseBindingEndpoint,
+): ReleaseBindingEndpoint {
+  return {
+    ...endpoint,
+    ...(endpoint.externalURLs
+      ? { externalURLs: prioritizeHttpsUrls(endpoint.externalURLs) }
+      : {}),
+    ...(endpoint.internalURLs
+      ? { internalURLs: prioritizeHttpsUrls(endpoint.internalURLs) }
+      : {}),
+  };
+}
+
+/**
  * Transforms a K8s-style ReleaseBinding resource into the flat
  * ReleaseBindingResponse shape expected by the frontend.
  */
@@ -172,10 +215,12 @@ export function transformReleaseBinding(
     endpoints: (() => {
       const raw = (binding.status as any)?.endpoints;
       if (!Array.isArray(raw)) return undefined;
-      return raw.filter(
-        (e): e is ReleaseBindingEndpoint =>
-          e !== null && typeof e === 'object' && typeof e.name === 'string',
-      );
+      return raw
+        .filter(
+          (e): e is ReleaseBindingEndpoint =>
+            e !== null && typeof e === 'object' && typeof e.name === 'string',
+        )
+        .map(prioritizeEndpointHttps);
     })(),
     conditions: (() => {
       const raw = binding.status?.conditions;


### PR DESCRIPTION
## Purpose
This PR adds the optional endpoint basepath to the endpoint editor.

<img width="1496" height="818" alt="Screenshot 2026-03-21 at 13 16 51" src="https://github.com/user-attachments/assets/41baf361-72cb-4f12-b97d-32c7af6759df" />



related to https://github.com/openchoreo/openchoreo/issues/3778