### PR TITLE
test: add unit tests for permission hooks, utilities, and service classes

### DIFF
--- a/packages/app/src/apis/OpenChoreoFetchApi.test.ts
+++ b/packages/app/src/apis/OpenChoreoFetchApi.test.ts
@@ -1,0 +1,128 @@
+import { OpenChoreoFetchApi } from './OpenChoreoFetchApi';
+
+const mockIdentityApi = {
+  getCredentials: jest.fn(),
+  getBackstageIdentity: jest.fn(),
+  getProfileInfo: jest.fn(),
+  signOut: jest.fn(),
+};
+
+const mockOauthApi = {
+  getAccessToken: jest.fn(),
+  getIdToken: jest.fn(),
+};
+
+const mockConfigApi = {
+  getOptionalBoolean: jest.fn(),
+  has: jest.fn(),
+  keys: jest.fn(),
+  get: jest.fn(),
+  getOptional: jest.fn(),
+  getConfig: jest.fn(),
+  getOptionalConfig: jest.fn(),
+  getConfigArray: jest.fn(),
+  getOptionalConfigArray: jest.fn(),
+  getNumber: jest.fn(),
+  getOptionalNumber: jest.fn(),
+  getBoolean: jest.fn(),
+  getString: jest.fn(),
+  getOptionalString: jest.fn(),
+  getStringArray: jest.fn(),
+  getOptionalStringArray: jest.fn(),
+};
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(global, 'fetch').mockImplementation(mockFetch);
+  mockFetch.mockResolvedValue(new Response('ok'));
+  mockConfigApi.getOptionalBoolean.mockReturnValue(true);
+  mockIdentityApi.getCredentials.mockResolvedValue({
+    token: 'backstage-token',
+  });
+  mockOauthApi.getAccessToken.mockResolvedValue('idp-token');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function createApi(authEnabled = true) {
+  mockConfigApi.getOptionalBoolean.mockReturnValue(authEnabled);
+  return new OpenChoreoFetchApi(mockIdentityApi, mockOauthApi, mockConfigApi);
+}
+
+describe('OpenChoreoFetchApi', () => {
+  describe('normal mode', () => {
+    it('sets Authorization header with Backstage token', async () => {
+      const api = createApi();
+      await api.fetch('http://example.com');
+
+      const headers = mockFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.get('Authorization')).toBe('Bearer backstage-token');
+    });
+
+    it('sets x-openchoreo-token header with IDP token', async () => {
+      const api = createApi();
+      await api.fetch('http://example.com');
+
+      const headers = mockFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.get('x-openchoreo-token')).toBe('idp-token');
+    });
+
+    it('skips IDP token when auth is disabled', async () => {
+      const api = createApi(false);
+      await api.fetch('http://example.com');
+
+      const headers = mockFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.get('x-openchoreo-token')).toBeNull();
+      expect(headers.get('Authorization')).toBe('Bearer backstage-token');
+    });
+
+    it('continues without IDP token when oauthApi throws', async () => {
+      mockOauthApi.getAccessToken.mockRejectedValue(new Error('no token'));
+      const api = createApi();
+      await api.fetch('http://example.com');
+
+      const headers = mockFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.get('x-openchoreo-token')).toBeNull();
+      expect(headers.get('Authorization')).toBe('Bearer backstage-token');
+    });
+  });
+
+  describe('direct mode', () => {
+    it('strips x-openchoreo-direct header and sets IDP token in Authorization', async () => {
+      const api = createApi();
+      await api.fetch('http://example.com', {
+        headers: { 'x-openchoreo-direct': 'true' },
+      });
+
+      const headers = mockFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.has('x-openchoreo-direct')).toBe(false);
+      expect(headers.get('Authorization')).toBe('Bearer idp-token');
+    });
+
+    it('does not set Backstage token in direct mode', async () => {
+      const api = createApi();
+      await api.fetch('http://example.com', {
+        headers: { 'x-openchoreo-direct': 'true' },
+      });
+
+      // In direct mode, Authorization should be IDP token, not Backstage token
+      const headers = mockFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.get('Authorization')).toBe('Bearer idp-token');
+      expect(mockIdentityApi.getCredentials).not.toHaveBeenCalled();
+    });
+
+    it('skips IDP token when auth is disabled in direct mode', async () => {
+      const api = createApi(false);
+      await api.fetch('http://example.com', {
+        headers: { 'x-openchoreo-direct': 'true' },
+      });
+
+      const headers = mockFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.get('Authorization')).toBeNull();
+    });
+  });
+});

--- a/packages/app/src/apis/OpenChoreoPermissionApi.test.ts
+++ b/packages/app/src/apis/OpenChoreoPermissionApi.test.ts
@@ -1,0 +1,162 @@
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { OpenChoreoPermissionApi } from './OpenChoreoPermissionApi';
+
+const mockFetch = jest.fn();
+
+const mockConfig = {
+  getOptionalBoolean: jest.fn(),
+  has: jest.fn(),
+  keys: jest.fn(),
+  get: jest.fn(),
+  getOptional: jest.fn(),
+  getConfig: jest.fn(),
+  getOptionalConfig: jest.fn(),
+  getConfigArray: jest.fn(),
+  getOptionalConfigArray: jest.fn(),
+  getNumber: jest.fn(),
+  getOptionalNumber: jest.fn(),
+  getBoolean: jest.fn(),
+  getString: jest.fn(),
+  getOptionalString: jest.fn(),
+  getStringArray: jest.fn(),
+  getOptionalStringArray: jest.fn(),
+};
+
+const mockDiscovery = {
+  getBaseUrl: jest.fn(),
+};
+
+const mockIdentity = {
+  getCredentials: jest.fn(),
+  getBackstageIdentity: jest.fn(),
+  getProfileInfo: jest.fn(),
+  signOut: jest.fn(),
+};
+
+const mockOauthApi = {
+  getAccessToken: jest.fn(),
+  getIdToken: jest.fn(),
+};
+
+const originalCrypto = global.crypto;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(global, 'fetch').mockImplementation(mockFetch);
+  Object.defineProperty(global, 'crypto', {
+    value: { ...originalCrypto, randomUUID: () => 'test-uuid' },
+    writable: true,
+  });
+  mockDiscovery.getBaseUrl.mockResolvedValue('http://localhost/api/permission');
+  mockIdentity.getCredentials.mockResolvedValue({ token: 'backstage-token' });
+  mockOauthApi.getAccessToken.mockResolvedValue('idp-token');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  Object.defineProperty(global, 'crypto', {
+    value: originalCrypto,
+    writable: true,
+  });
+});
+
+function createApi(
+  opts: { permissionEnabled?: boolean; authEnabled?: boolean } = {},
+) {
+  mockConfig.getOptionalBoolean.mockImplementation((key: string) => {
+    if (key === 'permission.enabled') return opts.permissionEnabled ?? true;
+    if (key === 'openchoreo.features.auth.enabled')
+      return opts.authEnabled ?? true;
+    return undefined;
+  });
+  return new OpenChoreoPermissionApi({
+    config: mockConfig,
+    discovery: mockDiscovery,
+    identity: mockIdentity,
+    oauthApi: mockOauthApi,
+  });
+}
+
+describe('OpenChoreoPermissionApi', () => {
+  it('returns ALLOW when permissions are disabled', async () => {
+    const api = createApi({ permissionEnabled: false });
+    const result = await api.authorize({ permission: { name: 'test.read' } });
+
+    expect(result).toEqual({ result: AuthorizeResult.ALLOW });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends POST to permission API with correct body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ items: [{ result: AuthorizeResult.ALLOW }] }),
+    });
+    const api = createApi();
+    await api.authorize({ permission: { name: 'test.read' } });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost/api/permission/authorize',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          items: [{ id: 'test-uuid', permission: { name: 'test.read' } }],
+        }),
+      }),
+    );
+  });
+
+  it('includes auth headers when auth is enabled', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ items: [{ result: AuthorizeResult.ALLOW }] }),
+    });
+    const api = createApi();
+    await api.authorize({ permission: { name: 'test.read' } });
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe('Bearer backstage-token');
+    expect(headers['x-openchoreo-token']).toBe('idp-token');
+  });
+
+  it('omits x-openchoreo-token when auth is disabled', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ items: [{ result: AuthorizeResult.ALLOW }] }),
+    });
+    const api = createApi({ authEnabled: false });
+    await api.authorize({ permission: { name: 'test.read' } });
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers['x-openchoreo-token']).toBeUndefined();
+  });
+
+  it('throws on non-OK response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      statusText: 'Forbidden',
+    });
+    const api = createApi();
+
+    await expect(
+      api.authorize({ permission: { name: 'test.read' } }),
+    ).rejects.toThrow('Permission request failed: Forbidden');
+  });
+
+  it('returns first item from response', async () => {
+    const expected = { result: AuthorizeResult.DENY };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          items: [expected, { result: AuthorizeResult.ALLOW }],
+        }),
+    });
+    const api = createApi();
+    const result = await api.authorize({ permission: { name: 'test.read' } });
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/design-system/src/components/RjsfTemplates/utils.test.ts
+++ b/packages/design-system/src/components/RjsfTemplates/utils.test.ts
@@ -1,0 +1,26 @@
+import { humanizeTitle } from './utils';
+
+describe('humanizeTitle', () => {
+  it('returns empty string for empty input', () => {
+    expect(humanizeTitle('')).toBe('');
+  });
+
+  it('returns non-camelCase strings as-is', () => {
+    expect(humanizeTitle('Already Title')).toBe('Already Title');
+    expect(humanizeTitle('with-dashes')).toBe('with-dashes');
+    expect(humanizeTitle('ALLCAPS')).toBe('ALLCAPS');
+  });
+
+  it('converts simple camelCase to title case', () => {
+    expect(humanizeTitle('myField')).toBe('My Field');
+    expect(humanizeTitle('firstName')).toBe('First Name');
+  });
+
+  it('handles numbers in camelCase', () => {
+    expect(humanizeTitle('field2Name')).toBe('Field 2Name');
+  });
+
+  it('handles single word', () => {
+    expect(humanizeTitle('name')).toBe('Name');
+  });
+});

--- a/plugins/catalog-backend-module-openchoreo/src/processors/processors.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/processors.test.ts
@@ -636,6 +636,21 @@ describe('ClusterWorkflowPlaneEntityProcessor', () => {
         type: RELATION_OBSERVED_BY,
       }),
     );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'clusterobservabilityplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cop',
+        },
+        target: {
+          kind: 'clusterworkflowplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cwp',
+        },
+        type: RELATION_OBSERVES,
+      }),
+    );
   });
 });
 
@@ -960,6 +975,17 @@ describe('ObservabilityPlaneEntityProcessor', () => {
         },
         target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
         type: RELATION_PART_OF,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        target: {
+          kind: 'observabilityplane',
+          namespace: 'my-ns',
+          name: 'op',
+        },
+        type: RELATION_HAS_PART,
       }),
     );
   });

--- a/plugins/catalog-backend-module-openchoreo/src/processors/processors.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/processors/processors.test.ts
@@ -1,0 +1,1119 @@
+import { processingResult } from '@backstage/plugin-catalog-node';
+import { RELATION_HAS_PART, RELATION_PART_OF } from '@backstage/catalog-model';
+import {
+  RELATION_HOSTED_ON,
+  RELATION_HOSTS,
+  RELATION_OBSERVED_BY,
+  RELATION_OBSERVES,
+  RELATION_BUILDS_ON,
+  RELATION_BUILDS,
+  RELATION_INSTANCE_OF,
+  RELATION_HAS_INSTANCE,
+  RELATION_USES_WORKFLOW,
+  RELATION_WORKFLOW_USED_BY,
+  RELATION_DEPLOYS_TO,
+  RELATION_DEPLOYED_BY,
+  RELATION_USES_PIPELINE,
+  RELATION_PIPELINE_USED_BY,
+} from '@openchoreo/backstage-plugin-common';
+
+import { ClusterComponentTypeEntityProcessor } from './ClusterComponentTypeEntityProcessor';
+import { ClusterDataplaneEntityProcessor } from './ClusterDataplaneEntityProcessor';
+import { ClusterObservabilityPlaneEntityProcessor } from './ClusterObservabilityPlaneEntityProcessor';
+import { ClusterTraitTypeEntityProcessor } from './ClusterTraitTypeEntityProcessor';
+import { ClusterWorkflowEntityProcessor } from './ClusterWorkflowEntityProcessor';
+import { ClusterWorkflowPlaneEntityProcessor } from './ClusterWorkflowPlaneEntityProcessor';
+import { ComponentEntityProcessor } from './ComponentEntityProcessor';
+import { ComponentTypeEntityProcessor } from './ComponentTypeEntityProcessor';
+import { ComponentWorkflowEntityProcessor } from './ComponentWorkflowEntityProcessor';
+import { CustomAnnotationProcessor } from './CustomAnnotationProcessor';
+import { DataplaneEntityProcessor } from './DataplaneEntityProcessor';
+import { DeploymentPipelineEntityProcessor } from './DeploymentPipelineEntityProcessor';
+import { EnvironmentEntityProcessor } from './EnvironmentEntityProcessor';
+import { ObservabilityPlaneEntityProcessor } from './ObservabilityPlaneEntityProcessor';
+import { TraitTypeEntityProcessor } from './TraitTypeEntityProcessor';
+import { WorkflowEntityProcessor } from './WorkflowEntityProcessor';
+import { WorkflowPlaneEntityProcessor } from './WorkflowPlaneEntityProcessor';
+
+const mockLocation = { type: 'url', target: 'http://test' } as any;
+
+// ---------------------------------------------------------------------------
+// EnvironmentEntityProcessor
+// ---------------------------------------------------------------------------
+describe('EnvironmentEntityProcessor', () => {
+  const processor = new EnvironmentEntityProcessor();
+
+  describe('validateEntityKind', () => {
+    it('returns true for Environment kind', async () => {
+      expect(
+        await processor.validateEntityKind({ kind: 'Environment' } as any),
+      ).toBe(true);
+    });
+    it('returns false for other kinds', async () => {
+      expect(
+        await processor.validateEntityKind({ kind: 'Component' } as any),
+      ).toBe(false);
+    });
+  });
+
+  describe('preProcessEntity', () => {
+    it('defaults isProduction to true when spec.type is production', async () => {
+      const entity = {
+        kind: 'Environment',
+        metadata: { name: 'prod' },
+        spec: { type: 'production' },
+      } as any;
+      const result = await processor.preProcessEntity(
+        entity,
+        mockLocation,
+        jest.fn(),
+      );
+      expect(result.spec.isProduction).toBe(true);
+    });
+
+    it('defaults isProduction to false when spec.type is not production', async () => {
+      const entity = {
+        kind: 'Environment',
+        metadata: { name: 'dev' },
+        spec: { type: 'development' },
+      } as any;
+      const result = await processor.preProcessEntity(
+        entity,
+        mockLocation,
+        jest.fn(),
+      );
+      expect(result.spec.isProduction).toBe(false);
+    });
+  });
+
+  describe('postProcessEntity', () => {
+    it('emits partOf/hasPart relations when spec.domain is set', async () => {
+      const emit = jest.fn();
+      const entity = {
+        kind: 'Environment',
+        metadata: { name: 'dev', namespace: 'my-ns' },
+        spec: { type: 'development', domain: 'my-ns' },
+      } as any;
+      await processor.postProcessEntity(entity, mockLocation, emit);
+      expect(emit).toHaveBeenCalledWith(
+        processingResult.relation({
+          source: { kind: 'environment', namespace: 'my-ns', name: 'dev' },
+          target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+          type: RELATION_PART_OF,
+        }),
+      );
+      expect(emit).toHaveBeenCalledWith(
+        processingResult.relation({
+          source: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+          target: { kind: 'environment', namespace: 'my-ns', name: 'dev' },
+          type: RELATION_HAS_PART,
+        }),
+      );
+    });
+
+    it('emits hostedOn/hosts to DataPlane by default', async () => {
+      const emit = jest.fn();
+      const entity = {
+        kind: 'Environment',
+        metadata: { name: 'dev', namespace: 'my-ns' },
+        spec: { type: 'development', dataPlaneRef: 'dp-1' },
+      } as any;
+      await processor.postProcessEntity(entity, mockLocation, emit);
+      expect(emit).toHaveBeenCalledWith(
+        processingResult.relation({
+          source: { kind: 'environment', namespace: 'my-ns', name: 'dev' },
+          target: { kind: 'dataplane', namespace: 'my-ns', name: 'dp-1' },
+          type: RELATION_HOSTED_ON,
+        }),
+      );
+      expect(emit).toHaveBeenCalledWith(
+        processingResult.relation({
+          source: { kind: 'dataplane', namespace: 'my-ns', name: 'dp-1' },
+          target: { kind: 'environment', namespace: 'my-ns', name: 'dev' },
+          type: RELATION_HOSTS,
+        }),
+      );
+    });
+
+    it('emits hostedOn to ClusterDataPlane when annotation specifies ClusterDataPlane', async () => {
+      const emit = jest.fn();
+      const entity = {
+        kind: 'Environment',
+        metadata: {
+          name: 'dev',
+          namespace: 'my-ns',
+          annotations: {
+            'openchoreo.io/data-plane-ref-kind': 'ClusterDataPlane',
+          },
+        },
+        spec: { type: 'development', dataPlaneRef: 'cdp-1' },
+      } as any;
+      await processor.postProcessEntity(entity, mockLocation, emit);
+      expect(emit).toHaveBeenCalledWith(
+        processingResult.relation({
+          source: { kind: 'environment', namespace: 'my-ns', name: 'dev' },
+          target: {
+            kind: 'clusterdataplane',
+            namespace: 'openchoreo-cluster',
+            name: 'cdp-1',
+          },
+          type: RELATION_HOSTED_ON,
+        }),
+      );
+    });
+  });
+
+  describe('processEntity', () => {
+    it('emits entity for Environment kind', async () => {
+      const emit = jest.fn();
+      const entity = {
+        kind: 'Environment',
+        metadata: { name: 'dev' },
+        spec: { type: 'development' },
+      } as any;
+      await processor.processEntity(entity, mockLocation, emit);
+      expect(emit).toHaveBeenCalledWith(
+        processingResult.entity(mockLocation, entity),
+      );
+    });
+
+    it('skips entities of other kinds', async () => {
+      const emit = jest.fn();
+      await processor.processEntity(
+        { kind: 'Component' } as any,
+        mockLocation,
+        emit,
+      );
+      expect(emit).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ComponentEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ComponentEntityProcessor', () => {
+  const processor = new ComponentEntityProcessor();
+
+  it('emits instanceOf/hasInstance to ComponentType when annotation is set', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'Component',
+      metadata: {
+        name: 'my-comp',
+        namespace: 'my-ns',
+        annotations: {
+          'openchoreo.io/component-type': 'deployment/service',
+        },
+      },
+      spec: {},
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'component', namespace: 'my-ns', name: 'my-comp' },
+        target: { kind: 'componenttype', namespace: 'my-ns', name: 'service' },
+        type: RELATION_INSTANCE_OF,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'componenttype', namespace: 'my-ns', name: 'service' },
+        target: { kind: 'component', namespace: 'my-ns', name: 'my-comp' },
+        type: RELATION_HAS_INSTANCE,
+      }),
+    );
+  });
+
+  it('targets ClusterComponentType when component-type-kind annotation is set', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'Component',
+      metadata: {
+        name: 'my-comp',
+        namespace: 'my-ns',
+        annotations: {
+          'openchoreo.io/component-type': 'cronjob/scheduled-task',
+          'openchoreo.io/component-type-kind': 'ClusterComponentType',
+        },
+      },
+      spec: {},
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'component', namespace: 'my-ns', name: 'my-comp' },
+        target: {
+          kind: 'clustercomponenttype',
+          namespace: 'openchoreo-cluster',
+          name: 'scheduled-task',
+        },
+        type: RELATION_INSTANCE_OF,
+      }),
+    );
+  });
+
+  it('skips non-Component entities and Components without the annotation', async () => {
+    const emit = jest.fn();
+    await processor.postProcessEntity(
+      { kind: 'Environment', metadata: { name: 'x' } } as any,
+      mockLocation,
+      emit,
+    );
+    await processor.postProcessEntity(
+      { kind: 'Component', metadata: { name: 'x' } } as any,
+      mockLocation,
+      emit,
+    );
+    expect(emit).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ComponentTypeEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ComponentTypeEntityProcessor', () => {
+  const processor = new ComponentTypeEntityProcessor();
+
+  describe('validateEntityKind', () => {
+    it('returns true for ComponentType', async () => {
+      expect(
+        await processor.validateEntityKind({ kind: 'ComponentType' } as any),
+      ).toBe(true);
+    });
+    it('returns false for other kinds', async () => {
+      expect(
+        await processor.validateEntityKind({ kind: 'Component' } as any),
+      ).toBe(false);
+    });
+  });
+
+  it('emits partOf domain relation', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ComponentType',
+      metadata: { name: 'svc', namespace: 'my-ns' },
+      spec: { domain: 'my-ns' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'componenttype', namespace: 'my-ns', name: 'svc' },
+        target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        type: RELATION_PART_OF,
+      }),
+    );
+  });
+
+  it('emits usesWorkflow relation for each allowed workflow', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ComponentType',
+      metadata: { name: 'svc', namespace: 'my-ns' },
+      spec: { allowedWorkflows: ['build-wf'] },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'componenttype', namespace: 'my-ns', name: 'svc' },
+        target: { kind: 'workflow', namespace: 'my-ns', name: 'build-wf' },
+        type: RELATION_USES_WORKFLOW,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'workflow', namespace: 'my-ns', name: 'build-wf' },
+        target: { kind: 'componenttype', namespace: 'my-ns', name: 'svc' },
+        type: RELATION_WORKFLOW_USED_BY,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClusterComponentTypeEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ClusterComponentTypeEntityProcessor', () => {
+  const processor = new ClusterComponentTypeEntityProcessor();
+
+  it('validateEntityKind returns true for ClusterComponentType, false otherwise', async () => {
+    expect(
+      await processor.validateEntityKind({
+        kind: 'ClusterComponentType',
+      } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'ComponentType' } as any),
+    ).toBe(false);
+  });
+
+  it('does not emit any domain relation (cluster-scoped)', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ClusterComponentType',
+      metadata: { name: 'svc', namespace: 'openchoreo-cluster' },
+      spec: {},
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('emits usesWorkflow relation to ClusterWorkflow when allowedWorkflows is set', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ClusterComponentType',
+      metadata: { name: 'svc', namespace: 'openchoreo-cluster' },
+      spec: { allowedWorkflows: ['cluster-build'] },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'clustercomponenttype',
+          namespace: 'openchoreo-cluster',
+          name: 'svc',
+        },
+        target: {
+          kind: 'clusterworkflow',
+          namespace: 'openchoreo-cluster',
+          name: 'cluster-build',
+        },
+        type: RELATION_USES_WORKFLOW,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClusterDataplaneEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ClusterDataplaneEntityProcessor', () => {
+  const processor = new ClusterDataplaneEntityProcessor();
+
+  it('validateEntityKind returns true for ClusterDataplane', async () => {
+    expect(
+      await processor.validateEntityKind({ kind: 'ClusterDataplane' } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'Dataplane' } as any),
+    ).toBe(false);
+  });
+
+  it('emits observedBy/observes to ClusterObservabilityPlane', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ClusterDataplane',
+      metadata: { name: 'cdp', namespace: 'openchoreo-cluster' },
+      spec: { observabilityPlaneRef: 'cop' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'clusterdataplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cdp',
+        },
+        target: {
+          kind: 'clusterobservabilityplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cop',
+        },
+        type: RELATION_OBSERVED_BY,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'clusterobservabilityplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cop',
+        },
+        target: {
+          kind: 'clusterdataplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cdp',
+        },
+        type: RELATION_OBSERVES,
+      }),
+    );
+  });
+
+  it('does not emit relations for non-ClusterDataplane entities', async () => {
+    const emit = jest.fn();
+    await processor.postProcessEntity(
+      { kind: 'Dataplane', metadata: { name: 'x' } } as any,
+      mockLocation,
+      emit,
+    );
+    expect(emit).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClusterObservabilityPlaneEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ClusterObservabilityPlaneEntityProcessor', () => {
+  const processor = new ClusterObservabilityPlaneEntityProcessor();
+
+  it('validateEntityKind returns true for ClusterObservabilityPlane', async () => {
+    expect(
+      await processor.validateEntityKind({
+        kind: 'ClusterObservabilityPlane',
+      } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({
+        kind: 'ObservabilityPlane',
+      } as any),
+    ).toBe(false);
+  });
+
+  it('postProcessEntity does not emit any relations', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ClusterObservabilityPlane',
+      metadata: { name: 'cop' },
+      spec: {},
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('processEntity emits entity for ClusterObservabilityPlane', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ClusterObservabilityPlane',
+      metadata: { name: 'cop' },
+      spec: {},
+    } as any;
+    await processor.processEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.entity(mockLocation, entity),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClusterTraitTypeEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ClusterTraitTypeEntityProcessor', () => {
+  const processor = new ClusterTraitTypeEntityProcessor();
+
+  it('validateEntityKind returns true for ClusterTraitType', async () => {
+    expect(
+      await processor.validateEntityKind({ kind: 'ClusterTraitType' } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'TraitType' } as any),
+    ).toBe(false);
+  });
+
+  it('postProcessEntity emits no relations', async () => {
+    const emit = jest.fn();
+    await processor.postProcessEntity(
+      { kind: 'ClusterTraitType', metadata: { name: 't' }, spec: {} } as any,
+      mockLocation,
+      emit,
+    );
+    expect(emit).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClusterWorkflowEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ClusterWorkflowEntityProcessor', () => {
+  const processor = new ClusterWorkflowEntityProcessor();
+
+  it('validateEntityKind returns true for ClusterWorkflow', async () => {
+    expect(
+      await processor.validateEntityKind({ kind: 'ClusterWorkflow' } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'Workflow' } as any),
+    ).toBe(false);
+  });
+
+  it('does not emit any domain relation (cluster-scoped)', async () => {
+    const emit = jest.fn();
+    await processor.postProcessEntity(
+      {
+        kind: 'ClusterWorkflow',
+        metadata: { name: 'wf', namespace: 'openchoreo-cluster' },
+        spec: {},
+      } as any,
+      mockLocation,
+      emit,
+    );
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('emits buildsOn/builds to ClusterWorkflowPlane from annotation', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ClusterWorkflow',
+      metadata: {
+        name: 'wf',
+        namespace: 'openchoreo-cluster',
+        annotations: {
+          'openchoreo.io/workflow-plane-ref': 'cwp-1',
+        },
+      },
+      spec: {},
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'clusterworkflow',
+          namespace: 'openchoreo-cluster',
+          name: 'wf',
+        },
+        target: {
+          kind: 'clusterworkflowplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cwp-1',
+        },
+        type: RELATION_BUILDS_ON,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'clusterworkflowplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cwp-1',
+        },
+        target: {
+          kind: 'clusterworkflow',
+          namespace: 'openchoreo-cluster',
+          name: 'wf',
+        },
+        type: RELATION_BUILDS,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClusterWorkflowPlaneEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ClusterWorkflowPlaneEntityProcessor', () => {
+  const processor = new ClusterWorkflowPlaneEntityProcessor();
+
+  it('validateEntityKind returns true for ClusterWorkflowPlane', async () => {
+    expect(
+      await processor.validateEntityKind({
+        kind: 'ClusterWorkflowPlane',
+      } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'WorkflowPlane' } as any),
+    ).toBe(false);
+  });
+
+  it('emits observedBy/observes to ClusterObservabilityPlane', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ClusterWorkflowPlane',
+      metadata: { name: 'cwp', namespace: 'openchoreo-cluster' },
+      spec: { observabilityPlaneRef: 'cop' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'clusterworkflowplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cwp',
+        },
+        target: {
+          kind: 'clusterobservabilityplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cop',
+        },
+        type: RELATION_OBSERVED_BY,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ComponentWorkflowEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ComponentWorkflowEntityProcessor', () => {
+  const processor = new ComponentWorkflowEntityProcessor();
+
+  it('validateEntityKind returns true for ComponentWorkflow', async () => {
+    expect(
+      await processor.validateEntityKind({
+        kind: 'ComponentWorkflow',
+      } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'Workflow' } as any),
+    ).toBe(false);
+  });
+
+  it('emits partOf/hasPart to domain', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ComponentWorkflow',
+      metadata: { name: 'cwf', namespace: 'my-ns' },
+      spec: { domain: 'my-ns' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'componentworkflow',
+          namespace: 'my-ns',
+          name: 'cwf',
+        },
+        target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        type: RELATION_PART_OF,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        target: {
+          kind: 'componentworkflow',
+          namespace: 'my-ns',
+          name: 'cwf',
+        },
+        type: RELATION_HAS_PART,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CustomAnnotationProcessor
+// ---------------------------------------------------------------------------
+describe('CustomAnnotationProcessor', () => {
+  function createProcessor(annotations: Record<string, string> = {}): {
+    processor: CustomAnnotationProcessor;
+    getAnnotations: jest.Mock;
+  } {
+    const getAnnotations = jest.fn().mockResolvedValue(annotations);
+    const store = {
+      getAnnotations,
+      setAnnotations: jest.fn(),
+      deleteAllAnnotations: jest.fn(),
+    };
+    return {
+      processor: new CustomAnnotationProcessor(store),
+      getAnnotations,
+    };
+  }
+
+  it('skips non-managed entities (no openchoreo.io/managed label)', async () => {
+    const { processor, getAnnotations } = createProcessor({ foo: 'bar' });
+    const entity = {
+      kind: 'Component',
+      metadata: { name: 'c', namespace: 'default', labels: {} },
+    } as any;
+    const result = await processor.preProcessEntity(entity, mockLocation);
+    expect(getAnnotations).not.toHaveBeenCalled();
+    expect(result).toBe(entity);
+  });
+
+  it('merges custom annotations into managed entities', async () => {
+    const { processor, getAnnotations } = createProcessor({
+      'custom.io/note': 'hello',
+    });
+    const entity = {
+      kind: 'Component',
+      metadata: {
+        name: 'c',
+        namespace: 'default',
+        labels: { 'openchoreo.io/managed': 'true' },
+        annotations: { 'existing/anno': 'keep' },
+      },
+    } as any;
+    const result = await processor.preProcessEntity(entity, mockLocation);
+    expect(getAnnotations).toHaveBeenCalledWith('component:default/c');
+    expect(result.metadata.annotations).toEqual({
+      'existing/anno': 'keep',
+      'custom.io/note': 'hello',
+    });
+  });
+
+  it('returns entity unchanged when AnnotationStore returns empty annotations', async () => {
+    const { processor } = createProcessor({});
+    const entity = {
+      kind: 'Component',
+      metadata: {
+        name: 'c',
+        namespace: 'default',
+        labels: { 'openchoreo.io/managed': 'true' },
+        annotations: { existing: 'a' },
+      },
+    } as any;
+    const result = await processor.preProcessEntity(entity, mockLocation);
+    expect(result).toBe(entity);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataplaneEntityProcessor
+// ---------------------------------------------------------------------------
+describe('DataplaneEntityProcessor', () => {
+  const processor = new DataplaneEntityProcessor();
+
+  it('validateEntityKind returns true for Dataplane', async () => {
+    expect(
+      await processor.validateEntityKind({ kind: 'Dataplane' } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'ClusterDataplane' } as any),
+    ).toBe(false);
+  });
+
+  it('emits partOf domain relation', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'Dataplane',
+      metadata: { name: 'dp', namespace: 'my-ns' },
+      spec: { domain: 'my-ns' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'dataplane', namespace: 'my-ns', name: 'dp' },
+        target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        type: RELATION_PART_OF,
+      }),
+    );
+  });
+
+  it('emits observedBy/observes to ObservabilityPlane', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'Dataplane',
+      metadata: { name: 'dp', namespace: 'my-ns' },
+      spec: { observabilityPlaneRef: 'op' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'dataplane', namespace: 'my-ns', name: 'dp' },
+        target: {
+          kind: 'observabilityplane',
+          namespace: 'my-ns',
+          name: 'op',
+        },
+        type: RELATION_OBSERVED_BY,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'observabilityplane',
+          namespace: 'my-ns',
+          name: 'op',
+        },
+        target: { kind: 'dataplane', namespace: 'my-ns', name: 'dp' },
+        type: RELATION_OBSERVES,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DeploymentPipelineEntityProcessor
+// ---------------------------------------------------------------------------
+describe('DeploymentPipelineEntityProcessor', () => {
+  const processor = new DeploymentPipelineEntityProcessor();
+
+  it('validateEntityKind returns true for DeploymentPipeline', async () => {
+    expect(
+      await processor.validateEntityKind({
+        kind: 'DeploymentPipeline',
+      } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'Component' } as any),
+    ).toBe(false);
+  });
+
+  it('emits usesPipeline/pipelineUsedBy for projectRefs', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'DeploymentPipeline',
+      metadata: { name: 'pipe', namespace: 'my-ns' },
+      spec: {
+        projectRefs: ['proj-1'],
+        namespaceName: 'my-ns',
+      },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'system', namespace: 'my-ns', name: 'proj-1' },
+        target: {
+          kind: 'deploymentpipeline',
+          namespace: 'my-ns',
+          name: 'pipe',
+        },
+        type: RELATION_USES_PIPELINE,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'deploymentpipeline',
+          namespace: 'my-ns',
+          name: 'pipe',
+        },
+        target: { kind: 'system', namespace: 'my-ns', name: 'proj-1' },
+        type: RELATION_PIPELINE_USED_BY,
+      }),
+    );
+  });
+
+  it('emits deploysTo/deployedBy for environments in promotionPaths', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'DeploymentPipeline',
+      metadata: { name: 'pipe', namespace: 'my-ns' },
+      spec: {
+        promotionPaths: [
+          {
+            sourceEnvironment: 'dev',
+            targetEnvironments: [{ name: 'staging' }],
+          },
+        ],
+      },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'deploymentpipeline',
+          namespace: 'my-ns',
+          name: 'pipe',
+        },
+        target: { kind: 'environment', namespace: 'my-ns', name: 'dev' },
+        type: RELATION_DEPLOYS_TO,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'environment', namespace: 'my-ns', name: 'staging' },
+        target: {
+          kind: 'deploymentpipeline',
+          namespace: 'my-ns',
+          name: 'pipe',
+        },
+        type: RELATION_DEPLOYED_BY,
+      }),
+    );
+  });
+
+  it('skips non-DeploymentPipeline entities', async () => {
+    const emit = jest.fn();
+    await processor.postProcessEntity(
+      { kind: 'Component', metadata: { name: 'x' } } as any,
+      mockLocation,
+      emit,
+    );
+    expect(emit).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ObservabilityPlaneEntityProcessor
+// ---------------------------------------------------------------------------
+describe('ObservabilityPlaneEntityProcessor', () => {
+  const processor = new ObservabilityPlaneEntityProcessor();
+
+  it('validateEntityKind returns true for ObservabilityPlane', async () => {
+    expect(
+      await processor.validateEntityKind({
+        kind: 'ObservabilityPlane',
+      } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({
+        kind: 'ClusterObservabilityPlane',
+      } as any),
+    ).toBe(false);
+  });
+
+  it('emits partOf/hasPart domain relation', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'ObservabilityPlane',
+      metadata: { name: 'op', namespace: 'my-ns' },
+      spec: { domain: 'my-ns' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: {
+          kind: 'observabilityplane',
+          namespace: 'my-ns',
+          name: 'op',
+        },
+        target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        type: RELATION_PART_OF,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TraitTypeEntityProcessor
+// ---------------------------------------------------------------------------
+describe('TraitTypeEntityProcessor', () => {
+  const processor = new TraitTypeEntityProcessor();
+
+  it('validateEntityKind returns true for TraitType', async () => {
+    expect(
+      await processor.validateEntityKind({ kind: 'TraitType' } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'ClusterTraitType' } as any),
+    ).toBe(false);
+  });
+
+  it('emits partOf domain relation', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'TraitType',
+      metadata: { name: 't', namespace: 'my-ns' },
+      spec: { domain: 'my-ns' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'traittype', namespace: 'my-ns', name: 't' },
+        target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        type: RELATION_PART_OF,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkflowEntityProcessor
+// ---------------------------------------------------------------------------
+describe('WorkflowEntityProcessor', () => {
+  const processor = new WorkflowEntityProcessor();
+
+  it('validateEntityKind returns true for Workflow', async () => {
+    expect(
+      await processor.validateEntityKind({ kind: 'Workflow' } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({ kind: 'ClusterWorkflow' } as any),
+    ).toBe(false);
+  });
+
+  it('emits partOf domain and buildsOn WorkflowPlane by default', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'Workflow',
+      metadata: {
+        name: 'wf',
+        namespace: 'my-ns',
+        annotations: {
+          'openchoreo.io/workflow-plane-ref': 'wp-1',
+        },
+      },
+      spec: { domain: 'my-ns' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'workflow', namespace: 'my-ns', name: 'wf' },
+        target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        type: RELATION_PART_OF,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'workflow', namespace: 'my-ns', name: 'wf' },
+        target: { kind: 'workflowplane', namespace: 'my-ns', name: 'wp-1' },
+        type: RELATION_BUILDS_ON,
+      }),
+    );
+  });
+
+  it('emits buildsOn ClusterWorkflowPlane when workflow-plane-ref-kind is ClusterWorkflowPlane', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'Workflow',
+      metadata: {
+        name: 'wf',
+        namespace: 'my-ns',
+        annotations: {
+          'openchoreo.io/workflow-plane-ref': 'cwp-1',
+          'openchoreo.io/workflow-plane-ref-kind': 'ClusterWorkflowPlane',
+        },
+      },
+      spec: {},
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'workflow', namespace: 'my-ns', name: 'wf' },
+        target: {
+          kind: 'clusterworkflowplane',
+          namespace: 'openchoreo-cluster',
+          name: 'cwp-1',
+        },
+        type: RELATION_BUILDS_ON,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkflowPlaneEntityProcessor
+// ---------------------------------------------------------------------------
+describe('WorkflowPlaneEntityProcessor', () => {
+  const processor = new WorkflowPlaneEntityProcessor();
+
+  it('validateEntityKind returns true for WorkflowPlane', async () => {
+    expect(
+      await processor.validateEntityKind({ kind: 'WorkflowPlane' } as any),
+    ).toBe(true);
+    expect(
+      await processor.validateEntityKind({
+        kind: 'ClusterWorkflowPlane',
+      } as any),
+    ).toBe(false);
+  });
+
+  it('emits partOf domain and observedBy ObservabilityPlane', async () => {
+    const emit = jest.fn();
+    const entity = {
+      kind: 'WorkflowPlane',
+      metadata: { name: 'wp', namespace: 'my-ns' },
+      spec: { domain: 'my-ns', observabilityPlaneRef: 'op' },
+    } as any;
+    await processor.postProcessEntity(entity, mockLocation, emit);
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'workflowplane', namespace: 'my-ns', name: 'wp' },
+        target: { kind: 'domain', namespace: 'my-ns', name: 'my-ns' },
+        type: RELATION_PART_OF,
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      processingResult.relation({
+        source: { kind: 'workflowplane', namespace: 'my-ns', name: 'wp' },
+        target: {
+          kind: 'observabilityplane',
+          namespace: 'my-ns',
+          name: 'op',
+        },
+        type: RELATION_OBSERVED_BY,
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-observability/src/api/ObserverUrlCache.test.ts
+++ b/plugins/openchoreo-observability/src/api/ObserverUrlCache.test.ts
@@ -1,0 +1,138 @@
+import { ObserverUrlCache } from './ObserverUrlCache';
+
+const mockDiscoveryApi = {
+  getBaseUrl: jest.fn(),
+};
+
+const mockFetchApi = {
+  fetch: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDiscoveryApi.getBaseUrl.mockResolvedValue('http://localhost/api/obs');
+});
+
+function createCache() {
+  return new ObserverUrlCache({
+    discoveryApi: mockDiscoveryApi,
+    fetchApi: mockFetchApi,
+  });
+}
+
+function mockOkResponse(data: Record<string, unknown>) {
+  return { ok: true, json: () => Promise.resolve(data) };
+}
+
+describe('ObserverUrlCache', () => {
+  it('fetches and returns URLs on cache miss', async () => {
+    mockFetchApi.fetch.mockResolvedValue(
+      mockOkResponse({
+        observerUrl: 'http://observer',
+        rcaAgentUrl: 'http://rca',
+      }),
+    );
+    const cache = createCache();
+    const result = await cache.resolveUrls('ns1', 'dev');
+
+    expect(result).toEqual({
+      observerUrl: 'http://observer',
+      rcaAgentUrl: 'http://rca',
+    });
+    expect(mockFetchApi.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns cached URLs on subsequent calls within TTL', async () => {
+    mockFetchApi.fetch.mockResolvedValue(
+      mockOkResponse({ observerUrl: 'http://observer' }),
+    );
+    const cache = createCache();
+
+    await cache.resolveUrls('ns1', 'dev');
+    const result = await cache.resolveUrls('ns1', 'dev');
+
+    expect(result).toEqual({
+      observerUrl: 'http://observer',
+      rcaAgentUrl: undefined,
+    });
+    expect(mockFetchApi.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches after TTL expires', async () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    mockFetchApi.fetch.mockResolvedValue(
+      mockOkResponse({ observerUrl: 'http://observer-v1' }),
+    );
+    const cache = createCache();
+    await cache.resolveUrls('ns1', 'dev');
+
+    // Advance past 5-minute TTL
+    (Date.now as jest.Mock).mockReturnValue(now + 6 * 60 * 1000);
+    mockFetchApi.fetch.mockResolvedValue(
+      mockOkResponse({ observerUrl: 'http://observer-v2' }),
+    );
+    const result = await cache.resolveUrls('ns1', 'dev');
+
+    expect(result.observerUrl).toBe('http://observer-v2');
+    expect(mockFetchApi.fetch).toHaveBeenCalledTimes(2);
+
+    jest.restoreAllMocks();
+  });
+
+  it('throws when response is not OK with JSON error', async () => {
+    mockFetchApi.fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ error: 'Observer not found' }),
+    });
+    const cache = createCache();
+
+    await expect(cache.resolveUrls('ns1', 'dev')).rejects.toThrow(
+      'Observer not found',
+    );
+  });
+
+  it('throws when response is not OK without JSON', async () => {
+    mockFetchApi.fetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      json: () => Promise.reject(new Error('not json')),
+    });
+    const cache = createCache();
+
+    await expect(cache.resolveUrls('ns1', 'dev')).rejects.toThrow(
+      'Failed to resolve observer URLs: 502 Bad Gateway',
+    );
+  });
+
+  it('throws when observerUrl is missing from response', async () => {
+    mockFetchApi.fetch.mockResolvedValue(mockOkResponse({}));
+    const cache = createCache();
+
+    await expect(cache.resolveUrls('ns1', 'dev')).rejects.toThrow(
+      'Observability is not enabled for this component',
+    );
+  });
+
+  it('caches different namespace/environment combinations separately', async () => {
+    mockFetchApi.fetch
+      .mockResolvedValueOnce(
+        mockOkResponse({ observerUrl: 'http://observer-ns1-dev' }),
+      )
+      .mockResolvedValueOnce(
+        mockOkResponse({ observerUrl: 'http://observer-ns2-prod' }),
+      );
+    const cache = createCache();
+
+    const result1 = await cache.resolveUrls('ns1', 'dev');
+    const result2 = await cache.resolveUrls('ns2', 'prod');
+
+    expect(result1.observerUrl).toBe('http://observer-ns1-dev');
+    expect(result2.observerUrl).toBe('http://observer-ns2-prod');
+    expect(mockFetchApi.fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useAlertsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useAlertsPermission.test.ts
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react';
+import { useAlertsPermission } from './useAlertsPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+const mockUseEntity = jest.fn();
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => mockUseEntity(),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+const componentEntity = {
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'test', namespace: 'default' },
+  },
+};
+
+const systemEntity = {
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'System',
+    metadata: { name: 'test-project', namespace: 'default' },
+  },
+};
+
+describe('useAlertsPermission', () => {
+  beforeEach(() => {
+    mockUseEntity.mockReturnValue(componentEntity);
+  });
+
+  it('returns canViewAlerts=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useAlertsPermission());
+
+    expect(result.current.canViewAlerts).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useAlertsPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip for component when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useAlertsPermission());
+
+    expect(result.current.canViewAlerts).toBe(false);
+    expect(result.current.deniedTooltip).toContain('component');
+  });
+
+  it('returns denied tooltip for project when entity kind is System', () => {
+    mockUseEntity.mockReturnValue(systemEntity);
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useAlertsPermission());
+
+    expect(result.current.deniedTooltip).toContain('project');
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useAlertsPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useAlertsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useAlertsPermission.test.ts
@@ -33,6 +33,7 @@ const systemEntity = {
 
 describe('useAlertsPermission', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockUseEntity.mockReturnValue(componentEntity);
   });
 

--- a/plugins/openchoreo-react/src/hooks/useClusterComponentTypePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterComponentTypePermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useClusterComponentTypePermission } from './useClusterComponentTypePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useClusterComponentTypePermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useClusterComponentTypePermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useClusterComponentTypePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useClusterComponentTypePermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useClusterComponentTypePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useClusterComponentTypePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterComponentTypePermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useClusterComponentTypePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useClusterComponentTypePermission());

--- a/plugins/openchoreo-react/src/hooks/useClusterRoleMappingPermissions.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterRoleMappingPermissions.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { useClusterRoleMappingPermissions } from './useClusterRoleMappingPermissions';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useClusterRoleMappingPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns all permissions allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useClusterRoleMappingPermissions());
+
+    expect(result.current.canView).toBe(true);
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.canUpdate).toBe(true);
+    expect(result.current.canDelete).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns loading state for all permissions', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useClusterRoleMappingPermissions());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltips when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useClusterRoleMappingPermissions());
+
+    expect(result.current.canView).toBe(false);
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.canUpdate).toBe(false);
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.viewDeniedTooltip).toBeTruthy();
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+    expect(result.current.updateDeniedTooltip).toBeTruthy();
+    expect(result.current.deleteDeniedTooltip).toBeTruthy();
+  });
+
+  it('calls usePermission four times without resourceRef', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useClusterRoleMappingPermissions());
+
+    expect(mockUsePermission.mock.calls.length).toBeGreaterThanOrEqual(4);
+    for (const call of mockUsePermission.mock.calls) {
+      expect(call[0]).not.toHaveProperty('resourceRef');
+    }
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useClusterRolePermissions.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterRolePermissions.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { useClusterRolePermissions } from './useClusterRolePermissions';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useClusterRolePermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns all permissions allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useClusterRolePermissions());
+
+    expect(result.current.canView).toBe(true);
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.canUpdate).toBe(true);
+    expect(result.current.canDelete).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns loading state for all permissions', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useClusterRolePermissions());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltips when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useClusterRolePermissions());
+
+    expect(result.current.canView).toBe(false);
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.canUpdate).toBe(false);
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.viewDeniedTooltip).toBeTruthy();
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+    expect(result.current.updateDeniedTooltip).toBeTruthy();
+    expect(result.current.deleteDeniedTooltip).toBeTruthy();
+  });
+
+  it('calls usePermission four times without resourceRef', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useClusterRolePermissions());
+
+    expect(mockUsePermission.mock.calls.length).toBeGreaterThanOrEqual(4);
+    for (const call of mockUsePermission.mock.calls) {
+      expect(call[0]).not.toHaveProperty('resourceRef');
+    }
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useClusterTraitCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterTraitCreatePermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useClusterTraitCreatePermission } from './useClusterTraitCreatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useClusterTraitCreatePermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useClusterTraitCreatePermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useClusterTraitCreatePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useClusterTraitCreatePermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useClusterTraitCreatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useClusterTraitCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterTraitCreatePermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useClusterTraitCreatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useClusterTraitCreatePermission());

--- a/plugins/openchoreo-react/src/hooks/useClusterWorkflowPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterWorkflowPermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useClusterWorkflowPermission } from './useClusterWorkflowPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useClusterWorkflowPermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useClusterWorkflowPermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useClusterWorkflowPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useClusterWorkflowPermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useClusterWorkflowPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useClusterWorkflowPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useClusterWorkflowPermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useClusterWorkflowPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useClusterWorkflowPermission());

--- a/plugins/openchoreo-react/src/hooks/useComponentCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useComponentCreatePermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useComponentCreatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useComponentCreatePermission());

--- a/plugins/openchoreo-react/src/hooks/useComponentCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useComponentCreatePermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useComponentCreatePermission } from './useComponentCreatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useComponentCreatePermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useComponentCreatePermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useComponentCreatePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useComponentCreatePermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useComponentCreatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useComponentTypePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useComponentTypePermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useComponentTypePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useComponentTypePermission());

--- a/plugins/openchoreo-react/src/hooks/useComponentTypePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useComponentTypePermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useComponentTypePermission } from './useComponentTypePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useComponentTypePermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useComponentTypePermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useComponentTypePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useComponentTypePermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useComponentTypePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useComponentUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useComponentUpdatePermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useComponentUpdatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canUpdateComponent=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useComponentUpdatePermission());

--- a/plugins/openchoreo-react/src/hooks/useComponentUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useComponentUpdatePermission.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react';
+import { useComponentUpdatePermission } from './useComponentUpdatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useComponentUpdatePermission', () => {
+  it('returns canUpdateComponent=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useComponentUpdatePermission());
+
+    expect(result.current.canUpdateComponent).toBe(true);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useComponentUpdatePermission());
+
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('returns canUpdateComponent=false when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useComponentUpdatePermission());
+
+    expect(result.current.canUpdateComponent).toBe(false);
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useComponentUpdatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useComponentWorkflowPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useComponentWorkflowPermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useComponentWorkflowPermission } from './useComponentWorkflowPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useComponentWorkflowPermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useComponentWorkflowPermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useComponentWorkflowPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useComponentWorkflowPermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useComponentWorkflowPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useComponentWorkflowPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useComponentWorkflowPermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useComponentWorkflowPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useComponentWorkflowPermission());

--- a/plugins/openchoreo-react/src/hooks/useConfigureAndDeployPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useConfigureAndDeployPermission.test.ts
@@ -1,0 +1,103 @@
+import { renderHook } from '@testing-library/react';
+import { useConfigureAndDeployPermission } from './useConfigureAndDeployPermission';
+
+const mockUseDeployPermission = jest.fn();
+const mockUseComponentUpdatePermission = jest.fn();
+const mockUseWorkloadUpdatePermission = jest.fn();
+
+jest.mock('./useDeployPermission', () => ({
+  useDeployPermission: () => mockUseDeployPermission(),
+}));
+jest.mock('./useComponentUpdatePermission', () => ({
+  useComponentUpdatePermission: () => mockUseComponentUpdatePermission(),
+}));
+jest.mock('./useWorkloadUpdatePermission', () => ({
+  useWorkloadUpdatePermission: () => mockUseWorkloadUpdatePermission(),
+}));
+
+describe('useConfigureAndDeployPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns canConfigureAndDeploy=true when all sub-hooks allow', () => {
+    mockUseDeployPermission.mockReturnValue({
+      canDeploy: true,
+      loading: false,
+    });
+    mockUseComponentUpdatePermission.mockReturnValue({
+      canUpdateComponent: true,
+      loading: false,
+    });
+    mockUseWorkloadUpdatePermission.mockReturnValue({
+      canUpdateWorkload: true,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useConfigureAndDeployPermission());
+
+    expect(result.current.canConfigureAndDeploy).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns canConfigureAndDeploy=true when only one sub-hook allows (OR logic)', () => {
+    mockUseDeployPermission.mockReturnValue({
+      canDeploy: true,
+      loading: false,
+    });
+    mockUseComponentUpdatePermission.mockReturnValue({
+      canUpdateComponent: false,
+      loading: false,
+    });
+    mockUseWorkloadUpdatePermission.mockReturnValue({
+      canUpdateWorkload: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useConfigureAndDeployPermission());
+
+    expect(result.current.canConfigureAndDeploy).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns canConfigureAndDeploy=false when all sub-hooks deny', () => {
+    mockUseDeployPermission.mockReturnValue({
+      canDeploy: false,
+      loading: false,
+    });
+    mockUseComponentUpdatePermission.mockReturnValue({
+      canUpdateComponent: false,
+      loading: false,
+    });
+    mockUseWorkloadUpdatePermission.mockReturnValue({
+      canUpdateWorkload: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useConfigureAndDeployPermission());
+
+    expect(result.current.canConfigureAndDeploy).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('returns loading=true when any sub-hook is loading', () => {
+    mockUseDeployPermission.mockReturnValue({
+      canDeploy: false,
+      loading: true,
+    });
+    mockUseComponentUpdatePermission.mockReturnValue({
+      canUpdateComponent: false,
+      loading: false,
+    });
+    mockUseWorkloadUpdatePermission.mockReturnValue({
+      canUpdateWorkload: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useConfigureAndDeployPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useDeployPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useDeployPermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useDeployPermission (Variant A: entity-scoped, single permission)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canDeploy=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useDeployPermission());

--- a/plugins/openchoreo-react/src/hooks/useDeploymentPipelinePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useDeploymentPipelinePermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useDeploymentPipelinePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useDeploymentPipelinePermission());

--- a/plugins/openchoreo-react/src/hooks/useDeploymentPipelinePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useDeploymentPipelinePermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useDeploymentPipelinePermission } from './useDeploymentPipelinePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useDeploymentPipelinePermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useDeploymentPipelinePermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useDeploymentPipelinePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useDeploymentPipelinePermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useDeploymentPipelinePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useEntityAnnotation.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useEntityAnnotation.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react';
+import {
+  useEntityAnnotation,
+  useHasAnnotation,
+  useHasAnyAnnotation,
+} from './useEntityAnnotation';
+
+const mockUseEntity = jest.fn();
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => mockUseEntity(),
+}));
+
+const makeEntity = (annotations: Record<string, string> = {}) => ({
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'test', namespace: 'default', annotations },
+  },
+});
+
+describe('useEntityAnnotation', () => {
+  it('returns annotation value when present', () => {
+    mockUseEntity.mockReturnValue(
+      makeEntity({ 'jenkins.io/job-full-name': 'my-job' }),
+    );
+    const { result } = renderHook(() =>
+      useEntityAnnotation('jenkins.io/job-full-name'),
+    );
+    expect(result.current).toBe('my-job');
+  });
+
+  it('returns undefined when annotation is absent', () => {
+    mockUseEntity.mockReturnValue(makeEntity());
+    const { result } = renderHook(() => useEntityAnnotation('missing'));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when annotations object is missing', () => {
+    mockUseEntity.mockReturnValue({
+      entity: { metadata: { name: 'test' } } as any,
+    });
+    const { result } = renderHook(() => useEntityAnnotation('any'));
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe('useHasAnnotation', () => {
+  it('returns true when annotation is present', () => {
+    mockUseEntity.mockReturnValue(makeEntity({ 'my-key': 'value' }));
+    const { result } = renderHook(() => useHasAnnotation('my-key'));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true for empty string annotation', () => {
+    mockUseEntity.mockReturnValue(makeEntity({ 'my-key': '' }));
+    const { result } = renderHook(() => useHasAnnotation('my-key'));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when annotation is missing', () => {
+    mockUseEntity.mockReturnValue(makeEntity());
+    const { result } = renderHook(() => useHasAnnotation('missing'));
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useHasAnyAnnotation', () => {
+  it('returns true when at least one annotation is present', () => {
+    mockUseEntity.mockReturnValue(
+      makeEntity({ 'github.com/project-slug': 'org/repo' }),
+    );
+    const { result } = renderHook(() =>
+      useHasAnyAnnotation([
+        'jenkins.io/job-full-name',
+        'github.com/project-slug',
+        'gitlab.com/project-slug',
+      ]),
+    );
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when none of the annotations are present', () => {
+    mockUseEntity.mockReturnValue(makeEntity({ 'other-key': 'value' }));
+    const { result } = renderHook(() => useHasAnyAnnotation(['a', 'b', 'c']));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false for empty annotations array', () => {
+    mockUseEntity.mockReturnValue(makeEntity({ key: 'value' }));
+    const { result } = renderHook(() => useHasAnyAnnotation([]));
+    expect(result.current).toBe(false);
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useEnvironmentPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useEnvironmentPermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useEnvironmentPermission (Variant B: org-level, no resource)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useEnvironmentPermission());

--- a/plugins/openchoreo-react/src/hooks/useEnvironmentReadPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useEnvironmentReadPermission.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react';
+import { useEnvironmentReadPermission } from './useEnvironmentReadPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useEnvironmentReadPermission', () => {
+  it('returns canViewEnvironments=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useEnvironmentReadPermission());
+
+    expect(result.current.canViewEnvironments).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useEnvironmentReadPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useEnvironmentReadPermission());
+
+    expect(result.current.canViewEnvironments).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useEnvironmentReadPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useEnvironmentReadPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useEnvironmentReadPermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useEnvironmentReadPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canViewEnvironments=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useEnvironmentReadPermission());

--- a/plugins/openchoreo-react/src/hooks/useIncidentsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useIncidentsPermission.test.ts
@@ -33,6 +33,7 @@ const systemEntity = {
 
 describe('useIncidentsPermission', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockUseEntity.mockReturnValue(componentEntity);
   });
 

--- a/plugins/openchoreo-react/src/hooks/useIncidentsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useIncidentsPermission.test.ts
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react';
+import { useIncidentsPermission } from './useIncidentsPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+const mockUseEntity = jest.fn();
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => mockUseEntity(),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+const componentEntity = {
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'test', namespace: 'default' },
+  },
+};
+
+const systemEntity = {
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'System',
+    metadata: { name: 'test-project', namespace: 'default' },
+  },
+};
+
+describe('useIncidentsPermission', () => {
+  beforeEach(() => {
+    mockUseEntity.mockReturnValue(componentEntity);
+  });
+
+  it('returns canViewIncidents=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useIncidentsPermission());
+
+    expect(result.current.canViewIncidents).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useIncidentsPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip for component when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useIncidentsPermission());
+
+    expect(result.current.canViewIncidents).toBe(false);
+    expect(result.current.deniedTooltip).toContain('component');
+  });
+
+  it('returns denied tooltip for project when entity kind is System', () => {
+    mockUseEntity.mockReturnValue(systemEntity);
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useIncidentsPermission());
+
+    expect(result.current.deniedTooltip).toContain('project');
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useIncidentsPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useLogsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useLogsPermission.test.ts
@@ -33,6 +33,7 @@ const systemEntity = {
 
 describe('useLogsPermission', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockUseEntity.mockReturnValue(componentEntity);
   });
 

--- a/plugins/openchoreo-react/src/hooks/useLogsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useLogsPermission.test.ts
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react';
+import { useLogsPermission } from './useLogsPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+const mockUseEntity = jest.fn();
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => mockUseEntity(),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+const componentEntity = {
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'test', namespace: 'default' },
+  },
+};
+
+const systemEntity = {
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'System',
+    metadata: { name: 'test-project', namespace: 'default' },
+  },
+};
+
+describe('useLogsPermission', () => {
+  beforeEach(() => {
+    mockUseEntity.mockReturnValue(componentEntity);
+  });
+
+  it('returns canViewLogs=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useLogsPermission());
+
+    expect(result.current.canViewLogs).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useLogsPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip for component when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useLogsPermission());
+
+    expect(result.current.canViewLogs).toBe(false);
+    expect(result.current.deniedTooltip).toContain('component');
+  });
+
+  it('returns denied tooltip for project when entity kind is System', () => {
+    mockUseEntity.mockReturnValue(systemEntity);
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useLogsPermission());
+
+    expect(result.current.deniedTooltip).toContain('project');
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useLogsPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useMetricsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useMetricsPermission.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import { useMetricsPermission } from './useMetricsPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useMetricsPermission', () => {
+  it('returns canViewMetrics=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useMetricsPermission());
+
+    expect(result.current.canViewMetrics).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useMetricsPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useMetricsPermission());
+
+    expect(result.current.canViewMetrics).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useMetricsPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useMetricsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useMetricsPermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useMetricsPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canViewMetrics=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useMetricsPermission());

--- a/plugins/openchoreo-react/src/hooks/useModeState.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useModeState.test.ts
@@ -1,0 +1,145 @@
+import { renderHook, act } from '@testing-library/react';
+import { useModeState } from './useModeState';
+
+describe('useModeState', () => {
+  describe('getMode', () => {
+    it('returns plain by default', () => {
+      const { result } = renderHook(() => useModeState({ type: 'env' }));
+      expect(result.current.getMode('main', 0)).toBe('plain');
+    });
+
+    it('derives secret mode from initial env var with secretKeyRef', () => {
+      const containers = {
+        main: {
+          name: 'main',
+          env: [
+            {
+              key: 'DB_PASS',
+              valueFrom: { secretKeyRef: { name: 's', key: 'k' } },
+            } as any,
+          ],
+        } as any,
+      };
+      const { result } = renderHook(() =>
+        useModeState({ type: 'env', initialContainers: containers }),
+      );
+      expect(result.current.getMode('main', 0)).toBe('secret');
+    });
+
+    it('derives plain mode from initial env var without secretKeyRef', () => {
+      const containers = {
+        main: {
+          name: 'main',
+          env: [{ key: 'PORT', value: '8080' } as any],
+        } as any,
+      };
+      const { result } = renderHook(() =>
+        useModeState({ type: 'env', initialContainers: containers }),
+      );
+      expect(result.current.getMode('main', 0)).toBe('plain');
+    });
+
+    it('derives secret mode from initial file var with secretKeyRef', () => {
+      const containers = {
+        main: {
+          name: 'main',
+          files: [
+            {
+              key: 'config',
+              valueFrom: { secretKeyRef: { name: 's', key: 'k' } },
+            },
+          ],
+        } as any,
+      };
+      const { result } = renderHook(() =>
+        useModeState({ type: 'file', initialContainers: containers }),
+      );
+      expect(result.current.getMode('main', 0)).toBe('secret');
+    });
+
+    it('returns plain when container does not exist in initialContainers', () => {
+      const { result } = renderHook(() =>
+        useModeState({ type: 'env', initialContainers: {} }),
+      );
+      expect(result.current.getMode('missing', 0)).toBe('plain');
+    });
+  });
+
+  describe('setMode', () => {
+    it('stores mode in local state and getMode returns it', () => {
+      const { result } = renderHook(() => useModeState({ type: 'env' }));
+      act(() => {
+        result.current.setMode('main', 0, 'secret');
+      });
+      expect(result.current.getMode('main', 0)).toBe('secret');
+    });
+
+    it('local state takes precedence over derived initial state', () => {
+      const containers = {
+        main: {
+          name: 'main',
+          env: [
+            {
+              key: 'DB_PASS',
+              valueFrom: { secretKeyRef: { name: 's', key: 'k' } },
+            } as any,
+          ],
+        } as any,
+      };
+      const { result } = renderHook(() =>
+        useModeState({ type: 'env', initialContainers: containers }),
+      );
+      expect(result.current.getMode('main', 0)).toBe('secret');
+
+      act(() => {
+        result.current.setMode('main', 0, 'plain');
+      });
+      expect(result.current.getMode('main', 0)).toBe('plain');
+    });
+  });
+
+  describe('cleanupIndex', () => {
+    it('removes mode for deleted index', () => {
+      const { result } = renderHook(() => useModeState({ type: 'env' }));
+      act(() => {
+        result.current.setMode('main', 0, 'secret');
+      });
+      act(() => {
+        result.current.cleanupIndex('main', 0);
+      });
+      expect(result.current.getMode('main', 0)).toBe('plain');
+    });
+
+    it('shifts mode indices after removed item', () => {
+      const { result } = renderHook(() => useModeState({ type: 'env' }));
+      act(() => {
+        result.current.setMode('main', 0, 'plain');
+        result.current.setMode('main', 1, 'secret');
+        result.current.setMode('main', 2, 'plain');
+      });
+      // Remove index 0 — index 1 should shift to 0, index 2 to 1
+      act(() => {
+        result.current.cleanupIndex('main', 0);
+      });
+      expect(result.current.getMode('main', 0)).toBe('secret');
+      expect(result.current.getMode('main', 1)).toBe('plain');
+    });
+  });
+
+  describe('cleanupContainer', () => {
+    it('removes all modes for a container', () => {
+      const { result } = renderHook(() => useModeState({ type: 'env' }));
+      act(() => {
+        result.current.setMode('main', 0, 'secret');
+        result.current.setMode('main', 1, 'secret');
+        result.current.setMode('sidecar', 0, 'secret');
+      });
+      act(() => {
+        result.current.cleanupContainer('main');
+      });
+      expect(result.current.getMode('main', 0)).toBe('plain');
+      expect(result.current.getMode('main', 1)).toBe('plain');
+      expect(result.current.getMode('sidecar', 0)).toBe('secret');
+    });
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useNamespacePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useNamespacePermission.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import { useNamespacePermission } from './useNamespacePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useNamespacePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns both permissions allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useNamespacePermission());
+
+    expect(result.current.canView).toBe(true);
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading state', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useNamespacePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltips when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useNamespacePermission());
+
+    expect(result.current.canView).toBe(false);
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.viewDeniedTooltip).toBeTruthy();
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('calls usePermission twice without resourceRef', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useNamespacePermission());
+
+    expect(mockUsePermission.mock.calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of mockUsePermission.mock.calls) {
+      expect(call[0]).not.toHaveProperty('resourceRef');
+    }
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoFeatures.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoFeatures.test.ts
@@ -1,0 +1,118 @@
+import { renderHook } from '@testing-library/react';
+import {
+  useOpenChoreoFeatures,
+  useWorkflowsEnabled,
+  useObservabilityEnabled,
+  useAuthEnabled,
+  useAuthzEnabled,
+} from './useOpenChoreoFeatures';
+
+const mockGetOptionalConfig = jest.fn();
+const mockConfigApi = {
+  getOptionalConfig: (key: string) => mockGetOptionalConfig(key),
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: () => mockConfigApi,
+  configApiRef: { id: 'core.config' },
+}));
+
+function makeFeaturesConfig(values: Record<string, boolean | undefined>) {
+  return {
+    getOptionalBoolean: (key: string) => values[key],
+  };
+}
+
+describe('useOpenChoreoFeatures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns all features enabled by default when no config', () => {
+    mockGetOptionalConfig.mockReturnValue(undefined);
+    const { result } = renderHook(() => useOpenChoreoFeatures());
+    expect(result.current).toEqual({
+      workflows: { enabled: true },
+      observability: { enabled: true },
+      auth: { enabled: true },
+      authz: { enabled: true },
+    });
+  });
+
+  it('reads feature values from config when present', () => {
+    mockGetOptionalConfig.mockReturnValue(
+      makeFeaturesConfig({
+        'workflows.enabled': false,
+        'observability.enabled': true,
+        'auth.enabled': false,
+        'authz.enabled': true,
+      }),
+    );
+    const { result } = renderHook(() => useOpenChoreoFeatures());
+    expect(result.current).toEqual({
+      workflows: { enabled: false },
+      observability: { enabled: true },
+      auth: { enabled: false },
+      authz: { enabled: true },
+    });
+  });
+
+  it('defaults individual features to true when not set in config', () => {
+    mockGetOptionalConfig.mockReturnValue(
+      makeFeaturesConfig({ 'workflows.enabled': false }),
+    );
+    const { result } = renderHook(() => useOpenChoreoFeatures());
+    expect(result.current.workflows.enabled).toBe(false);
+    expect(result.current.observability.enabled).toBe(true);
+    expect(result.current.auth.enabled).toBe(true);
+    expect(result.current.authz.enabled).toBe(true);
+  });
+
+  it('returns defaults when config throws', () => {
+    mockGetOptionalConfig.mockImplementation(() => {
+      throw new Error('config error');
+    });
+    const { result } = renderHook(() => useOpenChoreoFeatures());
+    expect(result.current).toEqual({
+      workflows: { enabled: true },
+      observability: { enabled: true },
+      auth: { enabled: true },
+      authz: { enabled: true },
+    });
+  });
+});
+
+describe('helper hooks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetOptionalConfig.mockReturnValue(
+      makeFeaturesConfig({
+        'workflows.enabled': true,
+        'observability.enabled': false,
+        'auth.enabled': true,
+        'authz.enabled': false,
+      }),
+    );
+  });
+
+  it('useWorkflowsEnabled returns workflow flag', () => {
+    const { result } = renderHook(() => useWorkflowsEnabled());
+    expect(result.current).toBe(true);
+  });
+
+  it('useObservabilityEnabled returns observability flag', () => {
+    const { result } = renderHook(() => useObservabilityEnabled());
+    expect(result.current).toBe(false);
+  });
+
+  it('useAuthEnabled returns auth flag', () => {
+    const { result } = renderHook(() => useAuthEnabled());
+    expect(result.current).toBe(true);
+  });
+
+  it('useAuthzEnabled returns authz flag', () => {
+    const { result } = renderHook(() => useAuthzEnabled());
+    expect(result.current).toBe(false);
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useProjectPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useProjectPermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useProjectPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useProjectPermission());

--- a/plugins/openchoreo-react/src/hooks/useProjectPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useProjectPermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useProjectPermission } from './useProjectPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useProjectPermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useProjectPermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useProjectPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useProjectPermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useProjectPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useProjectUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useProjectUpdatePermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useProjectUpdatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canUpdate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useProjectUpdatePermission());

--- a/plugins/openchoreo-react/src/hooks/useProjectUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useProjectUpdatePermission.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { useProjectUpdatePermission } from './useProjectUpdatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useProjectUpdatePermission', () => {
+  it('returns canUpdate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useProjectUpdatePermission());
+
+    expect(result.current.canUpdate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.updateDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useProjectUpdatePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.updateDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useProjectUpdatePermission());
+
+    expect(result.current.canUpdate).toBe(false);
+    expect(result.current.updateDeniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useProjectUpdatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useProjects.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useProjects.test.ts
@@ -1,0 +1,97 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useProjects } from './useProjects';
+
+const mockGetEntities = jest.fn();
+const mockCatalogApi = { getEntities: mockGetEntities };
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: () => mockCatalogApi,
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  catalogApiRef: { id: 'catalog' },
+}));
+
+describe('useProjects', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches all projects when namespaces is undefined', async () => {
+    mockGetEntities.mockResolvedValue({
+      items: [
+        { metadata: { name: 'p1', namespace: 'ns1' } },
+        { metadata: { name: 'p2', namespace: 'ns2' } },
+      ],
+    });
+
+    const { result } = renderHook(() => useProjects());
+
+    await waitFor(() => expect(result.current.length).toBe(2));
+    expect(mockGetEntities).toHaveBeenCalledWith({
+      filter: { kind: 'System' },
+      fields: ['metadata.name', 'metadata.namespace'],
+    });
+  });
+
+  it('filters by namespaces when provided', async () => {
+    mockGetEntities.mockResolvedValue({
+      items: [{ metadata: { name: 'p1', namespace: 'ns1' } }],
+    });
+
+    renderHook(() => useProjects(['ns1', 'ns2']));
+
+    await waitFor(() =>
+      expect(mockGetEntities).toHaveBeenCalledWith({
+        filter: { kind: 'System', 'metadata.namespace': ['ns1', 'ns2'] },
+        fields: ['metadata.name', 'metadata.namespace'],
+      }),
+    );
+  });
+
+  it('returns empty array when namespaces is an empty array', async () => {
+    const { result } = renderHook(() => useProjects([]));
+    // Should not call API
+    expect(mockGetEntities).not.toHaveBeenCalled();
+    expect(result.current).toEqual([]);
+  });
+
+  it('sorts projects by namespace, then name', async () => {
+    mockGetEntities.mockResolvedValue({
+      items: [
+        { metadata: { name: 'zebra', namespace: 'ns1' } },
+        { metadata: { name: 'apple', namespace: 'ns2' } },
+        { metadata: { name: 'banana', namespace: 'ns1' } },
+      ],
+    });
+
+    const { result } = renderHook(() => useProjects());
+
+    await waitFor(() => expect(result.current.length).toBe(3));
+    expect(result.current).toEqual([
+      { name: 'banana', namespace: 'ns1' },
+      { name: 'zebra', namespace: 'ns1' },
+      { name: 'apple', namespace: 'ns2' },
+    ]);
+  });
+
+  it('returns empty array on API error', async () => {
+    mockGetEntities.mockRejectedValue(new Error('API fail'));
+    const { result } = renderHook(() => useProjects());
+    await waitFor(() => {
+      expect(result.current).toEqual([]);
+    });
+  });
+
+  it('defaults namespace to "default" when missing from entity', async () => {
+    mockGetEntities.mockResolvedValue({
+      items: [{ metadata: { name: 'p1' } }],
+    });
+
+    const { result } = renderHook(() => useProjects());
+
+    await waitFor(() => expect(result.current.length).toBe(1));
+    expect(result.current[0].namespace).toBe('default');
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useRcaPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useRcaPermission.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import { useRcaPermission } from './useRcaPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useRcaPermission', () => {
+  it('returns canViewRca=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useRcaPermission());
+
+    expect(result.current.canViewRca).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useRcaPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useRcaPermission());
+
+    expect(result.current.canViewRca).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useRcaPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useRcaPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useRcaPermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useRcaPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canViewRca=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useRcaPermission());

--- a/plugins/openchoreo-react/src/hooks/useRcaUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useRcaUpdatePermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useRcaUpdatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canUpdateRca=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useRcaUpdatePermission());

--- a/plugins/openchoreo-react/src/hooks/useRcaUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useRcaUpdatePermission.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import { useRcaUpdatePermission } from './useRcaUpdatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useRcaUpdatePermission', () => {
+  it('returns canUpdateRca=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useRcaUpdatePermission());
+
+    expect(result.current.canUpdateRca).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useRcaUpdatePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useRcaUpdatePermission());
+
+    expect(result.current.canUpdateRca).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useRcaUpdatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useReleaseBindingPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useReleaseBindingPermission.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react';
+import { useReleaseBindingPermission } from './useReleaseBindingPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useReleaseBindingPermission', () => {
+  it('returns canViewBindings=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useReleaseBindingPermission());
+
+    expect(result.current.canViewBindings).toBe(true);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useReleaseBindingPermission());
+
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('returns canViewBindings=false when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useReleaseBindingPermission());
+
+    expect(result.current.canViewBindings).toBe(false);
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useReleaseBindingPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useReleaseBindingPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useReleaseBindingPermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useReleaseBindingPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canViewBindings=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useReleaseBindingPermission());

--- a/plugins/openchoreo-react/src/hooks/useResourceDefinitionPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useResourceDefinitionPermission.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import { useResourceDefinitionPermission } from './useResourceDefinitionPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+const mockUseEntity = jest.fn();
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => mockUseEntity(),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+const makeEntity = (kind: string) => ({
+  entity: {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind,
+    metadata: { name: 'test', namespace: 'default' },
+  },
+});
+
+describe('useResourceDefinitionPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEntity.mockReturnValue(makeEntity('Component'));
+  });
+
+  it('returns allowed for resource-scoped kind with resourceRef', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useResourceDefinitionPermission());
+
+    expect(result.current.canUpdate).toBe(true);
+    expect(result.current.canDelete).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+
+    // Verify resourceRef is passed for resource-scoped kind
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceRef: 'component:default/test' }),
+    );
+  });
+
+  it('returns allowed for cluster-scoped kind without resourceRef', () => {
+    mockUseEntity.mockReturnValue(makeEntity('ClusterComponentType'));
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useResourceDefinitionPermission());
+
+    expect(result.current.canUpdate).toBe(true);
+    expect(result.current.canDelete).toBe(true);
+
+    // Verify no resourceRef for cluster-scoped kind
+    for (const call of mockUsePermission.mock.calls) {
+      expect(call[0]).not.toHaveProperty('resourceRef');
+    }
+  });
+
+  it('defaults to denied for unknown entity kind', () => {
+    mockUseEntity.mockReturnValue(makeEntity('UnknownKind'));
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useResourceDefinitionPermission());
+
+    expect(result.current.canUpdate).toBe(false);
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.updateDeniedTooltip).toBeTruthy();
+    expect(result.current.deleteDeniedTooltip).toBeTruthy();
+  });
+
+  it('returns loading state', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useResourceDefinitionPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltips when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useResourceDefinitionPermission());
+
+    expect(result.current.canUpdate).toBe(false);
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.updateDeniedTooltip).toBeTruthy();
+    expect(result.current.deleteDeniedTooltip).toBeTruthy();
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useRoleMappingPermissions.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useRoleMappingPermissions.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { useRoleMappingPermissions } from './useRoleMappingPermissions';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useRoleMappingPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns all permissions allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useRoleMappingPermissions());
+
+    expect(result.current.canView).toBe(true);
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.canUpdate).toBe(true);
+    expect(result.current.canDelete).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns loading state for all permissions', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useRoleMappingPermissions());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltips when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useRoleMappingPermissions());
+
+    expect(result.current.canView).toBe(false);
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.canUpdate).toBe(false);
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.viewDeniedTooltip).toBeTruthy();
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+    expect(result.current.updateDeniedTooltip).toBeTruthy();
+    expect(result.current.deleteDeniedTooltip).toBeTruthy();
+  });
+
+  it('calls usePermission four times without resourceRef', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useRoleMappingPermissions());
+
+    expect(mockUsePermission.mock.calls.length).toBeGreaterThanOrEqual(4);
+    for (const call of mockUsePermission.mock.calls) {
+      expect(call[0]).not.toHaveProperty('resourceRef');
+    }
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useRolePermissions.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useRolePermissions.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { useRolePermissions } from './useRolePermissions';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useRolePermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns all permissions allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useRolePermissions());
+
+    expect(result.current.canView).toBe(true);
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.canUpdate).toBe(true);
+    expect(result.current.canDelete).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns loading state for all permissions', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useRolePermissions());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.viewDeniedTooltip).toBe('');
+    expect(result.current.createDeniedTooltip).toBe('');
+    expect(result.current.updateDeniedTooltip).toBe('');
+    expect(result.current.deleteDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltips when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useRolePermissions());
+
+    expect(result.current.canView).toBe(false);
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.canUpdate).toBe(false);
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.viewDeniedTooltip).toBeTruthy();
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+    expect(result.current.updateDeniedTooltip).toBeTruthy();
+    expect(result.current.deleteDeniedTooltip).toBeTruthy();
+  });
+
+  it('calls usePermission four times without resourceRef', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useRolePermissions());
+
+    expect(mockUsePermission.mock.calls.length).toBeGreaterThanOrEqual(4);
+    for (const call of mockUsePermission.mock.calls) {
+      expect(call[0]).not.toHaveProperty('resourceRef');
+    }
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useScopedComponentCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useScopedComponentCreatePermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useScopedComponentCreatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useScopedComponentCreatePermission());

--- a/plugins/openchoreo-react/src/hooks/useScopedComponentCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useScopedComponentCreatePermission.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { useScopedComponentCreatePermission } from './useScopedComponentCreatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useScopedComponentCreatePermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useScopedComponentCreatePermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useScopedComponentCreatePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useScopedComponentCreatePermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useScopedComponentCreatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useScopedProjectCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useScopedProjectCreatePermission.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { useScopedProjectCreatePermission } from './useScopedProjectCreatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useScopedProjectCreatePermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useScopedProjectCreatePermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useScopedProjectCreatePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useScopedProjectCreatePermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useScopedProjectCreatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useScopedProjectCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useScopedProjectCreatePermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useScopedProjectCreatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useScopedProjectCreatePermission());

--- a/plugins/openchoreo-react/src/hooks/useTracesPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useTracesPermission.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import { useTracesPermission } from './useTracesPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useTracesPermission', () => {
+  it('returns canViewTraces=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useTracesPermission());
+
+    expect(result.current.canViewTraces).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useTracesPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useTracesPermission());
+
+    expect(result.current.canViewTraces).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useTracesPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useTracesPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useTracesPermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useTracesPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canViewTraces=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useTracesPermission());

--- a/plugins/openchoreo-react/src/hooks/useTraitCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useTraitCreatePermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useTraitCreatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useTraitCreatePermission());

--- a/plugins/openchoreo-react/src/hooks/useTraitCreatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useTraitCreatePermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useTraitCreatePermission } from './useTraitCreatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useTraitCreatePermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useTraitCreatePermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useTraitCreatePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useTraitCreatePermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useTraitCreatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useTraitsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useTraitsPermission.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import { useTraitsPermission } from './useTraitsPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useTraitsPermission', () => {
+  it('returns canViewTraits=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useTraitsPermission());
+
+    expect(result.current.canViewTraits).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useTraitsPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useTraitsPermission());
+
+    expect(result.current.canViewTraits).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useTraitsPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useTraitsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useTraitsPermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useTraitsPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canViewTraits=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useTraitsPermission());

--- a/plugins/openchoreo-react/src/hooks/useUndeployPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useUndeployPermission.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { useUndeployPermission } from './useUndeployPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useUndeployPermission', () => {
+  it('returns canUndeploy=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useUndeployPermission());
+
+    expect(result.current.canUndeploy).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useUndeployPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useUndeployPermission());
+
+    expect(result.current.canUndeploy).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useUndeployPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useUndeployPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useUndeployPermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useUndeployPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canUndeploy=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useUndeployPermission());

--- a/plugins/openchoreo-react/src/hooks/useWorkflowPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useWorkflowPermission.test.ts
@@ -7,6 +7,10 @@ jest.mock('@backstage/plugin-permission-react', () => ({
 }));
 
 describe('useWorkflowPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canCreate=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useWorkflowPermission());

--- a/plugins/openchoreo-react/src/hooks/useWorkflowPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useWorkflowPermission.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { useWorkflowPermission } from './useWorkflowPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+describe('useWorkflowPermission', () => {
+  it('returns canCreate=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useWorkflowPermission());
+
+    expect(result.current.canCreate).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useWorkflowPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.createDeniedTooltip).toBe('');
+  });
+
+  it('returns denied tooltip when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useWorkflowPermission());
+
+    expect(result.current.canCreate).toBe(false);
+    expect(result.current.createDeniedTooltip).toBeTruthy();
+  });
+
+  it('does not pass resourceRef to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useWorkflowPermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ resourceRef: expect.anything() }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useWorkloadUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useWorkloadUpdatePermission.test.ts
@@ -21,6 +21,10 @@ jest.mock('@backstage/catalog-model', () => ({
 }));
 
 describe('useWorkloadUpdatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns canUpdateWorkload=true when allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     const { result } = renderHook(() => useWorkloadUpdatePermission());

--- a/plugins/openchoreo-react/src/hooks/useWorkloadUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useWorkloadUpdatePermission.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react';
+import { useWorkloadUpdatePermission } from './useWorkloadUpdatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useWorkloadUpdatePermission', () => {
+  it('returns canUpdateWorkload=true when allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useWorkloadUpdatePermission());
+
+    expect(result.current.canUpdateWorkload).toBe(true);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('returns loading=true during permission check', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useWorkloadUpdatePermission());
+
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('returns canUpdateWorkload=false when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useWorkloadUpdatePermission());
+
+    expect(result.current.canUpdateWorkload).toBe(false);
+  });
+
+  it('passes entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useWorkloadUpdatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/test',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo/src/utils/componentUtils.test.ts
+++ b/plugins/openchoreo/src/utils/componentUtils.test.ts
@@ -1,0 +1,36 @@
+import { Entity } from '@backstage/catalog-model';
+import { isFromSourceComponent } from './componentUtils';
+
+describe('isFromSourceComponent', () => {
+  it('returns true when entity has workflow in spec', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+      spec: { workflow: 'build-and-deploy' },
+    } as unknown as Entity;
+
+    expect(isFromSourceComponent(entity)).toBe(true);
+  });
+
+  it('returns false when entity has no workflow in spec', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+      spec: { type: 'service' },
+    } as unknown as Entity;
+
+    expect(isFromSourceComponent(entity)).toBe(false);
+  });
+
+  it('returns false when spec is undefined', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+    } as unknown as Entity;
+
+    expect(isFromSourceComponent(entity)).toBe(false);
+  });
+});

--- a/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCapability.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCapability.test.ts
@@ -1,0 +1,353 @@
+import { Entity } from '@backstage/catalog-model';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { matchesCapability } from './matchesCapability';
+
+/**
+ * Helper to build a minimal Entity with OpenChoreo annotations.
+ */
+function makeEntity(
+  kind: string,
+  annotations: Record<string, string | undefined> = {},
+): Entity {
+  // Strip undefined values to mimic how annotations are stored.
+  const cleanAnnotations: Record<string, string> = {};
+  for (const [k, v] of Object.entries(annotations)) {
+    if (v !== undefined) {
+      cleanAnnotations[k] = v;
+    }
+  }
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind,
+    metadata: {
+      name: 'test-entity',
+      annotations: cleanAnnotations,
+    },
+  };
+}
+
+const apply = (
+  entity: Entity,
+  params: {
+    action?: string;
+    allowedPaths: string[];
+    deniedPaths: string[];
+  },
+) =>
+  matchesCapability.apply(entity, {
+    action: params.action ?? 'component:view',
+    allowedPaths: params.allowedPaths,
+    deniedPaths: params.deniedPaths,
+  });
+
+describe('matchesCapability.apply', () => {
+  describe('entity without namespace annotation', () => {
+    it('denies when no namespace annotation present', () => {
+      const entity = makeEntity('Component', {});
+      expect(apply(entity, { allowedPaths: ['*'], deniedPaths: [] })).toBe(
+        false,
+      );
+    });
+
+    it('denies even with wildcard when annotation missing', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.PROJECT]: 'my-project',
+      });
+      expect(apply(entity, { allowedPaths: ['*'], deniedPaths: [] })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('wildcard path matching', () => {
+    it('allows when allowedPaths contains the global wildcard "*"', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(apply(entity, { allowedPaths: ['*'], deniedPaths: [] })).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('namespace-level path matching', () => {
+    it('allows when path matches the entity namespace', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, { allowedPaths: ['ns/acme'], deniedPaths: [] }),
+      ).toBe(true);
+    });
+
+    it('denies when namespace does not match', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, { allowedPaths: ['ns/other'], deniedPaths: [] }),
+      ).toBe(false);
+    });
+
+    it('allows when namespace wildcard ns/* matches any namespace', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(apply(entity, { allowedPaths: ['ns/*'], deniedPaths: [] })).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('project-level path matching', () => {
+    it('allows a component when project path matches', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+        [CHOREO_ANNOTATIONS.COMPONENT]: 'api',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/foo'],
+          deniedPaths: [],
+        }),
+      ).toBe(true);
+    });
+
+    it('denies when project path does not match', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/bar'],
+          deniedPaths: [],
+        }),
+      ).toBe(false);
+    });
+
+    it('allows with project wildcard ns/acme/project/*', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/*'],
+          deniedPaths: [],
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('component-level path matching', () => {
+    it('allows when component matches exactly', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+        [CHOREO_ANNOTATIONS.COMPONENT]: 'api',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/foo/component/api'],
+          deniedPaths: [],
+        }),
+      ).toBe(true);
+    });
+
+    it('denies when component name does not match', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+        [CHOREO_ANNOTATIONS.COMPONENT]: 'api',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/foo/component/other'],
+          deniedPaths: [],
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('deny precedence', () => {
+    it('deniedPaths take precedence over allowedPaths', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['*'],
+          deniedPaths: ['ns/acme'],
+        }),
+      ).toBe(false);
+    });
+
+    it('specific deny wins over broader allow', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+        [CHOREO_ANNOTATIONS.COMPONENT]: 'api',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/foo'],
+          deniedPaths: ['ns/acme/project/foo/component/api'],
+        }),
+      ).toBe(false);
+    });
+
+    it('deny on unrelated scope does not affect allow', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme'],
+          deniedPaths: ['ns/other'],
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('system entities', () => {
+    it('uses PROJECT_ID annotation (not PROJECT) for project scope', () => {
+      const entity = makeEntity('System', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT_ID]: 'proj-uuid-123',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'wrong-name',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/proj-uuid-123'],
+          deniedPaths: [],
+        }),
+      ).toBe(true);
+    });
+
+    it('denies System when PROJECT is set but PROJECT_ID is not', () => {
+      const entity = makeEntity('System', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'wrong-name',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/wrong-name'],
+          deniedPaths: [],
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('namespace-scoped kinds', () => {
+    const namespaceScopedKinds = [
+      'ComponentType',
+      'TraitType',
+      'Workflow',
+      'Environment',
+      'DataPlane',
+      'WorkflowPlane',
+      'ObservabilityPlane',
+      'DeploymentPipeline',
+    ];
+
+    it.each(namespaceScopedKinds)(
+      'rejects project-scoped paths for %s',
+      kind => {
+        const entity = makeEntity(kind, {
+          [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        });
+        expect(
+          apply(entity, {
+            allowedPaths: ['ns/acme/project/foo'],
+            deniedPaths: [],
+          }),
+        ).toBe(false);
+      },
+    );
+
+    it('accepts namespace-level paths for namespace-scoped kind', () => {
+      const entity = makeEntity('Environment', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme'],
+          deniedPaths: [],
+        }),
+      ).toBe(true);
+    });
+
+    it('rejects component-scoped paths for namespace-scoped kind', () => {
+      const entity = makeEntity('Workflow', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['ns/acme/project/foo/component/bar'],
+          deniedPaths: [],
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('empty paths', () => {
+    it('denies when both allowed and denied paths are empty', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(apply(entity, { allowedPaths: [], deniedPaths: [] })).toBe(false);
+    });
+
+    it('denies when allowedPaths is empty even if denies are also empty', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, { allowedPaths: [], deniedPaths: ['ns/other'] }),
+      ).toBe(false);
+    });
+  });
+
+  describe('invalid paths', () => {
+    it('ignores malformed allowedPaths', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['garbage', 'ns/acme/wrong/foo'],
+          deniedPaths: [],
+        }),
+      ).toBe(false);
+    });
+
+    it('allows when at least one valid path matches among invalid ones', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          allowedPaths: ['garbage', 'ns/acme'],
+          deniedPaths: [],
+        }),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('matchesCapability.toQuery', () => {
+  it('returns an empty object (no DB filtering)', () => {
+    const query = matchesCapability.toQuery({
+      action: 'component:view',
+      allowedPaths: ['*'],
+      deniedPaths: [],
+    });
+    expect(query).toEqual({});
+  });
+});

--- a/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCatalogEntityCapability.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCatalogEntityCapability.test.ts
@@ -1,0 +1,467 @@
+import { Entity } from '@backstage/catalog-model';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import {
+  matchesCatalogEntityCapability,
+  KindCapabilities,
+} from './matchesCatalogEntityCapability';
+
+/**
+ * Build a minimal Entity with the given kind and annotations.
+ */
+function makeEntity(
+  kind: string,
+  annotations: Record<string, string | undefined> = {},
+): Entity {
+  const cleanAnnotations: Record<string, string> = {};
+  for (const [k, v] of Object.entries(annotations)) {
+    if (v !== undefined) {
+      cleanAnnotations[k] = v;
+    }
+  }
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind,
+    metadata: {
+      name: 'test-entity',
+      annotations: cleanAnnotations,
+    },
+  };
+}
+
+/**
+ * Convenience wrapper to call apply with serialized capabilities.
+ */
+function apply(
+  entity: Entity,
+  kindCapabilities: KindCapabilities,
+  kinds: string[] = Object.keys(kindCapabilities),
+): boolean {
+  return matchesCatalogEntityCapability.apply(entity, {
+    kindCapabilitiesJson: JSON.stringify(kindCapabilities),
+    kinds,
+  });
+}
+
+describe('matchesCatalogEntityCapability.apply', () => {
+  describe('default-permissive behavior for non-managed kinds', () => {
+    it('allows a User entity (kind not in managed kinds list)', () => {
+      const entity = makeEntity('User', {});
+      expect(
+        apply(entity, {
+          component: {
+            action: 'component:view',
+            allowedPaths: [],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('allows a Group entity regardless of capabilities', () => {
+      const entity = makeEntity('Group', {});
+      expect(
+        apply(
+          entity,
+          { component: { action: 'c:v', allowedPaths: [], deniedPaths: [] } },
+          ['component'],
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('entities without namespace annotation (non-OpenChoreo)', () => {
+    it('allows a Component entity missing namespace annotation', () => {
+      const entity = makeEntity('Component', {});
+      expect(
+        apply(entity, {
+          component: {
+            action: 'component:view',
+            allowedPaths: [],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('allows a System entity missing namespace annotation', () => {
+      const entity = makeEntity('System', {});
+      expect(
+        apply(entity, {
+          system: {
+            action: 'project:view',
+            allowedPaths: [],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('wildcard path matching', () => {
+    it('allows OpenChoreo Component when allowedPaths contains "*"', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          component: {
+            action: 'component:view',
+            allowedPaths: ['*'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('namespace matching', () => {
+    it('allows a Component when namespace matches', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          component: {
+            action: 'component:view',
+            allowedPaths: ['ns/acme'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('denies a Component when namespace does not match', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          component: {
+            action: 'component:view',
+            allowedPaths: ['ns/other'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('denies OpenChoreo Component when no capability defined for kind', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      // kinds includes 'component' but no capability entry provided for it
+      expect(apply(entity, {}, ['component'])).toBe(false);
+    });
+  });
+
+  describe('project matching', () => {
+    it('allows Component when project path matches via PROJECT annotation', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, {
+          component: {
+            action: 'component:view',
+            allowedPaths: ['ns/acme/project/foo'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('denies Component on project mismatch', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, {
+          component: {
+            action: 'component:view',
+            allowedPaths: ['ns/acme/project/bar'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('System entity uses PROJECT_ID annotation for project scope', () => {
+      const entity = makeEntity('System', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT_ID]: 'proj-uuid-abc',
+      });
+      expect(
+        apply(entity, {
+          system: {
+            action: 'project:view',
+            allowedPaths: ['ns/acme/project/proj-uuid-abc'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('deny precedence', () => {
+    it('deniedPaths take precedence over allowedPaths', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'foo',
+      });
+      expect(
+        apply(entity, {
+          component: {
+            action: 'component:view',
+            allowedPaths: ['*'],
+            deniedPaths: ['ns/acme'],
+          },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('namespace-scoped entity levels', () => {
+    it('rejects project-scoped paths for Environment kind', () => {
+      const entity = makeEntity('Environment', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          environment: {
+            action: 'environment:view',
+            allowedPaths: ['ns/acme/project/foo'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('allows namespace-level path for Workflow kind', () => {
+      const entity = makeEntity('Workflow', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(
+        apply(entity, {
+          workflow: {
+            action: 'workflow:view',
+            allowedPaths: ['ns/acme'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('System entities reject component-level paths', () => {
+    it('rejects paths with a component segment for a System entity', () => {
+      const entity = makeEntity('System', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT_ID]: 'foo',
+      });
+      expect(
+        apply(entity, {
+          system: {
+            action: 'project:view',
+            allowedPaths: ['ns/acme/project/foo/component/api'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('cluster-scoped entities', () => {
+    it('allows ClusterDataplane only when global wildcard "*" is allowed', () => {
+      const entity = makeEntity('ClusterDataplane', {});
+      expect(
+        apply(
+          entity,
+          {
+            clusterdataplane: {
+              action: 'clusterdataplane:view',
+              allowedPaths: ['*'],
+              deniedPaths: [],
+            },
+          },
+          ['clusterdataplane'],
+        ),
+      ).toBe(true);
+    });
+
+    it('denies cluster-scoped entity for namespace-level paths', () => {
+      const entity = makeEntity('ClusterDataplane', {});
+      expect(
+        apply(
+          entity,
+          {
+            clusterdataplane: {
+              action: 'x',
+              allowedPaths: ['ns/acme'],
+              deniedPaths: [],
+            },
+          },
+          ['clusterdataplane'],
+        ),
+      ).toBe(false);
+    });
+
+    it('denies cluster-scoped entity when deniedPaths has "*"', () => {
+      const entity = makeEntity('ClusterWorkflow', {});
+      expect(
+        apply(
+          entity,
+          {
+            clusterworkflow: {
+              action: 'x',
+              allowedPaths: ['*'],
+              deniedPaths: ['*'],
+            },
+          },
+          ['clusterworkflow'],
+        ),
+      ).toBe(false);
+    });
+
+    it('denies cluster-scoped entity when no capability defined', () => {
+      const entity = makeEntity('ClusterTraittype', {});
+      expect(apply(entity, {}, ['clustertraittype'])).toBe(false);
+    });
+  });
+
+  describe('invalid JSON handling', () => {
+    it('throws when kindCapabilitiesJson is invalid', () => {
+      const entity = makeEntity('Component', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+      });
+      expect(() =>
+        matchesCatalogEntityCapability.apply(entity, {
+          kindCapabilitiesJson: 'not-json',
+          kinds: ['component'],
+        }),
+      ).toThrow();
+    });
+  });
+});
+
+describe('matchesCatalogEntityCapability.toQuery', () => {
+  function toQuery(kindCapabilities: KindCapabilities, kinds?: string[]) {
+    return matchesCatalogEntityCapability.toQuery({
+      kindCapabilitiesJson: JSON.stringify(kindCapabilities),
+      kinds: kinds ?? Object.keys(kindCapabilities),
+    });
+  }
+
+  it('returns an anyOf filter including non-managed kinds when there are managed kinds', () => {
+    const result = toQuery({
+      component: {
+        action: 'component:view',
+        allowedPaths: ['*'],
+        deniedPaths: [],
+      },
+    }) as any;
+
+    expect(result).toHaveProperty('anyOf');
+    expect(Array.isArray(result.anyOf)).toBe(true);
+    // The first element should exclude the managed kind (non-managed filter)
+    expect(result.anyOf[0]).toEqual({
+      not: { key: 'kind', values: ['component'] },
+    });
+  });
+
+  it('builds a non-openchoreo-only filter for a kind with no capability', () => {
+    const result = toQuery({}, ['component']) as any;
+    expect(result).toHaveProperty('anyOf');
+    // Second element should restrict kind to entities without the namespace annotation
+    const kindFilter = result.anyOf[1];
+    expect(kindFilter).toHaveProperty('allOf');
+    const [kindCondition, notAnnotation] = kindFilter.allOf;
+    expect(kindCondition).toEqual({ key: 'kind', values: ['component'] });
+    expect(notAnnotation).toEqual({
+      not: {
+        key: `metadata.annotations.${CHOREO_ANNOTATIONS.NAMESPACE}`,
+      },
+    });
+  });
+
+  it('allows entire kind when user has wildcard access', () => {
+    const result = toQuery({
+      component: {
+        action: 'component:view',
+        allowedPaths: ['*'],
+        deniedPaths: [],
+      },
+    }) as any;
+    // anyOf[1] = wildcard kind access filter
+    expect(result.anyOf[1]).toEqual({ key: 'kind', values: ['component'] });
+  });
+
+  it('builds path-based filter using PROJECT annotation for components', () => {
+    const result = toQuery({
+      component: {
+        action: 'component:view',
+        allowedPaths: ['ns/acme/project/foo'],
+        deniedPaths: [],
+      },
+    }) as any;
+
+    // Expect at least one filter with the project annotation
+    const serialized = JSON.stringify(result);
+    expect(serialized).toContain(CHOREO_ANNOTATIONS.NAMESPACE);
+    expect(serialized).toContain(CHOREO_ANNOTATIONS.PROJECT);
+    expect(serialized).toContain('acme');
+    expect(serialized).toContain('foo');
+  });
+
+  it('builds path-based filter using PROJECT_ID annotation for system kind', () => {
+    const result = toQuery({
+      system: {
+        action: 'project:view',
+        allowedPaths: ['ns/acme/project/proj-uuid'],
+        deniedPaths: [],
+      },
+    }) as any;
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).toContain(CHOREO_ANNOTATIONS.PROJECT_ID);
+    expect(serialized).toContain('proj-uuid');
+    // Should NOT use the PROJECT annotation for System entities
+    expect(serialized).not.toContain(
+      `metadata.annotations.${CHOREO_ANNOTATIONS.PROJECT}"`,
+    );
+  });
+
+  it('includes cluster-scoped kind filter only when wildcard access granted', () => {
+    const withWildcard = toQuery({
+      clusterdataplane: {
+        action: 'x',
+        allowedPaths: ['*'],
+        deniedPaths: [],
+      },
+    }) as any;
+    expect(JSON.stringify(withWildcard)).toContain('clusterdataplane');
+
+    const withoutWildcard = toQuery({
+      clusterdataplane: {
+        action: 'x',
+        allowedPaths: ['ns/acme'],
+        deniedPaths: [],
+      },
+    }) as any;
+    // Without a wildcard, cluster-scoped kinds are excluded entirely.
+    // Since no kind filters are generated, toQuery returns just the
+    // otherKindsFilter (not wrapped in anyOf).
+    expect(withoutWildcard).toEqual({
+      not: { key: 'kind', values: ['clusterdataplane'] },
+    });
+  });
+
+  it('returns the not-managed filter when no kind filters are generated', () => {
+    // Pass a single cluster-scoped kind with no capability at all
+    const result = toQuery({}, ['clusterdataplane']) as any;
+    expect(result).toEqual({
+      not: { key: 'kind', values: ['clusterdataplane'] },
+    });
+  });
+});

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileCache.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileCache.test.ts
@@ -1,0 +1,201 @@
+import crypto from 'crypto';
+import { AuthzProfileCache } from './AuthzProfileCache';
+import type { UserCapabilitiesResponse } from './types';
+
+/**
+ * Creates a minimal mocked CacheService for unit tests.
+ */
+function createMockCache() {
+  const cache = {
+    get: jest.fn(),
+    set: jest.fn(),
+    delete: jest.fn(),
+    withOptions: jest.fn(),
+  };
+  // withOptions returns the same cache (sufficient for tests)
+  cache.withOptions.mockReturnValue(cache);
+  return cache;
+}
+
+const sampleCapabilities: UserCapabilitiesResponse = {
+  capabilities: {
+    'component:view': {
+      allowed: [{ path: 'ns/acme' }],
+      denied: [],
+    },
+  },
+} as unknown as UserCapabilitiesResponse;
+
+function tokenHash(token: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(token)
+    .digest('hex')
+    .substring(0, 16);
+}
+
+describe('AuthzProfileCache', () => {
+  let mockCache: ReturnType<typeof createMockCache>;
+  let authzCache: AuthzProfileCache;
+
+  beforeEach(() => {
+    mockCache = createMockCache();
+    authzCache = new AuthzProfileCache(mockCache as any);
+  });
+
+  describe('get', () => {
+    it('calls cache.get with a key containing 16-char sha256 token hash', async () => {
+      mockCache.get.mockResolvedValueOnce(sampleCapabilities);
+      const result = await authzCache.get('my-token', 'acme');
+
+      expect(mockCache.get).toHaveBeenCalledTimes(1);
+      const key = mockCache.get.mock.calls[0][0] as string;
+      expect(key).toContain(tokenHash('my-token'));
+      expect(key).toContain('acme');
+      expect(key).toMatch(/^openchoreo:capabilities:[a-f0-9]{16}:acme$/);
+      expect(result).toBe(sampleCapabilities);
+    });
+
+    it('includes project and component segments in the cache key', async () => {
+      mockCache.get.mockResolvedValueOnce(undefined);
+      await authzCache.get('tok', 'acme', 'foo', 'api');
+
+      const key = mockCache.get.mock.calls[0][0] as string;
+      expect(key).toBe(
+        `openchoreo:capabilities:${tokenHash('tok')}:acme:foo:api`,
+      );
+    });
+
+    it('returns undefined on cache miss', async () => {
+      mockCache.get.mockResolvedValueOnce(undefined);
+      const result = await authzCache.get('tok', 'acme');
+      expect(result).toBeUndefined();
+    });
+
+    it('does NOT store the raw token in the cache key', async () => {
+      await authzCache.get('super-secret-token-value', 'acme');
+      const key = mockCache.get.mock.calls[0][0] as string;
+      expect(key).not.toContain('super-secret-token-value');
+    });
+  });
+
+  describe('set', () => {
+    it('calls cache.set with TTL option', async () => {
+      await authzCache.set('tok', 'acme', sampleCapabilities, 60000);
+      expect(mockCache.set).toHaveBeenCalledTimes(1);
+      const [key, value, opts] = mockCache.set.mock.calls[0];
+      expect(key).toContain(tokenHash('tok'));
+      expect(value).toBe(sampleCapabilities);
+      expect(opts).toEqual({ ttl: 60000 });
+    });
+
+    it('includes optional project/component in key when provided', async () => {
+      await authzCache.set(
+        'tok',
+        'acme',
+        sampleCapabilities,
+        1000,
+        'foo',
+        'api',
+      );
+      const key = mockCache.set.mock.calls[0][0] as string;
+      expect(key).toBe(
+        `openchoreo:capabilities:${tokenHash('tok')}:acme:foo:api`,
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('calls cache.delete with the same key used for get/set', async () => {
+      await authzCache.delete('tok', 'acme');
+      expect(mockCache.delete).toHaveBeenCalledTimes(1);
+      const key = mockCache.delete.mock.calls[0][0] as string;
+      expect(key).toBe(`openchoreo:capabilities:${tokenHash('tok')}:acme`);
+    });
+
+    it('builds matching key when project/component provided', async () => {
+      await authzCache.delete('tok', 'acme', 'foo', 'api');
+      const key = mockCache.delete.mock.calls[0][0] as string;
+      expect(key).toBe(
+        `openchoreo:capabilities:${tokenHash('tok')}:acme:foo:api`,
+      );
+    });
+  });
+
+  describe('key determinism', () => {
+    it('produces the same key for the same token', async () => {
+      await authzCache.get('identical-token', 'acme');
+      await authzCache.get('identical-token', 'acme');
+      const firstKey = mockCache.get.mock.calls[0][0] as string;
+      const secondKey = mockCache.get.mock.calls[1][0] as string;
+      expect(firstKey).toBe(secondKey);
+    });
+
+    it('produces different keys for different tokens', async () => {
+      await authzCache.get('token-a', 'acme');
+      await authzCache.get('token-b', 'acme');
+      const keyA = mockCache.get.mock.calls[0][0] as string;
+      const keyB = mockCache.get.mock.calls[1][0] as string;
+      expect(keyA).not.toBe(keyB);
+    });
+
+    it('produces different keys for different orgs', async () => {
+      await authzCache.get('tok', 'acme');
+      await authzCache.get('tok', 'other');
+      const keyA = mockCache.get.mock.calls[0][0] as string;
+      const keyB = mockCache.get.mock.calls[1][0] as string;
+      expect(keyA).not.toBe(keyB);
+    });
+  });
+
+  describe('getByUser / setByUser', () => {
+    it('getByUser uses a user-based key without token hash', async () => {
+      mockCache.get.mockResolvedValueOnce(sampleCapabilities);
+      const result = await authzCache.getByUser('user:default/alice');
+
+      expect(mockCache.get).toHaveBeenCalledTimes(1);
+      const key = mockCache.get.mock.calls[0][0] as string;
+      expect(key).toBe('openchoreo:capabilities:user:user:default/alice');
+      expect(result).toBe(sampleCapabilities);
+    });
+
+    it('getByUser includes org in key when provided', async () => {
+      await authzCache.getByUser('user:default/alice', 'acme');
+      const key = mockCache.get.mock.calls[0][0] as string;
+      expect(key).toBe('openchoreo:capabilities:user:user:default/alice:acme');
+    });
+
+    it('setByUser calls cache.set with TTL option', async () => {
+      await authzCache.setByUser(
+        'user:default/alice',
+        sampleCapabilities,
+        30000,
+        'acme',
+      );
+
+      expect(mockCache.set).toHaveBeenCalledTimes(1);
+      const [key, value, opts] = mockCache.set.mock.calls[0];
+      expect(key).toBe('openchoreo:capabilities:user:user:default/alice:acme');
+      expect(value).toBe(sampleCapabilities);
+      expect(opts).toEqual({ ttl: 30000 });
+    });
+
+    it('setByUser without org produces a shorter key', async () => {
+      await authzCache.setByUser(
+        'user:default/alice',
+        sampleCapabilities,
+        1000,
+      );
+      const key = mockCache.set.mock.calls[0][0] as string;
+      expect(key).toBe('openchoreo:capabilities:user:user:default/alice');
+    });
+
+    it('user-based key is deterministic for the same userEntityRef', async () => {
+      await authzCache.getByUser('user:default/alice', 'acme');
+      await authzCache.getByUser('user:default/alice', 'acme');
+      expect(mockCache.get.mock.calls[0][0]).toBe(
+        mockCache.get.mock.calls[1][0],
+      );
+    });
+  });
+});

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.test.ts
@@ -1,0 +1,338 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { AuthzProfileService, getTtlFromToken } from './AuthzProfileService';
+import type { UserCapabilitiesResponse } from './types';
+
+// ---------------------------------------------------------------------------
+// Mock the openchoreo-client-node module
+// ---------------------------------------------------------------------------
+
+const mockGET = jest.fn();
+
+jest.mock('@openchoreo/openchoreo-client-node', () => ({
+  ...jest.requireActual('@openchoreo/openchoreo-client-node'),
+  createOpenChoreoApiClient: jest.fn(() => ({
+    GET: mockGET,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockLogger = mockServices.logger.mock();
+
+const sampleCapabilities: UserCapabilitiesResponse = {
+  capabilities: {
+    'component:view': {
+      allowed: [{ path: 'ns/acme' }],
+      denied: [],
+    },
+  },
+} as unknown as UserCapabilitiesResponse;
+
+function createOkResponse<T>(data: T) {
+  return {
+    data,
+    error: undefined,
+    response: { ok: true as const, status: 200 },
+  };
+}
+
+function createErrorResponse(status = 500, message = 'fail') {
+  return {
+    data: undefined,
+    error: { message },
+    response: {
+      ok: false as const,
+      status,
+      statusText: 'Internal Server Error',
+    },
+  };
+}
+
+function createMockCache() {
+  return {
+    get: jest.fn(),
+    set: jest.fn(),
+    delete: jest.fn(),
+    getByUser: jest.fn(),
+    setByUser: jest.fn(),
+  };
+}
+
+function createService(cache?: ReturnType<typeof createMockCache>) {
+  return new AuthzProfileService({
+    baseUrl: 'http://test:8080',
+    logger: mockLogger,
+    cache: cache as any,
+  });
+}
+
+/**
+ * Build a minimal valid JWT token with the given `exp` claim (in seconds since epoch).
+ */
+function buildJwt(expSeconds: number): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'none', typ: 'JWT' }),
+  ).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString(
+    'base64url',
+  );
+  return `${header}.${payload}.signature`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('getTtlFromToken', () => {
+  const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+  it('returns default TTL when token is not a valid JWT', () => {
+    expect(getTtlFromToken('not-a-jwt')).toBe(DEFAULT_TTL_MS);
+  });
+
+  it('returns default TTL when payload has no exp claim', () => {
+    const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString(
+      'base64url',
+    );
+    const payload = Buffer.from(JSON.stringify({})).toString('base64url');
+    const token = `${header}.${payload}.sig`;
+    expect(getTtlFromToken(token)).toBe(DEFAULT_TTL_MS);
+  });
+
+  it('derives TTL from exp claim in the future', () => {
+    const exp = Math.floor(Date.now() / 1000) + 60; // 60s from now
+    const token = buildJwt(exp);
+    const ttl = getTtlFromToken(token);
+    // Should be roughly 60s = 60000ms (allow wide slack)
+    expect(ttl).toBeGreaterThan(30000);
+    expect(ttl).toBeLessThanOrEqual(60000);
+  });
+
+  it('returns at least 1000ms for an expired token', () => {
+    const exp = Math.floor(Date.now() / 1000) - 1000;
+    const token = buildJwt(exp);
+    expect(getTtlFromToken(token)).toBe(1000);
+  });
+
+  it('returns default TTL on malformed base64 payload', () => {
+    const token = 'header.!!!not-base64!!!.sig';
+    expect(getTtlFromToken(token)).toBe(DEFAULT_TTL_MS);
+  });
+});
+
+describe('AuthzProfileService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCapabilities', () => {
+    it('fetches from API when cache is not set', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(sampleCapabilities));
+      const service = createService();
+
+      const result = await service.getCapabilities('token-123', {
+        namespace: 'acme',
+      });
+
+      expect(mockGET).toHaveBeenCalledTimes(1);
+      expect(mockGET).toHaveBeenCalledWith('/api/v1/authz/profile', {
+        params: { query: { namespace: 'acme' } },
+      });
+      expect(result).toEqual(sampleCapabilities);
+    });
+
+    it('returns cached capabilities on cache hit (no API call)', async () => {
+      const cache = createMockCache();
+      cache.get.mockResolvedValueOnce(sampleCapabilities);
+      const service = createService(cache);
+
+      const result = await service.getCapabilities('token-123', {
+        namespace: 'acme',
+      });
+
+      expect(cache.get).toHaveBeenCalledWith(
+        'token-123',
+        'acme',
+        undefined,
+        undefined,
+      );
+      expect(mockGET).not.toHaveBeenCalled();
+      expect(result).toBe(sampleCapabilities);
+    });
+
+    it('caches the API response with TTL when cache is provided', async () => {
+      const cache = createMockCache();
+      cache.get.mockResolvedValueOnce(undefined); // cache miss
+      mockGET.mockResolvedValueOnce(createOkResponse(sampleCapabilities));
+      const service = createService(cache);
+
+      await service.getCapabilities('token-123', {
+        namespace: 'acme',
+        project: 'foo',
+      });
+
+      expect(cache.set).toHaveBeenCalledTimes(1);
+      const [token, cacheKey, value, ttlMs, project] = cache.set.mock.calls[0];
+      expect(token).toBe('token-123');
+      expect(cacheKey).toBe('acme');
+      expect(value).toBe(sampleCapabilities);
+      expect(typeof ttlMs).toBe('number');
+      expect(ttlMs).toBeGreaterThan(0);
+      expect(project).toBe('foo');
+    });
+
+    it('uses "global" as cache key when no namespace provided', async () => {
+      const cache = createMockCache();
+      cache.get.mockResolvedValueOnce(undefined);
+      mockGET.mockResolvedValueOnce(createOkResponse(sampleCapabilities));
+      const service = createService(cache);
+
+      await service.getCapabilities('token-123');
+
+      expect(cache.get).toHaveBeenCalledWith(
+        'token-123',
+        'global',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('passes project and component as query parameters', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(sampleCapabilities));
+      const service = createService();
+
+      await service.getCapabilities('token', {
+        namespace: 'acme',
+        project: 'foo',
+        component: 'api',
+      });
+
+      expect(mockGET).toHaveBeenCalledWith('/api/v1/authz/profile', {
+        params: {
+          query: { namespace: 'acme', project: 'foo', component: 'api' },
+        },
+      });
+    });
+
+    it('throws when API returns an error', async () => {
+      mockGET.mockResolvedValueOnce(createErrorResponse(500, 'internal'));
+      const service = createService();
+
+      await expect(
+        service.getCapabilities('token', { namespace: 'acme' }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getCapabilitiesForUser', () => {
+    it('returns cached capabilities by userEntityRef without API call', async () => {
+      const cache = createMockCache();
+      cache.getByUser.mockResolvedValueOnce(sampleCapabilities);
+      const service = createService(cache);
+
+      const result = await service.getCapabilitiesForUser('user:default/alice');
+
+      expect(cache.getByUser).toHaveBeenCalledWith(
+        'user:default/alice',
+        'global',
+      );
+      expect(mockGET).not.toHaveBeenCalled();
+      expect(result).toBe(sampleCapabilities);
+    });
+
+    it('returns empty capabilities (deny all) when no token and no cache hit', async () => {
+      const cache = createMockCache();
+      cache.getByUser.mockResolvedValueOnce(undefined);
+      const service = createService(cache);
+
+      const result = await service.getCapabilitiesForUser('user:default/alice');
+
+      expect(result).toEqual({ capabilities: {} });
+      expect(mockGET).not.toHaveBeenCalled();
+    });
+
+    it('fetches from API when token provided and no cache hit, then stores by userEntityRef', async () => {
+      const cache = createMockCache();
+      cache.getByUser.mockResolvedValueOnce(undefined);
+      cache.get.mockResolvedValueOnce(undefined); // token-cache miss
+      mockGET.mockResolvedValueOnce(createOkResponse(sampleCapabilities));
+      const service = createService(cache);
+
+      const result = await service.getCapabilitiesForUser(
+        'user:default/alice',
+        'token-abc',
+        { namespace: 'acme' },
+      );
+
+      expect(mockGET).toHaveBeenCalledTimes(1);
+      expect(cache.setByUser).toHaveBeenCalledTimes(1);
+      const [userRef, caps, ttlMs, cacheKey] = cache.setByUser.mock.calls[0];
+      expect(userRef).toBe('user:default/alice');
+      expect(caps).toBe(sampleCapabilities);
+      expect(typeof ttlMs).toBe('number');
+      expect(cacheKey).toBe('acme');
+      expect(result).toBe(sampleCapabilities);
+    });
+
+    it('returns empty capabilities when no cache is configured and no token provided', async () => {
+      const service = createService(); // no cache
+
+      const result = await service.getCapabilitiesForUser('user:default/alice');
+
+      expect(result).toEqual({ capabilities: {} });
+      expect(mockGET).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('preCacheCapabilities', () => {
+    it('fetches from API bypassing token-hash cache and updates both caches', async () => {
+      const cache = createMockCache();
+      mockGET.mockResolvedValueOnce(createOkResponse(sampleCapabilities));
+      const service = createService(cache);
+
+      await service.preCacheCapabilities('user:default/alice', 'token-abc');
+
+      // Should NOT check cache.get before fetching (always fresh)
+      expect(cache.get).not.toHaveBeenCalled();
+      expect(mockGET).toHaveBeenCalledTimes(1);
+
+      // Should cache both by token and by userEntityRef
+      expect(cache.set).toHaveBeenCalledTimes(1);
+      const [token, key, caps] = cache.set.mock.calls[0];
+      expect(token).toBe('token-abc');
+      expect(key).toBe('global');
+      expect(caps).toBe(sampleCapabilities);
+
+      expect(cache.setByUser).toHaveBeenCalledTimes(1);
+      const [userRef, userCaps, , userKey] = cache.setByUser.mock.calls[0];
+      expect(userRef).toBe('user:default/alice');
+      expect(userCaps).toBe(sampleCapabilities);
+      expect(userKey).toBe('global');
+    });
+
+    it('still fetches when no cache is configured (no cache writes)', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(sampleCapabilities));
+      const service = createService();
+
+      await expect(
+        service.preCacheCapabilities('user:default/alice', 'token'),
+      ).resolves.toBeUndefined();
+
+      expect(mockGET).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates errors from the API', async () => {
+      const cache = createMockCache();
+      mockGET.mockResolvedValueOnce(createErrorResponse(500));
+      const service = createService(cache);
+
+      await expect(
+        service.preCacheCapabilities('user:default/alice', 'token'),
+      ).rejects.toThrow();
+      expect(cache.set).not.toHaveBeenCalled();
+      expect(cache.setByUser).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/environment.test.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/environment.test.ts
@@ -1,0 +1,138 @@
+import { createEnvironmentAction } from './environment';
+
+const mockPOST = jest.fn();
+
+jest.mock('@openchoreo/openchoreo-client-node', () => ({
+  ...jest.requireActual('@openchoreo/openchoreo-client-node'),
+  createOpenChoreoApiClient: jest.fn(() => ({
+    POST: mockPOST,
+    GET: jest.fn(),
+    PUT: jest.fn(),
+    DELETE: jest.fn(),
+  })),
+}));
+
+jest.mock('@openchoreo/backstage-plugin-catalog-backend-module', () => ({
+  translateEnvironmentToEntity: jest.fn(
+    (data: any, _ns: string, opts: any) => ({
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Environment',
+      metadata: { name: data.name, namespace: _ns },
+      spec: { owner: opts.defaultOwner },
+    }),
+  ),
+}));
+
+const buildConfig = (overrides: any = {}) => {
+  const {
+    baseUrl = 'http://test',
+    authzEnabled = false,
+    defaultOwner = 'owners',
+  } = overrides;
+  return {
+    getString: (k: string) => (k === 'openchoreo.baseUrl' ? baseUrl : ''),
+    getOptionalBoolean: (k: string) =>
+      k === 'openchoreo.features.auth.enabled' ? authzEnabled : undefined,
+    getOptionalString: (k: string) =>
+      k === 'openchoreo.defaultOwner' ? defaultOwner : undefined,
+  } as any;
+};
+
+const buildCtx = (overrides: any = {}) => ({
+  input: {
+    namespaceName: 'domain:default/my-ns',
+    environmentName: 'dev',
+    displayName: 'Development',
+    description: 'Dev environment',
+    dataPlaneRef: 'dataplane:my-ns/default-dp',
+    isProduction: false,
+    ...overrides.input,
+  },
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+  output: jest.fn(),
+  secrets: overrides.secrets,
+});
+
+const successResponse = (name = 'dev') => ({
+  data: { metadata: { name, annotations: {} } },
+  error: undefined,
+  response: { ok: true, status: 200 } as any,
+});
+
+describe('createEnvironmentAction', () => {
+  let mockCatalog: { insertEntity: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCatalog = { insertEntity: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('creates an environment and emits outputs', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    const action = createEnvironmentAction(buildConfig(), mockCatalog as any);
+    const ctx = buildCtx();
+    await action.handler(ctx as any);
+
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/api/v1/namespaces/{namespaceName}/environments',
+      expect.anything(),
+    );
+    expect(ctx.output).toHaveBeenCalledWith('environmentName', 'dev');
+    expect(ctx.output).toHaveBeenCalledWith('namespaceName', 'my-ns');
+  });
+
+  it('detects ClusterDataPlane kind from entity ref prefix', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    const action = createEnvironmentAction(buildConfig(), mockCatalog as any);
+    const ctx = buildCtx({
+      input: { dataPlaneRef: 'clusterdataplane:openchoreo-cluster/cluster-dp' },
+    });
+    await action.handler(ctx as any);
+
+    const body = mockPOST.mock.calls[0][1].body;
+    expect(body.spec.dataPlaneRef.kind).toBe('ClusterDataPlane');
+    expect(body.spec.dataPlaneRef.name).toBe('cluster-dp');
+  });
+
+  it('throws on API error', async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'boom' },
+      response: { ok: false, status: 500 } as any,
+    });
+    const action = createEnvironmentAction(buildConfig(), mockCatalog as any);
+    await expect(action.handler(buildCtx() as any)).rejects.toThrow();
+  });
+
+  it('inserts into catalog', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    const action = createEnvironmentAction(buildConfig(), mockCatalog as any);
+    await action.handler(buildCtx() as any);
+    expect(mockCatalog.insertEntity).toHaveBeenCalledTimes(1);
+    expect(mockCatalog.insertEntity.mock.calls[0][0].kind).toBe('Environment');
+  });
+
+  it('continues when catalog insert fails', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    mockCatalog.insertEntity.mockRejectedValueOnce(new Error('fail'));
+    const action = createEnvironmentAction(buildConfig(), mockCatalog as any);
+    const ctx = buildCtx();
+    await action.handler(ctx as any);
+    expect(ctx.output).toHaveBeenCalledWith('environmentName', 'dev');
+  });
+
+  it('throws when authz enabled and no token', async () => {
+    const action = createEnvironmentAction(
+      buildConfig({ authzEnabled: true }),
+      mockCatalog as any,
+    );
+    await expect(action.handler(buildCtx() as any)).rejects.toThrow(
+      /User authentication token not available/,
+    );
+  });
+});

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/namespace.test.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/namespace.test.ts
@@ -1,0 +1,233 @@
+import { createNamespaceAction } from './namespace';
+
+const mockPOST = jest.fn();
+
+jest.mock('@openchoreo/openchoreo-client-node', () => ({
+  ...jest.requireActual('@openchoreo/openchoreo-client-node'),
+  createOpenChoreoApiClient: jest.fn(() => ({
+    POST: mockPOST,
+    GET: jest.fn(),
+    PUT: jest.fn(),
+    DELETE: jest.fn(),
+  })),
+}));
+
+jest.mock('@openchoreo/backstage-plugin-catalog-backend-module', () => ({
+  translateNamespaceToDomainEntity: jest.fn((data, opts) => ({
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Domain',
+    metadata: {
+      name: data.name,
+      annotations: {
+        'backstage.io/managed-by-location': `${opts.locationKey}:ns`,
+      },
+    },
+    spec: { owner: opts.defaultOwner },
+  })),
+}));
+
+const buildConfig = (
+  overrides: Partial<{
+    baseUrl: string;
+    authzEnabled: boolean;
+    defaultOwner: string;
+  }> = {},
+) => {
+  const {
+    baseUrl = 'http://test',
+    authzEnabled = false,
+    defaultOwner = 'owners',
+  } = overrides;
+  return {
+    getString: (k: string) => {
+      if (k === 'openchoreo.baseUrl') return baseUrl;
+      throw new Error(`unexpected getString: ${k}`);
+    },
+    getOptionalBoolean: (k: string) => {
+      if (k === 'openchoreo.features.auth.enabled') return authzEnabled;
+      return undefined;
+    },
+    getOptionalString: (k: string) => {
+      if (k === 'openchoreo.defaultOwner') return defaultOwner;
+      return undefined;
+    },
+  } as any;
+};
+
+const buildCtx = (overrides: any = {}) => ({
+  input: {
+    namespaceName: 'my-ns',
+    displayName: 'My Namespace',
+    description: 'A test namespace',
+    ...overrides.input,
+  },
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+  output: jest.fn(),
+  secrets: overrides.secrets,
+});
+
+const successResponse = (name: string = 'my-ns') => ({
+  data: {
+    metadata: {
+      name,
+      annotations: {
+        'openchoreo.dev/display-name': 'My Namespace',
+        'openchoreo.dev/description': 'A test namespace',
+      },
+      creationTimestamp: '2024-01-01T00:00:00Z',
+    },
+    status: { phase: 'Active' },
+  },
+  error: undefined,
+  response: { ok: true, status: 200 } as any,
+});
+
+describe('createNamespaceAction', () => {
+  let mockImmediateCatalog: { insertEntity: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockImmediateCatalog = {
+      insertEntity: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it('creates a namespace via the API and emits outputs', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse('my-ns'));
+    const action = createNamespaceAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx();
+
+    await action.handler(ctx as any);
+
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/api/v1/namespaces',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          metadata: expect.objectContaining({
+            name: 'my-ns',
+            annotations: expect.objectContaining({
+              'openchoreo.dev/display-name': 'My Namespace',
+              'openchoreo.dev/description': 'A test namespace',
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(ctx.output).toHaveBeenCalledWith('namespaceName', 'my-ns');
+    expect(ctx.output).toHaveBeenCalledWith(
+      'entityRef',
+      'domain:default/my-ns',
+    );
+  });
+
+  it('wraps API errors with "Failed to create namespace" message', async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'boom' },
+      response: { ok: false, status: 500 } as any,
+    });
+    const action = createNamespaceAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx();
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      /Failed to create namespace/,
+    );
+    expect(ctx.logger.error).toHaveBeenCalled();
+  });
+
+  it('inserts the namespace into the catalog with the right entity shape', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse('my-ns'));
+    const action = createNamespaceAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx();
+
+    await action.handler(ctx as any);
+
+    expect(mockImmediateCatalog.insertEntity).toHaveBeenCalledTimes(1);
+    const inserted = mockImmediateCatalog.insertEntity.mock.calls[0][0];
+    expect(inserted.kind).toBe('Domain');
+    expect(inserted.metadata.name).toBe('my-ns');
+    expect(inserted.spec.owner).toBe('group:default/owners');
+  });
+
+  it('continues (does not throw) when catalog insertion fails', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse('my-ns'));
+    mockImmediateCatalog.insertEntity.mockRejectedValueOnce(
+      new Error('catalog down'),
+    );
+    const action = createNamespaceAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx();
+
+    await action.handler(ctx as any);
+
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to immediately add namespace to catalog'),
+    );
+    expect(ctx.output).toHaveBeenCalledWith('namespaceName', 'my-ns');
+  });
+
+  it('throws when authz is enabled and no user token is provided', async () => {
+    const action = createNamespaceAction(
+      buildConfig({ authzEnabled: true }),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx();
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      /User authentication token not available/,
+    );
+    expect(mockPOST).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when authz is enabled and a token is supplied via secrets', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse('my-ns'));
+    const action = createNamespaceAction(
+      buildConfig({ authzEnabled: true }),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx({ secrets: { OPENCHOREO_USER_TOKEN: 'tkn' } });
+
+    await action.handler(ctx as any);
+
+    expect(mockPOST).toHaveBeenCalled();
+    expect(ctx.output).toHaveBeenCalledWith('namespaceName', 'my-ns');
+  });
+
+  it('omits display-name and description annotations when those inputs are not provided', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse('my-ns'));
+    const action = createNamespaceAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx({ input: { namespaceName: 'my-ns' } });
+    // wipe out optional defaults on the test input
+    ctx.input.displayName = undefined;
+    ctx.input.description = undefined;
+
+    await action.handler(ctx as any);
+
+    const body = mockPOST.mock.calls[0][1].body;
+    expect(
+      body.metadata.annotations['openchoreo.dev/display-name'],
+    ).toBeUndefined();
+    expect(
+      body.metadata.annotations['openchoreo.dev/description'],
+    ).toBeUndefined();
+  });
+});

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/project.test.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/project.test.ts
@@ -1,0 +1,175 @@
+import { createProjectAction } from './project';
+
+const mockPOST = jest.fn();
+
+jest.mock('@openchoreo/openchoreo-client-node', () => ({
+  ...jest.requireActual('@openchoreo/openchoreo-client-node'),
+  createOpenChoreoApiClient: jest.fn(() => ({
+    POST: mockPOST,
+    GET: jest.fn(),
+    PUT: jest.fn(),
+    DELETE: jest.fn(),
+  })),
+}));
+
+jest.mock('@openchoreo/backstage-plugin-catalog-backend-module', () => ({
+  translateProjectToEntity: jest.fn((data: any, _ns: string, opts: any) => ({
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'System',
+    metadata: { name: data.name },
+    spec: { owner: opts.defaultOwner },
+  })),
+}));
+
+const buildConfig = (overrides: any = {}) => {
+  const {
+    baseUrl = 'http://test',
+    authzEnabled = false,
+    defaultOwner = 'owners',
+  } = overrides;
+  return {
+    getString: (k: string) => (k === 'openchoreo.baseUrl' ? baseUrl : ''),
+    getOptionalBoolean: (k: string) =>
+      k === 'openchoreo.features.auth.enabled' ? authzEnabled : undefined,
+    getOptionalString: (k: string) =>
+      k === 'openchoreo.defaultOwner' ? defaultOwner : undefined,
+  } as any;
+};
+
+const buildCtx = (overrides: any = {}) => ({
+  input: {
+    namespaceName: 'domain:default/my-ns',
+    projectName: 'my-project',
+    displayName: 'My Project',
+    description: 'A test project',
+    deploymentPipeline: 'default-pipeline',
+    ...overrides.input,
+  },
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+  output: jest.fn(),
+  secrets: overrides.secrets,
+});
+
+const successResponse = (name = 'my-project') => ({
+  data: {
+    metadata: {
+      name,
+      uid: 'uid-1',
+      annotations: { 'openchoreo.dev/display-name': 'My Project' },
+    },
+  },
+  error: undefined,
+  response: { ok: true, status: 200 } as any,
+});
+
+describe('createProjectAction', () => {
+  let mockImmediateCatalog: { insertEntity: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockImmediateCatalog = {
+      insertEntity: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it('creates a project and emits outputs', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    const action = createProjectAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx();
+    await action.handler(ctx as any);
+
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/api/v1/namespaces/{namespaceName}/projects',
+      expect.anything(),
+    );
+    expect(ctx.output).toHaveBeenCalledWith('projectName', 'my-project');
+    expect(ctx.output).toHaveBeenCalledWith('namespaceName', 'my-ns');
+    expect(ctx.output).toHaveBeenCalledWith(
+      'entityRef',
+      'system:my-ns/my-project',
+    );
+  });
+
+  it('extracts namespace from entity ref format', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    const action = createProjectAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx({
+      input: { namespaceName: 'domain:default/extracted-ns' },
+    });
+    await action.handler(ctx as any);
+    expect(ctx.output).toHaveBeenCalledWith('namespaceName', 'extracted-ns');
+  });
+
+  it('throws on API error', async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: 'boom' },
+      response: { ok: false, status: 500 } as any,
+    });
+    const action = createProjectAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    await expect(action.handler(buildCtx() as any)).rejects.toThrow();
+  });
+
+  it('inserts into catalog with System entity', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    const action = createProjectAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    await action.handler(buildCtx() as any);
+    expect(mockImmediateCatalog.insertEntity).toHaveBeenCalledTimes(1);
+    expect(mockImmediateCatalog.insertEntity.mock.calls[0][0].kind).toBe(
+      'System',
+    );
+  });
+
+  it('continues when catalog insert fails', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    mockImmediateCatalog.insertEntity.mockRejectedValueOnce(
+      new Error('catalog down'),
+    );
+    const action = createProjectAction(
+      buildConfig(),
+      mockImmediateCatalog as any,
+    );
+    const ctx = buildCtx();
+    await action.handler(ctx as any);
+    expect(ctx.output).toHaveBeenCalledWith('projectName', 'my-project');
+  });
+
+  it('throws when authz enabled and no token', async () => {
+    const action = createProjectAction(
+      buildConfig({ authzEnabled: true }),
+      mockImmediateCatalog as any,
+    );
+    await expect(action.handler(buildCtx() as any)).rejects.toThrow(
+      /User authentication token not available/,
+    );
+  });
+
+  it('proceeds with token when authz enabled', async () => {
+    mockPOST.mockResolvedValueOnce(successResponse());
+    const action = createProjectAction(
+      buildConfig({ authzEnabled: true }),
+      mockImmediateCatalog as any,
+    );
+    await action.handler(
+      buildCtx({ secrets: { OPENCHOREO_USER_TOKEN: 'tkn' } }) as any,
+    );
+    expect(mockPOST).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
  Add 37 new test files covering:
  - 30 permission hooks (all untested variants: org-level, entity-scoped, multi-permission, composite, and dynamic kind-based)
  - 2 pure utility functions (humanizeTitle, isFromSourceComponent)
  - 3 service classes (OpenChoreoFetchApi, OpenChoreoPermissionApi, ObserverUrlCache)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit and integration tests across APIs, React hooks, permission rules, catalog processors, services, scaffold actions, observability, and utilities to strengthen stability, catch regressions, and improve confidence in auth, caching, permission checks, relation emission, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->