### PR TITLE
test: add unit tests for ReleaseDataRenderer components and hooks

### DIFF
--- a/packages/app/src/scaffolder/utils/rjsfUtils.test.ts
+++ b/packages/app/src/scaffolder/utils/rjsfUtils.test.ts
@@ -79,6 +79,8 @@ describe('generateUiSchemaWithTitles', () => {
     };
     const result = generateUiSchemaWithTitles(schema);
 
+    // Parent object without title also gets ui:title
+    expect(result.docker['ui:title']).toBe('Docker');
     // Nested property without title gets ui:title
     expect(result.docker.build_context['ui:title']).toBe('Build Context');
     // Nested property with title is not overridden

--- a/packages/app/src/scaffolder/utils/rjsfUtils.test.ts
+++ b/packages/app/src/scaffolder/utils/rjsfUtils.test.ts
@@ -1,0 +1,157 @@
+import { generateUiSchemaWithTitles } from './rjsfUtils';
+
+describe('generateUiSchemaWithTitles', () => {
+  it('returns empty object for null/undefined schema', () => {
+    expect(generateUiSchemaWithTitles(null)).toEqual({});
+    expect(generateUiSchemaWithTitles(undefined)).toEqual({});
+  });
+
+  it('returns empty object for non-object schema', () => {
+    expect(generateUiSchemaWithTitles('string')).toEqual({});
+    expect(generateUiSchemaWithTitles(42)).toEqual({});
+  });
+
+  it('returns empty object for schema with no properties', () => {
+    expect(generateUiSchemaWithTitles({ type: 'object' })).toEqual({});
+  });
+
+  it('adds ui:title for properties without a title', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        port_number: { type: 'integer' },
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    expect(result.port_number).toBeDefined();
+    expect(result.port_number['ui:title']).toBe('Port Number');
+  });
+
+  it('does not add ui:title for properties that already have a title', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        port: { type: 'integer', title: 'Port' },
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    expect(result.port).toBeUndefined();
+  });
+
+  it('handles camelCase keys', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        containerPort: { type: 'integer' },
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    expect(result.containerPort['ui:title']).toBe('Container Port');
+  });
+
+  it('handles snake_case keys', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        file_path: { type: 'string' },
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    expect(result.file_path['ui:title']).toBe('File Path');
+  });
+
+  it('recurses into nested object properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        docker: {
+          type: 'object',
+          properties: {
+            build_context: { type: 'string' },
+            filePath: { type: 'string', title: 'Dockerfile Path' },
+          },
+        },
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    // Nested property without title gets ui:title
+    expect(result.docker.build_context['ui:title']).toBe('Build Context');
+    // Nested property with title is not overridden
+    expect(result.docker.filePath).toBeUndefined();
+  });
+
+  it('handles array items with nested properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        envVars: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              var_name: { type: 'string' },
+              var_value: { type: 'string', title: 'Value' },
+            },
+          },
+        },
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    expect(result.envVars.items.var_name['ui:title']).toBe('Var Name');
+    expect(result.envVars.items.var_value).toBeUndefined();
+  });
+
+  it('skips non-object property schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        valid: { type: 'string' },
+        invalid: null,
+        alsoInvalid: 'not-an-object',
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    expect(result.valid).toBeDefined();
+    expect(result.invalid).toBeUndefined();
+    expect(result.alsoInvalid).toBeUndefined();
+  });
+
+  it('handles mixed titled and untitled properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        port: { type: 'integer', title: 'Port Number' },
+        replicas: { type: 'integer' },
+        service_name: { type: 'string' },
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    expect(result.port).toBeUndefined();
+    expect(result.replicas['ui:title']).toBe('Replicas');
+    expect(result.service_name['ui:title']).toBe('Service Name');
+  });
+
+  it('does not add items key for arrays without nested object items', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    };
+    const result = generateUiSchemaWithTitles(schema);
+
+    // String array items have no properties, so no items key added
+    expect(result.tags?.items).toBeUndefined();
+  });
+});

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.cluster.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.cluster.test.ts
@@ -86,10 +86,14 @@ describe('CtdToTemplateConverter – convertClusterCtdToTemplateEntity', () => {
 
     const noDisplayName: ComponentType = {
       ...baseCtd,
-      metadata: { ...baseCtd.metadata, displayName: undefined },
+      metadata: {
+        ...baseCtd.metadata,
+        name: 'my-custom-svc',
+        displayName: undefined,
+      },
     };
     const fallback = converter.convertClusterCtdToTemplateEntity(noDisplayName);
-    expect(fallback.metadata.title).toBe('Web Service'); // formatted from "web-service"
+    expect(fallback.metadata.title).toBe('My Custom Svc'); // formatted from "my-custom-svc"
   });
 
   it('generates default description when none provided', () => {

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.cluster.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.cluster.test.ts
@@ -1,0 +1,236 @@
+import {
+  CtdToTemplateConverter,
+  ComponentType,
+} from './CtdToTemplateConverter';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+
+describe('CtdToTemplateConverter – convertClusterCtdToTemplateEntity', () => {
+  let converter: CtdToTemplateConverter;
+
+  beforeEach(() => {
+    converter = new CtdToTemplateConverter({ defaultOwner: 'test-owner' });
+  });
+
+  const baseCtd: ComponentType = {
+    metadata: {
+      workloadType: 'deployment',
+      createdAt: '2025-01-01T00:00:00Z',
+      name: 'web-service',
+      displayName: 'Web Service',
+      description: 'A cluster-level web service',
+    },
+    spec: {
+      inputParametersSchema: {
+        type: 'object',
+        properties: {
+          port: { type: 'integer', title: 'Port', default: 8080 },
+        },
+        required: ['port'],
+      },
+    },
+  };
+
+  it('produces a Template entity with correct apiVersion and kind', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+
+    expect(result.apiVersion).toBe('scaffolder.backstage.io/v1beta3');
+    expect(result.kind).toBe('Template');
+  });
+
+  it('uses openchoreo-cluster namespace instead of a user namespace', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+
+    expect(result.metadata.namespace).toBe('openchoreo-cluster');
+  });
+
+  it('sets CTD_KIND annotation to ClusterComponentType', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+
+    expect(
+      result.metadata.annotations?.[CHOREO_ANNOTATIONS.CTD_KIND],
+    ).toBe('ClusterComponentType');
+  });
+
+  it('sets standard CTD annotations (name, generated, workload type)', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    const annotations = result.metadata.annotations!;
+
+    expect(annotations[CHOREO_ANNOTATIONS.CTD_NAME]).toBe('web-service');
+    expect(annotations[CHOREO_ANNOTATIONS.CTD_GENERATED]).toBe('true');
+    expect(annotations[CHOREO_ANNOTATIONS.WORKLOAD_TYPE]).toBe('deployment');
+  });
+
+  it('sets CTD_DISPLAY_NAME annotation when displayName is provided', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+
+    expect(
+      result.metadata.annotations?.[CHOREO_ANNOTATIONS.CTD_DISPLAY_NAME],
+    ).toBe('Web Service');
+  });
+
+  it('does not set CTD_DISPLAY_NAME when displayName is absent', () => {
+    const ctd: ComponentType = {
+      ...baseCtd,
+      metadata: { ...baseCtd.metadata, displayName: undefined },
+    };
+    const result = converter.convertClusterCtdToTemplateEntity(ctd);
+
+    expect(
+      result.metadata.annotations?.[CHOREO_ANNOTATIONS.CTD_DISPLAY_NAME],
+    ).toBeUndefined();
+  });
+
+  it('uses displayName for title, falls back to formatted name', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    expect(result.metadata.title).toBe('Web Service');
+
+    const noDisplayName: ComponentType = {
+      ...baseCtd,
+      metadata: { ...baseCtd.metadata, displayName: undefined },
+    };
+    const fallback = converter.convertClusterCtdToTemplateEntity(noDisplayName);
+    expect(fallback.metadata.title).toBe('Web Service'); // formatted from "web-service"
+  });
+
+  it('generates default description when none provided', () => {
+    const ctd: ComponentType = {
+      ...baseCtd,
+      metadata: { ...baseCtd.metadata, description: undefined },
+    };
+    const result = converter.convertClusterCtdToTemplateEntity(ctd);
+
+    expect(result.metadata.description).toBe(
+      'Create a Web Service component',
+    );
+  });
+
+  it('generates 3 parameter sections', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    const parameters = result.spec?.parameters as any[];
+
+    expect(parameters).toHaveLength(3);
+    expect(parameters[0].title).toBe('Component Metadata');
+    expect(parameters[1].title).toBe('Build & Deploy');
+    expect(parameters[2].title).toBe('Web Service Details');
+  });
+
+  it('passes empty namespace to ProjectNamespaceField for namespace dropdown', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    const parameters = result.spec?.parameters as any[];
+    const nsField = parameters[0].properties.project_namespace;
+
+    expect(nsField['ui:options'].defaultNamespace).toBe('');
+  });
+
+  it('passes ClusterComponentType to scaffolder step input', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    const steps = result.spec?.steps as any[];
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].input.component_type_kind).toBe('ClusterComponentType');
+  });
+
+  it('uses ClusterWorkflow as default workflow kind for allowedWorkflows strings', () => {
+    const ctd: ComponentType = {
+      ...baseCtd,
+      metadata: {
+        ...baseCtd.metadata,
+        allowedWorkflows: ['docker-build', 'buildpacks'],
+      },
+    };
+    const result = converter.convertClusterCtdToTemplateEntity(ctd);
+    const parameters = result.spec?.parameters as any[];
+    const buildSection = parameters[1];
+    const buildBranch = buildSection.dependencies.deploymentSource.oneOf[0];
+
+    expect(
+      buildBranch.properties.workflow_name['ui:options'].allowedWorkflows,
+    ).toEqual([
+      { kind: 'ClusterWorkflow', name: 'docker-build' },
+      { kind: 'ClusterWorkflow', name: 'buildpacks' },
+    ]);
+  });
+
+  it('preserves explicit kind in mixed allowedWorkflows', () => {
+    const ctd: ComponentType = {
+      ...baseCtd,
+      metadata: {
+        ...baseCtd.metadata,
+        allowedWorkflows: [
+          'default-build',
+          { kind: 'Workflow', name: 'ns-build' },
+        ] as any,
+      },
+    };
+    const result = converter.convertClusterCtdToTemplateEntity(ctd);
+    const parameters = result.spec?.parameters as any[];
+    const buildBranch =
+      parameters[1].dependencies.deploymentSource.oneOf[0];
+
+    expect(
+      buildBranch.properties.workflow_name['ui:options'].allowedWorkflows,
+    ).toEqual([
+      { kind: 'ClusterWorkflow', name: 'default-build' },
+      { kind: 'Workflow', name: 'ns-build' },
+    ]);
+  });
+
+  it('passes allowedTraits through to WorkloadDetailsField', () => {
+    const ctd: ComponentType = {
+      ...baseCtd,
+      metadata: {
+        ...baseCtd.metadata,
+        allowedTraits: [
+          { kind: 'ClusterTrait', name: 'ingress' },
+          { kind: 'ClusterTrait', name: 'autoscaler' },
+        ],
+      },
+    };
+    const result = converter.convertClusterCtdToTemplateEntity(ctd);
+    const parameters = result.spec?.parameters as any[];
+    const options = parameters[2].properties.workloadDetails['ui:options'];
+
+    expect(options.allowedTraits).toEqual([
+      { kind: 'ClusterTrait', name: 'ingress' },
+      { kind: 'ClusterTrait', name: 'autoscaler' },
+    ]);
+  });
+
+  it('passes CTD schema in workloadDetails ui:options', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    const parameters = result.spec?.parameters as any[];
+    const options = parameters[2].properties.workloadDetails['ui:options'];
+
+    expect(options.ctdSchema).toBeDefined();
+    expect(options.ctdSchema.properties.port.type).toBe('integer');
+    expect(options.ctdSchema.required).toEqual(['port']);
+  });
+
+  it('uses default owner when custom config provided', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    expect(result.spec?.owner).toBe('test-owner');
+  });
+
+  it('uses guests as owner when no config provided', () => {
+    const defaultConverter = new CtdToTemplateConverter();
+    const result = defaultConverter.convertClusterCtdToTemplateEntity(baseCtd);
+    expect(result.spec?.owner).toBe('guests');
+  });
+
+  it('includes form decorator for user token injection', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    expect(result.spec?.EXPERIMENTAL_formDecorators).toEqual([
+      { id: 'openchoreo:inject-user-token' },
+    ]);
+  });
+
+  it('includes output link with entity ref template', () => {
+    const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
+    const output = result.spec?.output as any;
+
+    expect(output.links).toHaveLength(1);
+    expect(output.links[0].entityRef).toContain(
+      "steps['create-component'].output",
+    );
+  });
+});

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.cluster.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.cluster.test.ts
@@ -46,9 +46,9 @@ describe('CtdToTemplateConverter – convertClusterCtdToTemplateEntity', () => {
   it('sets CTD_KIND annotation to ClusterComponentType', () => {
     const result = converter.convertClusterCtdToTemplateEntity(baseCtd);
 
-    expect(
-      result.metadata.annotations?.[CHOREO_ANNOTATIONS.CTD_KIND],
-    ).toBe('ClusterComponentType');
+    expect(result.metadata.annotations?.[CHOREO_ANNOTATIONS.CTD_KIND]).toBe(
+      'ClusterComponentType',
+    );
   });
 
   it('sets standard CTD annotations (name, generated, workload type)', () => {
@@ -103,9 +103,7 @@ describe('CtdToTemplateConverter – convertClusterCtdToTemplateEntity', () => {
     };
     const result = converter.convertClusterCtdToTemplateEntity(ctd);
 
-    expect(result.metadata.description).toBe(
-      'Create a Web Service component',
-    );
+    expect(result.metadata.description).toBe('Create a Web Service component');
   });
 
   it('generates 3 parameter sections', () => {
@@ -168,8 +166,7 @@ describe('CtdToTemplateConverter – convertClusterCtdToTemplateEntity', () => {
     };
     const result = converter.convertClusterCtdToTemplateEntity(ctd);
     const parameters = result.spec?.parameters as any[];
-    const buildBranch =
-      parameters[1].dependencies.deploymentSource.oneOf[0];
+    const buildBranch = parameters[1].dependencies.deploymentSource.oneOf[0];
 
     expect(
       buildBranch.properties.workflow_name['ui:options'].allowedWorkflows,

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
@@ -651,4 +651,129 @@ describe('CtdToTemplateConverter', () => {
       expect(result.metadata.namespace).toBe('test-org');
     });
   });
+
+  describe('external-ci and ciPlatform conditional fields', () => {
+    const baseCtd: ComponentType = {
+      metadata: {
+        workloadType: 'deployment',
+        createdAt: '2025-01-01T00:00:00Z',
+        name: 'web-service',
+        allowedWorkflows: ['docker-build'],
+      },
+      spec: {
+        inputParametersSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    };
+
+    it('should include external-ci branch in oneOf', () => {
+      const result = converter.convertCtdToTemplateEntity(baseCtd, 'test-org');
+      const parameters = result.spec?.parameters as any[];
+      const buildSection = parameters[1];
+      const externalCIBranch =
+        buildSection.dependencies.deploymentSource.oneOf[2];
+
+      expect(externalCIBranch.properties.deploymentSource.const).toBe(
+        'external-ci',
+      );
+      expect(externalCIBranch.properties.ciPlatform).toBeDefined();
+      expect(externalCIBranch.properties.ciPlatform.enum).toEqual([
+        'none',
+        'jenkins',
+        'github-actions',
+        'gitlab-ci',
+      ]);
+    });
+
+    it('should include ciPlatform conditional dependencies for each platform', () => {
+      const result = converter.convertCtdToTemplateEntity(baseCtd, 'test-org');
+      const parameters = result.spec?.parameters as any[];
+      const buildSection = parameters[1];
+
+      const ciPlatformDeps = buildSection.dependencies.ciPlatform;
+      expect(ciPlatformDeps).toBeDefined();
+      expect(ciPlatformDeps.oneOf).toHaveLength(4);
+
+      // none, jenkins, github-actions, gitlab-ci
+      const platforms = ciPlatformDeps.oneOf.map(
+        (o: any) => o.properties.ciPlatform.const,
+      );
+      expect(platforms).toEqual([
+        'none',
+        'jenkins',
+        'github-actions',
+        'gitlab-ci',
+      ]);
+    });
+
+    it('should require ciIdentifier for jenkins but not for none', () => {
+      const result = converter.convertCtdToTemplateEntity(baseCtd, 'test-org');
+      const parameters = result.spec?.parameters as any[];
+      const ciPlatformDeps = parameters[1].dependencies.ciPlatform;
+
+      const noneBranch = ciPlatformDeps.oneOf[0];
+      const jenkinsBranch = ciPlatformDeps.oneOf[1];
+
+      expect(noneBranch.properties.ciIdentifier).toBeUndefined();
+      expect(jenkinsBranch.properties.ciIdentifier).toBeDefined();
+      expect(jenkinsBranch.properties.ciIdentifier.title).toBe(
+        'Jenkins Job Path',
+      );
+    });
+  });
+
+  describe('allowedTraits passthrough', () => {
+    it('should pass allowedTraits to WorkloadDetailsField ui:options', () => {
+      const ctd: ComponentType = {
+        metadata: {
+          workloadType: 'deployment',
+          createdAt: '2025-01-01T00:00:00Z',
+          name: 'web-service',
+          allowedTraits: [
+            { kind: 'Trait', name: 'ingress' },
+            { kind: 'Trait', name: 'hpa' },
+          ],
+        },
+        spec: {
+          inputParametersSchema: {
+            type: 'object',
+            properties: {},
+          },
+        },
+      };
+
+      const result = converter.convertCtdToTemplateEntity(ctd, 'test-org');
+      const parameters = result.spec?.parameters as any[];
+      const options = parameters[2].properties.workloadDetails['ui:options'];
+
+      expect(options.allowedTraits).toEqual([
+        { kind: 'Trait', name: 'ingress' },
+        { kind: 'Trait', name: 'hpa' },
+      ]);
+    });
+
+    it('should pass undefined allowedTraits when not set', () => {
+      const ctd: ComponentType = {
+        metadata: {
+          workloadType: 'deployment',
+          createdAt: '2025-01-01T00:00:00Z',
+          name: 'web-service',
+        },
+        spec: {
+          inputParametersSchema: {
+            type: 'object',
+            properties: {},
+          },
+        },
+      };
+
+      const result = converter.convertCtdToTemplateEntity(ctd, 'test-org');
+      const parameters = result.spec?.parameters as any[];
+      const options = parameters[2].properties.workloadDetails['ui:options'];
+
+      expect(options.allowedTraits).toBeUndefined();
+    });
+  });
 });

--- a/plugins/openchoreo-react/src/utils/graphUtils.test.ts
+++ b/plugins/openchoreo-react/src/utils/graphUtils.test.ts
@@ -20,7 +20,9 @@ describe('graphUtils', () => {
     it('returns correct color for known kinds', () => {
       expect(getNodeColor('component')).toBe(ENTITY_KIND_COLORS.component);
       expect(getNodeColor('environment')).toBe(ENTITY_KIND_COLORS.environment);
-      expect(getNodeColor('deploymentpipeline')).toBe(ENTITY_KIND_COLORS.deploymentpipeline);
+      expect(getNodeColor('deploymentpipeline')).toBe(
+        ENTITY_KIND_COLORS.deploymentpipeline,
+      );
       expect(getNodeColor('system')).toBe(ENTITY_KIND_COLORS.system);
     });
 
@@ -44,11 +46,15 @@ describe('graphUtils', () => {
     const environmentColor = ENTITY_KIND_COLORS.environment;
 
     it('returns light tint for known accent', () => {
-      expect(getNodeTintFill(environmentColor, false)).toBe(ENTITY_KIND_TINTS[environmentColor].light);
+      expect(getNodeTintFill(environmentColor, false)).toBe(
+        ENTITY_KIND_TINTS[environmentColor].light,
+      );
     });
 
     it('returns dark tint for known accent', () => {
-      expect(getNodeTintFill(environmentColor, true)).toBe(ENTITY_KIND_TINTS[environmentColor].dark);
+      expect(getNodeTintFill(environmentColor, true)).toBe(
+        ENTITY_KIND_TINTS[environmentColor].dark,
+      );
     });
 
     it('returns default tint for unknown accent', () => {

--- a/plugins/openchoreo-react/src/utils/graphUtils.test.ts
+++ b/plugins/openchoreo-react/src/utils/graphUtils.test.ts
@@ -18,15 +18,15 @@ describe('graphUtils', () => {
 
   describe('getNodeColor', () => {
     it('returns correct color for known kinds', () => {
-      expect(getNodeColor('component')).toBe('#64748b');
-      expect(getNodeColor('environment')).toBe('#10b981');
-      expect(getNodeColor('deploymentpipeline')).toBe('#f59e0b');
-      expect(getNodeColor('system')).toBe('#6c7fd8');
+      expect(getNodeColor('component')).toBe(ENTITY_KIND_COLORS.component);
+      expect(getNodeColor('environment')).toBe(ENTITY_KIND_COLORS.environment);
+      expect(getNodeColor('deploymentpipeline')).toBe(ENTITY_KIND_COLORS.deploymentpipeline);
+      expect(getNodeColor('system')).toBe(ENTITY_KIND_COLORS.system);
     });
 
     it('is case-insensitive', () => {
-      expect(getNodeColor('Component')).toBe('#64748b');
-      expect(getNodeColor('ENVIRONMENT')).toBe('#10b981');
+      expect(getNodeColor('Component')).toBe(ENTITY_KIND_COLORS.component);
+      expect(getNodeColor('ENVIRONMENT')).toBe(ENTITY_KIND_COLORS.environment);
     });
 
     it('returns default color for unknown kind', () => {
@@ -41,15 +41,18 @@ describe('graphUtils', () => {
   // ---- getNodeTintFill ----
 
   describe('getNodeTintFill', () => {
+    const environmentColor = ENTITY_KIND_COLORS.environment;
+
     it('returns light tint for known accent', () => {
-      expect(getNodeTintFill('#10b981', false)).toBe('#ecfdf5');
+      expect(getNodeTintFill(environmentColor, false)).toBe(ENTITY_KIND_TINTS[environmentColor].light);
     });
 
     it('returns dark tint for known accent', () => {
-      expect(getNodeTintFill('#10b981', true)).toBe('#162a22');
+      expect(getNodeTintFill(environmentColor, true)).toBe(ENTITY_KIND_TINTS[environmentColor].dark);
     });
 
     it('returns default tint for unknown accent', () => {
+      // DEFAULT_TINT is not exported, so we verify the fallback values directly
       expect(getNodeTintFill('#ff0000', false)).toBe('#f3f4f6');
       expect(getNodeTintFill('#ff0000', true)).toBe('#1f2128');
     });

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReleaseBindingDetailTabs } from './ReleaseBindingDetailTabs';
+
+// Mock design-system YamlViewer
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  YamlViewer: ({ value }: { value: string }) => (
+    <pre data-testid="yaml-viewer">{value}</pre>
+  ),
+}));
+
+// ---- Tests ----
+
+describe('ReleaseBindingDetailTabs', () => {
+  describe('Summary tab — legacy flat format', () => {
+    const legacyBinding: Record<string, unknown> = {
+      name: 'my-binding',
+      releaseName: 'my-release',
+      environment: 'development',
+      status: 'Ready',
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'AllReady',
+          message: 'All resources ready',
+          lastTransitionTime: '2026-03-01T12:00:00Z',
+        },
+      ],
+    };
+
+    it('renders release name', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={legacyBinding} />);
+
+      expect(screen.getByText('Component Release')).toBeInTheDocument();
+      expect(screen.getByText('my-release')).toBeInTheDocument();
+    });
+
+    it('renders status chip', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={legacyBinding} />);
+
+      // "Status" appears as both a property key and table column header
+      expect(screen.getAllByText('Status').length).toBeGreaterThanOrEqual(1);
+      // The status value chip shows "Ready"
+      expect(screen.getAllByText('Ready').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders environment', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={legacyBinding} />);
+
+      expect(screen.getByText('Environment')).toBeInTheDocument();
+      expect(screen.getByText('development')).toBeInTheDocument();
+    });
+
+    it('renders conditions table with correct columns', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={legacyBinding} />);
+
+      expect(screen.getByText('Conditions')).toBeInTheDocument();
+      expect(screen.getByText('Type')).toBeInTheDocument();
+      expect(screen.getByText('Reason')).toBeInTheDocument();
+      expect(screen.getByText('Message')).toBeInTheDocument();
+      expect(screen.getByText('Last Transition')).toBeInTheDocument();
+    });
+
+    it('renders condition row data', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={legacyBinding} />);
+
+      // "Ready" appears as: status value chip, condition type cell, condition status chip (True)
+      expect(screen.getAllByText('Ready').length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText('AllReady')).toBeInTheDocument();
+      expect(screen.getByText('All resources ready')).toBeInTheDocument();
+    });
+  });
+
+  describe('Summary tab — new K8s API format', () => {
+    const newApiBinding: Record<string, unknown> = {
+      metadata: { name: 'new-binding' },
+      spec: {
+        releaseName: 'new-release',
+        environment: 'staging',
+        state: 'Active',
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+            reason: 'Reconciled',
+            message: 'Successfully reconciled',
+            lastTransitionTime: '2026-04-01T08:00:00Z',
+          },
+          {
+            type: 'Deployed',
+            status: 'True',
+            reason: 'AllDeployed',
+            message: 'All resources deployed',
+          },
+        ],
+      },
+    };
+
+    it('reads releaseName from spec', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={newApiBinding} />);
+
+      expect(screen.getByText('new-release')).toBeInTheDocument();
+    });
+
+    it('reads environment from spec', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={newApiBinding} />);
+
+      expect(screen.getByText('staging')).toBeInTheDocument();
+    });
+
+    it('reads status from spec.state', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={newApiBinding} />);
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    it('reads conditions from status.conditions', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={newApiBinding} />);
+
+      expect(screen.getByText('Reconciled')).toBeInTheDocument();
+      expect(screen.getByText('AllDeployed')).toBeInTheDocument();
+    });
+
+    it('renders multiple condition rows', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={newApiBinding} />);
+
+      expect(screen.getByText('Deployed')).toBeInTheDocument();
+      expect(screen.getByText('All resources deployed')).toBeInTheDocument();
+    });
+  });
+
+  describe('Summary tab — null binding data', () => {
+    it('renders without crashing when binding data is null', () => {
+      render(<ReleaseBindingDetailTabs releaseBindingData={null} />);
+
+      // Should not show release name, status, or environment
+      expect(screen.queryByText('Component Release')).not.toBeInTheDocument();
+      expect(screen.queryByText('Status')).not.toBeInTheDocument();
+      expect(screen.queryByText('Environment')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Summary tab — missing optional fields', () => {
+    it('hides release name when not present', () => {
+      render(
+        <ReleaseBindingDetailTabs releaseBindingData={{ status: 'Ready' }} />,
+      );
+
+      expect(screen.queryByText('Component Release')).not.toBeInTheDocument();
+    });
+
+    it('shows dash for condition fields that are undefined', () => {
+      render(
+        <ReleaseBindingDetailTabs
+          releaseBindingData={{
+            conditions: [{ type: 'Ready', status: 'True' }],
+          }}
+        />,
+      );
+
+      // reason and message should show '-' when not provided
+      const dashes = screen.getAllByText('-');
+      expect(dashes.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('Definition tab', () => {
+    it('shows YAML viewer with binding data when Definition tab is clicked', async () => {
+      const user = userEvent.setup();
+      const binding = { name: 'test-binding', status: 'Ready' };
+
+      render(<ReleaseBindingDetailTabs releaseBindingData={binding} />);
+
+      await user.click(screen.getByText('Definition'));
+
+      const viewer = screen.getByTestId('yaml-viewer');
+      expect(viewer).toBeInTheDocument();
+      expect(viewer.textContent).toContain('test-binding');
+    });
+
+    it('shows empty state when binding data is null on Definition tab', async () => {
+      const user = userEvent.setup();
+
+      render(<ReleaseBindingDetailTabs releaseBindingData={null} />);
+
+      await user.click(screen.getByText('Definition'));
+
+      expect(
+        screen.getByText('No release binding definition available'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseStatusBar.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseStatusBar.test.tsx
@@ -1,0 +1,340 @@
+import { render, screen } from '@testing-library/react';
+import { ReleaseStatusBar } from './ReleaseStatusBar';
+import type { ResourceTreeData, ResourceTreeNode } from '../types';
+
+// Mock design-system StatusBadge to expose props as text
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  StatusBadge: ({ label, status }: { label: string; status: string }) => (
+    <span data-testid="status-badge" data-status={status}>
+      {label}
+    </span>
+  ),
+}));
+
+// ---- Helpers ----
+
+function makeNode(
+  overrides: Partial<ResourceTreeNode> & {
+    uid: string;
+    kind: string;
+    name: string;
+  },
+): ResourceTreeNode {
+  return {
+    version: 'v1',
+    namespace: 'default',
+    resourceVersion: '1',
+    createdAt: '2026-01-01T00:00:00Z',
+    object: {},
+    health: { status: 'Healthy' },
+    ...overrides,
+  };
+}
+
+function makeTreeData(nodes: ResourceTreeNode[]): ResourceTreeData {
+  return {
+    renderedReleases: [{ name: 'release', targetPlane: 'dp', nodes }],
+  };
+}
+
+// ---- Tests ----
+
+describe('ReleaseStatusBar', () => {
+  describe('health section', () => {
+    it('shows Healthy for legacy Ready status', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{ status: 'Ready' }}
+        />,
+      );
+
+      const badge = screen.getByTestId('status-badge');
+      expect(badge).toHaveTextContent('Healthy');
+    });
+
+    it('shows Degraded for legacy Failed status', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{ status: 'Failed' }}
+        />,
+      );
+
+      expect(screen.getByTestId('status-badge')).toHaveTextContent('Degraded');
+    });
+
+    it('shows Progressing for legacy NotReady status', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{ status: 'NotReady' }}
+        />,
+      );
+
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        'Progressing',
+      );
+    });
+
+    it('shows Undeployed for legacy NotReady with ResourcesUndeployed reason', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{
+            status: 'NotReady',
+            statusReason: 'ResourcesUndeployed',
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        'Undeployed',
+      );
+    });
+
+    it('shows reason and message when present (legacy)', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{
+            status: 'Failed',
+            statusReason: 'DeployFailed',
+            statusMessage: 'OOM killed',
+          }}
+        />,
+      );
+
+      expect(screen.getByText('Reason: DeployFailed')).toBeInTheDocument();
+      expect(screen.getByText('OOM killed')).toBeInTheDocument();
+    });
+
+    it('shows Healthy for new API Ready=True condition', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{
+            status: { conditions: [{ type: 'Ready', status: 'True' }] },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('status-badge')).toHaveTextContent('Healthy');
+    });
+
+    it('shows Degraded for new API Ready=False condition', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{
+            status: { conditions: [{ type: 'Ready', status: 'False' }] },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('status-badge')).toHaveTextContent('Degraded');
+    });
+
+    it('shows Undeployed for new API Ready=False with ResourcesUndeployed', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{
+            status: {
+              conditions: [
+                {
+                  type: 'Ready',
+                  status: 'False',
+                  reason: 'ResourcesUndeployed',
+                },
+              ],
+            },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        'Undeployed',
+      );
+    });
+
+    it('shows Progressing for new API Ready=Unknown condition', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={{
+            status: { conditions: [{ type: 'Ready', status: 'Unknown' }] },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        'Progressing',
+      );
+    });
+
+    it('shows Unknown when no binding data', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+        />,
+      );
+
+      expect(screen.getByTestId('status-badge')).toHaveTextContent('Unknown');
+    });
+  });
+
+  describe('resources section', () => {
+    it('shows "No Resources" when tree has no nodes', () => {
+      render(
+        <ReleaseStatusBar resourceTreeData={{}} releaseBindingData={null} />,
+      );
+
+      expect(screen.getByText('No Resources')).toBeInTheDocument();
+    });
+
+    it('shows singular "1 resource" for a single node', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+          ])}
+          releaseBindingData={null}
+        />,
+      );
+
+      expect(screen.getByText('1 resource')).toBeInTheDocument();
+    });
+
+    it('shows plural "N resources" for multiple nodes', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({ uid: '1', kind: 'Deployment', name: 'dep' }),
+            makeNode({ uid: '2', kind: 'Service', name: 'svc' }),
+            makeNode({ uid: '3', kind: 'Pod', name: 'pod' }),
+          ])}
+          releaseBindingData={null}
+        />,
+      );
+
+      expect(screen.getByText('3 resources')).toBeInTheDocument();
+    });
+
+    it('shows health breakdown with counts per status', () => {
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({
+              uid: '1',
+              kind: 'Deployment',
+              name: 'dep',
+              health: { status: 'Healthy' },
+            }),
+            makeNode({
+              uid: '2',
+              kind: 'Service',
+              name: 'svc',
+              health: { status: 'Healthy' },
+            }),
+            makeNode({
+              uid: '3',
+              kind: 'Pod',
+              name: 'pod',
+              health: { status: 'Degraded' },
+            }),
+          ])}
+          releaseBindingData={null}
+        />,
+      );
+
+      // formatResourceBreakdown uses · separator and orders: Healthy, Progressing, Suspended, Degraded, Undeployed, Unknown
+      expect(screen.getByText(/2 Healthy/)).toBeInTheDocument();
+      expect(screen.getByText(/1 Degraded/)).toBeInTheDocument();
+    });
+  });
+
+  describe('last updated section', () => {
+    it('shows N/A when no nodes exist', () => {
+      render(
+        <ReleaseStatusBar resourceTreeData={{}} releaseBindingData={null} />,
+      );
+
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+
+    it('shows relative time for recent nodes', () => {
+      // Set createdAt to a known time in the past
+      const twoHoursAgo = new Date(
+        Date.now() - 2 * 60 * 60 * 1000,
+      ).toISOString();
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({
+              uid: '1',
+              kind: 'Deployment',
+              name: 'dep',
+              createdAt: twoHoursAgo,
+            }),
+          ])}
+          releaseBindingData={null}
+        />,
+      );
+
+      expect(screen.getByText('2 hours ago')).toBeInTheDocument();
+    });
+
+    it('picks the latest createdAt among multiple nodes', () => {
+      const oneHourAgo = new Date(
+        Date.now() - 1 * 60 * 60 * 1000,
+      ).toISOString();
+      const threeDaysAgo = new Date(
+        Date.now() - 3 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+
+      render(
+        <ReleaseStatusBar
+          resourceTreeData={makeTreeData([
+            makeNode({
+              uid: '1',
+              kind: 'Deployment',
+              name: 'dep',
+              createdAt: threeDaysAgo,
+            }),
+            makeNode({
+              uid: '2',
+              kind: 'Service',
+              name: 'svc',
+              createdAt: oneHourAgo,
+            }),
+          ])}
+          releaseBindingData={null}
+        />,
+      );
+
+      // Should show "1 hour ago" (the most recent), not "3 days ago"
+      expect(screen.getByText('1 hour ago')).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen } from '@testing-library/react';
+import { ResourceDetailPanel } from './ResourceDetailPanel';
+import type { LayoutNode } from './treeTypes';
+
+// Mock child components to isolate panel logic
+jest.mock('./ReleaseBindingDetailTabs', () => ({
+  ReleaseBindingDetailTabs: ({
+    releaseBindingData,
+  }: {
+    releaseBindingData: unknown;
+  }) => (
+    <div data-testid="release-binding-detail-tabs">
+      {releaseBindingData ? 'has-data' : 'no-data'}
+    </div>
+  ),
+}));
+
+jest.mock('./ResourceDetailTabs', () => ({
+  ResourceDetailTabs: ({ node }: { node: { kind: string; name: string } }) => (
+    <div data-testid="resource-detail-tabs">
+      {node.kind}/{node.name}
+    </div>
+  ),
+}));
+
+jest.mock('./ResourceKindIcon', () => ({
+  ResourceKindIcon: ({ kind }: { kind: string }) => (
+    <span data-testid="kind-icon">{kind}</span>
+  ),
+}));
+
+jest.mock('@openchoreo/backstage-design-system', () => ({}));
+
+// ---- Helpers ----
+
+function makeLayoutNode(overrides: Partial<LayoutNode>): LayoutNode {
+  return {
+    id: 'test-node',
+    kind: 'Deployment',
+    name: 'test-name',
+    parentIds: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 50,
+    ...overrides,
+  };
+}
+
+// ---- Tests ----
+
+describe('ResourceDetailPanel', () => {
+  const defaultProps = {
+    onClose: jest.fn(),
+    releaseBindingData: null,
+    namespaceName: 'default-ns',
+    releaseBindingName: 'rb-name',
+  };
+
+  it('renders nothing visible when node is null (drawer closed)', () => {
+    const { container } = render(
+      <ResourceDetailPanel {...defaultProps} node={null} />,
+    );
+
+    // Drawer should not render content
+    expect(screen.queryByTestId('kind-icon')).not.toBeInTheDocument();
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders header with kind icon and node name', () => {
+    const node = makeLayoutNode({
+      kind: 'Deployment',
+      name: 'nginx',
+    });
+
+    render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+    expect(screen.getByTestId('kind-icon')).toHaveTextContent('Deployment');
+    expect(screen.getByText('nginx')).toBeInTheDocument();
+  });
+
+  it('renders close button', () => {
+    const node = makeLayoutNode({ kind: 'Deployment', name: 'dep' });
+
+    render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+    expect(screen.getByLabelText('Close')).toBeInTheDocument();
+  });
+
+  describe('metadata chips', () => {
+    it('shows namespace chip when namespace is present', () => {
+      const node = makeLayoutNode({ namespace: 'my-namespace' });
+
+      render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+      expect(screen.getByText('my-namespace')).toBeInTheDocument();
+    });
+
+    it('shows health status chip when healthStatus is present', () => {
+      const node = makeLayoutNode({ healthStatus: 'Healthy' });
+
+      render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+      expect(screen.getByText('Healthy')).toBeInTheDocument();
+    });
+
+    it('shows API group/version chip', () => {
+      const node = makeLayoutNode({ group: 'apps', version: 'v1' });
+
+      render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+      expect(screen.getByText('apps/v1')).toBeInTheDocument();
+    });
+
+    it('shows only version when group is absent', () => {
+      const node = makeLayoutNode({ group: undefined, version: 'v1' });
+
+      render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+      expect(screen.getByText('v1')).toBeInTheDocument();
+    });
+  });
+
+  describe('content routing', () => {
+    it('renders ReleaseBindingDetailTabs for root node', () => {
+      const node = makeLayoutNode({
+        kind: 'ReleaseBinding',
+        name: 'rb',
+        isRoot: true,
+      });
+
+      render(
+        <ResourceDetailPanel
+          {...defaultProps}
+          node={node}
+          releaseBindingData={{ status: 'Ready' }}
+        />,
+      );
+
+      expect(
+        screen.getByTestId('release-binding-detail-tabs'),
+      ).toHaveTextContent('has-data');
+      expect(
+        screen.queryByTestId('resource-detail-tabs'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders release name and target plane for RenderedRelease node', () => {
+      const node = makeLayoutNode({
+        kind: 'RenderedRelease',
+        name: 'my-release',
+        version: 'dataplane-1',
+        isRoot: false,
+      });
+
+      render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+      expect(screen.getByText('Release Name')).toBeInTheDocument();
+      // "my-release" appears in header and body
+      expect(screen.getAllByText('my-release')).toHaveLength(2);
+      expect(screen.getByText('Target Plane')).toBeInTheDocument();
+      // "dataplane-1" appears in metadata chip (version) and in body text
+      expect(screen.getAllByText('dataplane-1').length).toBeGreaterThanOrEqual(
+        1,
+      );
+    });
+
+    it('renders ResourceDetailTabs for regular resource nodes', () => {
+      const node = makeLayoutNode({
+        kind: 'Deployment',
+        name: 'nginx',
+        isRoot: false,
+      });
+
+      render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+      expect(screen.getByTestId('resource-detail-tabs')).toHaveTextContent(
+        'Deployment/nginx',
+      );
+    });
+
+    it('does not render ResourceDetailTabs for root node', () => {
+      const node = makeLayoutNode({
+        kind: 'ReleaseBinding',
+        name: 'rb',
+        isRoot: true,
+      });
+
+      render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+      expect(
+        screen.queryByTestId('resource-detail-tabs'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render RenderedRelease content for non-RenderedRelease kinds', () => {
+      const node = makeLayoutNode({
+        kind: 'Service',
+        name: 'svc',
+        isRoot: false,
+      });
+
+      render(<ResourceDetailPanel {...defaultProps} node={node} />);
+
+      expect(screen.queryByText('Release Name')).not.toBeInTheDocument();
+      expect(screen.queryByText('Target Plane')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.test.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.test.ts
@@ -1,0 +1,450 @@
+// Polyfill structuredClone for jsdom (used by dagre internally)
+if (typeof globalThis.structuredClone === 'undefined') {
+  globalThis.structuredClone = <T>(val: T): T =>
+    JSON.parse(JSON.stringify(val));
+}
+
+import {
+  getResourceTreeNodes,
+  buildTreeNodes,
+  computeTreeLayout,
+  NODE_WIDTH,
+  NODE_HEIGHT,
+} from './treeLayoutUtils';
+import type { ResourceTreeData, ResourceTreeNode } from '../types';
+
+// ---- Helpers ----
+
+function makeNode(
+  overrides: Partial<ResourceTreeNode> & {
+    uid: string;
+    kind: string;
+    name: string;
+  },
+): ResourceTreeNode {
+  return {
+    version: 'v1',
+    namespace: 'default',
+    resourceVersion: '1',
+    createdAt: '2026-01-01T00:00:00Z',
+    object: {},
+    health: { status: 'Healthy' },
+    ...overrides,
+  };
+}
+
+// ---- Tests ----
+
+describe('getResourceTreeNodes', () => {
+  it('returns empty array for undefined data', () => {
+    expect(getResourceTreeNodes(undefined)).toEqual([]);
+    expect(getResourceTreeNodes(null)).toEqual([]);
+  });
+
+  it('returns empty array when no renderedReleases', () => {
+    expect(getResourceTreeNodes({})).toEqual([]);
+  });
+
+  it('flattens nodes from multiple releases', () => {
+    const data: ResourceTreeData = {
+      renderedReleases: [
+        {
+          name: 'release-a',
+          targetPlane: 'dp',
+          nodes: [makeNode({ uid: '1', kind: 'Deployment', name: 'dep-a' })],
+        },
+        {
+          name: 'release-b',
+          targetPlane: 'dp',
+          nodes: [
+            makeNode({ uid: '2', kind: 'Service', name: 'svc-b' }),
+            makeNode({ uid: '3', kind: 'Pod', name: 'pod-b' }),
+          ],
+        },
+      ],
+    };
+
+    const result = getResourceTreeNodes(data);
+    expect(result).toHaveLength(3);
+    expect(result.map(n => n.uid)).toEqual(['1', '2', '3']);
+  });
+});
+
+describe('buildTreeNodes', () => {
+  const singleReleaseData: ResourceTreeData = {
+    renderedReleases: [
+      {
+        name: 'my-release',
+        targetPlane: 'dataplane',
+        nodes: [
+          makeNode({ uid: 'dep-1', kind: 'Deployment', name: 'nginx' }),
+          makeNode({
+            uid: 'svc-1',
+            kind: 'Service',
+            name: 'nginx-svc',
+            parentRefs: [
+              {
+                uid: 'dep-1',
+                kind: 'Deployment',
+                name: 'nginx',
+                version: 'v1',
+                namespace: 'default',
+              },
+            ],
+          }),
+        ],
+      },
+    ],
+  };
+
+  it('creates a root ReleaseBinding node', () => {
+    const nodes = buildTreeNodes(singleReleaseData);
+    const root = nodes.find(n => n.isRoot);
+
+    expect(root).toBeDefined();
+    expect(root!.kind).toBe('ReleaseBinding');
+    expect(root!.parentIds).toEqual([]);
+  });
+
+  it('creates intermediate RenderedRelease nodes per release', () => {
+    const nodes = buildTreeNodes(singleReleaseData);
+    const releaseNodes = nodes.filter(n => n.kind === 'RenderedRelease');
+
+    expect(releaseNodes).toHaveLength(1);
+    expect(releaseNodes[0].name).toBe('my-release');
+    expect(releaseNodes[0].version).toBe('dataplane');
+  });
+
+  it('links RenderedRelease nodes to root', () => {
+    const nodes = buildTreeNodes(singleReleaseData);
+    const releaseNode = nodes.find(n => n.kind === 'RenderedRelease')!;
+
+    expect(releaseNode.parentIds).toEqual(['__release_binding__']);
+  });
+
+  it('links resource nodes to release node when no parentRefs', () => {
+    const data: ResourceTreeData = {
+      renderedReleases: [
+        {
+          name: 'rel',
+          targetPlane: 'dp',
+          nodes: [makeNode({ uid: 'np-1', kind: 'NetworkPolicy', name: 'np' })],
+        },
+      ],
+    };
+    const nodes = buildTreeNodes(data);
+    const npNode = nodes.find(n => n.kind === 'NetworkPolicy')!;
+
+    expect(npNode.parentIds).toEqual(['__release__rel']);
+  });
+
+  it('links resource nodes to parentRefs when provided', () => {
+    const nodes = buildTreeNodes(singleReleaseData);
+    const svcNode = nodes.find(n => n.kind === 'Service')!;
+
+    expect(svcNode.parentIds).toEqual(['dep-1']);
+  });
+
+  it('preserves resource node metadata', () => {
+    const nodes = buildTreeNodes(singleReleaseData);
+    const depNode = nodes.find(n => n.kind === 'Deployment')!;
+
+    expect(depNode.uid).toBe('dep-1');
+    expect(depNode.name).toBe('nginx');
+    expect(depNode.namespace).toBe('default');
+    expect(depNode.healthStatus).toBe('Healthy');
+  });
+
+  // ---- Root health derivation ----
+
+  describe('root health from legacy binding data', () => {
+    it('sets Healthy when status is Ready', () => {
+      const nodes = buildTreeNodes(singleReleaseData, { status: 'Ready' });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.healthStatus).toBe('Healthy');
+    });
+
+    it('sets Degraded when status is Failed', () => {
+      const nodes = buildTreeNodes(singleReleaseData, { status: 'Failed' });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.healthStatus).toBe('Degraded');
+    });
+
+    it('sets Progressing when status is NotReady', () => {
+      const nodes = buildTreeNodes(singleReleaseData, { status: 'NotReady' });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.healthStatus).toBe('Progressing');
+    });
+
+    it('sets Undeployed when NotReady with ResourcesUndeployed reason', () => {
+      const nodes = buildTreeNodes(singleReleaseData, {
+        status: 'NotReady',
+        statusReason: 'ResourcesUndeployed',
+      });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.healthStatus).toBe('Undeployed');
+    });
+
+    it('uses binding name for root node name', () => {
+      const nodes = buildTreeNodes(singleReleaseData, {
+        name: 'nginx-development',
+        status: 'Ready',
+      });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.name).toBe('nginx-development');
+    });
+  });
+
+  describe('root health from new API binding data', () => {
+    it('sets Healthy when Ready condition status is True', () => {
+      const nodes = buildTreeNodes(singleReleaseData, {
+        metadata: { name: 'my-binding' },
+        status: {
+          conditions: [{ type: 'Ready', status: 'True' }],
+        },
+      });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.healthStatus).toBe('Healthy');
+      expect(root.name).toBe('my-binding');
+    });
+
+    it('sets Degraded when Ready condition status is False', () => {
+      const nodes = buildTreeNodes(singleReleaseData, {
+        metadata: { name: 'my-binding' },
+        status: {
+          conditions: [{ type: 'Ready', status: 'False' }],
+        },
+      });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.healthStatus).toBe('Degraded');
+    });
+
+    it('sets Undeployed when False with ResourcesUndeployed reason', () => {
+      const nodes = buildTreeNodes(singleReleaseData, {
+        metadata: { name: 'my-binding' },
+        status: {
+          conditions: [
+            { type: 'Ready', status: 'False', reason: 'ResourcesUndeployed' },
+          ],
+        },
+      });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.healthStatus).toBe('Undeployed');
+    });
+
+    it('sets Progressing when Ready condition status is neither True nor False', () => {
+      const nodes = buildTreeNodes(singleReleaseData, {
+        metadata: { name: 'my-binding' },
+        status: {
+          conditions: [{ type: 'Ready', status: 'Unknown' }],
+        },
+      });
+      const root = nodes.find(n => n.isRoot)!;
+      expect(root.healthStatus).toBe('Progressing');
+    });
+  });
+
+  it('defaults root health to Unknown when no binding data', () => {
+    const nodes = buildTreeNodes(singleReleaseData);
+    const root = nodes.find(n => n.isRoot)!;
+    expect(root.healthStatus).toBe('Unknown');
+  });
+
+  // ---- Aggregated health for release nodes ----
+
+  it('aggregates child health — Degraded wins over all', () => {
+    const data: ResourceTreeData = {
+      renderedReleases: [
+        {
+          name: 'rel',
+          targetPlane: 'dp',
+          nodes: [
+            makeNode({
+              uid: '1',
+              kind: 'A',
+              name: 'a',
+              health: { status: 'Healthy' },
+            }),
+            makeNode({
+              uid: '2',
+              kind: 'B',
+              name: 'b',
+              health: { status: 'Degraded' },
+            }),
+            makeNode({
+              uid: '3',
+              kind: 'C',
+              name: 'c',
+              health: { status: 'Progressing' },
+            }),
+          ],
+        },
+      ],
+    };
+    const nodes = buildTreeNodes(data);
+    const releaseNode = nodes.find(n => n.kind === 'RenderedRelease')!;
+    expect(releaseNode.healthStatus).toBe('Degraded');
+  });
+
+  it('aggregates child health — Unknown > Suspended > Progressing', () => {
+    const data: ResourceTreeData = {
+      renderedReleases: [
+        {
+          name: 'rel',
+          targetPlane: 'dp',
+          nodes: [
+            makeNode({
+              uid: '1',
+              kind: 'A',
+              name: 'a',
+              health: { status: 'Progressing' },
+            }),
+            makeNode({
+              uid: '2',
+              kind: 'B',
+              name: 'b',
+              health: { status: 'Unknown' },
+            }),
+            makeNode({
+              uid: '3',
+              kind: 'C',
+              name: 'c',
+              health: { status: 'Suspended' },
+            }),
+          ],
+        },
+      ],
+    };
+    const nodes = buildTreeNodes(data);
+    const releaseNode = nodes.find(n => n.kind === 'RenderedRelease')!;
+    expect(releaseNode.healthStatus).toBe('Unknown');
+  });
+
+  it('aggregates child health — all Healthy returns Healthy', () => {
+    const data: ResourceTreeData = {
+      renderedReleases: [
+        {
+          name: 'rel',
+          targetPlane: 'dp',
+          nodes: [
+            makeNode({
+              uid: '1',
+              kind: 'A',
+              name: 'a',
+              health: { status: 'Healthy' },
+            }),
+            makeNode({
+              uid: '2',
+              kind: 'B',
+              name: 'b',
+              health: { status: 'Healthy' },
+            }),
+          ],
+        },
+      ],
+    };
+    const nodes = buildTreeNodes(data);
+    const releaseNode = nodes.find(n => n.kind === 'RenderedRelease')!;
+    expect(releaseNode.healthStatus).toBe('Healthy');
+  });
+});
+
+describe('computeTreeLayout', () => {
+  it('returns empty layout for empty nodes', () => {
+    const layout = computeTreeLayout([]);
+    expect(layout.nodes).toEqual([]);
+    expect(layout.edges).toEqual([]);
+    expect(layout.width).toBe(0);
+    expect(layout.height).toBe(0);
+  });
+
+  it('positions a single node', () => {
+    const layout = computeTreeLayout([
+      {
+        id: 'root',
+        kind: 'ReleaseBinding',
+        name: 'rb',
+        isRoot: true,
+        parentIds: [],
+      },
+    ]);
+
+    expect(layout.nodes).toHaveLength(1);
+    expect(layout.nodes[0].width).toBe(NODE_WIDTH);
+    expect(layout.nodes[0].height).toBe(NODE_HEIGHT);
+    expect(layout.edges).toEqual([]);
+  });
+
+  it('creates edges between parent and child nodes', () => {
+    const layout = computeTreeLayout([
+      {
+        id: 'root',
+        kind: 'ReleaseBinding',
+        name: 'rb',
+        isRoot: true,
+        parentIds: [],
+      },
+      { id: 'child', kind: 'RenderedRelease', name: 'rr', parentIds: ['root'] },
+    ]);
+
+    expect(layout.edges).toHaveLength(1);
+    expect(layout.edges[0].from).toBe('root');
+    expect(layout.edges[0].to).toBe('child');
+    expect(layout.edges[0].lines.length).toBeGreaterThan(0);
+  });
+
+  it('lays out nodes left-to-right (root has smaller x)', () => {
+    const layout = computeTreeLayout([
+      {
+        id: 'root',
+        kind: 'ReleaseBinding',
+        name: 'rb',
+        isRoot: true,
+        parentIds: [],
+      },
+      { id: 'child', kind: 'Deployment', name: 'dep', parentIds: ['root'] },
+    ]);
+
+    const root = layout.nodes.find(n => n.id === 'root')!;
+    const child = layout.nodes.find(n => n.id === 'child')!;
+    expect(root.x).toBeLessThan(child.x);
+  });
+
+  it('computes graph dimensions from node positions', () => {
+    const layout = computeTreeLayout([
+      {
+        id: 'root',
+        kind: 'ReleaseBinding',
+        name: 'rb',
+        isRoot: true,
+        parentIds: [],
+      },
+      { id: 'child', kind: 'Deployment', name: 'dep', parentIds: ['root'] },
+    ]);
+
+    expect(layout.width).toBeGreaterThan(0);
+    expect(layout.height).toBeGreaterThan(0);
+    // Width should accommodate at least 2 nodes side by side
+    expect(layout.width).toBeGreaterThan(NODE_WIDTH);
+  });
+
+  it('handles multi-level tree with correct edge count', () => {
+    const layout = computeTreeLayout([
+      {
+        id: 'root',
+        kind: 'ReleaseBinding',
+        name: 'rb',
+        isRoot: true,
+        parentIds: [],
+      },
+      { id: 'rr', kind: 'RenderedRelease', name: 'rr', parentIds: ['root'] },
+      { id: 'dep', kind: 'Deployment', name: 'dep', parentIds: ['rr'] },
+      { id: 'svc', kind: 'Service', name: 'svc', parentIds: ['rr'] },
+      { id: 'pod', kind: 'Pod', name: 'pod', parentIds: ['dep'] },
+    ]);
+
+    // Edges: root→rr, rr→dep, rr→svc, dep→pod = 4 edges
+    expect(layout.edges).toHaveLength(4);
+    expect(layout.nodes).toHaveLength(5);
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/utils.test.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/utils.test.ts
@@ -1,0 +1,96 @@
+import {
+  formatTimestamp,
+  getHealthStatusForTab,
+  getHealthChipClass,
+} from './utils';
+
+describe('formatTimestamp', () => {
+  it('returns locale string for valid ISO timestamp', () => {
+    const result = formatTimestamp('2026-03-04T10:23:20Z');
+    // Just verify it returns a non-empty string that isn't the raw ISO
+    expect(result).toBeTruthy();
+    expect(result).not.toBe('N/A');
+  });
+
+  it('returns N/A for undefined', () => {
+    expect(formatTimestamp(undefined)).toBe('N/A');
+  });
+
+  it('returns N/A for empty string', () => {
+    expect(formatTimestamp('')).toBe('N/A');
+  });
+});
+
+describe('getHealthStatusForTab', () => {
+  it('maps Healthy to success', () => {
+    expect(getHealthStatusForTab('Healthy')).toBe('success');
+  });
+
+  it('maps Progressing to warning', () => {
+    expect(getHealthStatusForTab('Progressing')).toBe('warning');
+  });
+
+  it('maps Unknown to warning', () => {
+    expect(getHealthStatusForTab('Unknown')).toBe('warning');
+  });
+
+  it('maps Degraded to error', () => {
+    expect(getHealthStatusForTab('Degraded')).toBe('error');
+  });
+
+  it('maps Suspended to warning', () => {
+    expect(getHealthStatusForTab('Suspended')).toBe('warning');
+  });
+
+  it('maps Undeployed to default', () => {
+    expect(getHealthStatusForTab('Undeployed')).toBe('default');
+  });
+
+  it('returns default for undefined', () => {
+    expect(getHealthStatusForTab(undefined)).toBe('default');
+  });
+});
+
+describe('getHealthChipClass', () => {
+  const mockClasses = {
+    healthyChip: 'healthy-class',
+    progressingChip: 'progressing-class',
+    degradedChip: 'degraded-class',
+    suspendedChip: 'suspended-class',
+    unknownChip: 'unknown-class',
+  } as any;
+
+  it('returns healthyChip for Healthy', () => {
+    expect(getHealthChipClass('Healthy', mockClasses)).toBe('healthy-class');
+  });
+
+  it('returns progressingChip for Progressing', () => {
+    expect(getHealthChipClass('Progressing', mockClasses)).toBe(
+      'progressing-class',
+    );
+  });
+
+  it('returns degradedChip for Degraded', () => {
+    expect(getHealthChipClass('Degraded', mockClasses)).toBe('degraded-class');
+  });
+
+  it('returns suspendedChip for Suspended', () => {
+    expect(getHealthChipClass('Suspended', mockClasses)).toBe(
+      'suspended-class',
+    );
+  });
+
+  it('returns unknownChip for Undeployed', () => {
+    expect(getHealthChipClass('Undeployed', mockClasses)).toBe('unknown-class');
+  });
+
+  it('returns unknownChip for undefined', () => {
+    expect(getHealthChipClass(undefined, mockClasses)).toBe('unknown-class');
+  });
+
+  it('returns unknownChip for unrecognized status', () => {
+    expect(getHealthChipClass('SomethingElse', mockClasses)).toBe(
+      'unknown-class',
+    );
+  });
+});

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.test.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.test.ts
@@ -364,9 +364,7 @@ describe('buildWorkloadResource', () => {
       namespaceName: 'default',
       projectName: 'my-project',
       containerImage: 'nginx:latest',
-      fileMounts: [
-        { key: 'config', mountPath: '/etc/config', value: 'data' },
-      ],
+      fileMounts: [{ key: 'config', mountPath: '/etc/config', value: 'data' }],
     });
 
     expect(result.spec.container?.files).toEqual([
@@ -524,7 +522,7 @@ describe('buildComponentResource – additional cases', () => {
   });
 
   it('should protect against prototype pollution in annotation-mapped paths', () => {
-    const result = buildComponentResource({
+    buildComponentResource({
       ...minimalInput,
       deploymentSource: 'build-from-source',
       workflow: { name: 'test-build' },

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.test.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/componentResourceBuilder.test.ts
@@ -333,4 +333,209 @@ describe('buildWorkloadResource', () => {
 
     expect(result.spec.endpoints).toBeUndefined();
   });
+
+  it('should include env vars when image is provided', () => {
+    const result = buildWorkloadResource({
+      componentName: 'my-service',
+      namespaceName: 'default',
+      projectName: 'my-project',
+      containerImage: 'nginx:latest',
+      envVars: [
+        { key: 'NODE_ENV', value: 'production' },
+        {
+          key: 'DB_PASSWORD',
+          valueFrom: { secretKeyRef: { name: 'db-secret', key: 'password' } },
+        },
+      ],
+    });
+
+    expect(result.spec.container?.env).toEqual([
+      { key: 'NODE_ENV', value: 'production' },
+      {
+        key: 'DB_PASSWORD',
+        valueFrom: { secretKeyRef: { name: 'db-secret', key: 'password' } },
+      },
+    ]);
+  });
+
+  it('should include file mounts when image is provided', () => {
+    const result = buildWorkloadResource({
+      componentName: 'my-service',
+      namespaceName: 'default',
+      projectName: 'my-project',
+      containerImage: 'nginx:latest',
+      fileMounts: [
+        { key: 'config', mountPath: '/etc/config', value: 'data' },
+      ],
+    });
+
+    expect(result.spec.container?.files).toEqual([
+      { key: 'config', mountPath: '/etc/config', value: 'data' },
+    ]);
+  });
+
+  it('should omit container entirely when no image is provided', () => {
+    const result = buildWorkloadResource({
+      componentName: 'my-service',
+      namespaceName: 'default',
+      projectName: 'my-project',
+      envVars: [{ key: 'FOO', value: 'bar' }],
+    });
+
+    expect(result.spec.container).toBeUndefined();
+  });
+
+  it('should use endpoints map over legacy port when both provided', () => {
+    const result = buildWorkloadResource({
+      componentName: 'my-service',
+      namespaceName: 'default',
+      projectName: 'my-project',
+      containerImage: 'nginx:latest',
+      port: 3000,
+      endpoints: {
+        grpc: { type: 'GRPC', port: 9090, visibility: ['internal'] } as any,
+      },
+    });
+
+    // Endpoints map takes precedence over port
+    expect(result.spec.endpoints).toEqual({
+      grpc: { type: 'GRPC', port: 9090, visibility: ['internal'] },
+    });
+  });
+
+  it('should not add empty endpoints map', () => {
+    const result = buildWorkloadResource({
+      componentName: 'my-service',
+      namespaceName: 'default',
+      projectName: 'my-project',
+      containerImage: 'nginx:latest',
+      endpoints: {},
+    });
+
+    expect(result.spec.endpoints).toBeUndefined();
+  });
+
+  it('should not include env vars or file mounts when empty arrays', () => {
+    const result = buildWorkloadResource({
+      componentName: 'my-service',
+      namespaceName: 'default',
+      projectName: 'my-project',
+      containerImage: 'nginx:latest',
+      envVars: [],
+      fileMounts: [],
+    });
+
+    expect(result.spec.container?.env).toBeUndefined();
+    expect(result.spec.container?.files).toBeUndefined();
+  });
+});
+
+describe('buildComponentResource – additional cases', () => {
+  const minimalInput: ComponentResourceInput = {
+    componentName: 'my-service',
+    namespaceName: 'default',
+    projectName: 'my-project',
+    componentType: 'service',
+    componentTypeWorkloadType: 'deployment',
+  };
+
+  it('should use ClusterComponentType kind when specified', () => {
+    const result = buildComponentResource({
+      ...minimalInput,
+      componentTypeKind: 'ClusterComponentType',
+    });
+
+    expect(result.spec.componentType.kind).toBe('ClusterComponentType');
+  });
+
+  it('should default componentType kind to ComponentType', () => {
+    const result = buildComponentResource(minimalInput);
+    expect(result.spec.componentType.kind).toBe('ComponentType');
+  });
+
+  it('should handle workflow with explicit kind', () => {
+    const result = buildComponentResource({
+      ...minimalInput,
+      deploymentSource: 'build-from-source',
+      workflow: { kind: 'ClusterWorkflow', name: 'docker-build' },
+      workflowParameters: {},
+    });
+
+    expect(result.spec.workflow!.kind).toBe('ClusterWorkflow');
+    expect(result.spec.workflow!.name).toBe('docker-build');
+  });
+
+  it('should handle traits with explicit kind', () => {
+    const result = buildComponentResource({
+      ...minimalInput,
+      traits: [
+        {
+          kind: 'ClusterTrait',
+          name: 'autoscaler',
+          instanceName: 'my-autoscaler',
+          config: { 'scaling.minReplicas': 2, 'scaling.maxReplicas': 10 },
+        },
+      ],
+    });
+
+    expect(result.spec.traits).toEqual([
+      {
+        kind: 'ClusterTrait',
+        name: 'autoscaler',
+        instanceName: 'my-autoscaler',
+        parameters: {
+          scaling: { minReplicas: 2, maxReplicas: 10 },
+        },
+      },
+    ]);
+  });
+
+  it('should omit trait kind when undefined', () => {
+    const result = buildComponentResource({
+      ...minimalInput,
+      traits: [
+        {
+          name: 'ingress',
+          instanceName: 'my-ingress',
+          config: { path: '/api' },
+        },
+      ],
+    });
+
+    expect(result.spec.traits![0]).not.toHaveProperty('kind');
+  });
+
+  it('should protect against prototype pollution in workflow parameters', () => {
+    const result = buildComponentResource({
+      ...minimalInput,
+      deploymentSource: 'build-from-source',
+      workflow: { name: 'test-build' },
+      workflowParameters: {
+        '__proto__.polluted': 'yes',
+        'constructor.polluted': 'yes',
+        'safe.key': 'value',
+      },
+    });
+
+    // Safe key should be set
+    expect(result.spec.workflow!.parameters!.safe.key).toBe('value');
+    // Prototype pollution should not occur
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('should protect against prototype pollution in annotation-mapped paths', () => {
+    const result = buildComponentResource({
+      ...minimalInput,
+      deploymentSource: 'build-from-source',
+      workflow: { name: 'test-build' },
+      workflowParameters: {},
+      repoUrl: 'https://github.com/org/repo.git',
+      workflowParameterMapping: {
+        repoUrl: 'parameters.__proto__.polluted',
+      },
+    });
+
+    // Prototype pollution should not occur
+    expect(({} as any).polluted).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Purpose

Add unit tests for ReleaseDataRenderer components and hooks

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

This pull request adds comprehensive test coverage for several utility and converter modules, as well as improves test maintainability and clarity by referencing shared constants instead of hardcoded values. The changes are grouped below by theme.

### New and Expanded Test Coverage

This pull request adds comprehensive unit tests for several utility and converter modules, and improves the clarity and maintainability of color-related test logic. The most important changes are grouped below:

### New and Expanded Test Coverage

* Added a full test suite for `generateUiSchemaWithTitles` in `rjsfUtils`, covering various schema shapes, title generation, recursion, and edge cases.
* Added an extensive test suite for `CtdToTemplateConverter.convertClusterCtdToTemplateEntity`, validating metadata, annotations, parameters, allowed workflows/traits, owner logic, and output structure.
* Expanded tests for `CtdToTemplateConverter.convertCtdToTemplateEntity` to cover conditional fields for external CI platforms and allowedTraits passthrough, ensuring correct schema generation for different scenarios.
* Add new units tests to ReleaseDataRenderer components and hooks

### Test Logic Improvements

* Refactored `getNodeColor` and `getNodeTintFill` tests in `graphUtils.test.ts` to use color constants (`ENTITY_KIND_COLORS`, `ENTITY_KIND_TINTS`) instead of hardcoded values, improving maintainability and reducing duplication. [[1]](diffhunk://#diff-fa0b8516f66b928bbec4f9040d1670a5f97e86558df58b84a2dc57dd96a097aaL21-R31) [[2]](diffhunk://#diff-fa0b8516f66b928bbec4f9040d1670a5f97e86558df58b84a2dc57dd96a097aaR46-R61)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across scaffolder utilities, template conversion, component/resource builders, graph/layout utilities, and multiple release-management UI components (status bars, detail panels, tabs, trees, and helpers) to validate rendering, data mappings, health/timestamp formatting, and layout behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->