### PR TITLE
fix(theme): readable dark-mode tooltips, drop YamlEditor theme toggle

### DIFF
--- a/packages/design-system/src/theme/buildOpenChoreoTheme.ts
+++ b/packages/design-system/src/theme/buildOpenChoreoTheme.ts
@@ -527,7 +527,11 @@ export function buildOpenChoreoTheme(t: ThemeTokens): UnifiedTheme {
             backgroundColor: isDark
               ? t.surface.raised
               : 'rgba(33, 37, 41, 0.92)',
-            color: t.common.white,
+            // `t.common.white` is overloaded in dark tokens to a near-black
+            // inverted-surface value, which would render the label invisible.
+            // Pin to a literal #ffffff so the tooltip text stays readable in
+            // both modes.
+            color: '#ffffff',
             fontSize: 12,
             border: isDark ? `1px solid ${t.border.default}` : 'none',
           },

--- a/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
+++ b/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { StreamLanguage } from '@codemirror/language';
 import { yaml as yamlSupport } from '@codemirror/legacy-modes/mode/yaml';
 import { showPanel } from '@codemirror/view';
@@ -10,8 +10,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import SaveIcon from '@material-ui/icons/Save';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import DeleteIcon from '@material-ui/icons/Delete';
-import Brightness4Icon from '@material-ui/icons/Brightness4';
-import Brightness7Icon from '@material-ui/icons/Brightness7';
 import { useKeyboardEvent } from '@react-hookz/web';
 import CodeMirror from '@uiw/react-codemirror';
 import {
@@ -64,9 +62,6 @@ const useStyles = makeStyles(theme => ({
   deleteButton: {
     color: theme.palette.error.main,
   },
-  themeToggleButton: {
-    color: theme.palette.text.secondary,
-  },
   disabledButton: {
     opacity: 0.5,
   },
@@ -98,8 +93,7 @@ export interface YamlEditorProps {
   readOnly?: boolean;
   /**
    * Optional override for the CodeMirror color scheme. When omitted, the
-   * editor follows the global Backstage theme. The floating toggle button
-   * always sets a local override that persists until the component unmounts.
+   * editor follows the global Backstage theme.
    */
   isDarkTheme?: boolean;
 }
@@ -129,8 +123,7 @@ export function YamlEditor({
   const classes = useStyles();
   const tokens = useChoreoTokens();
   const globalIsDark = tokens.editor.codeMirrorTheme === 'dark';
-  const [override, setOverride] = useState<boolean | undefined>(undefined);
-  const effectiveDark = override ?? isDarkThemeProp ?? globalIsDark;
+  const effectiveDark = isDarkThemeProp ?? globalIsDark;
 
   // Error panel extension
   const panelExtension = useMemo(() => {
@@ -178,21 +171,6 @@ export function YamlEditor({
             </div>
           ) : (
             <>
-              <Tooltip
-                title={
-                  effectiveDark
-                    ? 'Switch to light theme'
-                    : 'Switch to dark theme'
-                }
-              >
-                <IconButton
-                  className={`${classes.floatingButton} ${classes.themeToggleButton}`}
-                  onClick={() => setOverride(!effectiveDark)}
-                  size="small"
-                >
-                  {effectiveDark ? <Brightness7Icon /> : <Brightness4Icon />}
-                </IconButton>
-              </Tooltip>
               {onSave && (
                 <Tooltip
                   title={


### PR DESCRIPTION
  - MuiTooltip used `t.common.white`, which dark tokens overload to near-black — pin to literal `#ffffff` so labels stay readable.
  - Remove the redundant sun/moon toggle from YamlEditor; the editor already follows the global Backstage theme.


<img width="1716" height="870" alt="Screenshot 2026-04-28 at 13 49 22" src="https://github.com/user-attachments/assets/f147806f-936e-457c-b896-ebafcf7e6f47" />
<img width="1716" height="870" alt="Screenshot 2026-04-28 at 13 49 58" src="https://github.com/user-attachments/assets/67b91208-b759-4b2b-989d-de7d94a743e0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltip text is now consistently white for improved visibility in dark mode.

* **Refactor**
  * Simplified YamlEditor theme handling to use global theme settings consistently instead of maintaining separate local controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->