### PR TITLE
refactor(app): drop OpenChoreo prefix from theme titles

### DIFF
--- a/packages/app/src/themes.tsx
+++ b/packages/app/src/themes.tsx
@@ -19,7 +19,7 @@ import {
 export const appThemes: AppTheme[] = [
   {
     id: 'openchoreo-dark',
-    title: 'OpenChoreo Dark',
+    title: 'Dark',
     variant: 'dark',
     icon: <OpenChoreoIcon />,
     Provider: ({ children }) => (
@@ -28,7 +28,7 @@ export const appThemes: AppTheme[] = [
   },
   {
     id: 'openchoreo-light',
-    title: 'OpenChoreo Light',
+    title: 'Light',
     variant: 'light',
     icon: <OpenChoreoIcon />,
     Provider: ({ children }) => (


### PR DESCRIPTION
  Settings page theme toggle now shows "Dark" / "Light" / "Auto" instead of
  "OpenChoreo Dark" / "OpenChoreo Light" / "Auto". The OpenChoreo brand is
  already conveyed by the adjacent theme icon, so the prefix only consumed
  horizontal space. Theme ids are kept as-is to preserve persisted user
  preferences.
  
<img width="1705" height="845" alt="Screenshot 2026-05-05 at 08 51 09" src="https://github.com/user-attachments/assets/da8d1707-5226-409b-b06c-3f6a70b31091" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated theme display names to use simpler, more generic titles ('Dark' and 'Light' instead of the previous longer variants).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->