### PR TITLE
feat: add Secrets settings tab

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -80,6 +80,7 @@ import BuildIcon from '@material-ui/icons/Build';
 import {
   AccessControlContent,
   GitSecretsContent,
+  SecretsContent,
 } from '@openchoreo/backstage-plugin';
 import {
   UserSettingsPage,
@@ -283,6 +284,9 @@ const routes = (
         </SettingsLayout.Route>
         <SettingsLayout.Route path="git-secrets" title="Git Secrets">
           <GitSecretsContent />
+        </SettingsLayout.Route>
+        <SettingsLayout.Route path="secrets" title="Secrets">
+          <SecretsContent />
         </SettingsLayout.Route>
       </SettingsLayout>
     </Route>

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -4579,6 +4579,99 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1alpha1/namespaces/{namespaceName}/secrets:
+    post:
+      operationId: createSecret
+      summary: Create a secret
+      description: |
+        Creates a new secret. The secret data is provisioned in the target plane
+        as a Kubernetes Secret plus a PushSecret that syncs it to the configured
+        external secret store. A SecretReference is created in the control plane
+        so consumers can reference the secret by key.
+      tags: [Secrets]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSecretRequest'
+      responses:
+        '201':
+          description: Secret created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}:
+    put:
+      operationId: updateSecret
+      summary: Update a secret
+      description: |
+        Replaces the data of an existing secret. The secret type and target
+        plane cannot be changed; only the data keys and values.
+      tags: [Secrets]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/SecretNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSecretRequest'
+      responses:
+        '200':
+          description: Secret updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    delete:
+      operationId: deleteSecret
+      summary: Delete a secret
+      description: Deletes a secret by name from the control plane and target plane.
+      tags: [Secrets]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/SecretNameParam'
+      responses:
+        '204':
+          description: Secret deleted successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
 components:
   # ===========================================================================
   # Security Schemes
@@ -4861,6 +4954,15 @@ components:
       schema:
         type: string
         example: my-git-secret
+
+    SecretNameParam:
+      name: secretName
+      in: path
+      required: true
+      description: Secret name
+      schema:
+        type: string
+        example: my-secret
 
     LabelSelectorParam:
       name: labelSelector
@@ -9270,6 +9372,14 @@ components:
           type: string
           description: How often to reconcile/refresh the secret
           example: 1h
+        targetPlane:
+          allOf:
+            - $ref: '#/components/schemas/TargetPlaneRef'
+          description: |
+            Identifies the plane to whose external secret store the secret
+            value was pushed for this SecretReference. When unset, the secret
+            value may live in any external secret store reachable through the
+            references in spec.data.
 
     SecretReferenceStatus:
       type: object
@@ -10014,3 +10124,101 @@ components:
         pageSize:
           type: integer
           description: Number of items per page
+
+    TargetPlaneRef:
+      type: object
+      description: Reference to the plane that hosts the secret data.
+      required:
+        - kind
+        - name
+      properties:
+        kind:
+          type: string
+          description: Kind of the target plane resource
+          enum:
+            - WorkflowPlane
+            - ClusterWorkflowPlane
+            - DataPlane
+            - ClusterDataPlane
+          example: DataPlane
+        name:
+          type: string
+          description: Name of the target plane resource
+          example: default
+
+    SecretType:
+      type: string
+      description: Kubernetes Secret type
+      enum:
+        - Opaque
+        - kubernetes.io/basic-auth
+        - kubernetes.io/ssh-auth
+        - kubernetes.io/dockerconfigjson
+        - kubernetes.io/tls
+      example: Opaque
+
+    CreateSecretRequest:
+      type: object
+      description: Request body for creating a secret
+      required:
+        - secretName
+        - secretType
+        - targetPlane
+        - data
+      properties:
+        secretName:
+          type: string
+          description: Name of the secret
+          example: my-secret
+        secretType:
+          $ref: '#/components/schemas/SecretType'
+        targetPlane:
+          $ref: '#/components/schemas/TargetPlaneRef'
+        data:
+          type: object
+          description: Map of secret keys to plaintext values. Required keys depend on secretType.
+          additionalProperties:
+            type: string
+          example:
+            username: alice
+            password: s3cret
+
+    UpdateSecretRequest:
+      type: object
+      description: Request body for updating a secret
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          description: New map of secret keys to plaintext values. Replaces all existing keys.
+          additionalProperties:
+            type: string
+          example:
+            username: alice
+            password: r0tated
+
+    SecretResponse:
+      type: object
+      description: Secret resource. Values are never returned, only key names.
+      properties:
+        name:
+          type: string
+          description: Name of the secret
+          example: my-secret
+        namespace:
+          type: string
+          description: Namespace of the secret
+          example: my-namespace
+        secretType:
+          $ref: '#/components/schemas/SecretType'
+        targetPlane:
+          $ref: '#/components/schemas/TargetPlaneRef'
+        keys:
+          type: array
+          description: Sorted list of keys present in the secret data
+          items:
+            type: string
+          example:
+            - password
+            - username

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -1930,6 +1930,54 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1alpha1/namespaces/{namespaceName}/secrets': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Create a secret
+     * @description Creates a new secret. The secret data is provisioned in the target plane
+     *     as a Kubernetes Secret plus a PushSecret that syncs it to the configured
+     *     external secret store. A SecretReference is created in the control plane
+     *     so consumers can reference the secret by key.
+     */
+    post: operations['createSecret'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /**
+     * Update a secret
+     * @description Replaces the data of an existing secret. The secret type and target
+     *     plane cannot be changed; only the data keys and values.
+     */
+    put: operations['updateSecret'];
+    post?: never;
+    /**
+     * Delete a secret
+     * @description Deletes a secret by name from the control plane and target plane.
+     */
+    delete: operations['deleteSecret'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -4960,6 +5008,13 @@ export interface components {
        * @example 1h
        */
       refreshInterval?: string;
+      /**
+       * @description Identifies the plane to whose external secret store the secret
+       *     value was pushed for this SecretReference. When unset, the secret
+       *     value may live in any external secret store reachable through the
+       *     references in spec.data.
+       */
+      targetPlane?: components['schemas']['TargetPlaneRef'];
     };
     /** @description Observed state of a SecretReference */
     SecretReferenceStatus: {
@@ -5464,6 +5519,91 @@ export interface components {
       /** @description Number of items per page */
       pageSize?: number;
     };
+    /** @description Reference to the plane that hosts the secret data. */
+    TargetPlaneRef: {
+      /**
+       * @description Kind of the target plane resource
+       * @example DataPlane
+       * @enum {string}
+       */
+      kind:
+        | 'WorkflowPlane'
+        | 'ClusterWorkflowPlane'
+        | 'DataPlane'
+        | 'ClusterDataPlane';
+      /**
+       * @description Name of the target plane resource
+       * @example default
+       */
+      name: string;
+    };
+    /**
+     * @description Kubernetes Secret type
+     * @example Opaque
+     * @enum {string}
+     */
+    SecretType:
+      | 'Opaque'
+      | 'kubernetes.io/basic-auth'
+      | 'kubernetes.io/ssh-auth'
+      | 'kubernetes.io/dockerconfigjson'
+      | 'kubernetes.io/tls';
+    /** @description Request body for creating a secret */
+    CreateSecretRequest: {
+      /**
+       * @description Name of the secret
+       * @example my-secret
+       */
+      secretName: string;
+      secretType: components['schemas']['SecretType'];
+      targetPlane: components['schemas']['TargetPlaneRef'];
+      /**
+       * @description Map of secret keys to plaintext values. Required keys depend on secretType.
+       * @example {
+       *       "username": "alice",
+       *       "password": "s3cret"
+       *     }
+       */
+      data: {
+        [key: string]: string;
+      };
+    };
+    /** @description Request body for updating a secret */
+    UpdateSecretRequest: {
+      /**
+       * @description New map of secret keys to plaintext values. Replaces all existing keys.
+       * @example {
+       *       "username": "alice",
+       *       "password": "r0tated"
+       *     }
+       */
+      data: {
+        [key: string]: string;
+      };
+    };
+    /** @description Secret resource. Values are never returned, only key names. */
+    SecretResponse: {
+      /**
+       * @description Name of the secret
+       * @example my-secret
+       */
+      name?: string;
+      /**
+       * @description Namespace of the secret
+       * @example my-namespace
+       */
+      namespace?: string;
+      secretType?: components['schemas']['SecretType'];
+      targetPlane?: components['schemas']['TargetPlaneRef'];
+      /**
+       * @description Sorted list of keys present in the secret data
+       * @example [
+       *       "password",
+       *       "username"
+       *     ]
+       */
+      keys?: string[];
+    };
   };
   responses: {
     /** @description Invalid request parameters */
@@ -5622,6 +5762,8 @@ export interface components {
     MappingIdParam: number;
     /** @description Git secret name */
     GitSecretNameParam: string;
+    /** @description Secret name */
+    SecretNameParam: string;
     /**
      * @description A label selector to filter resources using Kubernetes label selector syntax.
      *     Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
@@ -10656,6 +10798,100 @@ export interface operations {
         };
         content?: never;
       };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  createSecret: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateSecretRequest'];
+      };
+    };
+    responses: {
+      /** @description Secret created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SecretResponse'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  updateSecret: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Secret name */
+        secretName: components['parameters']['SecretNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateSecretRequest'];
+      };
+    };
+    responses: {
+      /** @description Secret updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SecretResponse'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteSecret: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Secret name */
+        secretName: components['parameters']['SecretNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Secret deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      400: components['responses']['BadRequest'];
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -16,6 +16,7 @@ import { ClusterTraitInfoService } from './services/ClusterTraitService/ClusterT
 import { ClusterComponentTypeInfoService } from './services/ClusterComponentTypeService/ClusterComponentTypeInfoService';
 import { SecretReferencesService } from './services/SecretReferencesService/SecretReferencesService';
 import { GitSecretsService } from './services/GitSecretsService/GitSecretsService';
+import { SecretsService } from './services/SecretsService/SecretsService';
 import { AuthzService } from './services/AuthzService/AuthzService';
 import { DataPlaneInfoService } from './services/DataPlaneService/DataPlaneInfoService';
 import { ClusterDataPlaneInfoService } from './services/ClusterDataPlaneService/ClusterDataPlaneInfoService';
@@ -114,6 +115,8 @@ export const choreoPlugin = createBackendPlugin({
 
         const gitSecretsService = new GitSecretsService(logger, baseUrl);
 
+        const secretsService = new SecretsService(logger, baseUrl);
+
         const authzService = new AuthzService(logger, baseUrl);
 
         const dataPlaneInfoService = new DataPlaneInfoService(logger, baseUrl);
@@ -176,6 +179,7 @@ export const choreoPlugin = createBackendPlugin({
             clusterComponentTypeInfoService,
             secretReferencesInfoService,
             gitSecretsService,
+            secretsService,
             authzService,
             dataPlaneInfoService,
             clusterDataPlaneInfoService,

--- a/plugins/openchoreo-backend/src/router.test.ts
+++ b/plugins/openchoreo-backend/src/router.test.ts
@@ -602,6 +602,28 @@ describe('createRouter', () => {
       expect(response.status).toBe(400);
       expect(response.body.error.message).toContain('data must be an object');
     });
+
+    it('rejects when a data value is not a string', async () => {
+      const response = await request(app)
+        .post('/secrets')
+        .query({ namespaceName: 'ns' })
+        .send({ ...validBody, data: { good: 'v', bad: 42 } });
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toContain(
+        'data.bad must be a string',
+      );
+    });
+
+    it('rejects when a data value is null', async () => {
+      const response = await request(app)
+        .post('/secrets')
+        .query({ namespaceName: 'ns' })
+        .send({ ...validBody, data: { good: 'v', bad: null } });
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toContain(
+        'data.bad must be a string',
+      );
+    });
   });
 
   describe('DELETE /secrets/:secretName', () => {

--- a/plugins/openchoreo-backend/src/router.test.ts
+++ b/plugins/openchoreo-backend/src/router.test.ts
@@ -77,6 +77,12 @@ function createMockServices() {
       createGitSecret: jest.fn(),
       deleteGitSecret: jest.fn(),
     },
+    secretsService: {
+      listSecrets: jest.fn(),
+      getSecret: jest.fn(),
+      createSecret: jest.fn(),
+      deleteSecret: jest.fn(),
+    },
     authzService: {
       checkAccess: jest.fn(),
     },
@@ -456,6 +462,168 @@ describe('createRouter', () => {
           ),
         }),
       });
+    });
+  });
+
+  describe('GET /secrets', () => {
+    it('returns secrets for the namespace', async () => {
+      const list = {
+        items: [{ name: 's1' }],
+        totalCount: 1,
+        page: 1,
+        pageSize: 100,
+      };
+      services.secretsService.listSecrets.mockResolvedValue(list);
+
+      const response = await request(app)
+        .get('/secrets')
+        .query({ namespaceName: 'ns' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(list);
+      expect(services.secretsService.listSecrets).toHaveBeenCalledWith(
+        'ns',
+        'mock-user-token',
+      );
+    });
+
+    it('returns 400 when namespaceName is missing', async () => {
+      const response = await request(app).get('/secrets');
+      expect(response.status).toBe(400);
+      expect(services.secretsService.listSecrets).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /secrets/:secretName', () => {
+    it('returns a single secret', async () => {
+      const secret = { name: 's1', namespace: 'ns', keys: ['k1'] };
+      services.secretsService.getSecret.mockResolvedValue(secret);
+
+      const response = await request(app)
+        .get('/secrets/s1')
+        .query({ namespaceName: 'ns' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(secret);
+      expect(services.secretsService.getSecret).toHaveBeenCalledWith(
+        'ns',
+        's1',
+        'mock-user-token',
+      );
+    });
+
+    it('returns 400 when namespaceName is missing', async () => {
+      const response = await request(app).get('/secrets/s1');
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('POST /secrets', () => {
+    const validBody = {
+      secretName: 's1',
+      secretType: 'Opaque',
+      targetPlane: { kind: 'DataPlane', name: 'dp' },
+      data: { k: 'v' },
+    };
+
+    it('creates a secret on valid request', async () => {
+      const created = { name: 's1', namespace: 'ns', keys: ['k'] };
+      services.secretsService.createSecret.mockResolvedValue(created);
+
+      const response = await request(app)
+        .post('/secrets')
+        .query({ namespaceName: 'ns' })
+        .send(validBody);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual(created);
+      expect(services.secretsService.createSecret).toHaveBeenCalledWith(
+        'ns',
+        validBody,
+        'mock-user-token',
+      );
+    });
+
+    it('rejects when namespaceName is missing', async () => {
+      const response = await request(app).post('/secrets').send(validBody);
+      expect(response.status).toBe(400);
+    });
+
+    it('rejects when required body fields are missing', async () => {
+      const response = await request(app)
+        .post('/secrets')
+        .query({ namespaceName: 'ns' })
+        .send({ secretName: 's1' });
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toContain('are required');
+    });
+
+    it('rejects unsupported secretType', async () => {
+      const response = await request(app)
+        .post('/secrets')
+        .query({ namespaceName: 'ns' })
+        .send({ ...validBody, secretType: 'NotARealType' });
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toContain(
+        'secretType must be one of',
+      );
+    });
+
+    it('rejects when targetPlane.kind/name are missing', async () => {
+      const response = await request(app)
+        .post('/secrets')
+        .query({ namespaceName: 'ns' })
+        .send({ ...validBody, targetPlane: { kind: 'DataPlane' } });
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toContain(
+        'targetPlane.kind and targetPlane.name are required',
+      );
+    });
+
+    it('rejects unsupported targetPlane.kind', async () => {
+      const response = await request(app)
+        .post('/secrets')
+        .query({ namespaceName: 'ns' })
+        .send({
+          ...validBody,
+          targetPlane: { kind: 'NotAPlane', name: 'dp' },
+        });
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toContain(
+        'targetPlane.kind must be one of',
+      );
+    });
+
+    it('rejects when data is not an object', async () => {
+      const response = await request(app)
+        .post('/secrets')
+        .query({ namespaceName: 'ns' })
+        .send({ ...validBody, data: ['k', 'v'] });
+      expect(response.status).toBe(400);
+      expect(response.body.error.message).toContain('data must be an object');
+    });
+  });
+
+  describe('DELETE /secrets/:secretName', () => {
+    it('deletes a secret and returns 204', async () => {
+      services.secretsService.deleteSecret.mockResolvedValue(undefined);
+
+      const response = await request(app)
+        .delete('/secrets/s1')
+        .query({ namespaceName: 'ns' });
+
+      expect(response.status).toBe(204);
+      expect(services.secretsService.deleteSecret).toHaveBeenCalledWith(
+        'ns',
+        's1',
+        'mock-user-token',
+      );
+    });
+
+    it('returns 400 when namespaceName is missing', async () => {
+      const response = await request(app).delete('/secrets/s1');
+      expect(response.status).toBe(400);
+      expect(services.secretsService.deleteSecret).not.toHaveBeenCalled();
     });
   });
 });

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -1201,6 +1201,15 @@ export async function createRouter({
         'data must be an object of string keys to string values',
       );
     }
+    for (const [key, value] of Object.entries(data)) {
+      if (typeof value !== 'string') {
+        throw new InputError(
+          `data.${key} must be a string (got ${
+            value === null ? 'null' : typeof value
+          })`,
+        );
+      }
+    }
 
     const userToken = getUserTokenFromRequest(req);
 

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -14,6 +14,7 @@ import {
   WorkloadService,
   SecretReferencesService,
   GitSecretsService,
+  SecretsService,
 } from './types';
 import { ComponentInfoService } from './services/ComponentService/ComponentInfoService';
 import { ProjectInfoService } from './services/ProjectService/ProjectInfoService';
@@ -77,6 +78,7 @@ export async function createRouter({
   clusterComponentTypeInfoService,
   secretReferencesInfoService,
   gitSecretsService,
+  secretsService,
   authzService,
   dataPlaneInfoService,
   clusterDataPlaneInfoService,
@@ -100,6 +102,7 @@ export async function createRouter({
   clusterComponentTypeInfoService: ClusterComponentTypeInfoService;
   secretReferencesInfoService: SecretReferencesService;
   gitSecretsService: GitSecretsService;
+  secretsService: SecretsService;
   authzService: AuthzService;
   dataPlaneInfoService: DataPlaneInfoService;
   clusterDataPlaneInfoService: ClusterDataPlaneInfoService;
@@ -1103,6 +1106,127 @@ export async function createRouter({
     const userToken = getUserTokenFromRequest(req);
 
     await gitSecretsService.deleteGitSecret(
+      namespaceName as string,
+      secretName,
+      userToken,
+    );
+
+    res.status(204).send();
+  });
+
+  // =====================
+  // Secrets Endpoints
+  // =====================
+
+  const SUPPORTED_SECRET_TYPES = [
+    'Opaque',
+    'kubernetes.io/basic-auth',
+    'kubernetes.io/ssh-auth',
+    'kubernetes.io/dockerconfigjson',
+    'kubernetes.io/tls',
+  ] as const;
+
+  const SUPPORTED_PLANE_KINDS = [
+    'WorkflowPlane',
+    'ClusterWorkflowPlane',
+    'DataPlane',
+    'ClusterDataPlane',
+  ] as const;
+
+  // List secrets in a namespace (filtered SecretReferences with spec.targetPlane set)
+  router.get('/secrets', async (req, res) => {
+    const { namespaceName } = req.query;
+
+    if (!namespaceName) {
+      throw new InputError('namespaceName is a required query parameter');
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    res.json(
+      await secretsService.listSecrets(namespaceName as string, userToken),
+    );
+  });
+
+  // Get a single secret by name
+  router.get('/secrets/:secretName', async (req, res) => {
+    const { namespaceName } = req.query;
+    const { secretName } = req.params;
+
+    if (!namespaceName) {
+      throw new InputError('namespaceName is a required query parameter');
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    res.json(
+      await secretsService.getSecret(
+        namespaceName as string,
+        secretName,
+        userToken,
+      ),
+    );
+  });
+
+  // Create a new secret
+  router.post('/secrets', requireAuth, async (req, res) => {
+    const { namespaceName } = req.query;
+    const { secretName, secretType, targetPlane, data } = req.body ?? {};
+
+    if (!namespaceName) {
+      throw new InputError('namespaceName is a required query parameter');
+    }
+    if (!secretName || !secretType || !targetPlane || !data) {
+      throw new InputError(
+        'secretName, secretType, targetPlane, and data are required in the request body',
+      );
+    }
+    if (!SUPPORTED_SECRET_TYPES.includes(secretType)) {
+      throw new InputError(
+        `secretType must be one of: ${SUPPORTED_SECRET_TYPES.join(', ')}`,
+      );
+    }
+    if (!targetPlane.kind || !targetPlane.name) {
+      throw new InputError(
+        'targetPlane.kind and targetPlane.name are required',
+      );
+    }
+    if (!SUPPORTED_PLANE_KINDS.includes(targetPlane.kind)) {
+      throw new InputError(
+        `targetPlane.kind must be one of: ${SUPPORTED_PLANE_KINDS.join(', ')}`,
+      );
+    }
+    if (typeof data !== 'object' || Array.isArray(data)) {
+      throw new InputError(
+        'data must be an object of string keys to string values',
+      );
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    res
+      .status(201)
+      .json(
+        await secretsService.createSecret(
+          namespaceName as string,
+          { secretName, secretType, targetPlane, data },
+          userToken,
+        ),
+      );
+  });
+
+  // Delete a secret
+  router.delete('/secrets/:secretName', requireAuth, async (req, res) => {
+    const { namespaceName } = req.query;
+    const { secretName } = req.params;
+
+    if (!namespaceName) {
+      throw new InputError('namespaceName is a required query parameter');
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    await secretsService.deleteSecret(
       namespaceName as string,
       secretName,
       userToken,

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
@@ -190,6 +190,7 @@ describe('EnvironmentInfoService', () => {
       expect(result[0].name).toBe('dev');
       expect(result[0].resourceName).toBe('dev');
       expect(result[0].dataPlaneRef).toBe('default-dp');
+      expect(result[0].dataPlaneKind).toBe('DataPlane');
       expect(result[0].deployment.status).toBe('Ready');
       expect(result[0].deployment.releaseName).toBe('release-1');
     });

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -400,6 +400,10 @@ export class EnvironmentInfoService implements EnvironmentService {
         binding?.componentTypeEnvironmentConfigs &&
         Object.keys(binding.componentTypeEnvironmentConfigs).length > 0,
       dataPlaneRef: envData.dataPlaneRef?.name,
+      dataPlaneKind: envData.dataPlaneRef?.kind as
+        | 'DataPlane'
+        | 'ClusterDataPlane'
+        | undefined,
       deployment: {
         status: deploymentStatus,
         statusReason: binding?.statusReason,

--- a/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.test.ts
+++ b/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.test.ts
@@ -1,0 +1,193 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { createOkResponse, createErrorResponse } from '@openchoreo/test-utils';
+import { SecretsService } from './SecretsService';
+
+const mockGET = jest.fn();
+const mockPOST = jest.fn();
+const mockDELETE = jest.fn();
+
+jest.mock('@openchoreo/openchoreo-client-node', () => ({
+  ...jest.requireActual('@openchoreo/openchoreo-client-node'),
+  createOpenChoreoApiClient: jest.fn(() => ({
+    GET: mockGET,
+    POST: mockPOST,
+    DELETE: mockDELETE,
+  })),
+}));
+
+const mockLogger = mockServices.logger.mock();
+
+function createService() {
+  return new SecretsService(mockLogger, 'http://test:8080');
+}
+
+const managedSecretRef = {
+  apiVersion: 'openchoreo.dev/v1alpha1',
+  kind: 'SecretReference',
+  metadata: { name: 'db-creds', namespace: 'test-ns' },
+  spec: {
+    template: { type: 'Opaque' },
+    targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+    data: [
+      { secretKey: 'DB_USER', remoteRef: { key: 'foo', property: 'DB_USER' } },
+      { secretKey: 'DB_HOST', remoteRef: { key: 'foo', property: 'DB_HOST' } },
+    ],
+  },
+};
+
+const legacyRef = {
+  apiVersion: 'openchoreo.dev/v1alpha1',
+  kind: 'SecretReference',
+  metadata: { name: 'legacy-git', namespace: 'test-ns' },
+  spec: {
+    template: { type: 'kubernetes.io/basic-auth' },
+    data: [
+      {
+        secretKey: 'password',
+        remoteRef: { key: 'git/foo', property: 'password' },
+      },
+    ],
+  },
+};
+
+describe('SecretsService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listSecrets', () => {
+    it('returns only secrets with spec.targetPlane and sorts keys', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [managedSecretRef, legacyRef],
+        }),
+      );
+
+      const result = await createService().listSecrets('test-ns', 'token');
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        name: 'db-creds',
+        namespace: 'test-ns',
+        secretType: 'Opaque',
+        targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+        keys: ['DB_HOST', 'DB_USER'],
+      });
+      expect(result.totalCount).toBe(1);
+    });
+
+    it('handles empty list', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
+
+      const result = await createService().listSecrets('test-ns', 'token');
+
+      expect(result.items).toEqual([]);
+      expect(result.totalCount).toBe(0);
+    });
+
+    it('throws on API error', async () => {
+      mockGET.mockResolvedValueOnce(createErrorResponse());
+      await expect(
+        createService().listSecrets('test-ns', 'token'),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getSecret', () => {
+    it('returns the secret when targetPlane is set', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(managedSecretRef));
+
+      const result = await createService().getSecret(
+        'test-ns',
+        'db-creds',
+        'token',
+      );
+
+      expect(result.name).toBe('db-creds');
+      expect(result.targetPlane).toEqual({
+        kind: 'DataPlane',
+        name: 'dp-prod',
+      });
+    });
+
+    it('throws NotFound when targetPlane is missing', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(legacyRef));
+      await expect(
+        createService().getSecret('test-ns', 'legacy-git', 'token'),
+      ).rejects.toThrow(/not found/i);
+    });
+  });
+
+  describe('createSecret', () => {
+    it('POSTs the request body and returns the response', async () => {
+      const created = {
+        name: 'db-creds',
+        namespace: 'test-ns',
+        secretType: 'Opaque',
+        targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+        keys: ['DB_HOST', 'DB_USER'],
+      };
+      mockPOST.mockResolvedValueOnce(createOkResponse(created));
+
+      const result = await createService().createSecret(
+        'test-ns',
+        {
+          secretName: 'db-creds',
+          secretType: 'Opaque',
+          targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+          data: { DB_USER: 'alice', DB_HOST: 'db.local' },
+        },
+        'token',
+      );
+
+      expect(result).toEqual(created);
+      expect(mockPOST).toHaveBeenCalledWith(
+        '/api/v1alpha1/namespaces/{namespaceName}/secrets',
+        expect.objectContaining({
+          params: { path: { namespaceName: 'test-ns' } },
+          body: expect.objectContaining({ secretName: 'db-creds' }),
+        }),
+      );
+    });
+
+    it('throws on API error', async () => {
+      mockPOST.mockResolvedValueOnce(createErrorResponse());
+      await expect(
+        createService().createSecret(
+          'test-ns',
+          {
+            secretName: 'x',
+            secretType: 'Opaque',
+            targetPlane: { kind: 'DataPlane', name: 'dp' },
+            data: { k: 'v' },
+          },
+          'token',
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('deleteSecret', () => {
+    it('DELETEs the secret', async () => {
+      mockDELETE.mockResolvedValueOnce(createOkResponse(undefined));
+
+      await createService().deleteSecret('test-ns', 'db-creds', 'token');
+
+      expect(mockDELETE).toHaveBeenCalledWith(
+        '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}',
+        expect.objectContaining({
+          params: {
+            path: { namespaceName: 'test-ns', secretName: 'db-creds' },
+          },
+        }),
+      );
+    });
+
+    it('throws on API error', async () => {
+      mockDELETE.mockResolvedValueOnce(createErrorResponse());
+      await expect(
+        createService().deleteSecret('test-ns', 'db-creds', 'token'),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.test.ts
+++ b/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.test.ts
@@ -91,6 +91,26 @@ describe('SecretsService', () => {
         createService().listSecrets('test-ns', 'token'),
       ).rejects.toThrow();
     });
+
+    it('returns secretType as undefined for unsupported template types', async () => {
+      const exoticRef = {
+        apiVersion: 'openchoreo.dev/v1alpha1',
+        kind: 'SecretReference',
+        metadata: { name: 'kubeadm-token', namespace: 'test-ns' },
+        spec: {
+          template: { type: 'bootstrap.kubernetes.io/token' },
+          targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+          data: [],
+        },
+      };
+      mockGET.mockResolvedValueOnce(createOkResponse({ items: [exoticRef] }));
+
+      const result = await createService().listSecrets('test-ns', 'token');
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].name).toBe('kubeadm-token');
+      expect(result.items[0].secretType).toBeUndefined();
+    });
   });
 
   describe('getSecret', () => {

--- a/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.ts
+++ b/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.ts
@@ -190,22 +190,30 @@ export class SecretsService {
   }
 }
 
+const SUPPORTED_SECRET_TYPES: ReadonlySet<SecretType> = new Set([
+  'Opaque',
+  'kubernetes.io/basic-auth',
+  'kubernetes.io/ssh-auth',
+  'kubernetes.io/dockerconfigjson',
+  'kubernetes.io/tls',
+]);
+
+function toSecretType(raw: string | undefined): SecretType | undefined {
+  if (raw && SUPPORTED_SECRET_TYPES.has(raw as SecretType)) {
+    return raw as SecretType;
+  }
+  return undefined;
+}
+
 function toSecretResponse(ref: SecretReference): SecretResponse {
   const keys = (ref.spec?.data ?? [])
     .map(d => d.secretKey)
     .sort((a, b) => a.localeCompare(b));
 
-  // template.type maps 1:1 onto SecretResponse.secretType for the values used
-  // here (Opaque, kubernetes.io/basic-auth, kubernetes.io/ssh-auth,
-  // kubernetes.io/dockerconfigjson, kubernetes.io/tls). The wider SecretTemplate
-  // enum allows a few extras (e.g. dockercfg, bootstrap-token) that the
-  // SecretResponse enum doesn't, so we coerce through the shared `SecretType`.
-  const secretType = ref.spec?.template?.type as SecretType | undefined;
-
   return {
     name: ref.metadata?.name ?? '',
     namespace: ref.metadata?.namespace ?? '',
-    secretType,
+    secretType: toSecretType(ref.spec?.template?.type),
     targetPlane: ref.spec?.targetPlane,
     keys,
   };

--- a/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.ts
+++ b/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.ts
@@ -1,0 +1,212 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { NotFoundError } from '@backstage/errors';
+import {
+  createOpenChoreoApiClient,
+  assertApiResponse,
+} from '@openchoreo/openchoreo-client-node';
+import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
+
+export type SecretType = OpenChoreoComponents['schemas']['SecretType'];
+export type TargetPlaneRef = OpenChoreoComponents['schemas']['TargetPlaneRef'];
+export type SecretResponse = OpenChoreoComponents['schemas']['SecretResponse'];
+export type CreateSecretRequest =
+  OpenChoreoComponents['schemas']['CreateSecretRequest'];
+type SecretReference = OpenChoreoComponents['schemas']['SecretReference'];
+
+export interface SecretsListResponse {
+  items: SecretResponse[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export class SecretsService {
+  private logger: LoggerService;
+  private baseUrl: string;
+
+  constructor(logger: LoggerService, baseUrl: string) {
+    this.logger = logger;
+    this.baseUrl = baseUrl;
+  }
+
+  async listSecrets(
+    namespaceName: string,
+    token?: string,
+  ): Promise<SecretsListResponse> {
+    this.logger.debug(`Listing secrets for namespace: ${namespaceName}`);
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      const { data, error, response } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/secretreferences',
+        {
+          params: {
+            path: { namespaceName },
+          },
+        },
+      );
+
+      assertApiResponse({ data, error, response }, 'list secrets');
+
+      const items = (data!.items ?? [])
+        .filter(ref => ref.spec?.targetPlane)
+        .map(toSecretResponse);
+
+      this.logger.debug(
+        `Successfully listed ${items.length} secrets for namespace: ${namespaceName}`,
+      );
+
+      return {
+        items,
+        totalCount: items.length,
+        page: 1,
+        pageSize: items.length,
+      };
+    } catch (err) {
+      this.logger.error(`Failed to list secrets for ${namespaceName}: ${err}`);
+      throw err;
+    }
+  }
+
+  async getSecret(
+    namespaceName: string,
+    secretName: string,
+    token?: string,
+  ): Promise<SecretResponse> {
+    this.logger.debug(
+      `Fetching secret ${secretName} from namespace: ${namespaceName}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      const { data, error, response } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}',
+        {
+          params: {
+            path: { namespaceName, secretReferenceName: secretName },
+          },
+        },
+      );
+
+      assertApiResponse({ data, error, response }, 'get secret');
+
+      if (!data!.spec?.targetPlane) {
+        throw new NotFoundError(
+          `secret '${secretName}' not found in namespace '${namespaceName}'`,
+        );
+      }
+
+      return toSecretResponse(data!);
+    } catch (err) {
+      this.logger.error(
+        `Failed to get secret ${secretName} from ${namespaceName}: ${err}`,
+      );
+      throw err;
+    }
+  }
+
+  async createSecret(
+    namespaceName: string,
+    body: CreateSecretRequest,
+    userToken?: string,
+  ): Promise<SecretResponse> {
+    this.logger.debug(
+      `Creating secret ${body.secretName} in namespace: ${namespaceName}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token: userToken,
+        logger: this.logger,
+      });
+
+      const { data, error, response } = await client.POST(
+        '/api/v1alpha1/namespaces/{namespaceName}/secrets',
+        {
+          params: { path: { namespaceName } },
+          body,
+        },
+      );
+
+      assertApiResponse({ data, error, response }, 'create secret');
+
+      this.logger.debug(
+        `Successfully created secret ${body.secretName} in namespace: ${namespaceName}`,
+      );
+      return data as SecretResponse;
+    } catch (err) {
+      this.logger.error(
+        `Failed to create secret ${body.secretName} in ${namespaceName}: ${err}`,
+      );
+      throw err;
+    }
+  }
+
+  async deleteSecret(
+    namespaceName: string,
+    secretName: string,
+    userToken?: string,
+  ): Promise<void> {
+    this.logger.debug(
+      `Deleting secret ${secretName} from namespace: ${namespaceName}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token: userToken,
+        logger: this.logger,
+      });
+
+      const { error, response } = await client.DELETE(
+        '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}',
+        {
+          params: { path: { namespaceName, secretName } },
+        },
+      );
+
+      assertApiResponse({ error, response }, 'delete secret');
+
+      this.logger.debug(
+        `Successfully deleted secret ${secretName} from namespace: ${namespaceName}`,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to delete secret ${secretName} from ${namespaceName}: ${err}`,
+      );
+      throw err;
+    }
+  }
+}
+
+function toSecretResponse(ref: SecretReference): SecretResponse {
+  const keys = (ref.spec?.data ?? [])
+    .map(d => d.secretKey)
+    .sort((a, b) => a.localeCompare(b));
+
+  // template.type maps 1:1 onto SecretResponse.secretType for the values used
+  // here (Opaque, kubernetes.io/basic-auth, kubernetes.io/ssh-auth,
+  // kubernetes.io/dockerconfigjson, kubernetes.io/tls). The wider SecretTemplate
+  // enum allows a few extras (e.g. dockercfg, bootstrap-token) that the
+  // SecretResponse enum doesn't, so we coerce through the shared `SecretType`.
+  const secretType = ref.spec?.template?.type as SecretType | undefined;
+
+  return {
+    name: ref.metadata?.name ?? '',
+    namespace: ref.metadata?.namespace ?? '',
+    secretType,
+    targetPlane: ref.spec?.targetPlane,
+    keys,
+  };
+}

--- a/plugins/openchoreo-backend/src/services/transformers/secret-reference.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/secret-reference.ts
@@ -25,12 +25,13 @@ export function transformSecretReference(
       kind: store.kind,
     })),
     refreshInterval: secret.spec?.refreshInterval,
-    targetPlane: secret.spec?.targetPlane
-      ? {
-          kind: secret.spec.targetPlane.kind,
-          name: secret.spec.targetPlane.name,
-        }
-      : undefined,
+    targetPlane:
+      secret.spec?.targetPlane?.kind && secret.spec?.targetPlane?.name
+        ? {
+            kind: secret.spec.targetPlane.kind,
+            name: secret.spec.targetPlane.name,
+          }
+        : undefined,
     data: secret.spec?.data?.map(d => ({
       secretKey: d.secretKey,
       remoteRef: {

--- a/plugins/openchoreo-backend/src/services/transformers/secret-reference.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/secret-reference.ts
@@ -25,6 +25,12 @@ export function transformSecretReference(
       kind: store.kind,
     })),
     refreshInterval: secret.spec?.refreshInterval,
+    targetPlane: secret.spec?.targetPlane
+      ? {
+          kind: secret.spec.targetPlane.kind,
+          name: secret.spec.targetPlane.name,
+        }
+      : undefined,
     data: secret.spec?.data?.map(d => ({
       secretKey: d.secretKey,
       remoteRef: {

--- a/plugins/openchoreo-backend/src/services/transformers/transformers.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/transformers.test.ts
@@ -578,6 +578,46 @@ describe('transformSecretReference', () => {
   it('maps status string', () => {
     expect(transformSecretReference(secret).status).toBe('Ready');
   });
+
+  it('maps targetPlane when both kind and name are present', () => {
+    const refWithPlane: OpenChoreoComponents['schemas']['SecretReference'] = {
+      ...secret,
+      spec: {
+        ...secret.spec!,
+        targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+      },
+    };
+    expect(transformSecretReference(refWithPlane).targetPlane).toEqual({
+      kind: 'DataPlane',
+      name: 'dp-prod',
+    });
+  });
+
+  it('omits targetPlane when kind is missing', () => {
+    const refMissingKind: OpenChoreoComponents['schemas']['SecretReference'] = {
+      ...secret,
+      spec: {
+        ...secret.spec!,
+        targetPlane: { name: 'dp-prod' } as any,
+      },
+    };
+    expect(
+      transformSecretReference(refMissingKind).targetPlane,
+    ).toBeUndefined();
+  });
+
+  it('omits targetPlane when name is missing', () => {
+    const refMissingName: OpenChoreoComponents['schemas']['SecretReference'] = {
+      ...secret,
+      spec: {
+        ...secret.spec!,
+        targetPlane: { kind: 'DataPlane' } as any,
+      },
+    };
+    expect(
+      transformSecretReference(refMissingName).targetPlane,
+    ).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/openchoreo-backend/src/types.ts
+++ b/plugins/openchoreo-backend/src/types.ts
@@ -6,6 +6,11 @@ import type {
   GitSecretResponse,
   GitSecretListResponse,
 } from './services/GitSecretsService/GitSecretsService';
+import type {
+  SecretResponse,
+  SecretsListResponse,
+  CreateSecretRequest,
+} from './services/SecretsService/SecretsService';
 
 // Log types from the unified /api/v1/logs/query endpoint
 export type LogEntry = ObservabilityComponents['schemas']['ComponentLogEntry'];
@@ -201,6 +206,28 @@ export interface GitSecretsService {
     workflowPlaneName?: string,
   ): Promise<GitSecretResponse>;
   deleteGitSecret(
+    namespaceName: string,
+    secretName: string,
+    userToken?: string,
+  ): Promise<void>;
+}
+
+export interface SecretsService {
+  listSecrets(
+    namespaceName: string,
+    token?: string,
+  ): Promise<SecretsListResponse>;
+  getSecret(
+    namespaceName: string,
+    secretName: string,
+    token?: string,
+  ): Promise<SecretResponse>;
+  createSecret(
+    namespaceName: string,
+    body: CreateSecretRequest,
+    userToken?: string,
+  ): Promise<SecretResponse>;
+  deleteSecret(
     namespaceName: string,
     secretName: string,
     userToken?: string,

--- a/plugins/openchoreo-backend/src/types.ts
+++ b/plugins/openchoreo-backend/src/types.ts
@@ -66,6 +66,7 @@ export interface Environment {
   bindingName?: string;
   hasComponentTypeOverrides?: boolean;
   dataPlaneRef?: string;
+  dataPlaneKind?: 'DataPlane' | 'ClusterDataPlane';
   deployment: {
     status?: 'Ready' | 'NotReady' | 'Failed' | undefined;
     statusReason?: string;

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -194,6 +194,7 @@ export type {
   WorkloadOwner,
   Schema,
   SecretReferenceResponse,
+  SecretReferenceTargetPlane,
   SecretStoreReference,
   SecretDataSourceInfo,
   RemoteReferenceInfo,

--- a/plugins/openchoreo-common/src/types/bff-types.ts
+++ b/plugins/openchoreo-common/src/types/bff-types.ts
@@ -770,6 +770,17 @@ export interface Schema {
 // Secrets
 // ---------------------------------------------------------------------------
 
+export interface SecretReferenceTargetPlane {
+  /** @description Kind of the target plane resource. */
+  kind:
+    | 'WorkflowPlane'
+    | 'ClusterWorkflowPlane'
+    | 'DataPlane'
+    | 'ClusterDataPlane';
+  /** @description Name of the target plane resource. */
+  name: string;
+}
+
 export interface SecretReferenceResponse {
   name: string;
   namespace: string;
@@ -779,6 +790,11 @@ export interface SecretReferenceResponse {
   /** @description Duration string for refresh interval (e.g., "5m", "1h") */
   refreshInterval?: string;
   data?: SecretDataSourceInfo[];
+  /**
+   * @description Plane that hosts the secret value. Unset for legacy refs whose
+   * value may live in any external secret store reachable through spec.data.
+   */
+  targetPlane?: SecretReferenceTargetPlane;
   /** Format: date-time */
   createdAt: string;
   /** Format: date-time */

--- a/plugins/openchoreo-react/src/hooks/useSecretReferences.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useSecretReferences.test.ts
@@ -1,0 +1,78 @@
+import {
+  filterSecretReferencesForEnvDataPlane,
+  type SecretReference,
+} from './useSecretReferences';
+
+function makeRef(
+  name: string,
+  targetPlane?: SecretReference['targetPlane'],
+): SecretReference {
+  return {
+    name,
+    namespace: 'ns',
+    targetPlane,
+    createdAt: '2025-01-01T00:00:00Z',
+    status: 'Ready',
+  };
+}
+
+describe('filterSecretReferencesForEnvDataPlane', () => {
+  const dpProd = { kind: 'DataPlane', name: 'dp-prod' };
+  const dpDev = { kind: 'DataPlane', name: 'dp-dev' };
+
+  it('keeps refs without targetPlane (legacy / unscoped)', () => {
+    const refs = [makeRef('legacy')];
+    expect(filterSecretReferencesForEnvDataPlane(refs, dpProd)).toEqual(refs);
+  });
+
+  it('keeps refs whose targetPlane matches the env by both kind and name', () => {
+    const ref = makeRef('match', dpProd);
+    expect(filterSecretReferencesForEnvDataPlane([ref], dpProd)).toEqual([ref]);
+  });
+
+  it('drops refs whose targetPlane name differs', () => {
+    const ref = makeRef('other-dp', dpDev);
+    expect(filterSecretReferencesForEnvDataPlane([ref], dpProd)).toEqual([]);
+  });
+
+  it('drops refs whose targetPlane kind differs (e.g. WorkflowPlane)', () => {
+    const wp = { kind: 'WorkflowPlane', name: 'dp-prod' };
+    const ref = makeRef('wp-by-name', wp);
+    expect(filterSecretReferencesForEnvDataPlane([ref], dpProd)).toEqual([]);
+  });
+
+  it('drops refs whose targetPlane kind is ClusterDataPlane when env is DataPlane', () => {
+    const cdp = { kind: 'ClusterDataPlane', name: 'dp-prod' };
+    const ref = makeRef('cdp', cdp);
+    expect(filterSecretReferencesForEnvDataPlane([ref], dpProd)).toEqual([]);
+  });
+
+  it('keeps unscoped refs but drops scoped refs when env data plane is missing', () => {
+    const legacy = makeRef('legacy');
+    const scoped = makeRef('scoped', dpProd);
+    expect(
+      filterSecretReferencesForEnvDataPlane([legacy, scoped], undefined),
+    ).toEqual([legacy]);
+  });
+
+  it('drops scoped refs when env data plane has only name (kind missing)', () => {
+    const legacy = makeRef('legacy');
+    const scoped = makeRef('scoped', dpProd);
+    expect(
+      filterSecretReferencesForEnvDataPlane([legacy, scoped], {
+        name: 'dp-prod',
+      }),
+    ).toEqual([legacy]);
+  });
+
+  it('mixed input — keeps unscoped + matching, drops mismatches', () => {
+    const refs = [
+      makeRef('legacy'),
+      makeRef('match', dpProd),
+      makeRef('other-name', dpDev),
+      makeRef('other-kind', { kind: 'ClusterDataPlane', name: 'dp-prod' }),
+    ];
+    const out = filterSecretReferencesForEnvDataPlane(refs, dpProd);
+    expect(out.map(r => r.name)).toEqual(['legacy', 'match']);
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useSecretReferences.ts
+++ b/plugins/openchoreo-react/src/hooks/useSecretReferences.ts
@@ -21,8 +21,31 @@ export interface SecretReference {
   displayName?: string;
   description?: string;
   data?: SecretDataSourceInfo[];
+  /** Plane that hosts the secret value. Unset for legacy refs reachable via spec.data. */
+  targetPlane?: { kind?: string; name: string };
   createdAt: string;
   status: string;
+}
+
+/**
+ * Filter to references usable in a workload deployed to a given environment:
+ * either no `targetPlane` (unscoped / legacy) or `targetPlane` matches the
+ * env's data plane by **both** kind and name. Plane refs of any other kind
+ * (e.g. WorkflowPlane) are excluded — they cannot be mounted into a workload
+ * running on a different plane.
+ */
+export function filterSecretReferencesForEnvDataPlane(
+  refs: SecretReference[],
+  envDataPlane: { kind?: string; name?: string } | undefined,
+): SecretReference[] {
+  return refs.filter(ref => {
+    if (!ref.targetPlane) return true;
+    if (!envDataPlane?.name || !envDataPlane.kind) return false;
+    return (
+      ref.targetPlane.kind === envDataPlane.kind &&
+      ref.targetPlane.name === envDataPlane.name
+    );
+  });
 }
 
 interface SecretReferencesResponse {

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -143,6 +143,7 @@ export {
 } from './hooks/useComponentEntityDetails';
 export {
   useSecretReferences,
+  filterSecretReferencesForEnvDataPlane,
   type UseSecretReferencesResult,
   type SecretReference,
   type SecretDataSourceInfo,

--- a/plugins/openchoreo/src/api/OpenChoreoClient.test.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.test.ts
@@ -1,0 +1,120 @@
+import { OpenChoreoClient } from './OpenChoreoClient';
+import type { CreateSecretRequest } from './OpenChoreoClientApi';
+
+const BASE_URL = 'http://backend/api/openchoreo';
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeNoContentResponse(): Response {
+  return new Response(null, { status: 204 });
+}
+
+describe('OpenChoreoClient — secrets', () => {
+  const fetchMock = jest.fn();
+  const discovery = { getBaseUrl: jest.fn().mockResolvedValue(BASE_URL) };
+  const fetchApi = { fetch: fetchMock };
+
+  let client: OpenChoreoClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    discovery.getBaseUrl.mockResolvedValue(BASE_URL);
+    client = new OpenChoreoClient(discovery as any, fetchApi as any);
+  });
+
+  describe('listSecrets', () => {
+    it('GETs /secrets with namespaceName and returns the parsed body', async () => {
+      const body = {
+        items: [{ name: 's1' }],
+        totalCount: 1,
+        page: 1,
+        pageSize: 100,
+      };
+      fetchMock.mockResolvedValueOnce(makeJsonResponse(body));
+
+      const result = await client.listSecrets('ns');
+
+      expect(result).toEqual(body);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [calledUrl, opts] = fetchMock.mock.calls[0];
+      expect(calledUrl).toBe(`${BASE_URL}/secrets?namespaceName=ns`);
+      expect(opts.method).toBe('GET');
+      expect(opts.body).toBeUndefined();
+    });
+
+    it('throws ResponseError on non-2xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeJsonResponse({ error: { message: 'forbidden' } }, 403),
+      );
+
+      await expect(client.listSecrets('ns')).rejects.toMatchObject({
+        statusCode: 403,
+      });
+    });
+  });
+
+  describe('getSecret', () => {
+    it('GETs /secrets/:name with namespaceName and url-encodes the name', async () => {
+      const body = { name: 'a/b', namespace: 'ns', keys: ['k'] };
+      fetchMock.mockResolvedValueOnce(makeJsonResponse(body));
+
+      const result = await client.getSecret('ns', 'a/b');
+
+      expect(result).toEqual(body);
+      const [calledUrl, opts] = fetchMock.mock.calls[0];
+      expect(calledUrl).toBe(
+        `${BASE_URL}/secrets/${encodeURIComponent('a/b')}?namespaceName=ns`,
+      );
+      expect(opts.method).toBe('GET');
+    });
+  });
+
+  describe('createSecret', () => {
+    it('POSTs /secrets with the request body and JSON content-type', async () => {
+      const created = { name: 's1', namespace: 'ns', keys: ['k'] };
+      fetchMock.mockResolvedValueOnce(makeJsonResponse(created, 201));
+
+      const request: CreateSecretRequest = {
+        secretName: 's1',
+        secretType: 'Opaque',
+        targetPlane: { kind: 'DataPlane', name: 'dp' },
+        data: { k: 'v' },
+      };
+      const result = await client.createSecret('ns', request);
+
+      expect(result).toEqual(created);
+      const [calledUrl, opts] = fetchMock.mock.calls[0];
+      expect(calledUrl).toBe(`${BASE_URL}/secrets?namespaceName=ns`);
+      expect(opts.method).toBe('POST');
+      expect(opts.headers).toEqual({ 'Content-Type': 'application/json' });
+      expect(JSON.parse(opts.body)).toEqual(request);
+    });
+  });
+
+  describe('deleteSecret', () => {
+    it('DELETEs /secrets/:name and resolves on 204', async () => {
+      fetchMock.mockResolvedValueOnce(makeNoContentResponse());
+
+      await expect(client.deleteSecret('ns', 's1')).resolves.toBeUndefined();
+
+      const [calledUrl, opts] = fetchMock.mock.calls[0];
+      expect(calledUrl).toBe(`${BASE_URL}/secrets/s1?namespaceName=ns`);
+      expect(opts.method).toBe('DELETE');
+    });
+
+    it('throws ResponseError on a non-2xx delete', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeJsonResponse({ error: { message: 'nope' } }, 404),
+      );
+
+      await expect(client.deleteSecret('ns', 's1')).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -23,6 +23,9 @@ import type {
   ComponentSummary,
   GitSecret,
   GitSecretsListResponse,
+  Secret,
+  SecretsListResponse,
+  CreateSecretRequest,
   PlatformResourceKind,
   ResourceCRUDResponse,
   ClusterRole,
@@ -81,6 +84,8 @@ const API_ENDPOINTS = {
   USER_TYPES: '/user-types',
   // Git secrets endpoints
   GIT_SECRETS: '/git-secrets',
+  // Secrets endpoints
+  SECRETS: '/secrets',
   // Hierarchy data endpoints
   NAMESPACES: '/namespaces',
   PROJECTS: '/projects', // GET /namespaces/{namespaceName}/projects
@@ -1311,6 +1316,46 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
   ): Promise<void> {
     await this.apiFetch<void>(
       `${API_ENDPOINTS.GIT_SECRETS}/${encodeURIComponent(secretName)}`,
+      {
+        method: 'DELETE',
+        params: { namespaceName },
+      },
+    );
+  }
+
+  // ============================================
+  // Secrets Operations
+  // ============================================
+
+  async listSecrets(namespaceName: string): Promise<SecretsListResponse> {
+    return this.apiFetch<SecretsListResponse>(API_ENDPOINTS.SECRETS, {
+      params: { namespaceName },
+    });
+  }
+
+  async getSecret(namespaceName: string, secretName: string): Promise<Secret> {
+    return this.apiFetch<Secret>(
+      `${API_ENDPOINTS.SECRETS}/${encodeURIComponent(secretName)}`,
+      {
+        params: { namespaceName },
+      },
+    );
+  }
+
+  async createSecret(
+    namespaceName: string,
+    request: CreateSecretRequest,
+  ): Promise<Secret> {
+    return this.apiFetch<Secret>(API_ENDPOINTS.SECRETS, {
+      method: 'POST',
+      params: { namespaceName },
+      body: request,
+    });
+  }
+
+  async deleteSecret(namespaceName: string, secretName: string): Promise<void> {
+    await this.apiFetch<void>(
+      `${API_ENDPOINTS.SECRETS}/${encodeURIComponent(secretName)}`,
       {
         method: 'DELETE',
         params: { namespaceName },

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -26,6 +26,54 @@ export interface GitSecretsListResponse {
   pageSize: number;
 }
 
+/** Kubernetes Secret type supported by the create/update API */
+export type SecretType =
+  | 'Opaque'
+  | 'kubernetes.io/basic-auth'
+  | 'kubernetes.io/ssh-auth'
+  | 'kubernetes.io/dockerconfigjson'
+  | 'kubernetes.io/tls';
+
+/** Kind of plane that hosts the secret data */
+export type TargetPlaneKind =
+  | 'WorkflowPlane'
+  | 'ClusterWorkflowPlane'
+  | 'DataPlane'
+  | 'ClusterDataPlane';
+
+/** Reference to the plane that hosts the secret data */
+export interface TargetPlaneRef {
+  kind: TargetPlaneKind;
+  name: string;
+}
+
+/** Secret resource. Values are never returned, only key names. */
+export interface Secret {
+  name: string;
+  namespace: string;
+  secretType?: SecretType;
+  targetPlane?: TargetPlaneRef;
+  /** Sorted list of keys present in the secret data */
+  keys: string[];
+}
+
+/** Secrets list response */
+export interface SecretsListResponse {
+  items: Secret[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+/** Body for creating a new secret */
+export interface CreateSecretRequest {
+  secretName: string;
+  secretType: SecretType;
+  targetPlane: TargetPlaneRef;
+  /** Required keys depend on secretType. */
+  data: Record<string, string>;
+}
+
 /** Schema response containing component-type and trait environment override schemas */
 export interface ComponentSchemaResponse {
   componentTypeEnvironmentConfigs?: {
@@ -635,6 +683,23 @@ export interface OpenChoreoClientApi {
 
   /** Delete a git secret */
   deleteGitSecret(namespaceName: string, secretName: string): Promise<void>;
+
+  // === Secrets Operations ===
+
+  /** List secrets for a namespace */
+  listSecrets(namespaceName: string): Promise<SecretsListResponse>;
+
+  /** Get a single secret by name */
+  getSecret(namespaceName: string, secretName: string): Promise<Secret>;
+
+  /** Create a new secret */
+  createSecret(
+    namespaceName: string,
+    request: CreateSecretRequest,
+  ): Promise<Secret>;
+
+  /** Delete a secret */
+  deleteSecret(namespaceName: string, secretName: string): Promise<void>;
 
   // === Entity Delete Operations ===
 

--- a/plugins/openchoreo/src/components/Environments/EnvironmentOverridesPage.tsx
+++ b/plugins/openchoreo/src/components/Environments/EnvironmentOverridesPage.tsx
@@ -31,7 +31,10 @@ import MemoryIcon from '@material-ui/icons/Memory';
 import SettingsIcon from '@material-ui/icons/Settings';
 import ExtensionIcon from '@material-ui/icons/Extension';
 import { ContainerContent } from './Workload/WorkloadEditor';
-import { useSecretReferences } from '@openchoreo/backstage-plugin-react';
+import {
+  useSecretReferences,
+  filterSecretReferencesForEnvDataPlane,
+} from '@openchoreo/backstage-plugin-react';
 import type { EnvVar } from '@openchoreo/backstage-plugin-common';
 import { TraitParameters } from './TraitParameters';
 
@@ -108,8 +111,17 @@ export const EnvironmentOverridesPage = ({
   // Check deploy permission for the final Deploy/Promote button
   const { canDeploy, loading: deployPermissionLoading } = useDeployPermission();
 
-  // Load secret references for workload overrides
-  const { secretReferences } = useSecretReferences();
+  // Load secret references for workload overrides — limited to refs whose
+  // value is reachable from this environment's data plane (or unscoped refs).
+  const { secretReferences: allSecretReferences } = useSecretReferences();
+  const secretReferences = useMemo(
+    () =>
+      filterSecretReferencesForEnvDataPlane(allSecretReferences, {
+        kind: environment.dataPlaneKind,
+        name: environment.dataPlaneRef,
+      }),
+    [allSecretReferences, environment.dataPlaneKind, environment.dataPlaneRef],
+  );
 
   // Fetch component traits to get trait type information
   useEffect(() => {

--- a/plugins/openchoreo/src/components/Environments/Workload/WorkloadConfigPage.tsx
+++ b/plugins/openchoreo/src/components/Environments/Workload/WorkloadConfigPage.tsx
@@ -65,6 +65,10 @@ interface WorkloadConfigPageProps {
   onNext: (releaseName: string, targetEnvironment: string) => void;
   /** The lowest environment name (first in deployment pipeline) */
   lowestEnvironment: string;
+  /**
+   * Data plane of the lowest environment.
+   */
+  lowestEnvDataPlane?: { kind?: string; name?: string };
   /** Initial tab to display (from URL) */
   initialTab?: string;
   /** Callback when tab changes (to update URL) */
@@ -75,6 +79,7 @@ export const WorkloadConfigPage = ({
   onBack,
   onNext,
   lowestEnvironment,
+  lowestEnvDataPlane,
   initialTab,
   onTabChange,
 }: WorkloadConfigPageProps) => {
@@ -621,6 +626,7 @@ export const WorkloadConfigPage = ({
             componentTypeName={
               entity.metadata.annotations?.[CHOREO_ANNOTATIONS.COMPONENT_TYPE]
             }
+            envDataPlane={lowestEnvDataPlane}
             initialTab={initialTab}
             onTabChange={onTabChange}
             traitsState={traitsState}

--- a/plugins/openchoreo/src/components/Environments/Workload/WorkloadEditor/WorkloadEditor.tsx
+++ b/plugins/openchoreo/src/components/Environments/Workload/WorkloadEditor/WorkloadEditor.tsx
@@ -21,6 +21,7 @@ import { ParametersContent } from './ParametersContent';
 import { useWorkloadContext } from '../WorkloadContext';
 import {
   useSecretReferences,
+  filterSecretReferencesForEnvDataPlane,
   useUrlSyncedTab,
   YamlEditor,
 } from '@openchoreo/backstage-plugin-react';
@@ -36,6 +37,11 @@ import type { WorkloadChanges } from '../hooks/useWorkloadChanges';
 
 interface WorkloadEditorProps {
   componentTypeName?: string;
+  /**
+   * Data plane the workload will be deployed to. Used to filter the
+   * secret-reference picker to refs whose value is reachable from this plane.
+   */
+  envDataPlane?: { kind?: string; name?: string };
   initialTab?: string;
   onTabChange?: (tab: string) => void;
   traitsState?: TraitWithState[];
@@ -179,6 +185,7 @@ function yamlToResource(yamlStr: string): WorkloadResource | null {
 
 export function WorkloadEditor({
   componentTypeName,
+  envDataPlane,
   initialTab,
   onTabChange,
   traitsState,
@@ -201,7 +208,12 @@ export function WorkloadEditor({
   const classes = useStyles();
   const { workloadResource, setWorkloadResource, isDeploying } =
     useWorkloadContext();
-  const { secretReferences } = useSecretReferences();
+  const { secretReferences: allSecretReferences } = useSecretReferences();
+  const secretReferences = useMemo(
+    () =>
+      filterSecretReferencesForEnvDataPlane(allSecretReferences, envDataPlane),
+    [allSecretReferences, envDataPlane],
+  );
 
   // Derive spec from the resource for form use
   const spec = workloadResource?.spec;

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentData.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentData.ts
@@ -26,6 +26,7 @@ export interface Environment {
   bindingName?: string;
   hasComponentTypeOverrides?: boolean;
   dataPlaneRef?: string;
+  dataPlaneKind?: 'DataPlane' | 'ClusterDataPlane';
   deployment: {
     status?: 'Ready' | 'NotReady' | 'Failed';
     statusReason?: string;

--- a/plugins/openchoreo/src/components/Environments/wrappers/WorkloadConfigWrapper.tsx
+++ b/plugins/openchoreo/src/components/Environments/wrappers/WorkloadConfigWrapper.tsx
@@ -11,7 +11,13 @@ import type { PendingAction } from '../types';
 export const WorkloadConfigWrapper = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { lowestEnvironment } = useEnvironmentsContext();
+  const { lowestEnvironment, environments } = useEnvironmentsContext();
+  const lowestEnv = environments.find(
+    env => env.name?.toLowerCase() === lowestEnvironment,
+  );
+  const envDataPlane = lowestEnv
+    ? { kind: lowestEnv.dataPlaneKind, name: lowestEnv.dataPlaneRef }
+    : undefined;
   const { navigateToList, navigateToOverrides } = useEnvironmentRouting();
 
   // Get active tab from URL (container, endpoints, dependencies)
@@ -48,6 +54,7 @@ export const WorkloadConfigWrapper = () => {
       onBack={handleBack}
       onNext={handleNext}
       lowestEnvironment={lowestEnvironment}
+      lowestEnvDataPlane={envDataPlane}
       initialTab={activeTab}
       onTabChange={handleTabChange}
     />

--- a/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.test.tsx
+++ b/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import {
+  CreateSecretDialog,
+  type TargetPlaneOption,
+} from './CreateSecretDialog';
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof CreateSecretDialog>> = {},
+) {
+  const defaults: React.ComponentProps<typeof CreateSecretDialog> = {
+    open: true,
+    onClose: jest.fn(),
+    onSubmit: jest.fn().mockResolvedValue({} as any),
+    namespaceName: 'ns',
+    targetPlanes: [] as TargetPlaneOption[],
+    targetPlanesLoading: false,
+  };
+  return render(<CreateSecretDialog {...defaults} {...overrides} />);
+}
+
+describe('CreateSecretDialog — target plane error surface', () => {
+  it('shows the error message in helper text when targetPlanesError is set', () => {
+    renderDialog({ targetPlanesError: new Error('catalog down') });
+    expect(
+      screen.getByText(/Failed to load target planes: catalog down/i),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the Create button when targetPlanesError is set', () => {
+    renderDialog({ targetPlanesError: new Error('nope') });
+    const create = screen.getByRole('button', { name: 'Create' });
+    expect(create).toBeDisabled();
+  });
+
+  it('uses the default helper text when there is no error', () => {
+    renderDialog({
+      targetPlanes: [{ kind: 'DataPlane', name: 'dp' }],
+    });
+    expect(
+      screen.getByText('Where this secret will be delivered.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.test.tsx
+++ b/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   CreateSecretDialog,
   type TargetPlaneOption,
@@ -39,5 +40,74 @@ describe('CreateSecretDialog — target plane error surface', () => {
     expect(
       screen.getByText('Where this secret will be delivered.'),
     ).toBeInTheDocument();
+  });
+});
+
+describe('CreateSecretDialog — Create button data validation', () => {
+  const planes: TargetPlaneOption[] = [{ kind: 'DataPlane', name: 'dp' }];
+
+  // MUI v4 TextField doesn't link <label> via htmlFor, so getByLabelText
+  // fails. Query by the visible label text rendered inside the wrapping
+  // FormControl and walk to the input it controls.
+  function inputForLabel(labelText: string): HTMLElement {
+    const labels = screen
+      .getAllByText(
+        (_, el) =>
+          (el?.textContent ?? '').replace(/\s*\*\s*$/, '').trim() === labelText,
+      )
+      .filter(el => el.tagName === 'LABEL');
+    for (const labelEl of labels) {
+      const formControl = labelEl.closest('.MuiFormControl-root');
+      const input =
+        formControl?.querySelector<HTMLElement>('input, textarea') ?? null;
+      if (input) return input;
+    }
+    throw new Error(`No input found near label "${labelText}"`);
+  }
+
+  it('keeps Create disabled with a valid name + plane but empty Opaque data', async () => {
+    const user = userEvent.setup();
+    renderDialog({ targetPlanes: planes });
+    await user.type(inputForLabel('Secret Name'), 'my-secret');
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('disables Create for Basic Auth when password is empty', async () => {
+    const user = userEvent.setup();
+    renderDialog({ targetPlanes: planes });
+    await user.type(inputForLabel('Secret Name'), 'basic');
+    await user.click(screen.getByRole('radio', { name: /Basic Auth/i }));
+    // Username alone is not enough — password is required.
+    await user.type(inputForLabel('Username'), 'alice');
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('enables Create for Basic Auth once a password is provided', async () => {
+    const user = userEvent.setup();
+    renderDialog({ targetPlanes: planes });
+    await user.type(inputForLabel('Secret Name'), 'basic');
+    await user.click(screen.getByRole('radio', { name: /Basic Auth/i }));
+    await user.type(inputForLabel('Password / Token'), 'hunter2');
+    expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
+  });
+
+  it('disables Create for Docker Config when JSON is invalid', async () => {
+    const user = userEvent.setup();
+    renderDialog({ targetPlanes: planes });
+    await user.type(inputForLabel('Secret Name'), 'docker');
+    await user.click(screen.getByRole('radio', { name: /Docker Config/i }));
+    await user.type(inputForLabel('.dockerconfigjson'), 'not-json-{{');
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('disables Create for TLS until both crt and key are provided', async () => {
+    const user = userEvent.setup();
+    renderDialog({ targetPlanes: planes });
+    await user.type(inputForLabel('Secret Name'), 'tls-secret');
+    await user.click(screen.getByRole('radio', { name: /^TLS/i }));
+    await user.type(inputForLabel('tls.crt'), 'crt-pem');
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+    await user.type(inputForLabel('tls.key'), 'key-pem');
+    expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
   });
 });

--- a/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
+++ b/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
@@ -100,7 +100,7 @@ const SECRET_TYPES: {
   {
     value: SECRET_TYPE.OPAQUE,
     label: 'Opaque',
-    description: 'Free-form key/value pairs',
+    description: 'key/value pairs',
   },
   {
     value: SECRET_TYPE.BASIC_AUTH,
@@ -255,6 +255,22 @@ export const CreateSecretDialog = ({
         return { ok: false, error: 'Unsupported secret type' };
     }
   };
+
+  const dataValid = useMemo(() => {
+    return buildData().ok;
+    // buildData reads many state values; recompute on each render is fine here
+    // — this dialog is small and the work is trivial.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    secretType,
+    opaqueRows,
+    basicUsername,
+    basicPassword,
+    sshKey,
+    dockerConfig,
+    tlsCrt,
+    tlsKey,
+  ]);
 
   const nameError = useMemo(() => {
     const name = secretName.trim();
@@ -630,7 +646,8 @@ export const CreateSecretDialog = ({
             !!nameError ||
             Boolean(targetPlanesError) ||
             targetPlanes.length === 0 ||
-            effectivePlaneIndex === ''
+            effectivePlaneIndex === '' ||
+            !dataValid
           }
           startIcon={loading ? <CircularProgress size={20} /> : null}
         >

--- a/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
+++ b/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
@@ -1,0 +1,616 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  CircularProgress,
+  Typography,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  FormControl,
+  FormLabel,
+  FormHelperText,
+  Box,
+  InputLabel,
+  Select,
+  MenuItem,
+  IconButton,
+  InputAdornment,
+  Link,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import AddIcon from '@material-ui/icons/Add';
+import CloseIcon from '@material-ui/icons/Close';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import {
+  CreateSecretRequest,
+  Secret,
+  SecretType,
+  TargetPlaneKind,
+} from '../../api/OpenChoreoClientApi';
+import { isForbiddenError, getErrorMessage } from '../../utils/errorUtils';
+
+export interface TargetPlaneOption {
+  name: string;
+  kind: TargetPlaneKind;
+}
+
+interface CreateSecretDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (request: CreateSecretRequest) => Promise<Secret>;
+  namespaceName: string;
+  existingSecretNames?: string[];
+  targetPlanes?: TargetPlaneOption[];
+  targetPlanesLoading?: boolean;
+}
+
+interface KeyValueRow {
+  key: string;
+  value: string;
+  show: boolean;
+}
+
+const useStyles = makeStyles(theme => ({
+  field: {
+    marginBottom: theme.spacing(2),
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+  rowKey: { flex: 1 },
+  rowValue: { flex: 2 },
+  removeBtn: {
+    marginTop: theme.spacing(1),
+  },
+  sectionLabel: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(1),
+  },
+  addLink: {
+    cursor: 'pointer',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  },
+}));
+
+const SECRET_TYPE = {
+  OPAQUE: 'Opaque',
+  BASIC_AUTH: 'kubernetes.io/basic-auth',
+  SSH_AUTH: 'kubernetes.io/ssh-auth',
+  DOCKER_CONFIG: 'kubernetes.io/dockerconfigjson',
+  TLS: 'kubernetes.io/tls',
+} as const satisfies Record<string, SecretType>;
+
+const SECRET_TYPES: {
+  value: SecretType;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: SECRET_TYPE.OPAQUE,
+    label: 'Opaque',
+    description: 'Free-form key/value pairs',
+  },
+  {
+    value: SECRET_TYPE.BASIC_AUTH,
+    label: 'Basic Auth',
+    description: 'Username and password/token',
+  },
+  {
+    value: SECRET_TYPE.SSH_AUTH,
+    label: 'SSH Auth',
+    description: 'Private SSH key',
+  },
+  {
+    value: SECRET_TYPE.DOCKER_CONFIG,
+    label: 'Docker Config',
+    description: 'Container registry credentials',
+  },
+  {
+    value: SECRET_TYPE.TLS,
+    label: 'TLS',
+    description: 'Certificate and private key',
+  },
+];
+
+const KUBE_NAME_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+export const CreateSecretDialog = ({
+  open,
+  onClose,
+  onSubmit,
+  namespaceName,
+  existingSecretNames = [],
+  targetPlanes = [],
+  targetPlanesLoading = false,
+}: CreateSecretDialogProps) => {
+  const classes = useStyles();
+
+  const [secretName, setSecretName] = useState('');
+  const [secretType, setSecretType] = useState<SecretType>(SECRET_TYPE.OPAQUE);
+  const [selectedPlaneIndex, setSelectedPlaneIndex] = useState<number | ''>('');
+  const [opaqueRows, setOpaqueRows] = useState<KeyValueRow[]>([
+    { key: '', value: '', show: false },
+  ]);
+  const [basicUsername, setBasicUsername] = useState('');
+  const [basicPassword, setBasicPassword] = useState('');
+  const [showBasicPassword, setShowBasicPassword] = useState(false);
+  const [sshKey, setSshKey] = useState('');
+  const [dockerConfig, setDockerConfig] = useState('');
+  const [tlsCrt, setTlsCrt] = useState('');
+  const [tlsKey, setTlsKey] = useState('');
+  const [showTlsKey, setShowTlsKey] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectivePlaneIndex =
+    selectedPlaneIndex === '' && targetPlanes.length > 0
+      ? 0
+      : selectedPlaneIndex;
+
+  // Reset on open
+  useEffect(() => {
+    if (open) {
+      setSecretName('');
+      setSecretType(SECRET_TYPE.OPAQUE);
+      setSelectedPlaneIndex('');
+      setOpaqueRows([{ key: '', value: '', show: false }]);
+      setBasicUsername('');
+      setBasicPassword('');
+      setSshKey('');
+      setDockerConfig('');
+      setTlsCrt('');
+      setTlsKey('');
+      setError(null);
+    }
+  }, [open]);
+
+  const updateRow = (index: number, patch: Partial<KeyValueRow>) => {
+    setOpaqueRows(rows =>
+      rows.map((r, i) => (i === index ? { ...r, ...patch } : r)),
+    );
+  };
+  const addRow = () => {
+    setOpaqueRows(rows => [...rows, { key: '', value: '', show: false }]);
+  };
+  const removeRow = (index: number) => {
+    setOpaqueRows(rows =>
+      rows.length === 1
+        ? [{ key: '', value: '', show: false }]
+        : rows.filter((_, i) => i !== index),
+    );
+  };
+
+  const buildData = ():
+    | { ok: true; data: Record<string, string> }
+    | {
+        ok: false;
+        error: string;
+      } => {
+    switch (secretType) {
+      case SECRET_TYPE.OPAQUE: {
+        const data: Record<string, string> = {};
+        const seen = new Set<string>();
+        for (const row of opaqueRows) {
+          const k = row.key.trim();
+          if (!k && !row.value) continue;
+          if (!k) return { ok: false, error: 'All keys must have a name' };
+          if (seen.has(k)) return { ok: false, error: `Duplicate key: ${k}` };
+          if (!row.value)
+            return { ok: false, error: `Value for "${k}" is required` };
+          seen.add(k);
+          data[k] = row.value;
+        }
+        if (Object.keys(data).length === 0) {
+          return {
+            ok: false,
+            error: 'At least one key/value pair is required',
+          };
+        }
+        return { ok: true, data };
+      }
+      case SECRET_TYPE.BASIC_AUTH: {
+        if (!basicPassword) return { ok: false, error: 'Password is required' };
+        const data: Record<string, string> = { password: basicPassword };
+        if (basicUsername) data.username = basicUsername;
+        return { ok: true, data };
+      }
+      case SECRET_TYPE.SSH_AUTH: {
+        if (!sshKey.trim())
+          return { ok: false, error: 'SSH private key is required' };
+        return { ok: true, data: { 'ssh-privatekey': sshKey } };
+      }
+      case SECRET_TYPE.DOCKER_CONFIG: {
+        if (!dockerConfig.trim())
+          return { ok: false, error: 'Docker config JSON is required' };
+        try {
+          JSON.parse(dockerConfig);
+        } catch {
+          return { ok: false, error: 'Docker config must be valid JSON' };
+        }
+        return { ok: true, data: { '.dockerconfigjson': dockerConfig } };
+      }
+      case SECRET_TYPE.TLS: {
+        if (!tlsCrt.trim())
+          return { ok: false, error: 'TLS certificate is required' };
+        if (!tlsKey.trim())
+          return { ok: false, error: 'TLS private key is required' };
+        return { ok: true, data: { 'tls.crt': tlsCrt, 'tls.key': tlsKey } };
+      }
+      default:
+        return { ok: false, error: 'Unsupported secret type' };
+    }
+  };
+
+  const nameError = useMemo(() => {
+    const name = secretName.trim();
+    if (!name) return null;
+    if (!KUBE_NAME_RE.test(name)) {
+      return 'Lowercase letters, numbers, and dashes only';
+    }
+    if (existingSecretNames.includes(name)) {
+      return 'A secret with this name already exists';
+    }
+    return null;
+  }, [secretName, existingSecretNames]);
+
+  const handleSubmit = async () => {
+    const name = secretName.trim();
+    if (!name) {
+      setError('Secret name is required');
+      return;
+    }
+    if (nameError) {
+      setError(nameError);
+      return;
+    }
+    if (targetPlanes.length === 0) {
+      setError('No target planes available');
+      return;
+    }
+    if (effectivePlaneIndex === '') {
+      setError('Target plane is required');
+      return;
+    }
+    const plane = targetPlanes[effectivePlaneIndex as number];
+
+    const built = buildData();
+    if (!built.ok) {
+      setError(built.error);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      await onSubmit({
+        secretName: name,
+        secretType,
+        targetPlane: { kind: plane.kind, name: plane.name },
+        data: built.data,
+      });
+      onClose();
+    } catch (err) {
+      if (isForbiddenError(err)) {
+        setError(
+          'You do not have permission to create secrets in this namespace.',
+        );
+      } else {
+        setError(getErrorMessage(err));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderDataSection = () => {
+    switch (secretType) {
+      case SECRET_TYPE.OPAQUE:
+        return (
+          <Box>
+            <Typography variant="subtitle2" className={classes.sectionLabel}>
+              Data
+            </Typography>
+            {opaqueRows.map((row, index) => (
+              <Box key={index} className={classes.row}>
+                <TextField
+                  className={classes.rowKey}
+                  label="Key"
+                  variant="outlined"
+                  size="small"
+                  value={row.key}
+                  onChange={e => updateRow(index, { key: e.target.value })}
+                />
+                <TextField
+                  className={classes.rowValue}
+                  label="Value"
+                  variant="outlined"
+                  size="small"
+                  type={row.show ? 'text' : 'password'}
+                  value={row.value}
+                  onChange={e => updateRow(index, { value: e.target.value })}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          size="small"
+                          onClick={() => updateRow(index, { show: !row.show })}
+                          tabIndex={-1}
+                        >
+                          {row.show ? (
+                            <VisibilityOffIcon />
+                          ) : (
+                            <VisibilityIcon />
+                          )}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                <IconButton
+                  size="small"
+                  className={classes.removeBtn}
+                  onClick={() => removeRow(index)}
+                  aria-label="Remove key"
+                >
+                  <CloseIcon />
+                </IconButton>
+              </Box>
+            ))}
+            <Link className={classes.addLink} onClick={addRow} color="primary">
+              <AddIcon fontSize="small" /> Add key
+            </Link>
+          </Box>
+        );
+      case SECRET_TYPE.BASIC_AUTH:
+        return (
+          <>
+            <TextField
+              className={classes.field}
+              label="Username"
+              variant="outlined"
+              size="small"
+              fullWidth
+              value={basicUsername}
+              onChange={e => setBasicUsername(e.target.value)}
+            />
+            <TextField
+              className={classes.field}
+              label="Password / Token"
+              variant="outlined"
+              size="small"
+              fullWidth
+              required
+              type={showBasicPassword ? 'text' : 'password'}
+              value={basicPassword}
+              onChange={e => setBasicPassword(e.target.value)}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      onClick={() => setShowBasicPassword(s => !s)}
+                      tabIndex={-1}
+                    >
+                      {showBasicPassword ? (
+                        <VisibilityOffIcon />
+                      ) : (
+                        <VisibilityIcon />
+                      )}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </>
+        );
+      case SECRET_TYPE.SSH_AUTH:
+        return (
+          <TextField
+            className={classes.field}
+            label="SSH Private Key"
+            variant="outlined"
+            size="small"
+            fullWidth
+            required
+            multiline
+            minRows={6}
+            value={sshKey}
+            onChange={e => setSshKey(e.target.value)}
+            placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
+          />
+        );
+      case SECRET_TYPE.DOCKER_CONFIG:
+        return (
+          <TextField
+            className={classes.field}
+            label=".dockerconfigjson"
+            variant="outlined"
+            size="small"
+            fullWidth
+            required
+            multiline
+            minRows={6}
+            value={dockerConfig}
+            onChange={e => setDockerConfig(e.target.value)}
+            placeholder='{"auths":{"registry.example.com":{"auth":"..."}}}'
+          />
+        );
+      case SECRET_TYPE.TLS:
+        return (
+          <>
+            <TextField
+              className={classes.field}
+              label="tls.crt"
+              variant="outlined"
+              size="small"
+              fullWidth
+              required
+              multiline
+              minRows={4}
+              value={tlsCrt}
+              onChange={e => setTlsCrt(e.target.value)}
+              placeholder="-----BEGIN CERTIFICATE-----"
+            />
+            <TextField
+              className={classes.field}
+              label="tls.key"
+              variant="outlined"
+              size="small"
+              fullWidth
+              required
+              multiline
+              minRows={4}
+              type={showTlsKey ? 'text' : 'password'}
+              value={tlsKey}
+              onChange={e => setTlsKey(e.target.value)}
+              placeholder="-----BEGIN PRIVATE KEY-----"
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      onClick={() => setShowTlsKey(s => !s)}
+                      tabIndex={-1}
+                    >
+                      {showTlsKey ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={loading ? undefined : onClose}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle disableTypography>
+        <Typography variant="h4">Create Secret</Typography>
+        <Typography variant="body2" color="textSecondary">
+          Create a new secret in namespace <strong>{namespaceName}</strong>.
+        </Typography>
+      </DialogTitle>
+      <DialogContent>
+        <TextField
+          className={classes.field}
+          label="Secret Name"
+          variant="outlined"
+          size="small"
+          fullWidth
+          required
+          value={secretName}
+          onChange={e => setSecretName(e.target.value)}
+          error={!!nameError}
+          helperText={nameError ?? 'Lowercase letters, numbers, dashes.'}
+        />
+
+        <FormControl
+          variant="outlined"
+          size="small"
+          fullWidth
+          className={classes.field}
+        >
+          <InputLabel id="target-plane-label">Target Plane</InputLabel>
+          <Select
+            labelId="target-plane-label"
+            label="Target Plane"
+            value={effectivePlaneIndex}
+            onChange={e => setSelectedPlaneIndex(e.target.value as number)}
+            disabled={
+              loading || targetPlanesLoading || targetPlanes.length === 0
+            }
+          >
+            {targetPlanesLoading && (
+              <MenuItem disabled value="">
+                <CircularProgress size={16} style={{ marginRight: 8 }} />
+                Loading planes...
+              </MenuItem>
+            )}
+            {!targetPlanesLoading && targetPlanes.length === 0 && (
+              <MenuItem disabled value="">
+                No target planes available
+              </MenuItem>
+            )}
+            {!targetPlanesLoading &&
+              targetPlanes.map((plane, index) => (
+                <MenuItem key={`${plane.kind}/${plane.name}`} value={index}>
+                  {plane.name} ({plane.kind})
+                </MenuItem>
+              ))}
+          </Select>
+          <FormHelperText>Where this secret will be delivered.</FormHelperText>
+        </FormControl>
+
+        <FormControl component="fieldset" className={classes.field}>
+          <FormLabel component="legend">Secret Type</FormLabel>
+          <RadioGroup
+            value={secretType}
+            onChange={e => setSecretType(e.target.value as SecretType)}
+          >
+            {SECRET_TYPES.map(t => (
+              <FormControlLabel
+                key={t.value}
+                value={t.value}
+                control={<Radio color="primary" />}
+                label={
+                  <Box>
+                    <Typography variant="body2">{t.label}</Typography>
+                    <Typography variant="caption" color="textSecondary">
+                      {t.description}
+                    </Typography>
+                  </Box>
+                }
+              />
+            ))}
+          </RadioGroup>
+        </FormControl>
+
+        {renderDataSection()}
+
+        {error && (
+          <Typography color="error" style={{ marginTop: 16 }}>
+            {error}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading} variant="contained">
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          color="primary"
+          variant="contained"
+          disabled={
+            loading ||
+            !secretName.trim() ||
+            !!nameError ||
+            (targetPlanes.length > 0 && effectivePlaneIndex === '')
+          }
+          startIcon={loading ? <CircularProgress size={20} /> : null}
+        >
+          {loading ? 'Creating...' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
+++ b/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
@@ -48,6 +48,7 @@ interface CreateSecretDialogProps {
   existingSecretNames?: string[];
   targetPlanes?: TargetPlaneOption[];
   targetPlanesLoading?: boolean;
+  targetPlanesError?: Error;
 }
 
 interface KeyValueRow {
@@ -123,7 +124,9 @@ const SECRET_TYPES: {
   },
 ];
 
-const KUBE_NAME_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+// DNS-1123 subdomain: lowercase alphanumerics, dashes and dots; must start
+// and end with an alphanumeric.
+const KUBE_NAME_RE = /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/;
 
 export const CreateSecretDialog = ({
   open,
@@ -133,6 +136,7 @@ export const CreateSecretDialog = ({
   existingSecretNames = [],
   targetPlanes = [],
   targetPlanesLoading = false,
+  targetPlanesError,
 }: CreateSecretDialogProps) => {
   const classes = useStyles();
 
@@ -256,7 +260,7 @@ export const CreateSecretDialog = ({
     const name = secretName.trim();
     if (!name) return null;
     if (!KUBE_NAME_RE.test(name)) {
-      return 'Lowercase letters, numbers, and dashes only';
+      return 'Lowercase letters, numbers, dashes and dots only; must start and end with an alphanumeric';
     }
     if (existingSecretNames.includes(name)) {
       return 'A secret with this name already exists';
@@ -520,7 +524,9 @@ export const CreateSecretDialog = ({
           value={secretName}
           onChange={e => setSecretName(e.target.value)}
           error={!!nameError}
-          helperText={nameError ?? 'Lowercase letters, numbers, dashes.'}
+          helperText={
+            nameError ?? 'Lowercase letters, numbers, dashes and dots.'
+          }
         />
 
         <FormControl
@@ -528,6 +534,7 @@ export const CreateSecretDialog = ({
           size="small"
           fullWidth
           className={classes.field}
+          error={Boolean(targetPlanesError)}
         >
           <InputLabel id="target-plane-label">Target Plane</InputLabel>
           <Select
@@ -536,7 +543,10 @@ export const CreateSecretDialog = ({
             value={effectivePlaneIndex}
             onChange={e => setSelectedPlaneIndex(e.target.value as number)}
             disabled={
-              loading || targetPlanesLoading || targetPlanes.length === 0
+              loading ||
+              targetPlanesLoading ||
+              Boolean(targetPlanesError) ||
+              targetPlanes.length === 0
             }
           >
             {targetPlanesLoading && (
@@ -545,19 +555,33 @@ export const CreateSecretDialog = ({
                 Loading planes...
               </MenuItem>
             )}
-            {!targetPlanesLoading && targetPlanes.length === 0 && (
+            {!targetPlanesLoading && targetPlanesError && (
               <MenuItem disabled value="">
-                No target planes available
+                Failed to load target planes
               </MenuItem>
             )}
             {!targetPlanesLoading &&
+              !targetPlanesError &&
+              targetPlanes.length === 0 && (
+                <MenuItem disabled value="">
+                  No target planes available
+                </MenuItem>
+              )}
+            {!targetPlanesLoading &&
+              !targetPlanesError &&
               targetPlanes.map((plane, index) => (
                 <MenuItem key={`${plane.kind}/${plane.name}`} value={index}>
                   {plane.name} ({plane.kind})
                 </MenuItem>
               ))}
           </Select>
-          <FormHelperText>Where this secret will be delivered.</FormHelperText>
+          <FormHelperText>
+            {targetPlanesError
+              ? `Failed to load target planes: ${
+                  targetPlanesError.message || 'unknown error'
+                }`
+              : 'Where this secret will be delivered.'}
+          </FormHelperText>
         </FormControl>
 
         <FormControl component="fieldset" className={classes.field}>
@@ -604,7 +628,9 @@ export const CreateSecretDialog = ({
             loading ||
             !secretName.trim() ||
             !!nameError ||
-            (targetPlanes.length > 0 && effectivePlaneIndex === '')
+            Boolean(targetPlanesError) ||
+            targetPlanes.length === 0 ||
+            effectivePlaneIndex === ''
           }
           startIcon={loading ? <CircularProgress size={20} /> : null}
         >

--- a/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
+++ b/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
@@ -175,6 +175,8 @@ export const CreateSecretDialog = ({
       setDockerConfig('');
       setTlsCrt('');
       setTlsKey('');
+      setShowBasicPassword(false);
+      setShowTlsKey(false);
       setError(null);
     }
   }, [open]);
@@ -366,6 +368,11 @@ export const CreateSecretDialog = ({
                           size="small"
                           onClick={() => updateRow(index, { show: !row.show })}
                           tabIndex={-1}
+                          aria-label={
+                            row.show
+                              ? `Hide value${row.key ? ` for ${row.key}` : ''}`
+                              : `Show value${row.key ? ` for ${row.key}` : ''}`
+                          }
                         >
                           {row.show ? (
                             <VisibilityOffIcon />
@@ -421,6 +428,9 @@ export const CreateSecretDialog = ({
                       size="small"
                       onClick={() => setShowBasicPassword(s => !s)}
                       tabIndex={-1}
+                      aria-label={
+                        showBasicPassword ? 'Hide password' : 'Show password'
+                      }
                     >
                       {showBasicPassword ? (
                         <VisibilityOffIcon />
@@ -502,6 +512,9 @@ export const CreateSecretDialog = ({
                       size="small"
                       onClick={() => setShowTlsKey(s => !s)}
                       tabIndex={-1}
+                      aria-label={
+                        showTlsKey ? 'Hide private key' : 'Show private key'
+                      }
                     >
                       {showTlsKey ? <VisibilityOffIcon /> : <VisibilityIcon />}
                     </IconButton>

--- a/plugins/openchoreo/src/components/Secrets/SecretsPage.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsPage.tsx
@@ -69,61 +69,64 @@ export const SecretsContent = () => {
   }, [client]);
 
   // Fetch all four plane kinds for the target-plane dropdown
-  const { value: targetPlanes, loading: targetPlanesLoading } =
-    useAsync(async (): Promise<TargetPlaneOption[]> => {
-      if (!selectedNamespace) return [];
+  const {
+    value: targetPlanes,
+    loading: targetPlanesLoading,
+    error: targetPlanesError,
+  } = useAsync(async (): Promise<TargetPlaneOption[]> => {
+    if (!selectedNamespace) return [];
 
-      const [wpResult, cwpResult, dpResult, cdpResult] = await Promise.all([
-        catalogApi.getEntities({
-          filter: {
-            kind: 'WorkflowPlane',
-            'metadata.namespace': selectedNamespace,
-          },
-        }),
-        catalogApi.getEntities({
-          filter: { kind: 'ClusterWorkflowPlane' },
-        }),
-        catalogApi.getEntities({
-          filter: {
-            kind: 'DataPlane',
-            'metadata.namespace': selectedNamespace,
-          },
-        }),
-        catalogApi.getEntities({
-          filter: { kind: 'ClusterDataPlane' },
-        }),
-      ]);
+    const [wpResult, cwpResult, dpResult, cdpResult] = await Promise.all([
+      catalogApi.getEntities({
+        filter: {
+          kind: 'WorkflowPlane',
+          'metadata.namespace': selectedNamespace,
+        },
+      }),
+      catalogApi.getEntities({
+        filter: { kind: 'ClusterWorkflowPlane' },
+      }),
+      catalogApi.getEntities({
+        filter: {
+          kind: 'DataPlane',
+          'metadata.namespace': selectedNamespace,
+        },
+      }),
+      catalogApi.getEntities({
+        filter: { kind: 'ClusterDataPlane' },
+      }),
+    ]);
 
-      const planes: TargetPlaneOption[] = [];
+    const planes: TargetPlaneOption[] = [];
 
-      // Cluster-scoped first, then namespaced
-      cdpResult.items.forEach(e => {
-        planes.push({
-          name: e.metadata.name,
-          kind: 'ClusterDataPlane' as TargetPlaneKind,
-        });
+    // Cluster-scoped first, then namespaced
+    cdpResult.items.forEach(e => {
+      planes.push({
+        name: e.metadata.name,
+        kind: 'ClusterDataPlane' as TargetPlaneKind,
       });
-      cwpResult.items.forEach(e => {
-        planes.push({
-          name: e.metadata.name,
-          kind: 'ClusterWorkflowPlane' as TargetPlaneKind,
-        });
+    });
+    cwpResult.items.forEach(e => {
+      planes.push({
+        name: e.metadata.name,
+        kind: 'ClusterWorkflowPlane' as TargetPlaneKind,
       });
-      dpResult.items.forEach(e => {
-        planes.push({
-          name: e.metadata.name,
-          kind: 'DataPlane' as TargetPlaneKind,
-        });
+    });
+    dpResult.items.forEach(e => {
+      planes.push({
+        name: e.metadata.name,
+        kind: 'DataPlane' as TargetPlaneKind,
       });
-      wpResult.items.forEach(e => {
-        planes.push({
-          name: e.metadata.name,
-          kind: 'WorkflowPlane' as TargetPlaneKind,
-        });
+    });
+    wpResult.items.forEach(e => {
+      planes.push({
+        name: e.metadata.name,
+        kind: 'WorkflowPlane' as TargetPlaneKind,
       });
+    });
 
-      return planes;
-    }, [catalogApi, selectedNamespace]);
+    return planes;
+  }, [catalogApi, selectedNamespace]);
 
   const {
     secrets,
@@ -265,6 +268,7 @@ export const SecretsContent = () => {
         existingSecretNames={secrets.map(s => s.name)}
         targetPlanes={targetPlanes || []}
         targetPlanesLoading={targetPlanesLoading}
+        targetPlanesError={targetPlanesError}
       />
     </Box>
   );

--- a/plugins/openchoreo/src/components/Secrets/SecretsPage.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsPage.tsx
@@ -1,0 +1,290 @@
+import { useState, useMemo, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  CircularProgress,
+  Button,
+  IconButton,
+} from '@material-ui/core';
+import {
+  Page,
+  Header,
+  Content,
+  WarningPanel,
+} from '@backstage/core-components';
+import { ForbiddenState } from '@openchoreo/backstage-plugin-react';
+import { makeStyles } from '@material-ui/core/styles';
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import AddIcon from '@material-ui/icons/Add';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import {
+  openChoreoClientApiRef,
+  TargetPlaneKind,
+} from '../../api/OpenChoreoClientApi';
+import { useSecrets } from './hooks/useSecrets';
+import { SecretsTable } from './SecretsTable';
+import {
+  CreateSecretDialog,
+  type TargetPlaneOption,
+} from './CreateSecretDialog';
+import { useAsync } from 'react-use';
+
+const useStyles = makeStyles(theme => ({
+  content: {
+    padding: theme.spacing(3),
+  },
+  root: {
+    width: '100%',
+    maxWidth: 1200,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    paddingTop: theme.spacing(3),
+  },
+  namespaceSelector: {
+    minWidth: 300,
+  },
+}));
+
+/**
+ * Secrets content without Page/Header/Content wrapper.
+ */
+export const SecretsContent = () => {
+  const classes = useStyles();
+  const client = useApi(openChoreoClientApiRef);
+  const catalogApi = useApi(catalogApiRef);
+  const [selectedNamespace, setSelectedNamespace] = useState<string>('');
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+  const {
+    value: namespaces,
+    loading: namespacesLoading,
+    error: namespacesError,
+  } = useAsync(async () => {
+    return client.listNamespaces();
+  }, [client]);
+
+  // Fetch all four plane kinds for the target-plane dropdown
+  const { value: targetPlanes, loading: targetPlanesLoading } =
+    useAsync(async (): Promise<TargetPlaneOption[]> => {
+      if (!selectedNamespace) return [];
+
+      const [wpResult, cwpResult, dpResult, cdpResult] = await Promise.all([
+        catalogApi.getEntities({
+          filter: {
+            kind: 'WorkflowPlane',
+            'metadata.namespace': selectedNamespace,
+          },
+        }),
+        catalogApi.getEntities({
+          filter: { kind: 'ClusterWorkflowPlane' },
+        }),
+        catalogApi.getEntities({
+          filter: {
+            kind: 'DataPlane',
+            'metadata.namespace': selectedNamespace,
+          },
+        }),
+        catalogApi.getEntities({
+          filter: { kind: 'ClusterDataPlane' },
+        }),
+      ]);
+
+      const planes: TargetPlaneOption[] = [];
+
+      // Cluster-scoped first, then namespaced
+      cdpResult.items.forEach(e => {
+        planes.push({
+          name: e.metadata.name,
+          kind: 'ClusterDataPlane' as TargetPlaneKind,
+        });
+      });
+      cwpResult.items.forEach(e => {
+        planes.push({
+          name: e.metadata.name,
+          kind: 'ClusterWorkflowPlane' as TargetPlaneKind,
+        });
+      });
+      dpResult.items.forEach(e => {
+        planes.push({
+          name: e.metadata.name,
+          kind: 'DataPlane' as TargetPlaneKind,
+        });
+      });
+      wpResult.items.forEach(e => {
+        planes.push({
+          name: e.metadata.name,
+          kind: 'WorkflowPlane' as TargetPlaneKind,
+        });
+      });
+
+      return planes;
+    }, [catalogApi, selectedNamespace]);
+
+  const {
+    secrets,
+    loading: secretsLoading,
+    error: secretsError,
+    isForbidden: secretsForbidden,
+    createSecret,
+    deleteSecret,
+    fetchSecrets,
+  } = useSecrets(selectedNamespace);
+
+  const handleNamespaceChange = (
+    event: React.ChangeEvent<{ value: unknown }>,
+  ) => {
+    setSelectedNamespace(event.target.value as string);
+  };
+
+  const handleDeleteSecret = async (secretName: string) => {
+    await deleteSecret(secretName);
+  };
+
+  const sortedNamespaces = useMemo(() => {
+    if (!namespaces) return [];
+    return [...namespaces].sort((a, b) => a.name.localeCompare(b.name));
+  }, [namespaces]);
+
+  useEffect(() => {
+    if (!selectedNamespace && sortedNamespaces.length > 0) {
+      setSelectedNamespace(sortedNamespaces[0].name);
+    }
+  }, [sortedNamespaces, selectedNamespace]);
+
+  return (
+    <Box className={classes.root}>
+      <Box
+        display="flex"
+        alignItems="center"
+        style={{ gap: 16, marginBottom: 16 }}
+      >
+        <FormControl
+          variant="outlined"
+          size="small"
+          className={classes.namespaceSelector}
+        >
+          <InputLabel id="secrets-namespace-select-label">Namespace</InputLabel>
+          <Select
+            labelId="secrets-namespace-select-label"
+            label="Namespace"
+            value={selectedNamespace}
+            onChange={handleNamespaceChange}
+            disabled={namespacesLoading}
+          >
+            {namespacesLoading && (
+              <MenuItem disabled>
+                <CircularProgress size={20} style={{ marginRight: 8 }} />
+                Loading namespaces...
+              </MenuItem>
+            )}
+            {!namespacesLoading && sortedNamespaces.length === 0 && (
+              <MenuItem disabled>No namespaces available</MenuItem>
+            )}
+            {!namespacesLoading &&
+              sortedNamespaces.map(ns => (
+                <MenuItem key={ns.name} value={ns.name}>
+                  {ns.displayName || ns.name}
+                </MenuItem>
+              ))}
+          </Select>
+        </FormControl>
+
+        <Box flexGrow={1} />
+
+        <IconButton
+          onClick={fetchSecrets}
+          size="small"
+          title="Refresh"
+          disabled={!selectedNamespace}
+        >
+          <RefreshIcon />
+        </IconButton>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={() => setCreateDialogOpen(true)}
+          disabled={!selectedNamespace}
+        >
+          Create Secret
+        </Button>
+      </Box>
+
+      {namespacesError && (
+        <WarningPanel severity="error" title="Failed to load namespaces">
+          <Typography>
+            {namespacesError.message ||
+              'An error occurred while loading namespaces.'}
+          </Typography>
+        </WarningPanel>
+      )}
+
+      {secretsError &&
+        (secretsForbidden ? (
+          <ForbiddenState
+            message="You do not have permission to view secrets."
+            onRetry={fetchSecrets}
+          />
+        ) : (
+          <WarningPanel severity="error" title="Failed to load secrets">
+            <Typography>
+              {secretsError.message ||
+                'An error occurred while loading secrets.'}
+            </Typography>
+          </WarningPanel>
+        ))}
+
+      {!selectedNamespace ? (
+        <Box textAlign="center" py={4}>
+          <Typography variant="h6" color="textSecondary">
+            Select a namespace to manage secrets
+          </Typography>
+        </Box>
+      ) : (
+        !secretsForbidden && (
+          <SecretsTable
+            secrets={secrets}
+            loading={secretsLoading}
+            onDelete={handleDeleteSecret}
+            namespaceName={selectedNamespace}
+          />
+        )
+      )}
+
+      <CreateSecretDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        onSubmit={createSecret}
+        namespaceName={selectedNamespace}
+        existingSecretNames={secrets.map(s => s.name)}
+        targetPlanes={targetPlanes || []}
+        targetPlanesLoading={targetPlanesLoading}
+      />
+    </Box>
+  );
+};
+
+/**
+ * Standalone Secrets page (sibling to GitSecretsPage).
+ */
+export const SecretsPage = () => {
+  const classes = useStyles();
+
+  return (
+    <Page themeId="tool">
+      <Header
+        title="Secrets"
+        subtitle="Manage credentials and configuration delivered to workloads"
+      />
+      <Content className={classes.content}>
+        <SecretsContent />
+      </Content>
+    </Page>
+  );
+};

--- a/plugins/openchoreo/src/components/Secrets/SecretsTable.test.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsTable.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SecretsTable } from './SecretsTable';
+import { Secret } from '../../api/OpenChoreoClientApi';
+
+const secrets: Secret[] = [
+  {
+    name: 'db-creds',
+    namespace: 'test-ns',
+    secretType: 'Opaque',
+    targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+    keys: ['DB_HOST', 'DB_PASSWORD', 'DB_USER'],
+  },
+  {
+    name: 'registry-pull',
+    namespace: 'test-ns',
+    secretType: 'kubernetes.io/dockerconfigjson',
+    targetPlane: { kind: 'ClusterDataPlane', name: 'shared-cdp' },
+    keys: ['.dockerconfigjson'],
+  },
+];
+
+function renderTable(
+  overrides: Partial<React.ComponentProps<typeof SecretsTable>> = {},
+) {
+  const defaultProps = {
+    secrets,
+    loading: false,
+    onDelete: jest.fn().mockResolvedValue(undefined),
+    namespaceName: 'test-ns',
+  };
+
+  return {
+    ...render(<SecretsTable {...defaultProps} {...overrides} />),
+    props: { ...defaultProps, ...overrides },
+  };
+}
+
+describe('SecretsTable', () => {
+  it('shows progress bar when loading', () => {
+    renderTable({ loading: true });
+    expect(screen.getByTestId('progress')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no secrets', () => {
+    renderTable({ secrets: [] });
+    expect(screen.getByText('No secrets in test-ns')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Create a secret to deliver credentials to your workloads.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders secret names, types, and target planes', () => {
+    renderTable();
+    expect(screen.getByText('db-creds')).toBeInTheDocument();
+    expect(screen.getByText('registry-pull')).toBeInTheDocument();
+    expect(screen.getByText('Opaque')).toBeInTheDocument();
+    expect(screen.getByText('Docker Config')).toBeInTheDocument();
+    expect(screen.getByText('dp-prod')).toBeInTheDocument();
+    expect(screen.getByText('shared-cdp')).toBeInTheDocument();
+    expect(screen.getByText('DataPlane')).toBeInTheDocument();
+    expect(screen.getByText('ClusterDataPlane')).toBeInTheDocument();
+  });
+
+  it('shows search field when secrets exist', () => {
+    renderTable();
+    expect(screen.getByLabelText('Search secrets')).toBeInTheDocument();
+  });
+
+  it('filters secrets by search query', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.type(screen.getByLabelText('Search secrets'), 'registry');
+
+    expect(screen.getByText('registry-pull')).toBeInTheDocument();
+    expect(screen.queryByText('db-creds')).not.toBeInTheDocument();
+  });
+
+  it('shows no match message when search has no results', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.type(screen.getByLabelText('Search secrets'), 'nonexistent');
+
+    expect(
+      screen.getByText('No secrets match your search'),
+    ).toBeInTheDocument();
+  });
+
+  it('opens delete confirmation dialog when delete icon is clicked', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    const deleteButtons = screen.getAllByTitle('Delete');
+    await user.click(deleteButtons[0]);
+
+    expect(screen.getByText('Delete Secret')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Are you sure you want to delete the secret/),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('db-creds').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('calls onDelete and closes dialog on confirm', async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    renderTable({ onDelete });
+
+    const deleteButtons = screen.getAllByTitle('Delete');
+    await user.click(deleteButtons[0]);
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith('db-creds');
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Delete Secret')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error when delete fails', async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn().mockRejectedValue(new Error('Delete failed'));
+    renderTable({ onDelete });
+
+    const deleteButtons = screen.getAllByTitle('Delete');
+    await user.click(deleteButtons[0]);
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete failed')).toBeInTheDocument();
+    });
+  });
+
+  it('closes delete dialog on cancel', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    const deleteButtons = screen.getAllByTitle('Delete');
+    await user.click(deleteButtons[0]);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Delete Secret')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders table headers', () => {
+    renderTable();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Type')).toBeInTheDocument();
+    expect(screen.getByText('Target Plane')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+    expect(screen.queryByText('Keys')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
@@ -268,6 +268,7 @@ export const SecretsTable = ({
                         size="small"
                         onClick={() => handleDeleteClick(secret.name)}
                         className={classes.deleteButton}
+                        aria-label={`Delete secret ${secret.name}`}
                       >
                         <DeleteOutlineIcon />
                       </IconButton>

--- a/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
@@ -1,0 +1,328 @@
+import { useState, useMemo, useEffect } from 'react';
+import {
+  IconButton,
+  Tooltip,
+  Typography,
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  CircularProgress,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  TextField,
+  InputAdornment,
+} from '@material-ui/core';
+import { Progress } from '@backstage/core-components';
+import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
+import VpnKeyOutlinedIcon from '@material-ui/icons/VpnKeyOutlined';
+import SearchIcon from '@material-ui/icons/Search';
+import { makeStyles } from '@material-ui/core/styles';
+import { Secret, SecretType } from '../../api/OpenChoreoClientApi';
+import { isForbiddenError, getErrorMessage } from '../../utils/errorUtils';
+
+const useStyles = makeStyles(theme => ({
+  searchField: {
+    width: 300,
+    marginBottom: theme.spacing(2),
+  },
+  tableContainer: {
+    marginTop: theme.spacing(2),
+  },
+  nameCell: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  nameIcon: {
+    color: theme.palette.text.secondary,
+    fontSize: '1.2rem',
+  },
+  scopeChip: {
+    height: 22,
+    fontSize: '0.75rem',
+    fontWeight: 500,
+  },
+  kindChip: {
+    height: 22,
+    fontSize: '0.75rem',
+    fontWeight: 500,
+  },
+  deleteButton: {
+    color: theme.palette.primary.main,
+    '&:hover': {
+      color: theme.palette.error.main,
+      backgroundColor: 'rgba(244, 67, 54, 0.08)',
+    },
+  },
+  confirmDeleteButton: {
+    borderColor: theme.palette.error.main,
+    color: theme.palette.error.main,
+    '&:hover': {
+      borderColor: theme.palette.error.dark,
+      backgroundColor: 'rgba(211, 47, 47, 0.04)',
+    },
+  },
+  emptyState: {
+    textAlign: 'center',
+    padding: theme.spacing(6, 2),
+  },
+  emptyStateIcon: {
+    fontSize: 48,
+    color: theme.palette.text.disabled,
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+const SECRET_TYPE_LABELS: Record<SecretType, string> = {
+  Opaque: 'Opaque',
+  'kubernetes.io/basic-auth': 'Basic Auth',
+  'kubernetes.io/ssh-auth': 'SSH Auth',
+  'kubernetes.io/dockerconfigjson': 'Docker Config',
+  'kubernetes.io/tls': 'TLS',
+};
+
+function formatSecretType(secretType?: SecretType | string): string {
+  if (!secretType) return '-';
+  return SECRET_TYPE_LABELS[secretType as SecretType] ?? secretType;
+}
+
+interface SecretsTableProps {
+  secrets: Secret[];
+  loading: boolean;
+  onDelete: (secretName: string) => Promise<void>;
+  namespaceName: string;
+}
+
+export const SecretsTable = ({
+  secrets,
+  loading,
+  onDelete,
+  namespaceName,
+}: SecretsTableProps) => {
+  const classes = useStyles();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [secretToDelete, setSecretToDelete] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (secrets.length === 0) {
+      setSearchQuery('');
+    }
+  }, [secrets]);
+
+  const filteredSecrets = useMemo(() => {
+    if (!searchQuery) return secrets;
+    const query = searchQuery.toLowerCase();
+    return secrets.filter(
+      secret =>
+        secret.name.toLowerCase().includes(query) ||
+        (secret.targetPlane?.name &&
+          secret.targetPlane.name.toLowerCase().includes(query)) ||
+        formatSecretType(secret.secretType).toLowerCase().includes(query),
+    );
+  }, [secrets, searchQuery]);
+
+  const handleDeleteClick = (secretName: string) => {
+    setSecretToDelete(secretName);
+    setDeleteDialogOpen(true);
+    setDeleteError(null);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!secretToDelete) return;
+
+    setDeleting(true);
+    setDeleteError(null);
+
+    try {
+      await onDelete(secretToDelete);
+      setDeleteDialogOpen(false);
+      setSecretToDelete(null);
+    } catch (err) {
+      if (isForbiddenError(err)) {
+        setDeleteError(
+          'You do not have permission to delete this secret. Contact your administrator.',
+        );
+      } else {
+        setDeleteError(getErrorMessage(err));
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleDeleteCancel = () => {
+    if (!deleting) {
+      setDeleteDialogOpen(false);
+      setSecretToDelete(null);
+      setDeleteError(null);
+    }
+  };
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  return (
+    <>
+      {secrets.length > 0 && (
+        <TextField
+          className={classes.searchField}
+          placeholder="Search secrets..."
+          variant="outlined"
+          size="small"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          inputProps={{ 'aria-label': 'Search secrets' }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon />
+              </InputAdornment>
+            ),
+          }}
+        />
+      )}
+
+      {filteredSecrets.length === 0 ? (
+        <Box className={classes.emptyState}>
+          {searchQuery ? (
+            <Typography variant="body1" color="textSecondary">
+              No secrets match your search
+            </Typography>
+          ) : (
+            <>
+              <VpnKeyOutlinedIcon className={classes.emptyStateIcon} />
+              <Typography variant="h6" color="textSecondary">
+                No secrets in {namespaceName}
+              </Typography>
+              <Typography variant="body2" color="textSecondary">
+                Create a secret to deliver credentials to your workloads.
+              </Typography>
+            </>
+          )}
+        </Box>
+      ) : (
+        <TableContainer component={Paper} className={classes.tableContainer}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell style={{ width: '32%' }}>Name</TableCell>
+                <TableCell style={{ width: '24%' }}>Type</TableCell>
+                <TableCell style={{ width: '32%' }}>Target Plane</TableCell>
+                <TableCell align="center" style={{ width: '12%' }}>
+                  Actions
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filteredSecrets.map(secret => (
+                <TableRow key={secret.name}>
+                  <TableCell>
+                    <Box className={classes.nameCell}>
+                      <VpnKeyOutlinedIcon className={classes.nameIcon} />
+                      <Typography variant="body2" style={{ fontWeight: 500 }}>
+                        {secret.name}
+                      </Typography>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">
+                      {formatSecretType(secret.secretType)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    {secret.targetPlane ? (
+                      <Box display="flex" alignItems="center" gridGap={8}>
+                        <Typography variant="body2">
+                          {secret.targetPlane.name}
+                        </Typography>
+                        <Chip
+                          label={secret.targetPlane.kind}
+                          size="small"
+                          variant="outlined"
+                          className={classes.kindChip}
+                        />
+                      </Box>
+                    ) : (
+                      <Typography variant="body2" color="textSecondary">
+                        -
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell align="center">
+                    <Tooltip title="Delete">
+                      <IconButton
+                        size="small"
+                        onClick={() => handleDeleteClick(secret.name)}
+                        className={classes.deleteButton}
+                      >
+                        <DeleteOutlineIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <Dialog
+        open={deleteDialogOpen}
+        onClose={handleDeleteCancel}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle disableTypography>
+          <Typography variant="h4">Delete Secret</Typography>
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to delete the secret{' '}
+            <strong>{secretToDelete}</strong>? This action cannot be undone.
+          </DialogContentText>
+          <DialogContentText color="error" style={{ marginTop: 16 }}>
+            Warning: Workloads referencing this secret will lose access to its
+            values.
+          </DialogContentText>
+          {deleteError && (
+            <Typography color="error" style={{ marginTop: 16 }}>
+              {deleteError}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleDeleteCancel}
+            disabled={deleting}
+            variant="contained"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDeleteConfirm}
+            variant="outlined"
+            disabled={deleting}
+            className={classes.confirmDeleteButton}
+            startIcon={deleting ? <CircularProgress size={20} /> : null}
+          >
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/plugins/openchoreo/src/components/Secrets/hooks/index.ts
+++ b/plugins/openchoreo/src/components/Secrets/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useSecrets } from './useSecrets';
+export type { UseSecretsResult } from './useSecrets';

--- a/plugins/openchoreo/src/components/Secrets/hooks/useSecrets.test.tsx
+++ b/plugins/openchoreo/src/components/Secrets/hooks/useSecrets.test.tsx
@@ -1,0 +1,187 @@
+import { renderHook, act } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { ResponseError } from '@backstage/errors';
+import { useSecrets } from './useSecrets';
+import {
+  openChoreoClientApiRef,
+  Secret,
+  SecretsListResponse,
+} from '../../../api/OpenChoreoClientApi';
+
+const mockClient = {
+  listSecrets: jest.fn<Promise<SecretsListResponse>, [string]>(),
+  createSecret: jest.fn(),
+  deleteSecret: jest.fn(),
+};
+
+function makeSecret(name: string): Secret {
+  return {
+    name,
+    namespace: 'ns',
+    secretType: 'Opaque',
+    targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+    keys: ['k1'],
+  } as Secret;
+}
+
+function renderUseSecrets(namespace: string) {
+  return renderHook(() => useSecrets(namespace), {
+    wrapper: ({ children }) => (
+      <TestApiProvider apis={[[openChoreoClientApiRef, mockClient as any]]}>
+        {children}
+      </TestApiProvider>
+    ),
+  });
+}
+
+describe('useSecrets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.listSecrets.mockResolvedValue({
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 100,
+    });
+    mockClient.createSecret.mockResolvedValue(makeSecret('new'));
+    mockClient.deleteSecret.mockResolvedValue(undefined);
+  });
+
+  it('fetches secrets on mount and exposes them', async () => {
+    const items = [makeSecret('a'), makeSecret('b')];
+    mockClient.listSecrets.mockResolvedValueOnce({
+      items,
+      totalCount: 2,
+      page: 1,
+      pageSize: 100,
+    });
+
+    const { result } = renderUseSecrets('ns');
+
+    await act(async () => {});
+
+    expect(mockClient.listSecrets).toHaveBeenCalledWith('ns');
+    expect(result.current.secrets).toEqual(items);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isForbidden).toBe(false);
+  });
+
+  it('clears secrets when namespace is empty (does not fetch)', async () => {
+    const { result } = renderUseSecrets('');
+
+    await act(async () => {});
+
+    expect(mockClient.listSecrets).not.toHaveBeenCalled();
+    expect(result.current.secrets).toEqual([]);
+  });
+
+  it('captures errors and clears items on failed fetch', async () => {
+    mockClient.listSecrets.mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderUseSecrets('ns');
+
+    await act(async () => {});
+
+    expect(result.current.error?.message).toBe('boom');
+    expect(result.current.secrets).toEqual([]);
+    expect(result.current.isForbidden).toBe(false);
+  });
+
+  it('flags forbidden errors via isForbidden', async () => {
+    const forbidden = await ResponseError.fromResponse(
+      new Response(
+        JSON.stringify({
+          error: { name: 'ForbiddenError', message: 'no' },
+        }),
+        { status: 403, statusText: 'Forbidden' },
+      ),
+    );
+    mockClient.listSecrets.mockRejectedValueOnce(forbidden);
+
+    const { result } = renderUseSecrets('ns');
+
+    await act(async () => {});
+
+    expect(result.current.isForbidden).toBe(true);
+  });
+
+  it('createSecret calls the client and refetches', async () => {
+    const created = makeSecret('new');
+    mockClient.createSecret.mockResolvedValueOnce(created);
+    mockClient.listSecrets.mockResolvedValueOnce({
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 100,
+    });
+    mockClient.listSecrets.mockResolvedValueOnce({
+      items: [created],
+      totalCount: 1,
+      page: 1,
+      pageSize: 100,
+    });
+
+    const { result } = renderUseSecrets('ns');
+    await act(async () => {});
+
+    let returned: Secret | undefined;
+    await act(async () => {
+      returned = await result.current.createSecret({
+        secretName: 'new',
+        secretType: 'Opaque',
+        targetPlane: { kind: 'DataPlane', name: 'dp' },
+        data: { k: 'v' },
+      });
+    });
+
+    expect(mockClient.createSecret).toHaveBeenCalledWith('ns', {
+      secretName: 'new',
+      secretType: 'Opaque',
+      targetPlane: { kind: 'DataPlane', name: 'dp' },
+      data: { k: 'v' },
+    });
+    expect(returned).toEqual(created);
+    expect(mockClient.listSecrets).toHaveBeenCalledTimes(2);
+    expect(result.current.secrets).toEqual([created]);
+  });
+
+  it('deleteSecret calls the client and refetches', async () => {
+    const initial = makeSecret('victim');
+    mockClient.listSecrets.mockResolvedValueOnce({
+      items: [initial],
+      totalCount: 1,
+      page: 1,
+      pageSize: 100,
+    });
+    mockClient.listSecrets.mockResolvedValueOnce({
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 100,
+    });
+
+    const { result } = renderUseSecrets('ns');
+    await act(async () => {});
+
+    expect(result.current.secrets).toEqual([initial]);
+
+    await act(async () => {
+      await result.current.deleteSecret('victim');
+    });
+
+    expect(mockClient.deleteSecret).toHaveBeenCalledWith('ns', 'victim');
+    expect(mockClient.listSecrets).toHaveBeenCalledTimes(2);
+    expect(result.current.secrets).toEqual([]);
+  });
+
+  it('wraps non-Error rejection values in an Error', async () => {
+    mockClient.listSecrets.mockRejectedValueOnce('not-an-error');
+
+    const { result } = renderUseSecrets('ns');
+    await act(async () => {});
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('Failed to fetch secrets');
+  });
+});

--- a/plugins/openchoreo/src/components/Secrets/hooks/useSecrets.ts
+++ b/plugins/openchoreo/src/components/Secrets/hooks/useSecrets.ts
@@ -1,0 +1,79 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import {
+  openChoreoClientApiRef,
+  CreateSecretRequest,
+  Secret,
+} from '../../../api/OpenChoreoClientApi';
+import { isForbiddenError } from '../../../utils/errorUtils';
+
+export interface UseSecretsResult {
+  secrets: Secret[];
+  loading: boolean;
+  error: Error | null;
+  isForbidden: boolean;
+  fetchSecrets: () => Promise<void>;
+  createSecret: (request: CreateSecretRequest) => Promise<Secret>;
+  deleteSecret: (secretName: string) => Promise<void>;
+}
+
+export function useSecrets(namespaceName: string): UseSecretsResult {
+  const [secrets, setSecrets] = useState<Secret[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const client = useApi(openChoreoClientApiRef);
+
+  const fetchSecrets = useCallback(async () => {
+    if (!namespaceName) {
+      setSecrets([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await client.listSecrets(namespaceName);
+      setSecrets(response.items || []);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err : new Error('Failed to fetch secrets'),
+      );
+      setSecrets([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [client, namespaceName]);
+
+  const createSecret = useCallback(
+    async (request: CreateSecretRequest): Promise<Secret> => {
+      const secret = await client.createSecret(namespaceName, request);
+      await fetchSecrets();
+      return secret;
+    },
+    [client, namespaceName, fetchSecrets],
+  );
+
+  const deleteSecret = useCallback(
+    async (secretName: string): Promise<void> => {
+      await client.deleteSecret(namespaceName, secretName);
+      await fetchSecrets();
+    },
+    [client, namespaceName, fetchSecrets],
+  );
+
+  useEffect(() => {
+    fetchSecrets();
+  }, [fetchSecrets]);
+
+  return {
+    secrets,
+    loading,
+    error,
+    isForbidden: isForbiddenError(error),
+    fetchSecrets,
+    createSecret,
+    deleteSecret,
+  };
+}

--- a/plugins/openchoreo/src/components/Secrets/index.ts
+++ b/plugins/openchoreo/src/components/Secrets/index.ts
@@ -1,0 +1,4 @@
+export { SecretsPage, SecretsContent } from './SecretsPage';
+export { useSecrets } from './hooks/useSecrets';
+export type { UseSecretsResult } from './hooks/useSecrets';
+export type { TargetPlaneOption } from './CreateSecretDialog';

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -11,6 +11,7 @@ export {
 } from './plugin';
 export { AccessControlContent } from './components/AccessControl';
 export { GitSecretsContent } from './components/GitSecrets';
+export { SecretsContent } from './components/Secrets';
 export * from './components/HomePage/MyProjectsWidget';
 export * from './components/HomePage/QuickActionsSection';
 export { ProjectComponentsCard } from './components/Projects/ProjectComponentsCard';
@@ -62,6 +63,7 @@ export {
   PromotionPathsCard,
 } from './components/DeploymentPipelineOverview';
 export { GitSecretsPage } from './components/GitSecrets';
+export { SecretsPage } from './components/Secrets';
 export { ComponentTypeOverviewCard } from './components/ComponentTypeOverview';
 export { TraitTypeOverviewCard } from './components/TraitTypeOverview';
 export { WorkflowOverviewCard } from './components/WorkflowOverview';


### PR DESCRIPTION
## Purpose


https://github.com/user-attachments/assets/98b46fe8-6e0b-466c-9477-7873e6d3670b



Adds a new **Secrets** tab to the OpenChoreo Settings page so users can create, list, and delete cross-plane secrets from the Backstage UI. The tab sits next to **Git Secrets** and uses the new `/api/v1alpha1/.../secrets` endpoints in `openchoreo-api` (per [openchoreo discussion #3220](https://github.com/openchoreo/openchoreo/discussions/3220)).

Secrets target any plane (`WorkflowPlane`, `ClusterWorkflowPlane`, `DataPlane`, `ClusterDataPlane`) and any Kubernetes Secret type (`Opaque`, `basic-auth`, `ssh-auth`, `dockerconfigjson`, `tls`).

## Approach

**OpenAPI client (`packages/openchoreo-client-node`)**
- Sync `openchoreo-api.yaml` with the new `POST /secrets`, `PUT /secrets/{name}`, `DELETE /secrets/{name}` operations and supporting schemas (`CreateSecretRequest`, `UpdateSecretRequest`, `SecretResponse`, `TargetPlaneRef`, `SecretType`, `SecretNameParam`).
- Add optional `spec.targetPlane` to `SecretReferenceSpec`.
- Regenerate the typed TS client.

**Backend (`plugins/openchoreo-backend`)**
- New `SecretsService` with `listSecrets` / `getSecret` / `createSecret` / `deleteSecret`. List/get reuse `listSecretReferences` / `getSecretReference` and filter to refs with `spec.targetPlane != nil`; writes hit the new openchoreo-api endpoints.
- New router endpoints: `GET /secrets`, `GET /secrets/:name`, `POST /secrets`, `DELETE /secrets/:name`. Writes are gated by the existing `requireAuth` middleware.

**Frontend (`plugins/openchoreo`)**
- New `Secret` / `SecretsListResponse` / `CreateSecretRequest` / `TargetPlaneRef` types and matching methods on `OpenChoreoClient`.
- New `Secrets/` components mirroring `GitSecrets/`: `SecretsPage` (with `SecretsContent` for the settings tab), `SecretsTable` (Name / Type / Target Plane / Actions), `CreateSecretDialog` with per-type data fields (Opaque key/value rows, basic-auth, ssh-auth, dockerconfigjson, tls), and a `useSecrets` hook.
- Target plane dropdown is populated from the Backstage catalog by querying all four plane kinds.

**App wiring (`packages/app`)**
- Mount `SecretsContent` as a sibling tab to `GitSecretsContent` under `/settings`.

## Related Issues

Related openchoreo/openchoreo#3220

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive secrets management: create, list, view, and delete secrets with UI and backend support.
  * New Secrets page and a Settings → Secrets entry for managing secrets.
  * Support for Opaque, Basic Auth, SSH, Docker Config, and TLS secret types; target secrets to specific deployment planes.
  * Secrets picker and editor now show only secrets reachable from the current environment's data plane.
* **Style/UX**
  * Validation, error/forbidden handling, and helpful messages added to creation and deletion flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->