### PR TITLE
chore: trigger build and test worflow for release branches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - 'release-v*'
   pull_request:
     branches:
       - main
+      - 'release-v*'
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'
@@ -181,7 +183,13 @@ jobs:
       - name: Set image tag
         id: tag
         run: |
-          echo "GIT_SHA_SHORT=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
+          SHA=$(git rev-parse --short=8 HEAD)
+          echo "GIT_SHA_SHORT=$SHA" >> $GITHUB_OUTPUT
+          TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$SHA"
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-dev"
+          fi
+          echo "TAGS=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Build and push commit image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -189,8 +197,6 @@ jobs:
           push: true
           file: ./packages/backend/Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.GIT_SHA_SHORT }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-dev
+          tags: ${{ steps.tag.outputs.TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
       - name: Retag existing image with release version
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          if ! docker buildx imagetools inspect "${IMAGE}:${{ env.GIT_SHA_SHORT }}" > /dev/null 2>&1; then
+            echo "::error::Image ${IMAGE}:${{ env.GIT_SHA_SHORT }} not found. Ensure the commit was pushed to a release branch before tagging."
+            exit 1
+          fi
           echo "Retagging ${IMAGE}:${{ env.GIT_SHA_SHORT }} -> ${IMAGE}:${{ env.RELEASE_TAG }}"
           docker buildx imagetools create \
             --tag "${IMAGE}:${{ env.RELEASE_TAG }}" \


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and test workflow to automatically run on release branches matching the `release-v*` pattern, in addition to the `main` branch. This ensures automated testing and validation are performed during release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->