### PR TITLE
fix: scope environment dropdown to project's deployment pipeline

### DIFF
--- a/plugins/openchoreo-observability-backend/src/router.test.ts
+++ b/plugins/openchoreo-observability-backend/src/router.test.ts
@@ -129,6 +129,22 @@ describe('createRouter', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ environments: mockEnvironments });
+    expect(
+      observabilityService.fetchEnvironmentsByNamespace,
+    ).toHaveBeenCalledWith('org-1', undefined, undefined);
+  });
+
+  it('should forward project query parameter to the service', async () => {
+    observabilityService.fetchEnvironmentsByNamespace.mockResolvedValue([]);
+
+    const response = await request(app)
+      .get('/environments')
+      .query({ namespace: 'org-1', project: 'proj-1' });
+
+    expect(response.status).toBe(200);
+    expect(
+      observabilityService.fetchEnvironmentsByNamespace,
+    ).toHaveBeenCalledWith('org-1', 'proj-1', undefined);
   });
 
   it('should return 400 when namespace is missing for environments', async () => {

--- a/plugins/openchoreo-observability-backend/src/router.ts
+++ b/plugins/openchoreo-observability-backend/src/router.ts
@@ -64,7 +64,7 @@ export async function createRouter({
     if (authEnabled) {
       await httpAuth.credentials(req, { allow: ['user'] });
     }
-    const { namespace } = req.query;
+    const { namespace, project } = req.query;
     if (!namespace) {
       return res.status(400).json({ error: 'Namespace is required' });
     }
@@ -73,6 +73,7 @@ export async function createRouter({
       const environments =
         await observabilityService.fetchEnvironmentsByNamespace(
           namespace as string,
+          project as string | undefined,
           userToken,
         );
       return res.status(200).json({ environments });

--- a/plugins/openchoreo-observability-backend/src/services/ObservabilityService.test.ts
+++ b/plugins/openchoreo-observability-backend/src/services/ObservabilityService.test.ts
@@ -1,0 +1,166 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { ObservabilityService } from './ObservabilityService';
+
+const mockGET = jest.fn();
+
+jest.mock('@openchoreo/openchoreo-client-node', () => ({
+  ...jest.requireActual('@openchoreo/openchoreo-client-node'),
+  createOpenChoreoApiClient: jest.fn(() => ({ GET: mockGET })),
+}));
+
+const createOkResponse = <T>(data: T) => ({
+  data,
+  error: undefined,
+  response: { ok: true as const, status: 200 },
+});
+
+const createErrorResponse = (status = 500, message = 'fail') => ({
+  data: undefined,
+  error: { message },
+  response: { ok: false as const, status, statusText: message },
+});
+
+const logger = mockServices.logger.mock();
+
+const makeProject = (pipelineName?: string) => ({
+  metadata: { name: 'proj-1', namespace: 'ns-1' },
+  spec: pipelineName
+    ? {
+        deploymentPipelineRef: {
+          kind: 'DeploymentPipeline' as const,
+          name: pipelineName,
+        },
+      }
+    : {},
+});
+
+const makePipeline = (paths: Array<{ source: string; targets: string[] }>) => ({
+  metadata: { name: 'pipe-1', namespace: 'ns-1' },
+  spec: {
+    promotionPaths: paths.map(p => ({
+      sourceEnvironmentRef: { kind: 'Environment' as const, name: p.source },
+      targetEnvironmentRefs: p.targets.map(t => ({
+        kind: 'Environment' as const,
+        name: t,
+      })),
+    })),
+  },
+});
+
+const envItem = (name: string) => ({
+  metadata: {
+    name,
+    namespace: 'ns-1',
+    uid: `uid-${name}`,
+    creationTimestamp: '2026-01-01T00:00:00Z',
+  },
+  spec: { isProduction: name === 'prod' },
+});
+
+const envList = (names: string[]) => ({
+  items: names.map(envItem),
+  pagination: { total: names.length },
+});
+
+describe('ObservabilityService.fetchEnvironmentsByNamespace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const service = ObservabilityService.create(logger, 'http://test:8080');
+
+  it('returns all environments when no project is specified', async () => {
+    mockGET.mockResolvedValueOnce(
+      createOkResponse(envList(['dev', 'staging', 'prod', 'sandbox'])),
+    );
+
+    const result = await service.fetchEnvironmentsByNamespace('ns-1');
+
+    expect(result.map(e => e.name)).toEqual([
+      'dev',
+      'staging',
+      'prod',
+      'sandbox',
+    ]);
+    expect(mockGET).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters environments to those in the project deployment pipeline', async () => {
+    mockGET
+      .mockResolvedValueOnce(createOkResponse(makeProject('pipe-1')))
+      .mockResolvedValueOnce(
+        createOkResponse(
+          makePipeline([
+            { source: 'dev', targets: ['staging'] },
+            { source: 'staging', targets: ['prod'] },
+          ]),
+        ),
+      )
+      .mockResolvedValueOnce(
+        createOkResponse(envList(['dev', 'staging', 'prod', 'sandbox'])),
+      );
+
+    const result = await service.fetchEnvironmentsByNamespace('ns-1', 'proj-1');
+
+    expect(result.map(e => e.name).sort()).toEqual(['dev', 'prod', 'staging']);
+    expect(mockGET).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns an empty list when project lookup fails', async () => {
+    mockGET
+      .mockResolvedValueOnce(createErrorResponse(404, 'project not found'))
+      .mockResolvedValueOnce(
+        createOkResponse(envList(['dev', 'staging', 'prod'])),
+      );
+
+    const result = await service.fetchEnvironmentsByNamespace('ns-1', 'proj-1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list when project has no deploymentPipelineRef', async () => {
+    mockGET
+      .mockResolvedValueOnce(createOkResponse(makeProject(undefined)))
+      .mockResolvedValueOnce(
+        createOkResponse(envList(['dev', 'staging', 'prod'])),
+      );
+
+    const result = await service.fetchEnvironmentsByNamespace('ns-1', 'proj-1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list when pipeline lookup fails', async () => {
+    mockGET
+      .mockResolvedValueOnce(createOkResponse(makeProject('pipe-1')))
+      .mockResolvedValueOnce(createErrorResponse(500, 'pipeline error'))
+      .mockResolvedValueOnce(
+        createOkResponse(envList(['dev', 'staging', 'prod'])),
+      );
+
+    const result = await service.fetchEnvironmentsByNamespace('ns-1', 'proj-1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list when the pipeline has no promotion paths', async () => {
+    mockGET
+      .mockResolvedValueOnce(createOkResponse(makeProject('pipe-1')))
+      .mockResolvedValueOnce(createOkResponse(makePipeline([])))
+      .mockResolvedValueOnce(
+        createOkResponse(envList(['dev', 'staging', 'prod'])),
+      );
+
+    const result = await service.fetchEnvironmentsByNamespace('ns-1', 'proj-1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list when the environments endpoint fails', async () => {
+    mockGET.mockResolvedValueOnce(createErrorResponse());
+
+    const result = await service.fetchEnvironmentsByNamespace('ns-1');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/plugins/openchoreo-observability-backend/src/services/ObservabilityService.ts
+++ b/plugins/openchoreo-observability-backend/src/services/ObservabilityService.ts
@@ -213,8 +213,7 @@ export class ObservabilityService {
       return null;
     }
 
-    const pipelineName =
-      projectResult.data.spec?.deploymentPipelineRef?.name;
+    const pipelineName = projectResult.data.spec?.deploymentPipelineRef?.name;
     if (!pipelineName) {
       this.logger.warn(
         `Project ${projectName} has no deploymentPipelineRef; returning unfiltered environment list`,

--- a/plugins/openchoreo-observability-backend/src/services/ObservabilityService.ts
+++ b/plugins/openchoreo-observability-backend/src/services/ObservabilityService.ts
@@ -91,17 +91,26 @@ export class ObservabilityService {
   /**
    * Fetches environments for observability filtering purposes.
    *
+   * When `projectName` is provided, the result is restricted to environments
+   * that appear in the project's deployment pipeline (as either a source or
+   * target of any promotion path). Without it, all environments in the
+   * namespace are returned.
+   *
    * @param namespaceName - The namespace name
+   * @param projectName - Optional project name to filter environments by the project's deployment pipeline
    * @param userToken - Optional user token for authentication (takes precedence over default token)
    */
   async fetchEnvironmentsByNamespace(
     namespaceName: string,
+    projectName?: string,
     userToken?: string,
   ): Promise<Environment[]> {
     const startTime = Date.now();
     try {
       this.logger.debug(
-        `Starting environment fetch for namespace: ${namespaceName}`,
+        `Starting environment fetch for namespace: ${namespaceName}${
+          projectName ? `, project: ${projectName}` : ''
+        }`,
       );
 
       const client = createOpenChoreoApiClient({
@@ -109,6 +118,18 @@ export class ObservabilityService {
         logger: this.logger,
         token: userToken,
       });
+
+      // Resolve the set of environment names allowed by the project's
+      // deployment pipeline, if a project is specified. A null result means
+      // no filter should be applied (project/pipeline lookup failed or no
+      // project context was given).
+      const allowedEnvNames = projectName
+        ? await this.resolveDeploymentPipelineEnvironments(
+            client,
+            namespaceName,
+            projectName,
+          )
+        : null;
 
       const { data, error, response } = await client.GET(
         '/api/v1/namespaces/{namespaceName}/environments',
@@ -133,7 +154,7 @@ export class ObservabilityService {
         return [];
       }
 
-      const environments: Environment[] = data.items.map((item: any) => ({
+      let environments: Environment[] = data.items.map((item: any) => ({
         uid: item.metadata?.uid ?? '',
         name: item.metadata?.name ?? '',
         namespace: item.metadata?.namespace ?? '',
@@ -143,6 +164,12 @@ export class ObservabilityService {
         dataPlaneRef: item.spec?.dataPlaneRef,
         createdAt: item.metadata?.creationTimestamp ?? '',
       }));
+
+      if (allowedEnvNames) {
+        environments = environments.filter(env =>
+          allowedEnvNames.has(env.name),
+        );
+      }
 
       const totalTime = Date.now() - startTime;
       this.logger.debug(
@@ -158,6 +185,74 @@ export class ObservabilityService {
       );
       return [];
     }
+  }
+
+  /**
+   * Resolves the set of environment names referenced by the project's
+   * deployment pipeline. Returns null when the lookup cannot be completed
+   * (project not found, no pipeline ref, etc.) so the caller can decide
+   * whether to skip filtering.
+   */
+  private async resolveDeploymentPipelineEnvironments(
+    client: ReturnType<typeof createOpenChoreoApiClient>,
+    namespaceName: string,
+    projectName: string,
+  ): Promise<Set<string> | null> {
+    const projectResult = await client.GET(
+      '/api/v1/namespaces/{namespaceName}/projects/{projectName}',
+      { params: { path: { namespaceName, projectName } } },
+    );
+    if (
+      projectResult.error ||
+      !projectResult.response.ok ||
+      !projectResult.data
+    ) {
+      this.logger.warn(
+        `Failed to fetch project ${projectName} in namespace ${namespaceName} for environment filtering; returning unfiltered list`,
+      );
+      return null;
+    }
+
+    const pipelineName =
+      projectResult.data.spec?.deploymentPipelineRef?.name;
+    if (!pipelineName) {
+      this.logger.warn(
+        `Project ${projectName} has no deploymentPipelineRef; returning unfiltered environment list`,
+      );
+      return null;
+    }
+
+    const pipelineResult = await client.GET(
+      '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
+      {
+        params: {
+          path: { namespaceName, deploymentPipelineName: pipelineName },
+        },
+      },
+    );
+    if (
+      pipelineResult.error ||
+      !pipelineResult.response.ok ||
+      !pipelineResult.data
+    ) {
+      this.logger.warn(
+        `Failed to fetch deployment pipeline ${pipelineName} in namespace ${namespaceName}; returning unfiltered environment list`,
+      );
+      return null;
+    }
+
+    const allowed = new Set<string>();
+    for (const path of pipelineResult.data.spec?.promotionPaths ?? []) {
+      if (path.sourceEnvironmentRef?.name) {
+        allowed.add(path.sourceEnvironmentRef.name);
+      }
+      for (const target of path.targetEnvironmentRefs ?? []) {
+        if (target.name) {
+          allowed.add(target.name);
+        }
+      }
+    }
+    return allowed;
   }
 }
 

--- a/plugins/openchoreo-observability-backend/src/services/ObservabilityService.ts
+++ b/plugins/openchoreo-observability-backend/src/services/ObservabilityService.ts
@@ -189,15 +189,15 @@ export class ObservabilityService {
 
   /**
    * Resolves the set of environment names referenced by the project's
-   * deployment pipeline. Returns null when the lookup cannot be completed
-   * (project not found, no pipeline ref, etc.) so the caller can decide
-   * whether to skip filtering.
+   * deployment pipeline. Returns an empty Set on any failure so the caller
+   * filters down to nothing — falling back to the full namespace list would
+   * silently reproduce the bug this scoping is meant to fix.
    */
   private async resolveDeploymentPipelineEnvironments(
     client: ReturnType<typeof createOpenChoreoApiClient>,
     namespaceName: string,
     projectName: string,
-  ): Promise<Set<string> | null> {
+  ): Promise<Set<string>> {
     const projectResult = await client.GET(
       '/api/v1/namespaces/{namespaceName}/projects/{projectName}',
       { params: { path: { namespaceName, projectName } } },
@@ -208,17 +208,15 @@ export class ObservabilityService {
       !projectResult.data
     ) {
       this.logger.warn(
-        `Failed to fetch project ${projectName} in namespace ${namespaceName} for environment filtering; returning unfiltered list`,
+        `Failed to fetch project ${projectName} in namespace ${namespaceName} for environment filtering`,
       );
-      return null;
+      return new Set();
     }
 
     const pipelineName = projectResult.data.spec?.deploymentPipelineRef?.name;
     if (!pipelineName) {
-      this.logger.warn(
-        `Project ${projectName} has no deploymentPipelineRef; returning unfiltered environment list`,
-      );
-      return null;
+      this.logger.warn(`Project ${projectName} has no deploymentPipelineRef`);
+      return new Set();
     }
 
     const pipelineResult = await client.GET(
@@ -235,9 +233,9 @@ export class ObservabilityService {
       !pipelineResult.data
     ) {
       this.logger.warn(
-        `Failed to fetch deployment pipeline ${pipelineName} in namespace ${namespaceName}; returning unfiltered environment list`,
+        `Failed to fetch deployment pipeline ${pipelineName} in namespace ${namespaceName}`,
       );
-      return null;
+      return new Set();
     }
 
     const allowed = new Set<string>();

--- a/plugins/openchoreo-observability/src/components/Alerts/ObservabilityAlertsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Alerts/ObservabilityAlertsPage.tsx
@@ -27,7 +27,7 @@ const ObservabilityAlertsContent = () => {
     environments,
     loading: environmentsLoading,
     error: environmentsError,
-  } = useGetEnvironmentsByNamespace(namespace);
+  } = useGetEnvironmentsByNamespace(namespace, project);
 
   const { filters, updateFilters } = useUrlFiltersForAlerts({
     environments,

--- a/plugins/openchoreo-observability/src/components/Incidents/ObservabilityProjectIncidentsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/ObservabilityProjectIncidentsPage.tsx
@@ -30,7 +30,7 @@ const ObservabilityProjectIncidentsContent = () => {
     environments,
     loading: environmentsLoading,
     error: environmentsError,
-  } = useGetEnvironmentsByNamespace(namespace);
+  } = useGetEnvironmentsByNamespace(namespace, projectName);
 
   const {
     components,

--- a/plugins/openchoreo-observability/src/components/Metrics/ObservabilityMetricsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Metrics/ObservabilityMetricsPage.tsx
@@ -46,7 +46,7 @@ const ObservabilityMetricsContent = () => {
     environments,
     loading: environmentsLoading,
     error: environmentsError,
-  } = useGetEnvironmentsByNamespace(namespace);
+  } = useGetEnvironmentsByNamespace(namespace, project);
 
   // URL-synced filters - must be after environments are available
   const { filters, updateFilters } = useUrlFilters({

--- a/plugins/openchoreo-observability/src/components/RCA/RCAPage.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAPage.tsx
@@ -24,6 +24,7 @@ import { EntityLinkContext } from './RCAReport/EntityLinkContext';
 const RCAListContent = () => {
   const { entity } = useEntity();
   const namespace = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
+  const projectName = entity.metadata.name;
   const namespaceValue = useMemo(
     () => ({ namespace: namespace || 'default' }),
     [namespace],
@@ -32,7 +33,7 @@ const RCAListContent = () => {
     environments,
     loading: environmentsLoading,
     error: environmentsError,
-  } = useGetEnvironmentsByNamespace(namespace);
+  } = useGetEnvironmentsByNamespace(namespace, projectName);
   const { filters, updateFilters } = useUrlFilters({ environments });
 
   const {

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport.tsx
@@ -26,9 +26,13 @@ const RCAReportContent = () => {
   const rcaAgentApi = useApi(rcaAgentApiRef);
   const discoveryApi = useApi(discoveryApiRef);
   const namespace = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
+  const projectName = entity.metadata.name as string;
 
   // Get environments to ensure we have environment data
-  const { environments } = useGetEnvironmentsByNamespace(namespace);
+  const { environments } = useGetEnvironmentsByNamespace(
+    namespace,
+    projectName,
+  );
   const environment = filters.environment || environments[0];
 
   const {
@@ -48,7 +52,7 @@ const RCAReportContent = () => {
   const chatContext = {
     namespaceName: namespace || '',
     environmentName: environment?.name || '',
-    projectName: entity.metadata.name as string,
+    projectName,
     rcaAgentApi,
     backendBaseUrl,
   };

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/ObservabilityProjectRuntimeLogsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/ObservabilityProjectRuntimeLogsPage.tsx
@@ -33,7 +33,7 @@ const ObservabilityProjectRuntimeLogsContent = () => {
     environments,
     loading: environmentsLoading,
     error: environmentsError,
-  } = useGetEnvironmentsByNamespace(namespace);
+  } = useGetEnvironmentsByNamespace(namespace, projectName);
 
   const {
     components,

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/ObservabilityRuntimeLogsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/ObservabilityRuntimeLogsPage.tsx
@@ -33,7 +33,7 @@ const ObservabilityRuntimeLogsContent = () => {
     environments,
     loading: environmentsLoading,
     error: environmentsError,
-  } = useGetEnvironmentsByNamespace(namespace);
+  } = useGetEnvironmentsByNamespace(namespace, project);
 
   const { filters, updateFilters } = useUrlFiltersForRuntimeLogs({
     environments,

--- a/plugins/openchoreo-observability/src/components/Traces/ObservabilityTracesPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/ObservabilityTracesPage.tsx
@@ -31,7 +31,7 @@ const ObservabilityTracesContent = () => {
     environments,
     loading: environmentsLoading,
     error: environmentsError,
-  } = useGetEnvironmentsByNamespace(namespace);
+  } = useGetEnvironmentsByNamespace(namespace, projectName);
   const {
     components,
     loading: componentsLoading,

--- a/plugins/openchoreo-observability/src/hooks/useGetEnvironmentsByNamespace.test.ts
+++ b/plugins/openchoreo-observability/src/hooks/useGetEnvironmentsByNamespace.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  useApi,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+import { useGetEnvironmentsByNamespace } from './useGetEnvironmentsByNamespace';
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return {
+    ...actual,
+    useApi: jest.fn(),
+  };
+});
+
+describe('useGetEnvironmentsByNamespace', () => {
+  const getBaseUrl = jest.fn();
+  const fetch = jest.fn();
+  // Stable singletons — useApi must return the same reference on every call,
+  // otherwise the hook's effect dep array sees a new object per render and
+  // re-runs forever.
+  const discoveryApi = { getBaseUrl };
+  const fetchApi = { fetch };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getBaseUrl.mockResolvedValue('http://backend/api/observability');
+    (useApi as jest.Mock).mockImplementation(ref => {
+      if (ref === discoveryApiRef) return discoveryApi;
+      if (ref === fetchApiRef) return fetchApi;
+      return undefined;
+    });
+  });
+
+  const okResponse = (environments: any[]) => ({
+    ok: true,
+    json: async () => ({ environments }),
+  });
+
+  it('omits the project query parameter when no project is given', async () => {
+    fetch.mockResolvedValueOnce(okResponse([{ name: 'dev' }]));
+
+    const { result } = renderHook(() => useGetEnvironmentsByNamespace('ns-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const url = fetch.mock.calls[0][0] as string;
+    expect(url).toContain('namespace=ns-1');
+    expect(url).not.toContain('project=');
+    expect(result.current.environments).toEqual([{ name: 'dev' }]);
+  });
+
+  it('forwards the project query parameter when provided', async () => {
+    fetch.mockResolvedValueOnce(okResponse([{ name: 'dev' }]));
+
+    const { result } = renderHook(() =>
+      useGetEnvironmentsByNamespace('ns-1', 'proj-1'),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const url = fetch.mock.calls[0][0] as string;
+    expect(url).toContain('namespace=ns-1');
+    expect(url).toContain('project=proj-1');
+  });
+
+  it('reports an error when the namespace is missing', async () => {
+    const { result } = renderHook(() =>
+      useGetEnvironmentsByNamespace(undefined),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.error).toBe('Namespace name is required');
+    expect(result.current.environments).toEqual([]);
+  });
+
+  it('reports an error when the response is not ok', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+    });
+
+    const { result } = renderHook(() => useGetEnvironmentsByNamespace('ns-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toMatch(/Failed to fetch environments/);
+  });
+});

--- a/plugins/openchoreo-observability/src/hooks/useGetEnvironmentsByNamespace.ts
+++ b/plugins/openchoreo-observability/src/hooks/useGetEnvironmentsByNamespace.ts
@@ -12,11 +12,16 @@ export interface UseGetEnvironmentsByNamespaceResult {
 /**
  * Hook to fetch environments for a specific namespace from the observability backend.
  *
+ * When `projectName` is provided, the backend restricts the result to
+ * environments referenced by the project's deployment pipeline.
+ *
  * @param namespaceName - The name of the namespace to fetch environments for
+ * @param projectName - Optional project name; when provided, environments are filtered to those in the project's deployment pipeline
  * @returns Object containing environments array, loading state, and error
  */
 export const useGetEnvironmentsByNamespace = (
   namespaceName: string | undefined,
+  projectName?: string,
 ): UseGetEnvironmentsByNamespaceResult => {
   const discoveryApi = useApi(discoveryApiRef);
   const fetchApi = useApi(fetchApiRef);
@@ -40,10 +45,12 @@ export const useGetEnvironmentsByNamespace = (
         const baseUrl = await discoveryApi.getBaseUrl(
           'openchoreo-observability-backend',
         );
+        const params = new URLSearchParams({ namespace: namespaceName });
+        if (projectName) {
+          params.set('project', projectName);
+        }
         const response = await fetchApi.fetch(
-          `${baseUrl}/environments?namespace=${encodeURIComponent(
-            namespaceName,
-          )}`,
+          `${baseUrl}/environments?${params.toString()}`,
         );
 
         if (!response.ok) {
@@ -65,7 +72,7 @@ export const useGetEnvironmentsByNamespace = (
     };
 
     fetchEnvironments();
-  }, [namespaceName, discoveryApi, fetchApi]);
+  }, [namespaceName, projectName, discoveryApi, fetchApi]);
 
   return { environments, loading, error };
 };


### PR DESCRIPTION
## Summary
Filter the environment dropdown on Logs, Metrics, Traces, RCA, Alerts, and Incidents pages to only the environments referenced by the project's deployment pipeline. The pages were showing every environment in the namespace.

The observability backend now resolves the project's `deploymentPipelineRef` and intersects the namespace's environment list with the source/target environments in its promotion paths. The hook and page components forward the project name they already have in scope.

Fixes openchoreo/openchoreo#3366

## Test plan
- [ ] With two projects pointing to different deployment pipelines, verify each project's pages only show its own environments
- [ ] Project with no `deploymentPipelineRef` falls back to all environments (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project-scoped environment filtering added across observability: alerts, incidents, metrics, runtime logs, traces, and RCA now show environments scoped to the current project; backend now accepts an optional project parameter to support this.

* **Tests**
  * Added/expanded tests covering project-scoped environment fetching and related backend and frontend behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->