### PR TITLE
fix: match environment by resource name in overrides wrapper

### DIFF
--- a/plugins/openchoreo/src/components/Environments/wrappers/OverridesWrapper.tsx
+++ b/plugins/openchoreo/src/components/Environments/wrappers/OverridesWrapper.tsx
@@ -46,15 +46,16 @@ export const OverridesWrapper = () => {
     [searchParams, navigate],
   );
 
-  // Find the environment by name
+  // Find the environment by display name or resource name.
   const environment = useMemo<Environment | undefined>(() => {
     if (!envName) return undefined;
 
     const decodedName = decodeURIComponent(envName);
 
-    // First try to find by exact name match
     let env = environments.find(
-      e => e.name.toLowerCase() === decodedName.toLowerCase(),
+      e =>
+        e.name.toLowerCase() === decodedName.toLowerCase() ||
+        e.resourceName?.toLowerCase() === decodedName.toLowerCase(),
     );
 
     // If not found and we have a pending action, create a minimal environment object


### PR DESCRIPTION
## Summary
- When promoting to an environment whose display name differs from its Kubernetes resource name, `OverridesWrapper` couldn't find the loaded env (it only matched by `name` / display name) and fell back to a stub with no `dataPlaneRef`.
- The secret-references filter on the overrides page (`filterSecretReferencesForEnvDataPlane`) then dropped every ref with a `targetPlane` set, even when the ref's plane matched the target env's plane.
- Match on `resourceName` as well so the already-loaded env (with `dataPlaneRef` / `dataPlaneKind` populated) is returned, and the secret list shows the correct refs.

## Test plan
- [ ] Create a SecretReference with `spec.targetPlane = { kind: ClusterDataPlane, name: default }` in a namespace.
- [ ] On a component whose target environment has `spec.dataPlaneRef = { kind: ClusterDataPlane, name: default }`, click **Promote**.
- [ ] Verify the SecretReference appears in the overrides page's secret list.
- [ ] Verify the same flow still works for environments whose display name equals the resource name (regression check).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment resolution logic for overrides to be more robust and reliable. The system now matches environments using multiple identifiers with case-insensitive comparison, reducing matching failures and enhancing overall consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/515)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->