### PR TITLE
feat(deploy): wire up Rollout restart via openchoreo.dev/restartedAt annotation

### DIFF
--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -246,6 +246,30 @@ export async function createRouter({
     );
   });
 
+  router.post('/rollout-restart-binding', requireAuth, async (req, res) => {
+    const { componentName, projectName, namespaceName, bindingName } = req.body;
+
+    if (!componentName || !projectName || !namespaceName || !bindingName) {
+      throw new InputError(
+        'componentName, projectName, namespaceName and bindingName are required in request body',
+      );
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    res.json(
+      await environmentInfoService.rolloutRestartReleaseBinding(
+        {
+          componentName: componentName as string,
+          projectName: projectName as string,
+          namespaceName: namespaceName as string,
+          bindingName: bindingName as string,
+        },
+        userToken,
+      ),
+    );
+  });
+
   router.get(
     '/cell-diagram',
     async (req: express.Request, res: express.Response) => {

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -847,6 +847,126 @@ export class EnvironmentInfoService implements EnvironmentService {
   }
 
   /**
+   * Triggers a rolling restart of the workloads owned by a ReleaseBinding
+   * by stamping `openchoreo.dev/restartedAt` on the binding's metadata.
+   * The controller (openchoreo#3301) propagates the annotation into the
+   * dataplane Deployment's pod template, which rolls the pods the same
+   * way `kubectl rollout restart deployment` would.
+   *
+   * Implementation: GET the binding, set the annotation to the current
+   * ISO timestamp (always overwrite — any change in value, or the first
+   * appearance, is enough to trigger a fresh rollout), PUT it back.
+   *
+   * @param {Object} request - The rollout-restart request parameters
+   * @param {string} request.componentName - Name of the component
+   * @param {string} request.projectName - Name of the project containing the component
+   * @param {string} request.namespaceName - Name of the namespace owning the project
+   * @param {string} request.bindingName - Name of the binding to restart
+   * @returns {Promise<Environment[]>} Array of environments with updated deployment information
+   * @throws {Error} When the binding cannot be fetched or updated
+   */
+  async rolloutRestartReleaseBinding(
+    request: {
+      componentName: string;
+      projectName: string;
+      namespaceName: string;
+      bindingName: string;
+    },
+    token?: string,
+  ): Promise<Environment[]> {
+    const startTime = Date.now();
+    try {
+      this.logger.info(
+        `Triggering rollout restart for component: ${request.componentName}, binding: ${request.bindingName}`,
+      );
+
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      const {
+        data: existing,
+        error: getError,
+        response: getResponse,
+      } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}',
+        {
+          params: {
+            path: {
+              namespaceName: request.namespaceName,
+              releaseBindingName: request.bindingName,
+            },
+          },
+        },
+      );
+
+      assertApiResponse(
+        { data: existing, error: getError, response: getResponse },
+        'fetch binding for rollout restart',
+      );
+
+      const restartedAt = new Date().toISOString();
+      const updated = {
+        ...existing!,
+        metadata: {
+          ...existing!.metadata,
+          annotations: {
+            ...(existing!.metadata.annotations ?? {}),
+            'openchoreo.dev/restartedAt': restartedAt,
+          },
+        },
+      };
+
+      const { error, response } = await client.PUT(
+        '/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}',
+        {
+          params: {
+            path: {
+              namespaceName: request.namespaceName,
+              releaseBindingName: request.bindingName,
+            },
+          },
+          body: updated,
+        },
+      );
+
+      assertApiResponse(
+        { data: undefined, error, response },
+        'rollout restart binding',
+      );
+
+      this.logger.debug(
+        `Rollout restart triggered successfully for ${request.bindingName} at ${restartedAt}.`,
+      );
+
+      const refreshedEnvironments = await this.fetchDeploymentInfo(
+        {
+          componentName: request.componentName,
+          projectName: request.projectName,
+          namespaceName: request.namespaceName,
+        },
+        token,
+      );
+
+      const totalTime = Date.now() - startTime;
+      this.logger.debug(
+        `Rollout restart completed for ${request.componentName}: Total: ${totalTime}ms`,
+      );
+
+      return refreshedEnvironments;
+    } catch (error: unknown) {
+      const totalTime = Date.now() - startTime;
+      this.logger.error(
+        `Error triggering rollout restart for binding ${request.bindingName} on component ${request.componentName} (${totalTime}ms):`,
+        error as Error,
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Creates a ComponentRelease with an optional release name.
    * If no release name is provided, the backend auto-generates one.
    *

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -53,6 +53,7 @@ const API_ENDPOINTS = {
   CELL_DIAGRAM: '/cell-diagram',
   DEPLOYEMNT_WORKLOAD: '/workload',
   UPDATE_BINDING: '/update-binding',
+  ROLLOUT_RESTART_BINDING: '/rollout-restart-binding',
   DASHBOARD_BINDINGS_COUNT: '/dashboard/bindings-count',
   CREATE_RELEASE: '/create-release',
   DEPLOY_RELEASE: '/deploy-release',
@@ -273,6 +274,23 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
         componentName: component,
         bindingName,
         releaseState,
+      },
+    });
+  }
+
+  async rolloutRestartReleaseBinding(
+    entity: Entity,
+    bindingName: string,
+  ): Promise<any> {
+    const { component, project, namespace } = extractEntityMetadata(entity);
+
+    return this.apiFetch(API_ENDPOINTS.ROLLOUT_RESTART_BINDING, {
+      method: 'POST',
+      body: {
+        namespaceName: namespace,
+        projectName: project,
+        componentName: component,
+        bindingName,
       },
     });
   }

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -437,6 +437,12 @@ export interface OpenChoreoClientApi {
     releaseState: 'Active' | 'Suspend' | 'Undeploy',
   ): Promise<any>;
 
+  /** Trigger a rolling restart of the binding's workloads via the openchoreo.dev/restartedAt annotation */
+  rolloutRestartReleaseBinding(
+    entity: Entity,
+    bindingName: string,
+  ): Promise<any>;
+
   /** Patch component settings (e.g., autoDeploy) */
   patchComponent(entity: Entity, autoDeploy: boolean): Promise<any>;
 

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentActions.test.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentActions.test.ts
@@ -6,6 +6,7 @@ import type { ItemActionTracker } from '../types';
 const mockClient = {
   deleteReleaseBinding: jest.fn(),
   fetchEnvironmentInfo: jest.fn(),
+  rolloutRestartReleaseBinding: jest.fn(),
 };
 
 jest.mock('@backstage/core-plugin-api', () => ({
@@ -170,6 +171,83 @@ describe('useEnvironmentActions.handleRemoveDeployment', () => {
           'staging-binding',
           'staging',
         );
+      }),
+    ).rejects.toThrow('forbidden');
+
+    expect(showSuccess).not.toHaveBeenCalled();
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('useEnvironmentActions.handleRolloutRestart', () => {
+  const entity = mockComponentEntity();
+  const refetch = jest.fn();
+  const showSuccess = jest.fn();
+  const showError = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.rolloutRestartReleaseBinding.mockResolvedValue({});
+  });
+
+  it('calls rolloutRestartReleaseBinding with the binding name', async () => {
+    const { result } = renderHook(() =>
+      useEnvironmentActions(
+        entity,
+        refetch,
+        { showSuccess, showError },
+        tracker(),
+      ),
+    );
+
+    await act(async () => {
+      await result.current.handleRolloutRestart('beta-web-staging');
+    });
+
+    expect(mockClient.rolloutRestartReleaseBinding).toHaveBeenCalledWith(
+      entity,
+      'beta-web-staging',
+    );
+  });
+
+  it('refetches and shows a success toast naming the binding', async () => {
+    const { result } = renderHook(() =>
+      useEnvironmentActions(
+        entity,
+        refetch,
+        { showSuccess, showError },
+        tracker(),
+      ),
+    );
+
+    await act(async () => {
+      await result.current.handleRolloutRestart('beta-web-staging');
+    });
+
+    expect(refetch).toHaveBeenCalled();
+    expect(showSuccess).toHaveBeenCalledWith(
+      expect.stringContaining('beta-web-staging'),
+    );
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('propagates API errors and does not show a success toast', async () => {
+    mockClient.rolloutRestartReleaseBinding.mockRejectedValue(
+      new Error('forbidden'),
+    );
+
+    const { result } = renderHook(() =>
+      useEnvironmentActions(
+        entity,
+        refetch,
+        { showSuccess, showError },
+        tracker(),
+      ),
+    );
+
+    await expect(
+      act(async () => {
+        await result.current.handleRolloutRestart('beta-web-staging');
       }),
     ).rejects.toThrow('forbidden');
 

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentActions.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentActions.ts
@@ -77,14 +77,19 @@ export function useEnvironmentActions(
     [entity, client, refetch, notification],
   );
 
-  // Stub: rollout-restart API + reconciliation lands in a follow-up. This
-  // handler is wired through the panel today so only the API call is left
-  // to swap in.
+  // Rollout restart is declarative on the platform side: we stamp
+  // openchoreo.dev/restartedAt on the ReleaseBinding and the controller
+  // (openchoreo#3301) propagates it into the data-plane Deployment's
+  // pod template, which rolls the pods like `kubectl rollout restart`.
+  // Fire-and-forget — no polling here; the new pods come up async and
+  // the user can watch the pod-status panel.
   const handleRolloutRestart = useCallback(
-    async (_bindingName: string) => {
-      notification.showError('Rollout restart is not yet wired up');
+    async (bindingName: string) => {
+      await client.rolloutRestartReleaseBinding(entity, bindingName);
+      await refetch();
+      notification.showSuccess(`Rollout restart triggered for ${bindingName}`);
     },
-    [notification],
+    [entity, client, refetch, notification],
   );
 
   // Removing the deployment deletes the release binding for the env;


### PR DESCRIPTION
  The Rollout restart button was UI-only since the redesign — its handler
  just showed an error toast. Wire it up to the declarative restart
  mechanism landed in openchoreo#3301 (closes openchoreo#3249): stamp
  `openchoreo.dev/restartedAt=<now>` on the ReleaseBinding and the
  controller rolls the dataplane Deployment.

  Implemented as GET-then-PUT in the Backstage backend (mirrors
  updateComponentBinding) → new POST /rollout-restart-binding route →
  OpenChoreoClient method → useEnvironmentActions handler. No openchoreo
  changes, no OpenAPI regen, no polling.


https://github.com/user-attachments/assets/f455693f-9399-47f5-83b3-c66938219fa5

- Fix https://github.com/openchoreo/openchoreo/issues/3249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to trigger rolling restart of release bindings directly from the UI.

* **Tests**
  * Added test coverage for rollout restart operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/516)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->