### PR TITLE
feat: add Secrets edit dialog and secret-management feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,10 +345,10 @@ Both are enabled by default. If the event-driven sync is disabled, the periodic 
 
 ### Configuration
 
-| Setting                         | Environment Variable                | Default | Description                                                                                                                       |
-| ------------------------------- | ----------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Setting                         | Environment Variable                | Default | Description                                                                                                                         |
+| ------------------------------- | ----------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `openchoreo.events.enabled`     | `OPENCHOREO_EVENTS_ENABLED`         | `true`  | Enables event-driven catalog sync. When `false`, the entity provider runs in poll-only mode. Should match `eventForwarder.enabled`. |
-| `openchoreo.schedule.frequency` | `OPENCHOREO_CATALOG_SYNC_FREQUENCY` | `300`   | Seconds between periodic full syncs. Lower the value when `eventForwarder.enabled` is `false`.                                    |
+| `openchoreo.schedule.frequency` | `OPENCHOREO_CATALOG_SYNC_FREQUENCY` | `300`   | Seconds between periodic full syncs. Lower the value when `eventForwarder.enabled` is `false`.                                      |
 
 The events HTTP topic is registered in `app-config.yaml` (`events.http.topics: [openchoreo]`). When running Backstage locally, see [Receiving live catalog-sync events locally](#receiving-live-catalog-sync-events-locally) for pointing the event-forwarder at your local backend.
 

--- a/app-config.local.yaml.example
+++ b/app-config.local.yaml.example
@@ -58,6 +58,8 @@ openchoreo:
       enabled: true    # Set to false for guest mode (no OAuth login required)
     authz:
       enabled: true    # Set to false to hide Access Control sidebar and pages
+    secretManagement:
+      enabled: true    # Set to false to hide Secrets settings tab
 
 # Thunder IDP configuration (k3d cluster)
 thunder:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -171,7 +171,7 @@ openchoreo:
 
   # Feature flags for enabling/disabling OpenChoreo functionality
   # These can be controlled via Helm values: backstage.features.*
-  # Environment variables: OPENCHOREO_FEATURES_WORKFLOWS_ENABLED, OPENCHOREO_FEATURES_OBSERVABILITY_ENABLED, OPENCHOREO_FEATURES_AUTH_ENABLED
+  # Environment variables: OPENCHOREO_FEATURES_WORKFLOWS_ENABLED, OPENCHOREO_FEATURES_OBSERVABILITY_ENABLED, OPENCHOREO_FEATURES_AUTH_ENABLED, OPENCHOREO_FEATURES_AUTHZ_ENABLED, OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED
   features:
     # Workflow plane / Workflows functionality
     # When disabled, hides Workflows tab and WorkflowsOverviewCard from entity pages
@@ -189,6 +189,10 @@ openchoreo:
     # When disabled, hides Access Control sidebar item and pages
     authz:
       enabled: ${OPENCHOREO_FEATURES_AUTHZ_ENABLED}
+    # Secret Management configuration
+    # When disabled, hides the Secrets settings tab and disables secret APIs
+    secretManagement:
+      enabled: ${OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED}
 
   # Component Type Mappings (optional - defaults provided)
   # Maps OpenChoreo component types to Backstage page variants

--- a/packages/app/src/components/catalog/FeatureGatedContent.tsx
+++ b/packages/app/src/components/catalog/FeatureGatedContent.tsx
@@ -30,6 +30,7 @@ export function FeatureGatedContent({
       observability: 'Observability',
       auth: 'Authentication',
       authz: 'Authorization',
+      secretManagement: 'Secret Management',
     };
 
     return (

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -4580,6 +4580,35 @@ paths:
           $ref: '#/components/responses/InternalError'
 
   /api/v1alpha1/namespaces/{namespaceName}/secrets:
+    get:
+      operationId: listSecrets
+      summary: List secrets
+      description: |
+        Returns a paginated list of secrets managed by the Secret API in this
+        namespace. Each item includes the Kubernetes Secret data fetched from
+        the target plane. Items whose target-plane Secret has not yet been
+        synced are omitted from the page.
+      tags: [Secrets]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
+      responses:
+        '200':
+          description: List of secrets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSecretsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
     post:
       operationId: createSecret
       summary: Create a secret
@@ -4616,6 +4645,33 @@ paths:
           $ref: '#/components/responses/InternalError'
 
   /api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}:
+    get:
+      operationId: getSecret
+      summary: Get a secret
+      description: |
+        Returns a secret managed by the Secret API, including its data fetched
+        from the target plane. Returns 404 if the SecretReference is missing or
+        the target-plane Kubernetes Secret has not yet been synced.
+      tags: [Secrets]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/SecretNameParam'
+      responses:
+        '200':
+          description: Secret found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Secret'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
     put:
       operationId: updateSecret
       summary: Update a secret
@@ -10222,3 +10278,51 @@ components:
           example:
             - password
             - username
+
+    Secret:
+      type: object
+      description: |
+        Kubernetes Secret. Wire shape matches `corev1.Secret`: `data` is a map
+        of keys to base64-encoded values.
+      required:
+        - apiVersion
+        - kind
+        - metadata
+        - type
+      properties:
+        apiVersion:
+          type: string
+          example: v1
+        kind:
+          type: string
+          example: Secret
+        metadata:
+          $ref: '#/components/schemas/ObjectMeta'
+        type:
+          $ref: '#/components/schemas/SecretType'
+        data:
+          type: object
+          description: |
+            Map of secret keys to base64-encoded values. Matches the
+            Kubernetes Secret `data` field semantics.
+          additionalProperties:
+            type: string
+            format: byte
+        immutable:
+          type: boolean
+          description: Whether the secret is immutable.
+
+    ListSecretsResponse:
+      type: object
+      description: Paginated list of secrets.
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          description: Page of secrets.
+          items:
+            $ref: '#/components/schemas/Secret'
+        pagination:
+          $ref: '#/components/schemas/Pagination'

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -1937,7 +1937,14 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
+    /**
+     * List secrets
+     * @description Returns a paginated list of secrets managed by the Secret API in this
+     *     namespace. Each item includes the Kubernetes Secret data fetched from
+     *     the target plane. Items whose target-plane Secret has not yet been
+     *     synced are omitted from the page.
+     */
+    get: operations['listSecrets'];
     put?: never;
     /**
      * Create a secret
@@ -1960,7 +1967,13 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
+    /**
+     * Get a secret
+     * @description Returns a secret managed by the Secret API, including its data fetched
+     *     from the target plane. Returns 404 if the SecretReference is missing or
+     *     the target-plane Kubernetes Secret has not yet been synced.
+     */
+    get: operations['getSecret'];
     /**
      * Update a secret
      * @description Replaces the data of an existing secret. The secret type and target
@@ -5603,6 +5616,33 @@ export interface components {
        *     ]
        */
       keys?: string[];
+    };
+    /**
+     * @description Kubernetes Secret. Wire shape matches `corev1.Secret`: `data` is a map
+     *     of keys to base64-encoded values.
+     */
+    Secret: {
+      /** @example v1 */
+      apiVersion: string;
+      /** @example Secret */
+      kind: string;
+      metadata: components['schemas']['ObjectMeta'];
+      type: components['schemas']['SecretType'];
+      /**
+       * @description Map of secret keys to base64-encoded values. Matches the
+       *     Kubernetes Secret `data` field semantics.
+       */
+      data?: {
+        [key: string]: string;
+      };
+      /** @description Whether the secret is immutable. */
+      immutable?: boolean;
+    };
+    /** @description Paginated list of secrets. */
+    ListSecretsResponse: {
+      /** @description Page of secrets. */
+      items: components['schemas']['Secret'][];
+      pagination: components['schemas']['Pagination'];
     };
   };
   responses: {
@@ -10804,6 +10844,41 @@ export interface operations {
       500: components['responses']['InternalError'];
     };
   };
+  listSecrets: {
+    parameters: {
+      query?: {
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of secrets */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ListSecretsResponse'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      500: components['responses']['InternalError'];
+    };
+  };
   createSecret: {
     parameters: {
       query?: never;
@@ -10833,6 +10908,35 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  getSecret: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Secret name */
+        secretName: components['parameters']['SecretNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Secret found */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Secret'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
       500: components['responses']['InternalError'];
     };
   };

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -1248,6 +1248,42 @@ export async function createRouter({
       );
   });
 
+  // Update an existing secret (replace its data)
+  router.put('/secrets/:secretName', requireAuth, async (req, res) => {
+    const { namespaceName } = req.query;
+    const { secretName } = req.params;
+    const { data } = req.body ?? {};
+
+    if (!namespaceName) {
+      throw new InputError('namespaceName is a required query parameter');
+    }
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new InputError(
+        'data must be an object of string keys to string values',
+      );
+    }
+    for (const [key, value] of Object.entries(data)) {
+      if (typeof value !== 'string') {
+        throw new InputError(
+          `data.${key} must be a string (got ${
+            value === null ? 'null' : typeof value
+          })`,
+        );
+      }
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    res.json(
+      await secretsService.updateSecret(
+        namespaceName as string,
+        secretName,
+        { data },
+        userToken,
+      ),
+    );
+  });
+
   // Delete a secret
   router.delete('/secrets/:secretName', requireAuth, async (req, res) => {
     const { namespaceName } = req.query;

--- a/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.test.ts
+++ b/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.test.ts
@@ -4,6 +4,7 @@ import { SecretsService } from './SecretsService';
 
 const mockGET = jest.fn();
 const mockPOST = jest.fn();
+const mockPUT = jest.fn();
 const mockDELETE = jest.fn();
 
 jest.mock('@openchoreo/openchoreo-client-node', () => ({
@@ -11,6 +12,7 @@ jest.mock('@openchoreo/openchoreo-client-node', () => ({
   createOpenChoreoApiClient: jest.fn(() => ({
     GET: mockGET,
     POST: mockPOST,
+    PUT: mockPUT,
     DELETE: mockDELETE,
   })),
 }));
@@ -20,6 +22,14 @@ const mockLogger = mockServices.logger.mock();
 function createService() {
   return new SecretsService(mockLogger, 'http://test:8080');
 }
+
+const SECRETS_LIST_PATH = '/api/v1alpha1/namespaces/{namespaceName}/secrets';
+const SECRETREFS_LIST_PATH =
+  '/api/v1/namespaces/{namespaceName}/secretreferences';
+const SECRET_GET_PATH =
+  '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}';
+const SECRETREF_GET_PATH =
+  '/api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}';
 
 const managedSecretRef = {
   apiVersion: 'openchoreo.dev/v1alpha1',
@@ -50,18 +60,45 @@ const legacyRef = {
   },
 };
 
+// New /secrets endpoint returns plain corev1.Secret objects with base64 data.
+const dbCredsSecret = {
+  apiVersion: 'v1',
+  kind: 'Secret',
+  metadata: { name: 'db-creds', namespace: 'test-ns' },
+  type: 'Opaque',
+  data: {
+    DB_USER: 'YWxpY2U=', // alice
+    DB_HOST: 'ZGIubG9jYWw=', // db.local
+  },
+};
+
+/**
+ * Wires the GET mock to respond based on path so listSecrets/getSecret tests
+ * don't depend on call order between the two parallel requests.
+ */
+function mockGetByPath(handlers: Record<string, unknown>) {
+  mockGET.mockImplementation((path: string) => {
+    const r = handlers[path];
+    if (r === undefined) {
+      throw new Error(`Unexpected GET to ${path}`);
+    }
+    return Promise.resolve(r);
+  });
+}
+
 describe('SecretsService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('listSecrets', () => {
-    it('returns only secrets with spec.targetPlane and sorts keys', async () => {
-      mockGET.mockResolvedValueOnce(
-        createOkResponse({
+    it('joins /secrets data with secretreferences for targetPlane and sorts keys', async () => {
+      mockGetByPath({
+        [SECRETS_LIST_PATH]: createOkResponse({ items: [dbCredsSecret] }),
+        [SECRETREFS_LIST_PATH]: createOkResponse({
           items: [managedSecretRef, legacyRef],
         }),
-      );
+      });
 
       const result = await createService().listSecrets('test-ns', 'token');
 
@@ -77,7 +114,10 @@ describe('SecretsService', () => {
     });
 
     it('handles empty list', async () => {
-      mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
+      mockGetByPath({
+        [SECRETS_LIST_PATH]: createOkResponse({ items: [] }),
+        [SECRETREFS_LIST_PATH]: createOkResponse({ items: [] }),
+      });
 
       const result = await createService().listSecrets('test-ns', 'token');
 
@@ -86,13 +126,23 @@ describe('SecretsService', () => {
     });
 
     it('throws on API error', async () => {
-      mockGET.mockResolvedValueOnce(createErrorResponse());
+      mockGetByPath({
+        [SECRETS_LIST_PATH]: createErrorResponse(),
+        [SECRETREFS_LIST_PATH]: createOkResponse({ items: [] }),
+      });
       await expect(
         createService().listSecrets('test-ns', 'token'),
       ).rejects.toThrow();
     });
 
-    it('returns secretType as undefined for unsupported template types', async () => {
+    it('returns secretType as undefined for unsupported types', async () => {
+      const exoticSecret = {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: { name: 'kubeadm-token', namespace: 'test-ns' },
+        type: 'bootstrap.kubernetes.io/token',
+        data: {},
+      };
       const exoticRef = {
         apiVersion: 'openchoreo.dev/v1alpha1',
         kind: 'SecretReference',
@@ -103,7 +153,10 @@ describe('SecretsService', () => {
           data: [],
         },
       };
-      mockGET.mockResolvedValueOnce(createOkResponse({ items: [exoticRef] }));
+      mockGetByPath({
+        [SECRETS_LIST_PATH]: createOkResponse({ items: [exoticSecret] }),
+        [SECRETREFS_LIST_PATH]: createOkResponse({ items: [exoticRef] }),
+      });
 
       const result = await createService().listSecrets('test-ns', 'token');
 
@@ -114,8 +167,11 @@ describe('SecretsService', () => {
   });
 
   describe('getSecret', () => {
-    it('returns the secret when targetPlane is set', async () => {
-      mockGET.mockResolvedValueOnce(createOkResponse(managedSecretRef));
+    it('returns the secret with base64 data and targetPlane from the ref', async () => {
+      mockGetByPath({
+        [SECRET_GET_PATH]: createOkResponse(dbCredsSecret),
+        [SECRETREF_GET_PATH]: createOkResponse(managedSecretRef),
+      });
 
       const result = await createService().getSecret(
         'test-ns',
@@ -128,10 +184,18 @@ describe('SecretsService', () => {
         kind: 'DataPlane',
         name: 'dp-prod',
       });
+      expect(result.keys).toEqual(['DB_HOST', 'DB_USER']);
+      expect(result.data).toEqual({
+        DB_USER: 'YWxpY2U=',
+        DB_HOST: 'ZGIubG9jYWw=',
+      });
     });
 
-    it('throws NotFound when targetPlane is missing', async () => {
-      mockGET.mockResolvedValueOnce(createOkResponse(legacyRef));
+    it('throws NotFound when targetPlane is missing on the ref', async () => {
+      mockGetByPath({
+        [SECRET_GET_PATH]: createOkResponse(dbCredsSecret),
+        [SECRETREF_GET_PATH]: createOkResponse(legacyRef),
+      });
       await expect(
         createService().getSecret('test-ns', 'legacy-git', 'token'),
       ).rejects.toThrow(/not found/i);
@@ -181,6 +245,49 @@ describe('SecretsService', () => {
             targetPlane: { kind: 'DataPlane', name: 'dp' },
             data: { k: 'v' },
           },
+          'token',
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('updateSecret', () => {
+    it('PUTs the request body and returns the response', async () => {
+      const updated = {
+        name: 'db-creds',
+        namespace: 'test-ns',
+        secretType: 'Opaque',
+        targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+        keys: ['DB_HOST', 'DB_USER'],
+      };
+      mockPUT.mockResolvedValueOnce(createOkResponse(updated));
+
+      const result = await createService().updateSecret(
+        'test-ns',
+        'db-creds',
+        { data: { DB_USER: 'bob', DB_HOST: 'db.local' } },
+        'token',
+      );
+
+      expect(result).toEqual(updated);
+      expect(mockPUT).toHaveBeenCalledWith(
+        '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}',
+        expect.objectContaining({
+          params: {
+            path: { namespaceName: 'test-ns', secretName: 'db-creds' },
+          },
+          body: expect.objectContaining({ data: expect.any(Object) }),
+        }),
+      );
+    });
+
+    it('throws on API error', async () => {
+      mockPUT.mockResolvedValueOnce(createErrorResponse());
+      await expect(
+        createService().updateSecret(
+          'test-ns',
+          'db-creds',
+          { data: { k: 'v' } },
           'token',
         ),
       ).rejects.toThrow();

--- a/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.ts
+++ b/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.ts
@@ -11,13 +11,28 @@ export type TargetPlaneRef = OpenChoreoComponents['schemas']['TargetPlaneRef'];
 export type SecretResponse = OpenChoreoComponents['schemas']['SecretResponse'];
 export type CreateSecretRequest =
   OpenChoreoComponents['schemas']['CreateSecretRequest'];
+export type UpdateSecretRequest =
+  OpenChoreoComponents['schemas']['UpdateSecretRequest'];
 type SecretReference = OpenChoreoComponents['schemas']['SecretReference'];
+type ListSecretsResponse =
+  OpenChoreoComponents['schemas']['ListSecretsResponse'];
+type SecretObject = OpenChoreoComponents['schemas']['Secret'];
 
 export interface SecretsListResponse {
   items: SecretResponse[];
   totalCount: number;
   page: number;
   pageSize: number;
+}
+
+/**
+ * Secret detail returned by getSecret. `data` carries base64-encoded values
+ * exactly as Kubernetes returns them; the frontend decodes when populating
+ * the edit dialog. Treat as sensitive — never log this object's `data`.
+ */
+export interface SecretDetail extends SecretResponse {
+  /** Base64-encoded value map (K8s Secret wire format). */
+  data: Record<string, string>;
 }
 
 export class SecretsService {
@@ -42,20 +57,45 @@ export class SecretsService {
         logger: this.logger,
       });
 
-      const { data, error, response } = await client.GET(
-        '/api/v1/namespaces/{namespaceName}/secretreferences',
-        {
-          params: {
-            path: { namespaceName },
-          },
-        },
-      );
+      // Fetch secrets (new API) and secretreferences (for targetPlane) in parallel.
+      // The new /secrets endpoint returns plain corev1.Secret objects without
+      // the targetPlane field, so we join with SecretReferences by name to
+      // surface targetPlane info in the table.
+      const [secretsRes, refsRes] = await Promise.all([
+        client.GET('/api/v1alpha1/namespaces/{namespaceName}/secrets', {
+          params: { path: { namespaceName } },
+        }),
+        client.GET('/api/v1/namespaces/{namespaceName}/secretreferences', {
+          params: { path: { namespaceName } },
+        }),
+      ]);
 
-      assertApiResponse({ data, error, response }, 'list secrets');
+      assertApiResponse(secretsRes, 'list secrets');
+      assertApiResponse(refsRes, 'list secret references');
 
-      const items = (data!.items ?? [])
-        .filter(ref => ref.spec?.targetPlane)
-        .map(toSecretResponse);
+      const secrets = (secretsRes.data as ListSecretsResponse).items ?? [];
+      const refs = refsRes.data!.items ?? [];
+
+      const refByName = new Map<string, SecretReference>();
+      for (const ref of refs) {
+        const name = ref.metadata?.name;
+        if (name) refByName.set(name, ref);
+      }
+
+      const items: SecretResponse[] = secrets.map(secret => {
+        const name = secret.metadata?.name ?? '';
+        const ref = refByName.get(name);
+        const keys = Object.keys(secret.data ?? {}).sort((a, b) =>
+          a.localeCompare(b),
+        );
+        return {
+          name,
+          namespace: secret.metadata?.namespace ?? namespaceName,
+          secretType: toSecretType(secret.type),
+          targetPlane: ref?.spec?.targetPlane,
+          keys,
+        };
+      });
 
       this.logger.debug(
         `Successfully listed ${items.length} secrets for namespace: ${namespaceName}`,
@@ -77,7 +117,7 @@ export class SecretsService {
     namespaceName: string,
     secretName: string,
     token?: string,
-  ): Promise<SecretResponse> {
+  ): Promise<SecretDetail> {
     this.logger.debug(
       `Fetching secret ${secretName} from namespace: ${namespaceName}`,
     );
@@ -89,24 +129,46 @@ export class SecretsService {
         logger: this.logger,
       });
 
-      const { data, error, response } = await client.GET(
-        '/api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}',
-        {
-          params: {
-            path: { namespaceName, secretReferenceName: secretName },
+      // Fetch the K8s Secret (with base64 data) and the SecretReference
+      // (for targetPlane info) in parallel.
+      const [secretRes, refRes] = await Promise.all([
+        client.GET(
+          '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}',
+          { params: { path: { namespaceName, secretName } } },
+        ),
+        client.GET(
+          '/api/v1/namespaces/{namespaceName}/secretreferences/{secretReferenceName}',
+          {
+            params: {
+              path: { namespaceName, secretReferenceName: secretName },
+            },
           },
-        },
-      );
+        ),
+      ]);
 
-      assertApiResponse({ data, error, response }, 'get secret');
+      assertApiResponse(secretRes, 'get secret');
+      assertApiResponse(refRes, 'get secret reference');
 
-      if (!data!.spec?.targetPlane) {
+      const secret = secretRes.data as SecretObject;
+      const ref = refRes.data!;
+
+      if (!ref.spec?.targetPlane) {
         throw new NotFoundError(
           `secret '${secretName}' not found in namespace '${namespaceName}'`,
         );
       }
 
-      return toSecretResponse(data!);
+      const data = (secret.data ?? {}) as Record<string, string>;
+      const keys = Object.keys(data).sort((a, b) => a.localeCompare(b));
+
+      return {
+        name: secret.metadata?.name ?? secretName,
+        namespace: secret.metadata?.namespace ?? namespaceName,
+        secretType: toSecretType(secret.type),
+        targetPlane: ref.spec?.targetPlane,
+        keys,
+        data,
+      };
     } catch (err) {
       this.logger.error(
         `Failed to get secret ${secretName} from ${namespaceName}: ${err}`,
@@ -148,6 +210,45 @@ export class SecretsService {
     } catch (err) {
       this.logger.error(
         `Failed to create secret ${body.secretName} in ${namespaceName}: ${err}`,
+      );
+      throw err;
+    }
+  }
+
+  async updateSecret(
+    namespaceName: string,
+    secretName: string,
+    body: UpdateSecretRequest,
+    userToken?: string,
+  ): Promise<SecretResponse> {
+    this.logger.debug(
+      `Updating secret ${secretName} in namespace: ${namespaceName}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token: userToken,
+        logger: this.logger,
+      });
+
+      const { data, error, response } = await client.PUT(
+        '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}',
+        {
+          params: { path: { namespaceName, secretName } },
+          body,
+        },
+      );
+
+      assertApiResponse({ data, error, response }, 'update secret');
+
+      this.logger.debug(
+        `Successfully updated secret ${secretName} in namespace: ${namespaceName}`,
+      );
+      return data as SecretResponse;
+    } catch (err) {
+      this.logger.error(
+        `Failed to update secret ${secretName} in ${namespaceName}: ${err}`,
       );
       throw err;
     }
@@ -203,18 +304,4 @@ function toSecretType(raw: string | undefined): SecretType | undefined {
     return raw as SecretType;
   }
   return undefined;
-}
-
-function toSecretResponse(ref: SecretReference): SecretResponse {
-  const keys = (ref.spec?.data ?? [])
-    .map(d => d.secretKey)
-    .sort((a, b) => a.localeCompare(b));
-
-  return {
-    name: ref.metadata?.name ?? '',
-    namespace: ref.metadata?.namespace ?? '',
-    secretType: toSecretType(ref.spec?.template?.type),
-    targetPlane: ref.spec?.targetPlane,
-    keys,
-  };
 }

--- a/plugins/openchoreo-backend/src/types.ts
+++ b/plugins/openchoreo-backend/src/types.ts
@@ -9,7 +9,9 @@ import type {
 import type {
   SecretResponse,
   SecretsListResponse,
+  SecretDetail,
   CreateSecretRequest,
+  UpdateSecretRequest,
 } from './services/SecretsService/SecretsService';
 
 // Log types from the unified /api/v1/logs/query endpoint
@@ -222,10 +224,16 @@ export interface SecretsService {
     namespaceName: string,
     secretName: string,
     token?: string,
-  ): Promise<SecretResponse>;
+  ): Promise<SecretDetail>;
   createSecret(
     namespaceName: string,
     body: CreateSecretRequest,
+    userToken?: string,
+  ): Promise<SecretResponse>;
+  updateSecret(
+    namespaceName: string,
+    secretName: string,
+    body: UpdateSecretRequest,
     userToken?: string,
   ): Promise<SecretResponse>;
   deleteSecret(

--- a/plugins/openchoreo-common/config.d.ts
+++ b/plugins/openchoreo-common/config.d.ts
@@ -92,6 +92,21 @@ export interface Config {
          */
         enabled?: boolean;
       };
+
+      /**
+       * Secret Management configuration.
+       * Controls the Secrets settings tab and related secret-management APIs.
+       * @deepVisibility frontend
+       */
+      secretManagement?: {
+        /**
+         * Enable or disable secret management features.
+         * When disabled, the Secrets settings tab is hidden and the page
+         * renders a "feature disabled" notice if reached directly.
+         * @visibility frontend
+         */
+        enabled?: boolean;
+      };
     };
 
     /**

--- a/plugins/openchoreo-common/src/types/features.ts
+++ b/plugins/openchoreo-common/src/types/features.ts
@@ -27,9 +27,16 @@ export interface OpenChoreoFeatures {
   auth: { enabled: boolean };
   /** Authorization feature (Access Control UI) */
   authz: { enabled: boolean };
+  /** Secret Management UI (Secrets settings tab + APIs) */
+  secretManagement: { enabled: boolean };
 }
 
 /**
  * Feature names that can be toggled.
  */
-export type FeatureName = 'workflows' | 'observability' | 'auth' | 'authz';
+export type FeatureName =
+  | 'workflows'
+  | 'observability'
+  | 'auth'
+  | 'authz'
+  | 'secretManagement';

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoFeatures.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoFeatures.test.ts
@@ -5,6 +5,7 @@ import {
   useObservabilityEnabled,
   useAuthEnabled,
   useAuthzEnabled,
+  useSecretManagementEnabled,
 } from './useOpenChoreoFeatures';
 
 const mockGetOptionalConfig = jest.fn();
@@ -29,7 +30,7 @@ describe('useOpenChoreoFeatures', () => {
     jest.clearAllMocks();
   });
 
-  it('returns all features enabled by default when no config', () => {
+  it('returns all features enabled by default when no config (secretManagement off)', () => {
     mockGetOptionalConfig.mockReturnValue(undefined);
     const { result } = renderHook(() => useOpenChoreoFeatures());
     expect(result.current).toEqual({
@@ -37,6 +38,7 @@ describe('useOpenChoreoFeatures', () => {
       observability: { enabled: true },
       auth: { enabled: true },
       authz: { enabled: true },
+      secretManagement: { enabled: false },
     });
   });
 
@@ -47,6 +49,7 @@ describe('useOpenChoreoFeatures', () => {
         'observability.enabled': true,
         'auth.enabled': false,
         'authz.enabled': true,
+        'secretManagement.enabled': true,
       }),
     );
     const { result } = renderHook(() => useOpenChoreoFeatures());
@@ -55,10 +58,11 @@ describe('useOpenChoreoFeatures', () => {
       observability: { enabled: true },
       auth: { enabled: false },
       authz: { enabled: true },
+      secretManagement: { enabled: true },
     });
   });
 
-  it('defaults individual features to true when not set in config', () => {
+  it('defaults individual features when not set in config', () => {
     mockGetOptionalConfig.mockReturnValue(
       makeFeaturesConfig({ 'workflows.enabled': false }),
     );
@@ -67,6 +71,7 @@ describe('useOpenChoreoFeatures', () => {
     expect(result.current.observability.enabled).toBe(true);
     expect(result.current.auth.enabled).toBe(true);
     expect(result.current.authz.enabled).toBe(true);
+    expect(result.current.secretManagement.enabled).toBe(false);
   });
 
   it('returns defaults when config throws', () => {
@@ -79,6 +84,7 @@ describe('useOpenChoreoFeatures', () => {
       observability: { enabled: true },
       auth: { enabled: true },
       authz: { enabled: true },
+      secretManagement: { enabled: false },
     });
   });
 });
@@ -92,6 +98,7 @@ describe('helper hooks', () => {
         'observability.enabled': false,
         'auth.enabled': true,
         'authz.enabled': false,
+        'secretManagement.enabled': true,
       }),
     );
   });
@@ -114,5 +121,10 @@ describe('helper hooks', () => {
   it('useAuthzEnabled returns authz flag', () => {
     const { result } = renderHook(() => useAuthzEnabled());
     expect(result.current).toBe(false);
+  });
+
+  it('useSecretManagementEnabled returns secretManagement flag', () => {
+    const { result } = renderHook(() => useSecretManagementEnabled());
+    expect(result.current).toBe(true);
   });
 });

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoFeatures.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoFeatures.ts
@@ -11,6 +11,7 @@ const defaultFeatures: OpenChoreoFeatures = {
   observability: { enabled: true },
   auth: { enabled: true },
   authz: { enabled: true },
+  secretManagement: { enabled: false },
 };
 
 /**
@@ -53,6 +54,11 @@ export function useOpenChoreoFeatures(): OpenChoreoFeatures {
         authz: {
           enabled: featuresConfig.getOptionalBoolean('authz.enabled') ?? true,
         },
+        secretManagement: {
+          enabled:
+            featuresConfig.getOptionalBoolean('secretManagement.enabled') ??
+            false,
+        },
       };
     } catch {
       // If config reading fails, use defaults to avoid breaking the app
@@ -91,4 +97,12 @@ export function useAuthEnabled(): boolean {
 export function useAuthzEnabled(): boolean {
   const features = useOpenChoreoFeatures();
   return features.authz.enabled;
+}
+
+/**
+ * Helper hook to check if Secret Management is enabled.
+ */
+export function useSecretManagementEnabled(): boolean {
+  const features = useOpenChoreoFeatures();
+  return features.secretManagement.enabled;
 }

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -164,6 +164,7 @@ export {
   useObservabilityEnabled,
   useAuthEnabled,
   useAuthzEnabled,
+  useSecretManagementEnabled,
 } from './hooks/useOpenChoreoFeatures';
 export {
   useComponentEntityDetails,

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -26,6 +26,7 @@ import type {
   Secret,
   SecretsListResponse,
   CreateSecretRequest,
+  UpdateSecretRequest,
   PlatformResourceKind,
   ResourceCRUDResponse,
   ClusterRole,
@@ -1369,6 +1370,21 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
       params: { namespaceName },
       body: request,
     });
+  }
+
+  async updateSecret(
+    namespaceName: string,
+    secretName: string,
+    request: UpdateSecretRequest,
+  ): Promise<Secret> {
+    return this.apiFetch<Secret>(
+      `${API_ENDPOINTS.SECRETS}/${encodeURIComponent(secretName)}`,
+      {
+        method: 'PUT',
+        params: { namespaceName },
+        body: request,
+      },
+    );
   }
 
   async deleteSecret(namespaceName: string, secretName: string): Promise<void> {

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -47,7 +47,11 @@ export interface TargetPlaneRef {
   name: string;
 }
 
-/** Secret resource. Values are never returned, only key names. */
+/**
+ * Secret resource. The list endpoint returns only `keys[]`; the single-secret
+ * GET endpoint additionally populates `data` with base64-encoded values
+ * (K8s Secret wire format). Decode at the UI boundary; treat as sensitive.
+ */
 export interface Secret {
   name: string;
   namespace: string;
@@ -55,6 +59,11 @@ export interface Secret {
   targetPlane?: TargetPlaneRef;
   /** Sorted list of keys present in the secret data */
   keys: string[];
+  /**
+   * Base64-encoded value map (K8s Secret wire format). Present only when
+   * fetched via getSecret. Decode with `atob` (or equivalent) before display.
+   */
+  data?: Record<string, string>;
 }
 
 /** Secrets list response */
@@ -71,6 +80,11 @@ export interface CreateSecretRequest {
   secretType: SecretType;
   targetPlane: TargetPlaneRef;
   /** Required keys depend on secretType. */
+  data: Record<string, string>;
+}
+
+/** Body for updating an existing secret. Replaces all data; omitted keys are pruned. */
+export interface UpdateSecretRequest {
   data: Record<string, string>;
 }
 
@@ -734,6 +748,13 @@ export interface OpenChoreoClientApi {
   createSecret(
     namespaceName: string,
     request: CreateSecretRequest,
+  ): Promise<Secret>;
+
+  /** Update (replace data of) an existing secret */
+  updateSecret(
+    namespaceName: string,
+    secretName: string,
+    request: UpdateSecretRequest,
   ): Promise<Secret>;
 
   /** Delete a secret */

--- a/plugins/openchoreo/src/components/Secrets/EditSecretDialog.test.tsx
+++ b/plugins/openchoreo/src/components/Secrets/EditSecretDialog.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestApiProvider } from '@backstage/test-utils';
+import { EditSecretDialog } from './EditSecretDialog';
+import { openChoreoClientApiRef, Secret } from '../../api/OpenChoreoClientApi';
+
+const mockClient = {
+  getSecret: jest.fn(),
+};
+
+function makeSecret(partial: Partial<Secret> = {}): Secret {
+  return {
+    name: 'db-creds',
+    namespace: 'ns',
+    secretType: 'Opaque',
+    targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+    keys: ['DB_HOST', 'DB_USER'],
+    ...partial,
+  };
+}
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof EditSecretDialog>> = {},
+) {
+  const defaults: React.ComponentProps<typeof EditSecretDialog> = {
+    open: true,
+    onClose: jest.fn(),
+    onSubmit: jest.fn().mockResolvedValue({} as any),
+    secret: makeSecret(),
+    namespaceName: 'ns',
+  };
+  return render(
+    <TestApiProvider apis={[[openChoreoClientApiRef, mockClient as any]]}>
+      <EditSecretDialog {...defaults} {...overrides} />
+    </TestApiProvider>,
+  );
+}
+
+describe('EditSecretDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.getSecret.mockResolvedValue({
+      name: 'db-creds',
+      namespace: 'ns',
+      secretType: 'Opaque',
+      targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
+      keys: ['DB_HOST', 'DB_USER'],
+      // Base64-encoded values; the dialog decodes at the UI boundary.
+      data: { DB_HOST: 'ZGIubG9jYWw=', DB_USER: 'YWxpY2U=' },
+    });
+  });
+
+  it('renders the title with the secret name and the type/plane meta', async () => {
+    renderDialog();
+    expect(screen.getByText('Edit Secret: db-creds')).toBeInTheDocument();
+    expect(screen.getByText('Opaque')).toBeInTheDocument();
+    expect(screen.getByText('dp-prod')).toBeInTheDocument();
+    expect(screen.getByText('DataPlane')).toBeInTheDocument();
+    // Wait for the async load so the spinner unmounts before the test ends.
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText('Value 1') as HTMLInputElement).value,
+      ).not.toBe(''),
+    );
+  });
+
+  it('prefills values with decoded plaintext from getSecret', async () => {
+    renderDialog();
+
+    await waitFor(() =>
+      expect(mockClient.getSecret).toHaveBeenCalledWith('ns', 'db-creds'),
+    );
+
+    // Keys are sorted alphabetically: DB_HOST then DB_USER.
+    await waitFor(() =>
+      expect((screen.getByLabelText('Value 1') as HTMLInputElement).value).toBe(
+        'db.local',
+      ),
+    );
+    expect((screen.getByLabelText('Value 2') as HTMLInputElement).value).toBe(
+      'alice',
+    );
+  });
+
+  it('keeps Save disabled until a value changes', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    // Wait for prefill to land.
+    await waitFor(() =>
+      expect((screen.getByLabelText('Value 1') as HTMLInputElement).value).toBe(
+        'db.local',
+      ),
+    );
+
+    const save = screen.getByRole('button', { name: 'Save' });
+    expect(save).toBeDisabled();
+
+    // Change a value -> Save enables.
+    await user.clear(screen.getByLabelText('Value 1'));
+    await user.type(screen.getByLabelText('Value 1'), 'new-host');
+    expect(save).toBeEnabled();
+  });
+
+  it('Save submits the current key/value map', async () => {
+    const onSubmit = jest.fn().mockResolvedValue({} as any);
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    renderDialog({ onSubmit, onClose });
+
+    await waitFor(() =>
+      expect((screen.getByLabelText('Value 1') as HTMLInputElement).value).toBe(
+        'db.local',
+      ),
+    );
+
+    await user.clear(screen.getByLabelText('Value 1'));
+    await user.type(screen.getByLabelText('Value 1'), 'new-host');
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith('db-creds', {
+        data: { DB_HOST: 'new-host', DB_USER: 'alice' },
+      }),
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('surfaces a load error when getSecret fails', async () => {
+    mockClient.getSecret.mockRejectedValueOnce(new Error('boom'));
+    renderDialog();
+
+    expect(
+      await screen.findByText(/Could not load current values: boom/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/Secrets/EditSecretDialog.tsx
+++ b/plugins/openchoreo/src/components/Secrets/EditSecretDialog.tsx
@@ -104,9 +104,15 @@ function decodeBase64Utf8(b64: string): string {
   if (!b64) return '';
   try {
     const binary = atob(b64);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-    return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+    if (typeof TextDecoder !== 'undefined') {
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+    }
+    // Fallback for environments without TextDecoder (e.g. older jsdom).
+    // decodeURIComponent(escape(...)) is the canonical pre-TextDecoder
+    // pattern for converting a binary-string atob result to UTF-8 text.
+    return decodeURIComponent(escape(binary));
   } catch {
     return '';
   }

--- a/plugins/openchoreo/src/components/Secrets/EditSecretDialog.tsx
+++ b/plugins/openchoreo/src/components/Secrets/EditSecretDialog.tsx
@@ -1,0 +1,429 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  InputAdornment,
+  Link,
+  TextField,
+  Typography,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import AddIcon from '@material-ui/icons/Add';
+import CloseIcon from '@material-ui/icons/Close';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import { useApi } from '@backstage/core-plugin-api';
+import {
+  openChoreoClientApiRef,
+  Secret,
+  SecretType,
+  UpdateSecretRequest,
+} from '../../api/OpenChoreoClientApi';
+import { getErrorMessage, isForbiddenError } from '../../utils/errorUtils';
+
+interface EditSecretDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (
+    secretName: string,
+    request: UpdateSecretRequest,
+  ) => Promise<Secret>;
+  secret: Secret | null;
+  namespaceName: string;
+}
+
+interface KeyValueRow {
+  key: string;
+  value: string;
+  show: boolean;
+  /** True if this key existed on the secret when the dialog opened. */
+  isOriginal?: boolean;
+}
+
+const useStyles = makeStyles(theme => ({
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(2),
+    justifyContent: 'center',
+  },
+  meta: {
+    marginBottom: theme.spacing(2),
+  },
+  metaRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(0.5),
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+  rowKey: { flex: 1 },
+  rowValue: { flex: 2 },
+  removeBtn: { marginTop: theme.spacing(1) },
+  addLink: {
+    cursor: 'pointer',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    marginTop: theme.spacing(1),
+  },
+}));
+
+const SECRET_TYPE_LABELS: Record<SecretType, string> = {
+  Opaque: 'Opaque',
+  'kubernetes.io/basic-auth': 'Basic Auth',
+  'kubernetes.io/ssh-auth': 'SSH Auth',
+  'kubernetes.io/dockerconfigjson': 'Docker Config',
+  'kubernetes.io/tls': 'TLS',
+};
+
+function formatSecretType(type?: SecretType): string {
+  if (!type) return 'Unknown';
+  return SECRET_TYPE_LABELS[type] ?? type;
+}
+
+/** Whether the user is allowed to add/remove keys for this secret type. */
+function isFixedKeySchema(type?: SecretType): boolean {
+  return type !== undefined && type !== 'Opaque';
+}
+
+function decodeBase64Utf8(b64: string): string {
+  if (!b64) return '';
+  try {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+  } catch {
+    return '';
+  }
+}
+
+export const EditSecretDialog = ({
+  open,
+  onClose,
+  onSubmit,
+  secret,
+  namespaceName,
+}: EditSecretDialogProps) => {
+  const classes = useStyles();
+  const client = useApi(openChoreoClientApiRef);
+  const [rows, setRows] = useState<KeyValueRow[]>([]);
+  const [baseline, setBaseline] = useState<Record<string, string> | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [loadingValues, setLoadingValues] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fixedKeys = isFixedKeySchema(secret?.secretType);
+
+  // Fetch the secret with plaintext values when the dialog opens so the user
+  // can see and edit current values. Values stay in memory only and are
+  // dropped when the dialog closes.
+  useEffect(() => {
+    if (!open || !secret) return undefined;
+
+    let cancelled = false;
+    setLoadingValues(true);
+    setLoadError(null);
+    setError(null);
+    setBaseline(null);
+    setRows(
+      secret.keys.map(key => ({
+        key,
+        value: '',
+        show: false,
+        isOriginal: true,
+      })),
+    );
+
+    client
+      .getSecret(namespaceName, secret.name)
+      .then(detail => {
+        if (cancelled) return;
+        // Backend forwards the K8s wire format unchanged: values are
+        // base64-encoded. Decode at the UI boundary so the inputs show
+        // plaintext and so dirty checks compare like-for-like.
+        const decoded: Record<string, string> = {};
+        for (const [k, b64] of Object.entries(detail.data ?? {})) {
+          decoded[k] = decodeBase64Utf8(b64);
+        }
+        const orderedKeys = detail.keys.length > 0 ? detail.keys : secret.keys;
+        setBaseline(
+          Object.fromEntries(orderedKeys.map(key => [key, decoded[key] ?? ''])),
+        );
+        setRows(
+          orderedKeys.map(key => ({
+            key,
+            value: decoded[key] ?? '',
+            show: false,
+            isOriginal: true,
+          })),
+        );
+      })
+      .catch(err => {
+        if (cancelled) return;
+        if (isForbiddenError(err)) {
+          setLoadError(
+            'You do not have permission to view this secret’s values.',
+          );
+        } else {
+          setLoadError(getErrorMessage(err));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingValues(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, secret, client, namespaceName]);
+
+  const duplicateKeys = useMemo(() => {
+    const seen = new Map<string, number>();
+    rows.forEach(r => {
+      const k = r.key.trim();
+      if (!k) return;
+      seen.set(k, (seen.get(k) ?? 0) + 1);
+    });
+    return new Set(
+      Array.from(seen.entries())
+        .filter(([, c]) => c > 1)
+        .map(([k]) => k),
+    );
+  }, [rows]);
+
+  const isChanged = useMemo(() => {
+    if (!baseline) return false;
+    const baselineKeys = Object.keys(baseline);
+    if (rows.length !== baselineKeys.length) return true;
+    for (const row of rows) {
+      const k = row.key.trim();
+      if (!(k in baseline)) return true;
+      if (baseline[k] !== row.value) return true;
+    }
+    return false;
+  }, [rows, baseline]);
+
+  const canSubmit = useMemo(() => {
+    if (!secret) return false;
+    if (loadingValues) return false;
+    if (duplicateKeys.size > 0) return false;
+    if (!isChanged) return false;
+    if (rows.length === 0) return false;
+    return rows.every(r => r.key.trim() !== '');
+  }, [rows, duplicateKeys, secret, loadingValues, isChanged]);
+
+  const handleRowChange = (
+    index: number,
+    field: 'key' | 'value',
+    value: string,
+  ) => {
+    setRows(prev =>
+      prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)),
+    );
+  };
+
+  const toggleShow = (index: number) => {
+    setRows(prev =>
+      prev.map((r, i) => (i === index ? { ...r, show: !r.show } : r)),
+    );
+  };
+
+  const removeRow = (index: number) => {
+    setRows(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const addRow = () => {
+    setRows(prev => [...prev, { key: '', value: '', show: false }]);
+  };
+
+  const handleClose = () => {
+    if (submitting) return;
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!secret || !canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+
+    const data: Record<string, string> = {};
+    for (const row of rows) {
+      data[row.key.trim()] = row.value;
+    }
+
+    try {
+      await onSubmit(secret.name, { data });
+      onClose();
+    } catch (err) {
+      if (isForbiddenError(err)) {
+        setError(
+          'You do not have permission to update this secret. Contact your administrator.',
+        );
+      } else {
+        setError(getErrorMessage(err));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!secret) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="edit-secret-dialog-title"
+    >
+      <DialogTitle disableTypography id="edit-secret-dialog-title">
+        <Typography variant="h4">Edit Secret: {secret.name}</Typography>
+      </DialogTitle>
+      <DialogContent>
+        <Box className={classes.meta}>
+          <Box className={classes.metaRow}>
+            <Typography variant="body2" color="textSecondary">
+              Type:
+            </Typography>
+            <Typography variant="body2">
+              {formatSecretType(secret.secretType)}
+            </Typography>
+          </Box>
+          {secret.targetPlane && (
+            <Box className={classes.metaRow}>
+              <Typography variant="body2" color="textSecondary">
+                Target Plane:
+              </Typography>
+              <Typography variant="body2">{secret.targetPlane.name}</Typography>
+              <Chip
+                label={secret.targetPlane.kind}
+                size="small"
+                variant="outlined"
+              />
+            </Box>
+          )}
+        </Box>
+
+        {loadingValues && (
+          <Box className={classes.loading}>
+            <CircularProgress size={20} />
+            <Typography variant="body2" color="textSecondary">
+              Loading values...
+            </Typography>
+          </Box>
+        )}
+
+        {loadError && (
+          <Typography color="error" style={{ marginBottom: 12 }}>
+            Could not load current values: {loadError}
+          </Typography>
+        )}
+
+        {rows.map((row, index) => (
+          <Box
+            key={`${row.isOriginal ? row.key : 'new'}-${index}`}
+            className={classes.row}
+          >
+            <TextField
+              className={classes.rowKey}
+              label="Key"
+              variant="outlined"
+              size="small"
+              value={row.key}
+              onChange={e => handleRowChange(index, 'key', e.target.value)}
+              disabled={fixedKeys || row.isOriginal === true}
+              error={duplicateKeys.has(row.key.trim())}
+              helperText={
+                duplicateKeys.has(row.key.trim()) ? 'Duplicate key' : undefined
+              }
+              inputProps={{ 'aria-label': `Key ${index + 1}` }}
+            />
+            <TextField
+              className={classes.rowValue}
+              label="Value"
+              variant="outlined"
+              size="small"
+              type={row.show ? 'text' : 'password'}
+              value={row.value}
+              placeholder="••••••••"
+              onChange={e => handleRowChange(index, 'value', e.target.value)}
+              inputProps={{ 'aria-label': `Value ${index + 1}` }}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      onClick={() => toggleShow(index)}
+                      aria-label={row.show ? 'Hide value' : 'Show value'}
+                    >
+                      {row.show ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+            {!fixedKeys && (
+              <IconButton
+                size="small"
+                className={classes.removeBtn}
+                onClick={() => removeRow(index)}
+                aria-label={`Remove ${row.key || 'row'}`}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            )}
+          </Box>
+        ))}
+
+        {!fixedKeys && (
+          <Link
+            component="button"
+            type="button"
+            className={classes.addLink}
+            onClick={addRow}
+            underline="always"
+          >
+            <AddIcon fontSize="small" /> Add key
+          </Link>
+        )}
+
+        {error && (
+          <Typography color="error" style={{ marginTop: 16 }}>
+            {error}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={submitting} variant="contained">
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          color="primary"
+          variant="contained"
+          disabled={!canSubmit || submitting}
+          startIcon={submitting ? <CircularProgress size={20} /> : null}
+        >
+          {submitting ? 'Saving...' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/plugins/openchoreo/src/components/Secrets/SecretsPage.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsPage.tsx
@@ -16,7 +16,11 @@ import {
   Content,
   WarningPanel,
 } from '@backstage/core-components';
-import { ForbiddenState } from '@openchoreo/backstage-plugin-react';
+import { Alert } from '@material-ui/lab';
+import {
+  ForbiddenState,
+  useSecretManagementEnabled,
+} from '@openchoreo/backstage-plugin-react';
 import { makeStyles } from '@material-ui/core/styles';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
@@ -24,6 +28,7 @@ import AddIcon from '@material-ui/icons/Add';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import {
   openChoreoClientApiRef,
+  Secret,
   TargetPlaneKind,
 } from '../../api/OpenChoreoClientApi';
 import { useSecrets } from './hooks/useSecrets';
@@ -32,6 +37,7 @@ import {
   CreateSecretDialog,
   type TargetPlaneOption,
 } from './CreateSecretDialog';
+import { EditSecretDialog } from './EditSecretDialog';
 import { useAsync } from 'react-use';
 
 const useStyles = makeStyles(theme => ({
@@ -57,8 +63,10 @@ export const SecretsContent = () => {
   const classes = useStyles();
   const client = useApi(openChoreoClientApiRef);
   const catalogApi = useApi(catalogApiRef);
+  const secretManagementEnabled = useSecretManagementEnabled();
   const [selectedNamespace, setSelectedNamespace] = useState<string>('');
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [editingSecret, setEditingSecret] = useState<Secret | null>(null);
 
   const {
     value: namespaces,
@@ -134,6 +142,7 @@ export const SecretsContent = () => {
     error: secretsError,
     isForbidden: secretsForbidden,
     createSecret,
+    updateSecret,
     deleteSecret,
     fetchSecrets,
   } = useSecrets(selectedNamespace);
@@ -158,6 +167,18 @@ export const SecretsContent = () => {
       setSelectedNamespace(sortedNamespaces[0].name);
     }
   }, [sortedNamespaces, selectedNamespace]);
+
+  if (!secretManagementEnabled) {
+    return (
+      <Box mt={2} mb={2} width="100%">
+        <Alert severity="info">
+          <Typography variant="body1">
+            Secret Management is disabled. Please enable it to manage secrets.
+          </Typography>
+        </Alert>
+      </Box>
+    );
+  }
 
   return (
     <Box className={classes.root}>
@@ -255,6 +276,7 @@ export const SecretsContent = () => {
             secrets={secrets}
             loading={secretsLoading}
             onDelete={handleDeleteSecret}
+            onEdit={setEditingSecret}
             namespaceName={selectedNamespace}
           />
         )
@@ -269,6 +291,14 @@ export const SecretsContent = () => {
         targetPlanes={targetPlanes || []}
         targetPlanesLoading={targetPlanesLoading}
         targetPlanesError={targetPlanesError}
+      />
+
+      <EditSecretDialog
+        open={editingSecret !== null}
+        onClose={() => setEditingSecret(null)}
+        onSubmit={updateSecret}
+        secret={editingSecret}
+        namespaceName={selectedNamespace}
       />
     </Box>
   );

--- a/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
@@ -24,6 +24,7 @@ import {
 } from '@material-ui/core';
 import { Progress } from '@backstage/core-components';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
+import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
 import VpnKeyOutlinedIcon from '@material-ui/icons/VpnKeyOutlined';
 import SearchIcon from '@material-ui/icons/Search';
 import { makeStyles } from '@material-ui/core/styles';
@@ -100,6 +101,7 @@ interface SecretsTableProps {
   secrets: Secret[];
   loading: boolean;
   onDelete: (secretName: string) => Promise<void>;
+  onEdit?: (secret: Secret) => void;
   namespaceName: string;
 }
 
@@ -107,6 +109,7 @@ export const SecretsTable = ({
   secrets,
   loading,
   onDelete,
+  onEdit,
   namespaceName,
 }: SecretsTableProps) => {
   const classes = useStyles();
@@ -263,6 +266,17 @@ export const SecretsTable = ({
                     )}
                   </TableCell>
                   <TableCell align="center">
+                    {onEdit && (
+                      <Tooltip title="Edit">
+                        <IconButton
+                          size="small"
+                          onClick={() => onEdit(secret)}
+                          aria-label={`Edit secret ${secret.name}`}
+                        >
+                          <EditOutlinedIcon />
+                        </IconButton>
+                      </Tooltip>
+                    )}
                     <Tooltip title="Delete">
                       <IconButton
                         size="small"

--- a/plugins/openchoreo/src/components/Secrets/hooks/useSecrets.test.tsx
+++ b/plugins/openchoreo/src/components/Secrets/hooks/useSecrets.test.tsx
@@ -11,6 +11,7 @@ import {
 const mockClient = {
   listSecrets: jest.fn<Promise<SecretsListResponse>, [string]>(),
   createSecret: jest.fn(),
+  updateSecret: jest.fn(),
   deleteSecret: jest.fn(),
 };
 
@@ -44,6 +45,7 @@ describe('useSecrets', () => {
       pageSize: 100,
     });
     mockClient.createSecret.mockResolvedValue(makeSecret('new'));
+    mockClient.updateSecret.mockResolvedValue(makeSecret('updated'));
     mockClient.deleteSecret.mockResolvedValue(undefined);
   });
 
@@ -144,6 +146,40 @@ describe('useSecrets', () => {
     expect(returned).toEqual(created);
     expect(mockClient.listSecrets).toHaveBeenCalledTimes(2);
     expect(result.current.secrets).toEqual([created]);
+  });
+
+  it('updateSecret calls the client and refetches', async () => {
+    const updated = makeSecret('victim');
+    mockClient.updateSecret.mockResolvedValueOnce(updated);
+    mockClient.listSecrets.mockResolvedValueOnce({
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 100,
+    });
+    mockClient.listSecrets.mockResolvedValueOnce({
+      items: [updated],
+      totalCount: 1,
+      page: 1,
+      pageSize: 100,
+    });
+
+    const { result } = renderUseSecrets('ns');
+    await act(async () => {});
+
+    let returned: Secret | undefined;
+    await act(async () => {
+      returned = await result.current.updateSecret('victim', {
+        data: { k1: 'new' },
+      });
+    });
+
+    expect(mockClient.updateSecret).toHaveBeenCalledWith('ns', 'victim', {
+      data: { k1: 'new' },
+    });
+    expect(returned).toEqual(updated);
+    expect(mockClient.listSecrets).toHaveBeenCalledTimes(2);
+    expect(result.current.secrets).toEqual([updated]);
   });
 
   it('deleteSecret calls the client and refetches', async () => {

--- a/plugins/openchoreo/src/components/Secrets/hooks/useSecrets.ts
+++ b/plugins/openchoreo/src/components/Secrets/hooks/useSecrets.ts
@@ -3,6 +3,7 @@ import { useApi } from '@backstage/core-plugin-api';
 import {
   openChoreoClientApiRef,
   CreateSecretRequest,
+  UpdateSecretRequest,
   Secret,
 } from '../../../api/OpenChoreoClientApi';
 import { isForbiddenError } from '../../../utils/errorUtils';
@@ -14,6 +15,10 @@ export interface UseSecretsResult {
   isForbidden: boolean;
   fetchSecrets: () => Promise<void>;
   createSecret: (request: CreateSecretRequest) => Promise<Secret>;
+  updateSecret: (
+    secretName: string,
+    request: UpdateSecretRequest,
+  ) => Promise<Secret>;
   deleteSecret: (secretName: string) => Promise<void>;
 }
 
@@ -55,6 +60,22 @@ export function useSecrets(namespaceName: string): UseSecretsResult {
     [client, namespaceName, fetchSecrets],
   );
 
+  const updateSecret = useCallback(
+    async (
+      secretName: string,
+      request: UpdateSecretRequest,
+    ): Promise<Secret> => {
+      const secret = await client.updateSecret(
+        namespaceName,
+        secretName,
+        request,
+      );
+      await fetchSecrets();
+      return secret;
+    },
+    [client, namespaceName, fetchSecrets],
+  );
+
   const deleteSecret = useCallback(
     async (secretName: string): Promise<void> => {
       await client.deleteSecret(namespaceName, secretName);
@@ -74,6 +95,7 @@ export function useSecrets(namespaceName: string): UseSecretsResult {
     isForbidden: isForbiddenError(error),
     fetchSecrets,
     createSecret,
+    updateSecret,
     deleteSecret,
   };
 }


### PR DESCRIPTION
## Summary

- **Edit dialog** for secrets managed by the new `/secrets` API. Lazy-fetches plaintext values via `getSecret`, prefills inputs, and gates Save until the user actually changes something. Backend now forwards K8s base64 wire format unchanged; the dialog decodes at the UI boundary.
- **PUT /secrets/:secretName** wired through `OpenChoreoClient` → backend router → `SecretsService.updateSecret` → openchoreo-api.
- **List view** combines the new `listSecrets` API (for keys/types) with `listSecretReferences` (for `targetPlane`) since the new endpoint omits target-plane info.
- **Feature flag** `openchoreo.features.secretManagement.enabled` (env: `OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED`). **Defaults to disabled** in production; when off, `SecretsContent` short-circuits with an info alert.

OpenAPI spec was extended locally with the new `listSecrets`, `getSecret`, `Secret`, and `ListSecretsResponse` schemas, then regenerated.

## Test plan

- [ ] With `OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED=false` (default), Settings → Secrets shows the disabled notice.
- [ ] With the flag enabled, the table lists secrets across all four plane kinds with the correct target-plane chip.
- [ ] Click Edit on a secret: dialog loads with current plaintext values populated.
- [ ] Save is disabled at open and enables only after a value/key change; disabled when all rows are removed.
- [ ] Submitting writes back via PUT and the table refreshes.
- [ ] Create and Delete flows still work unchanged.


https://github.com/user-attachments/assets/446d3b68-710a-42f7-9add-94630bbb2a1f


<img width="1726" height="988" alt="Screenshot 2026-05-13 at 22 28 32" src="https://github.com/user-attachments/assets/2cac648c-a160-4c49-9fa5-81acb456f01d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secret editing interface enabling users to view and modify secret key-value pairs
  * Introduced new Secrets API endpoints supporting retrieve, list, and update operations
  * Added feature toggle to control secrets management visibility and functionality

* **Documentation**
  * Updated configuration documentation and examples with secrets management settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/536)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->