### PR TITLE
fix: issue in tagging release by sha

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -126,9 +126,13 @@ jobs:
 
       - name: Validate VERSION file
         env:
+          ACTION: ${{ github.event.inputs.action }}
+          IN_COMMIT_SHA: ${{ github.event.inputs.commit_sha || '' }}
           BRANCH_EXISTS: ${{ steps.check-branch.outputs.branch-exists }}
         run: |
-          if [ "$BRANCH_EXISTS" = "true" ]; then
+          if [ "$ACTION" = "tag" ] && [ -n "$IN_COMMIT_SHA" ]; then
+            CONTENT=$(git show "${IN_COMMIT_SHA}:VERSION" | tr -d ' \n\r\t')
+          elif [ "$BRANCH_EXISTS" = "true" ]; then
             CONTENT=$(git show "origin/release-v${{ env.MAJOR }}.${{ env.MINOR }}:VERSION" | tr -d ' \n\r\t')
           else
             CONTENT=$(tr -d ' \n\r\t' < VERSION)


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release validation now supports reading the version from a specified (pinned) commit when performing tag releases.
  * If not using a pinned commit, validation falls back to checking the release branch, and otherwise reads the version from main instead of the local workspace, improving release robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/539)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->