### PR TITLE
chore: sync openchoreo-api spec from openchoreo main

### DIFF
--- a/packages/openchoreo-client-node/openapi-config.json
+++ b/packages/openchoreo-client-node/openapi-config.json
@@ -19,7 +19,7 @@
   ],
   "versionField": "openChoreoVersion",
   "versionFile": "src/version.ts",
-  "lastSyncCommit": "1880fc9e",
-  "lastSyncDate": "2026-03-02T00:00:00+05:30",
-  "lastSyncDescription": "feat: add workflow run event and log apis (#2325) - Query param renamed from 'step' to 'task' for filtering logs and events in /workflowruns/{runName}/logs and /workflowruns/{runName}/events"
+  "lastSyncCommit": "f5ad5206",
+  "lastSyncDate": "2026-05-14T13:51:50+05:30",
+  "lastSyncDescription": "fix(deps): bump agent dependencies to clear dependabot alerts (#3480)"
 }

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -79,6 +79,18 @@ tags:
     description: Observability alerts notification channel management
   - name: GitSecrets
     description: Git secret management for source code authentication
+  - name: Secrets
+    description: Secret management across workflow and data planes
+  - name: ClusterResourceTypes
+    description: Cluster-scoped ResourceType templates defined by platform engineers
+  - name: ResourceTypes
+    description: ResourceType templates defined by platform engineers
+  - name: Resources
+    description: Resource management within projects (managed-infrastructure dependencies)
+  - name: ResourceReleases
+    description: Resource release management
+  - name: ResourceReleaseBindings
+    description: Resource release binding management
 
 paths:
   # =============================================================================
@@ -226,6 +238,8 @@ paths:
                 $ref: '#/components/schemas/Namespace'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -281,6 +295,8 @@ paths:
                 $ref: '#/components/schemas/Namespace'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -364,6 +380,8 @@ paths:
                 $ref: '#/components/schemas/Project'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -421,6 +439,8 @@ paths:
                 $ref: '#/components/schemas/Project'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -508,6 +528,8 @@ paths:
                 $ref: '#/components/schemas/Component'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -570,6 +592,8 @@ paths:
                 $ref: '#/components/schemas/Environment'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -627,6 +651,8 @@ paths:
                 $ref: '#/components/schemas/Environment'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -711,6 +737,8 @@ paths:
                 $ref: '#/components/schemas/DataPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -768,6 +796,8 @@ paths:
                 $ref: '#/components/schemas/DataPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -852,6 +882,8 @@ paths:
                 $ref: '#/components/schemas/WorkflowPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -909,6 +941,8 @@ paths:
                 $ref: '#/components/schemas/WorkflowPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -993,6 +1027,8 @@ paths:
                 $ref: '#/components/schemas/ObservabilityPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1050,6 +1086,8 @@ paths:
                 $ref: '#/components/schemas/ObservabilityPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1131,6 +1169,8 @@ paths:
                 $ref: '#/components/schemas/ClusterDataPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1186,6 +1226,8 @@ paths:
                 $ref: '#/components/schemas/ClusterDataPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1266,6 +1308,8 @@ paths:
                 $ref: '#/components/schemas/ClusterWorkflowPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1331,6 +1375,8 @@ paths:
                 $ref: '#/components/schemas/ClusterWorkflowPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1416,6 +1462,8 @@ paths:
                 $ref: '#/components/schemas/ClusterObservabilityPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1471,6 +1519,8 @@ paths:
                 $ref: '#/components/schemas/ClusterObservabilityPlane'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1551,6 +1601,8 @@ paths:
                 $ref: '#/components/schemas/ClusterComponentType'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1606,6 +1658,8 @@ paths:
                 $ref: '#/components/schemas/ClusterComponentType'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1710,6 +1764,8 @@ paths:
                 $ref: '#/components/schemas/ClusterTrait'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1765,6 +1821,8 @@ paths:
                 $ref: '#/components/schemas/ClusterTrait'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1872,6 +1930,8 @@ paths:
                 $ref: '#/components/schemas/ComponentType'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1929,6 +1989,8 @@ paths:
                 $ref: '#/components/schemas/ComponentType'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2038,6 +2100,8 @@ paths:
                 $ref: '#/components/schemas/Trait'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2095,6 +2159,8 @@ paths:
                 $ref: '#/components/schemas/Trait'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2201,6 +2267,8 @@ paths:
                 $ref: '#/components/schemas/ClusterWorkflow'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2256,6 +2324,8 @@ paths:
                 $ref: '#/components/schemas/ClusterWorkflow'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2363,6 +2433,8 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2420,6 +2492,8 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2530,6 +2604,8 @@ paths:
                 $ref: '#/components/schemas/WorkflowRun'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2587,6 +2663,28 @@ paths:
                 $ref: '#/components/schemas/WorkflowRun'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    delete:
+      operationId: deleteWorkflowRun
+      summary: Delete workflow run
+      description: Deletes a workflow run by name.
+      tags: [Workflows]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/WorkflowRunNameParam'
+      responses:
+        '204':
+          description: Workflow run deleted successfully
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2741,6 +2839,8 @@ paths:
                 $ref: '#/components/schemas/Component'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2821,6 +2921,8 @@ paths:
                 $ref: '#/components/schemas/ComponentRelease'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2880,6 +2982,8 @@ paths:
                   $ref: '#/components/schemas/Decision'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
@@ -2972,6 +3076,8 @@ paths:
                 $ref: '#/components/schemas/ClusterAuthzRole'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3039,6 +3145,8 @@ paths:
                 $ref: '#/components/schemas/ClusterAuthzRole'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3121,6 +3229,8 @@ paths:
                 $ref: '#/components/schemas/ClusterAuthzRoleBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3188,6 +3298,8 @@ paths:
                 $ref: '#/components/schemas/ClusterAuthzRoleBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3273,6 +3385,8 @@ paths:
                 $ref: '#/components/schemas/AuthzRole'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3344,6 +3458,8 @@ paths:
                 $ref: '#/components/schemas/AuthzRole'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3432,6 +3548,8 @@ paths:
                 $ref: '#/components/schemas/AuthzRoleBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3503,6 +3621,8 @@ paths:
                 $ref: '#/components/schemas/AuthzRoleBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3618,6 +3738,8 @@ paths:
                 $ref: '#/components/schemas/WebhookEventResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
@@ -3676,6 +3798,8 @@ paths:
                 $ref: '#/components/schemas/SecretReference'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3733,6 +3857,8 @@ paths:
                 $ref: '#/components/schemas/SecretReference'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3818,6 +3944,8 @@ paths:
                 $ref: '#/components/schemas/Workload'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3875,6 +4003,8 @@ paths:
                 $ref: '#/components/schemas/Workload'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3937,6 +4067,38 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
+    post:
+      operationId: createComponentRelease
+      summary: Create component release
+      description: Creates a new component release within a namespace.
+      tags: [ComponentReleases]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComponentRelease'
+      responses:
+        '201':
+          description: Component release created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComponentRelease'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
 
   /api/v1/namespaces/{namespaceName}/componentreleases/{componentReleaseName}:
     get:
@@ -3954,6 +4116,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ComponentRelease'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    delete:
+      operationId: deleteComponentRelease
+      summary: Delete component release
+      description: Deletes a component release by name.
+      tags: [ComponentReleases]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ComponentReleaseNameParam'
+      responses:
+        '204':
+          description: Component release deleted successfully
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4019,6 +4200,8 @@ paths:
                 $ref: '#/components/schemas/ReleaseBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4076,6 +4259,8 @@ paths:
                 $ref: '#/components/schemas/ReleaseBinding'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4225,6 +4410,719 @@ paths:
           $ref: '#/components/responses/InternalError'
 
   # =============================================================================
+  # ClusterResourceType Endpoints (Cluster-Scoped)
+  # =============================================================================
+
+  /api/v1/clusterresourcetypes:
+    get:
+      operationId: listClusterResourceTypes
+      summary: List cluster resource types
+      description: Returns a list of cluster-scoped resource types.
+      tags: [ClusterResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/LabelSelectorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
+      responses:
+        '200':
+          description: List of cluster resource types
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterResourceTypeList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    post:
+      operationId: createClusterResourceType
+      summary: Create cluster resource type
+      description: Creates a new cluster-scoped resource type.
+      tags: [ClusterResourceTypes]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClusterResourceType'
+      responses:
+        '201':
+          description: Cluster resource type created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterResourceType'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/clusterresourcetypes/{crtName}:
+    get:
+      operationId: getClusterResourceType
+      summary: Get a cluster resource type
+      description: Returns details of a specific cluster-scoped resource type.
+      tags: [ClusterResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/ClusterResourceTypeNameParam'
+      responses:
+        '200':
+          description: Cluster resource type details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterResourceType'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    put:
+      operationId: updateClusterResourceType
+      summary: Update cluster resource type
+      description: Replaces an existing cluster-scoped resource type (full update).
+      tags: [ClusterResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/ClusterResourceTypeNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClusterResourceType'
+      responses:
+        '200':
+          description: Cluster resource type updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterResourceType'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    delete:
+      operationId: deleteClusterResourceType
+      summary: Delete cluster resource type
+      description: Deletes a cluster-scoped resource type by name.
+      tags: [ClusterResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/ClusterResourceTypeNameParam'
+      responses:
+        '204':
+          description: ClusterResourceType deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/clusterresourcetypes/{crtName}/schema:
+    get:
+      operationId: getClusterResourceTypeSchema
+      summary: Get cluster resource type schema
+      description: Returns the parameter schema for a specific cluster-scoped resource type.
+      tags: [ClusterResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/ClusterResourceTypeNameParam'
+      responses:
+        '200':
+          description: Cluster resource type schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # =============================================================================
+  # ResourceType Endpoints
+  # =============================================================================
+
+  /api/v1/namespaces/{namespaceName}/resourcetypes:
+    get:
+      operationId: listResourceTypes
+      summary: List resource types
+      description: Returns a paginated list of resource types available in the namespace.
+      tags: [ResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/LabelSelectorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
+      responses:
+        '200':
+          description: List of resource types
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceTypeList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    post:
+      operationId: createResourceType
+      summary: Create resource type
+      description: Creates a new resource type within a namespace.
+      tags: [ResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceType'
+      responses:
+        '201':
+          description: Resource type created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceType'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/namespaces/{namespaceName}/resourcetypes/{rtName}:
+    get:
+      operationId: getResourceType
+      summary: Get resource type
+      description: Returns details of a specific resource type.
+      tags: [ResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceTypeNameParam'
+      responses:
+        '200':
+          description: Resource type details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceType'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    put:
+      operationId: updateResourceType
+      summary: Update resource type
+      description: Replaces an existing resource type (full update).
+      tags: [ResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceTypeNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceType'
+      responses:
+        '200':
+          description: Resource type updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceType'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    delete:
+      operationId: deleteResourceType
+      summary: Delete resource type
+      description: Deletes a resource type by name.
+      tags: [ResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceTypeNameParam'
+      responses:
+        '204':
+          description: Resource type deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/namespaces/{namespaceName}/resourcetypes/{rtName}/schema:
+    get:
+      operationId: getResourceTypeSchema
+      summary: Get resource type schema
+      description: Returns the parameter schema for a specific resource type.
+      tags: [ResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceTypeNameParam'
+      responses:
+        '200':
+          description: Resource type schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # =============================================================================
+  # Resource Endpoints
+  # =============================================================================
+
+  /api/v1/namespaces/{namespaceName}/resources:
+    get:
+      operationId: listResources
+      summary: List resources
+      description: Returns a paginated list of resources within a namespace, optionally filtered by project.
+      tags: [Resources]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ProjectQueryParam'
+        - $ref: '#/components/parameters/LabelSelectorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
+      responses:
+        '200':
+          description: List of resources
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceInstanceList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    post:
+      operationId: createResource
+      summary: Create resource
+      description: Creates a new resource within a namespace.
+      tags: [Resources]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceInstance'
+      responses:
+        '201':
+          description: Resource created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceInstance'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/namespaces/{namespaceName}/resources/{resourceName}:
+    get:
+      operationId: getResource
+      summary: Get resource
+      description: Returns details of a specific resource.
+      tags: [Resources]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceNameParam'
+      responses:
+        '200':
+          description: Resource details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceInstance'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    put:
+      operationId: updateResource
+      summary: Update resource
+      description: Replaces an existing resource (full update). Mutating spec.parameters cuts a new ResourceRelease via the Resource controller.
+      tags: [Resources]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceInstance'
+      responses:
+        '200':
+          description: Resource updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceInstance'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    delete:
+      operationId: deleteResource
+      summary: Delete resource
+      description: Deletes a resource by name. The Resource finalizer blocks deletion until all owned ResourceReleaseBindings and ResourceReleases are cleaned up.
+      tags: [Resources]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceNameParam'
+      responses:
+        '204':
+          description: Resource deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # =============================================================================
+  # ResourceRelease Endpoints
+  # =============================================================================
+
+  /api/v1/namespaces/{namespaceName}/resourcereleases:
+    get:
+      operationId: listResourceReleases
+      summary: List resource releases
+      description: Returns a paginated list of resource releases within a namespace, optionally filtered by resource.
+      tags: [ResourceReleases]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceQueryParam'
+        - $ref: '#/components/parameters/LabelSelectorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
+      responses:
+        '200':
+          description: List of resource releases
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceReleaseList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    post:
+      operationId: createResourceRelease
+      summary: Create resource release
+      description: Creates a new resource release within a namespace. Normally cut by the Resource controller; exposed here for offline emit (e.g. `occ resource generate` in v1.2).
+      tags: [ResourceReleases]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceRelease'
+      responses:
+        '201':
+          description: Resource release created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceRelease'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/namespaces/{namespaceName}/resourcereleases/{resourceReleaseName}:
+    get:
+      operationId: getResourceRelease
+      summary: Get resource release
+      description: Returns details of a specific resource release.
+      tags: [ResourceReleases]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceReleaseNameParam'
+      responses:
+        '200':
+          description: Resource release details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceRelease'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    delete:
+      operationId: deleteResourceRelease
+      summary: Delete resource release
+      description: Deletes a resource release by name.
+      tags: [ResourceReleases]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceReleaseNameParam'
+      responses:
+        '204':
+          description: Resource release deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # =============================================================================
+  # ResourceReleaseBinding Endpoints
+  # =============================================================================
+
+  /api/v1/namespaces/{namespaceName}/resourcereleasebindings:
+    get:
+      operationId: listResourceReleaseBindings
+      summary: List resource release bindings
+      description: Returns a paginated list of resource release bindings within a namespace, optionally filtered by resource.
+      tags: [ResourceReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceQueryParam'
+        - $ref: '#/components/parameters/LabelSelectorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CursorParam'
+      responses:
+        '200':
+          description: List of resource release bindings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceReleaseBindingList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    post:
+      operationId: createResourceReleaseBinding
+      summary: Create resource release binding
+      description: Creates a new resource release binding within a namespace.
+      tags: [ResourceReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceReleaseBinding'
+      responses:
+        '201':
+          description: Resource release binding created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceReleaseBinding'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/namespaces/{namespaceName}/resourcereleasebindings/{resourceReleaseBindingName}:
+    get:
+      operationId: getResourceReleaseBinding
+      summary: Get resource release binding
+      description: Returns details of a specific resource release binding.
+      tags: [ResourceReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceReleaseBindingNameParam'
+      responses:
+        '200':
+          description: Resource release binding details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceReleaseBinding'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    put:
+      operationId: updateResourceReleaseBinding
+      summary: Update resource release binding
+      description: Replaces an existing resource release binding (full update). Used to advance `spec.resourceRelease` (the promote flow) or change `spec.retainPolicy` / `spec.resourceTypeEnvironmentConfigs`. `spec.owner` and `spec.environment` are immutable.
+      tags: [ResourceReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceReleaseBindingNameParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceReleaseBinding'
+      responses:
+        '200':
+          description: Resource release binding updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceReleaseBinding'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    delete:
+      operationId: deleteResourceReleaseBinding
+      summary: Delete resource release binding
+      description: Deletes a resource release binding by name. The binding finalizer either cascades the underlying RenderedRelease (retainPolicy=Delete) or holds (retainPolicy=Retain).
+      tags: [ResourceReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ResourceReleaseBindingNameParam'
+      responses:
+        '204':
+          description: Resource release binding deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  # =============================================================================
   # Deployment Pipeline Endpoints
   # =============================================================================
 
@@ -4277,6 +5175,8 @@ paths:
                 $ref: '#/components/schemas/DeploymentPipeline'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4334,6 +5234,8 @@ paths:
                 $ref: '#/components/schemas/DeploymentPipeline'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4416,6 +5318,8 @@ paths:
                 $ref: '#/components/schemas/ObservabilityAlertsNotificationChannel'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4473,6 +5377,8 @@ paths:
                 $ref: '#/components/schemas/ObservabilityAlertsNotificationChannel'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4549,6 +5455,8 @@ paths:
                 $ref: '#/components/schemas/GitSecretResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4579,6 +5487,9 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  # =============================================================================
+  # Secrets (v1alpha1)
+  # =============================================================================
   /api/v1alpha1/namespaces/{namespaceName}/secrets:
     get:
       operationId: listSecrets
@@ -4608,6 +5519,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 
     post:
       operationId: createSecret
@@ -4632,9 +5545,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SecretResponse'
+                $ref: '#/components/schemas/Secret'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4643,6 +5558,8 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 
   /api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}:
     get:
@@ -4671,13 +5588,18 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 
     put:
       operationId: updateSecret
       summary: Update a secret
       description: |
-        Replaces the data of an existing secret. The secret type and target
-        plane cannot be changed; only the data keys and values.
+        Replaces a secret's data with the supplied final state. Keys present
+        in the existing secret but absent from the request body are pruned
+        from the Kubernetes Secret, the PushSecret, and the SecretReference.
+        Returns 404 if the SecretReference does not exist or is not managed
+        by the Secret API. Secret type and target plane are immutable.
       tags: [Secrets]
       parameters:
         - $ref: '#/components/parameters/NamespaceNameParam'
@@ -4694,9 +5616,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SecretResponse'
+                $ref: '#/components/schemas/Secret'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4705,6 +5629,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 
     delete:
       operationId: deleteSecret
@@ -4719,6 +5645,8 @@ paths:
           description: Secret deleted successfully
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -4727,6 +5655,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 
 components:
   # ===========================================================================
@@ -4983,6 +5913,60 @@ components:
         type: string
         example: api-service-v1.0.0
 
+    ClusterResourceTypeNameParam:
+      name: crtName
+      in: path
+      required: true
+      description: ClusterResourceType name
+      schema:
+        type: string
+        example: mysql
+
+    ResourceTypeNameParam:
+      name: rtName
+      in: path
+      required: true
+      description: ResourceType name
+      schema:
+        type: string
+        example: mysql
+
+    ResourceNameParam:
+      name: resourceName
+      in: path
+      required: true
+      description: Resource name
+      schema:
+        type: string
+        example: analytics-shared-db
+
+    ResourceReleaseNameParam:
+      name: resourceReleaseName
+      in: path
+      required: true
+      description: Resource release name
+      schema:
+        type: string
+        example: analytics-shared-db-abc123
+
+    ResourceQueryParam:
+      name: resource
+      in: query
+      required: false
+      description: Filter resources by resource name (matches spec.owner.resourceName)
+      schema:
+        type: string
+        example: analytics-shared-db
+
+    ResourceReleaseBindingNameParam:
+      name: resourceReleaseBindingName
+      in: path
+      required: true
+      description: Resource release binding name
+      schema:
+        type: string
+        example: analytics-shared-db-dev
+
     RoleNameParam:
       name: roleName
       in: path
@@ -5032,7 +6016,7 @@ components:
         Multiple requirements are comma-separated and ANDed together.
       schema:
         type: string
-        example: 'app=frontend,environment notin (staging,qa),tier!=backend,!deprecated'
+        example: "app=frontend,environment notin (staging,qa),tier!=backend,!deprecated"
 
     LimitParam:
       name: limit
@@ -5066,7 +6050,7 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: 'Invalid request: name is required'
+            error: "Invalid request: name is required"
             code: BAD_REQUEST
             details:
               - field: name
@@ -5079,17 +6063,17 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: 'Authentication required'
+            error: "Authentication required"
             code: UNAUTHORIZED
 
     Forbidden:
-      description: Insufficient permissions to access the resource
+      description: Insufficient permissions to perform the operation
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: 'You do not have permission to access this resource'
+            error: "You do not have permission to perform this operation"
             code: FORBIDDEN
 
     NotFound:
@@ -5112,6 +6096,19 @@ components:
             error: "Project 'my-project' already exists"
             code: CONFLICT
 
+    UnprocessableContent:
+      description: Request body is well-formed but failed validation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "spec.outputs[0].value: undeclared reference to 'applied'"
+            code: UNPROCESSABLE_CONTENT
+            details:
+              - field: spec.outputs[0].value
+                message: undeclared reference to 'applied'
+
     InternalError:
       description: Internal server error
       content:
@@ -5119,8 +6116,18 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: 'Internal server error'
+            error: "Internal server error"
             code: INTERNAL_ERROR
+
+    NotImplemented:
+      description: Feature is disabled on this server
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "Secret API is disabled on this server"
+            code: NOT_IMPLEMENTED
 
   # ===========================================================================
   # Schemas
@@ -5149,7 +6156,9 @@ components:
             - FORBIDDEN
             - NOT_FOUND
             - CONFLICT
+            - UNPROCESSABLE_CONTENT
             - INTERNAL_ERROR
+            - NOT_IMPLEMENTED
             - UNKNOWN_GIT_PROVIDER
           example: NOT_FOUND
         details:
@@ -5204,12 +6213,17 @@ components:
           type: string
           format: date-time
           description: Creation timestamp
-          example: '2025-01-06T10:00:00Z'
+          example: "2025-01-06T10:00:00Z"
         deletionTimestamp:
           type: string
           format: date-time
-          description: Deletion timestamp (set when resource is being deleted)
-          example: '2025-01-06T10:00:00Z'
+          description: Timestamp when the resource was requested to be deleted
+          example: "2025-01-06T12:00:00Z"
+        deletionGracePeriodSeconds:
+          type: integer
+          format: int64
+          description: Number of seconds before the object is removed after deletion is requested
+          example: 0
 
     Condition:
       type: object
@@ -5227,8 +6241,8 @@ components:
         status:
           type: string
           description: Status of the condition
-          enum: ['True', 'False', 'Unknown']
-          example: 'True'
+          enum: ["True", "False", "Unknown"]
+          example: "True"
         observedGeneration:
           type: integer
           format: int64
@@ -5237,7 +6251,7 @@ components:
           type: string
           format: date-time
           description: Last time the condition transitioned
-          example: '2025-01-06T10:00:05Z'
+          example: "2025-01-06T10:00:05Z"
         reason:
           type: string
           description: Machine-readable reason for the condition
@@ -5245,7 +6259,7 @@ components:
         message:
           type: string
           description: Human-readable message
-          example: 'Project is ready'
+          example: "Project is ready"
 
     # -------------------------------------------------------------------------
     # Version
@@ -5277,7 +6291,7 @@ components:
         buildTime:
           type: string
           description: Build timestamp
-          example: '2025-01-06T10:00:00Z'
+          example: "2025-01-06T10:00:00Z"
         goOS:
           type: string
           description: Target operating system
@@ -5372,7 +6386,7 @@ components:
           minItems: 1
           items:
             type: string
-          example: ['openid', 'profile', 'email']
+          example: ["openid", "profile", "email"]
 
     # -------------------------------------------------------------------------
     # User Type Configuration
@@ -5449,7 +6463,7 @@ components:
             Opaque cursor for fetching the next page. Pass this value as the
             `cursor` query parameter in the next request. Absent when there
             are no more items.
-          example: 'eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MzQ0N30='
+          example: "eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MzQ0N30="
         remainingCount:
           type: integer
           format: int64
@@ -5571,6 +6585,23 @@ components:
           allOf:
             - $ref: '#/components/schemas/ProjectStatus'
 
+    PatchProjectRequest:
+      type: object
+      description: Request to patch a project
+      properties:
+        displayName:
+          type: string
+          description: Human-readable display name
+        description:
+          type: string
+          description: Human-readable description
+        deploymentPipeline:
+          type: string
+          description: Name of the deployment pipeline resource
+          minLength: 1
+          maxLength: 63
+          example: default
+
     ProjectList:
       type: object
       description: Paginated list of projects
@@ -5584,6 +6615,7 @@ components:
             $ref: '#/components/schemas/Project'
         pagination:
           $ref: '#/components/schemas/Pagination'
+
 
     # -------------------------------------------------------------------------
     # Components
@@ -5632,7 +6664,7 @@ components:
               default: ComponentType
             name:
               type: string
-              description: 'Component type reference in format: {workloadType}/{componentTypeName}'
+              description: "Component type reference in format: {workloadType}/{componentTypeName}"
               example: deployment/go-service
               pattern: '^(deployment|statefulset|cronjob|job|proxy)/[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         autoDeploy:
@@ -5709,50 +6741,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/ComponentStatus'
 
-    ComponentWorkflowConfig:
-      type: object
-      description: Component workflow configuration
-      properties:
-        kind:
-          type: string
-          description: Kind of workflow (Workflow or ClusterWorkflow)
-          enum: [Workflow, ClusterWorkflow]
-          default: Workflow
-        name:
-          type: string
-          description: Workflow name
-          example: docker-build
-        systemParameters:
-          type: object
-          description: System-managed parameters (repository info)
-          properties:
-            repository:
-              type: object
-              properties:
-                url:
-                  type: string
-                  description: Git repository URL
-                  example: https://github.com/org/repo.git
-                revision:
-                  type: object
-                  properties:
-                    branch:
-                      type: string
-                      description: Git branch
-                      example: main
-                    commit:
-                      type: string
-                      description: Git commit SHA
-                      example: abc1234
-                appPath:
-                  type: string
-                  description: Path to application within repository
-                  example: ./services/api
-        parameters:
-          type: object
-          description: User-defined workflow parameters
-          additionalProperties: true
-
     CreateComponentRequest:
       type: object
       description: Request to create a new component
@@ -5778,13 +6766,13 @@ components:
           maxLength: 1024
         type:
           type: string
-          description: 'DEPRECATED: Use componentType instead. Legacy component type field.'
+          description: "DEPRECATED: Use componentType instead. Legacy component type field."
           example: service/go-service
           deprecated: true
         componentType:
           type: string
-          description: 'Component type reference (format: {workloadType}/{componentTypeName})'
-          example: deployment/go-service
+          description: "Component type reference (format: {workloadType}/{componentTypeName})"
+          example: service/go-service
         autoDeploy:
           type: boolean
           description: Whether to automatically deploy to default environment
@@ -5833,51 +6821,16 @@ components:
       description: Workflow configuration for component creation
       required:
         - name
-        - systemParameters
       properties:
         kind:
           type: string
-          description: Kind of workflow (Workflow or ClusterWorkflow)
+          description: Kind of referenced workflow resource (Workflow or ClusterWorkflow)
           enum: [Workflow, ClusterWorkflow]
-          default: Workflow
+          default: ClusterWorkflow
         name:
           type: string
-          description: ComponentWorkflow resource name
+          description: Workflow resource name
           example: docker-build
-        systemParameters:
-          type: object
-          description: System parameters including repository configuration
-          required:
-            - repository
-          properties:
-            repository:
-              type: object
-              required:
-                - url
-                - revision
-                - appPath
-              properties:
-                url:
-                  type: string
-                  description: Git repository URL
-                  example: https://github.com/org/repo.git
-                revision:
-                  type: object
-                  required:
-                    - branch
-                  properties:
-                    branch:
-                      type: string
-                      description: Git branch to build from
-                      example: main
-                    commit:
-                      type: string
-                      description: Specific commit SHA (optional)
-                      example: abc1234
-                appPath:
-                  type: string
-                  description: Path to application within repository
-                  example: ./services/api
         parameters:
           type: object
           description: User-defined workflow parameters
@@ -6332,6 +7285,10 @@ components:
           type: string
           description: Base URL of the RCA Agent API in the observability plane cluster
           example: http://rca-agent.observability-plane.svc:8080
+        finOpsAgentURL:
+          type: string
+          description: Base URL of the FinOps Agent API in the observability plane cluster
+          example: http://finops-agent.observability-plane.svc:8080
 
     ObservabilityPlaneStatus:
       type: object
@@ -6592,6 +7549,10 @@ components:
           type: string
           description: Base URL of the RCA Agent API in the observability plane cluster
           example: http://rca-agent.observability-plane.svc:8080
+        finOpsAgentURL:
+          type: string
+          description: Base URL of the FinOps Agent API in the observability plane cluster
+          example: http://finops-agent.observability-plane.svc:8080
 
     ClusterObservabilityPlaneStatus:
       type: object
@@ -6767,11 +7728,11 @@ components:
                 default: dataplane
               includeWhen:
                 type: string
-                description: 'CEL expression determining if this resource should be created'
+                description: "CEL expression determining if this resource should be created"
                 pattern: '^\$\{[\s\S]+\}\s*$'
               forEach:
                 type: string
-                description: 'CEL expression for generating multiple resources from a list'
+                description: "CEL expression for generating multiple resources from a list"
                 pattern: '^\$\{[\s\S]+\}\s*$'
               var:
                 type: string
@@ -6857,10 +7818,10 @@ components:
                 default: dataplane
               includeWhen:
                 type: string
-                description: 'CEL expression determining if this resource should be created'
+                description: "CEL expression determining if this resource should be created"
               forEach:
                 type: string
-                description: 'CEL expression for generating multiple resources from a list'
+                description: "CEL expression for generating multiple resources from a list"
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -6879,7 +7840,7 @@ components:
             properties:
               forEach:
                 type: string
-                description: 'CEL expression for repeating this patch'
+                description: "CEL expression for repeating this patch"
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -6902,7 +7863,7 @@ components:
                     description: Resource type to patch
                   where:
                     type: string
-                    description: 'CEL expression to filter which resources to patch'
+                    description: "CEL expression to filter which resources to patch"
               targetPlane:
                 type: string
                 description: Target plane for this patch
@@ -6963,7 +7924,7 @@ components:
           example: deployment
         allowedWorkflows:
           type: array
-          description: List of allowed Workflow references for this component type
+          description: List of allowed Workflow or ClusterWorkflow references for this component type
           items:
             type: object
             required:
@@ -6971,17 +7932,17 @@ components:
             properties:
               kind:
                 type: string
-                description: Kind of the workflow reference. Currently only "Workflow" is supported.
-                enum: [Workflow]
-                default: Workflow
+                description: Kind of the workflow reference (Workflow or ClusterWorkflow)
+                enum: [Workflow, ClusterWorkflow]
+                default: ClusterWorkflow
               name:
                 type: string
                 description: Name of the workflow resource
                 minLength: 1
           example:
-            - kind: Workflow
+            - kind: ClusterWorkflow
               name: docker-build
-            - kind: Workflow
+            - kind: ClusterWorkflow
               name: buildpack-build
         parameters:
           $ref: '#/components/schemas/SchemaSection'
@@ -7061,10 +8022,10 @@ components:
                 default: dataplane
               includeWhen:
                 type: string
-                description: 'CEL expression determining if this resource should be created'
+                description: "CEL expression determining if this resource should be created"
               forEach:
                 type: string
-                description: 'CEL expression for generating multiple resources from a list'
+                description: "CEL expression for generating multiple resources from a list"
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -7149,10 +8110,10 @@ components:
                 default: dataplane
               includeWhen:
                 type: string
-                description: 'CEL expression determining if this resource should be created'
+                description: "CEL expression determining if this resource should be created"
               forEach:
                 type: string
-                description: 'CEL expression for generating multiple resources from a list'
+                description: "CEL expression for generating multiple resources from a list"
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -7171,7 +8132,7 @@ components:
             properties:
               forEach:
                 type: string
-                description: 'CEL expression for repeating this patch'
+                description: "CEL expression for repeating this patch"
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -7194,7 +8155,7 @@ components:
                     description: Resource type to patch
                   where:
                     type: string
-                    description: 'CEL expression to filter which resources to patch'
+                    description: "CEL expression to filter which resources to patch"
               targetPlane:
                 type: string
                 description: Target plane for this patch
@@ -7233,7 +8194,7 @@ components:
       properties:
         rule:
           type: string
-          description: 'CEL expression wrapped in ${...} that must evaluate to true'
+          description: "CEL expression wrapped in ${...} that must evaluate to true"
           pattern: '^\$\{[\s\S]+\}\s*$'
         message:
           type: string
@@ -7332,7 +8293,9 @@ components:
         - runTemplate
       properties:
         workflowPlaneRef:
-          $ref: '#/components/schemas/WorkflowPlaneRef'
+          description: Reference to the WorkflowPlane or ClusterWorkflowPlane for this workflow's operations. Defaults to ClusterWorkflowPlane named "default" when omitted.
+          allOf:
+            - $ref: '#/components/schemas/WorkflowPlaneRef'
         parameters:
           $ref: '#/components/schemas/SchemaSection'
         runTemplate:
@@ -7484,7 +8447,7 @@ components:
         - runTemplate
       properties:
         workflowPlaneRef:
-          description: Reference to the ClusterWorkflowPlane for this workflow's build operations. Defaults to the ClusterWorkflowPlane named "default" when omitted.
+          description: Reference to the ClusterWorkflowPlane for this workflow's build operations. Defaults to ClusterWorkflowPlane named "default" when omitted.
           allOf:
             - $ref: '#/components/schemas/ClusterWorkflowPlaneRef'
         parameters:
@@ -7587,20 +8550,39 @@ components:
           type: string
           description: Time-to-live for this workflow run after completion (duration string like 10d1h30m).
 
-    WorkflowRunConfig:
+    ComponentWorkflowConfig:
       type: object
-      description: Workflow configuration referencing the Workflow and providing schema values.
+      description: Workflow configuration for a component. Kind and name are mutable.
       required:
         - name
       properties:
         kind:
           type: string
-          description: Kind of workflow (Workflow or ClusterWorkflow)
+          description: Kind of referenced workflow resource (Workflow or ClusterWorkflow)
           enum: [Workflow, ClusterWorkflow]
-          default: Workflow
+          default: ClusterWorkflow
         name:
           type: string
-          description: Referenced Workflow name
+          description: Referenced workflow resource name
+        parameters:
+          type: object
+          description: Developer-provided parameters for the referenced workflow
+          additionalProperties: true
+
+    WorkflowRunConfig:
+      type: object
+      description: Workflow configuration referencing the Workflow and providing schema values. Kind and name are immutable after creation.
+      required:
+        - name
+      properties:
+        kind:
+          type: string
+          description: Kind of referenced workflow resource (Workflow or ClusterWorkflow)
+          enum: [Workflow, ClusterWorkflow]
+          default: ClusterWorkflow
+        name:
+          type: string
+          description: Referenced workflow resource name
         parameters:
           type: object
           description: Developer-provided parameters for the referenced workflow
@@ -7712,12 +8694,12 @@ components:
           type: string
           format: date-time
           description: When the step started
-          example: '2025-01-06T10:00:00Z'
+          example: "2025-01-06T10:00:00Z"
         finishedAt:
           type: string
           format: date-time
           description: When the step finished
-          example: '2025-01-06T10:01:00Z'
+          example: "2025-01-06T10:01:00Z"
 
     WorkflowRunLogEntry:
       type: object
@@ -7729,11 +8711,11 @@ components:
           type: string
           format: date-time
           description: Log entry timestamp
-          example: '2025-01-06T10:00:00Z'
+          example: "2025-01-06T10:00:00Z"
         log:
           type: string
           description: Log message
-          example: 'Step 1: Cloning repository...'
+          example: "Step 1: Cloning repository..."
 
     WorkflowRunEventEntry:
       type: object
@@ -7748,7 +8730,7 @@ components:
           type: string
           format: date-time
           description: Event timestamp
-          example: '2025-01-06T10:00:00Z'
+          example: "2025-01-06T10:00:00Z"
         type:
           type: string
           description: Event type
@@ -7760,7 +8742,7 @@ components:
         message:
           type: string
           description: Human-readable description of the event
-          example: 'Container main started'
+          example: "Container main started"
 
     CreateWorkflowRunRequest:
       type: object
@@ -7778,16 +8760,29 @@ components:
           description: User-defined workflow parameters
           additionalProperties: true
           example:
-            database_url: 'postgresql://localhost:5432/mydb'
-            migration_version: 'v2.1.0'
+            database_url: "postgresql://localhost:5432/mydb"
+            migration_version: "v2.1.0"
 
     # -------------------------------------------------------------------------
     # Component Extended Schemas
     # -------------------------------------------------------------------------
     PatchComponentRequest:
       type: object
-      description: Request to patch a component
+      description: |
+        Request to patch a component. All fields are optional. Each field follows partial-update
+        semantics: a field that is omitted from the request leaves the corresponding component
+        attribute unchanged. A provided field is applied as described below.
       properties:
+        displayName:
+          type: string
+          description: |
+            Human-readable display name. When provided, replaces the existing display name.
+            Empty string is treated as "no change" (omit the field instead).
+        description:
+          type: string
+          description: |
+            Human-readable description. When provided, replaces the existing description.
+            Empty string is treated as "no change" (omit the field instead).
         autoDeploy:
           type: boolean
           description: Controls auto-deployment to default environment
@@ -7796,6 +8791,16 @@ components:
           type: object
           description: ComponentType parameters
           additionalProperties: true
+        traits:
+          type: array
+          description: |
+            Trait instances attached to the component. When provided, replaces the entire
+            traits list (whole-list replace at the slice level). Pass an empty array to
+            clear all traits.
+          items:
+            $ref: '#/components/schemas/ComponentTraitInput'
+        workflow:
+          $ref: '#/components/schemas/ComponentWorkflowInput'
 
     ComponentTrait:
       type: object
@@ -7895,9 +8900,11 @@ components:
           description: Frozen ComponentType spec at release time
           additionalProperties: true
         traits:
-          type: object
-          description: Frozen trait specs at release time (keyed by trait name)
-          additionalProperties: true
+          type: array
+          description: Frozen trait specs at release time
+          items:
+            type: object
+            additionalProperties: true
         componentProfile:
           type: object
           description: Snapshot of component parameters and trait configs
@@ -8029,6 +9036,80 @@ components:
           description: Resolved invoke URLs for each named workload endpoint
           items:
             $ref: '#/components/schemas/EndpointURLStatus'
+        resolvedConnections:
+          type: array
+          description: Connections that have been successfully resolved
+          items:
+            $ref: '#/components/schemas/ResolvedConnection'
+        pendingConnections:
+          type: array
+          description: Connections that could not be resolved
+          items:
+            $ref: '#/components/schemas/PendingConnection'
+
+    ResolvedConnection:
+      type: object
+      description: Holds the resolved URL for a single connection
+      required:
+        - namespace
+        - project
+        - component
+        - endpoint
+        - visibility
+        - url
+      properties:
+        namespace:
+          type: string
+          description: Control plane namespace of the target component
+          minLength: 1
+        project:
+          type: string
+          description: Name of the project that owns the target component
+          minLength: 1
+        component:
+          type: string
+          description: Name of the target component
+          minLength: 1
+        endpoint:
+          type: string
+          description: Name of the endpoint on the target component
+          minLength: 1
+        visibility:
+          type: string
+          description: Visibility level at which the endpoint was resolved
+          enum: [project, namespace, internal, external]
+        url:
+          $ref: '#/components/schemas/EndpointURL'
+
+    PendingConnection:
+      type: object
+      description: Represents a connection that could not be resolved
+      required:
+        - namespace
+        - project
+        - component
+        - endpoint
+        - reason
+      properties:
+        namespace:
+          type: string
+          description: Control plane namespace of the target component
+          minLength: 1
+        project:
+          type: string
+          description: Name of the project that owns the target component
+          minLength: 1
+        component:
+          type: string
+          description: Name of the target component
+          minLength: 1
+        endpoint:
+          type: string
+          description: Name of the endpoint on the target component
+          minLength: 1
+        reason:
+          type: string
+          description: Describes why the connection could not be resolved
 
     EndpointURLStatus:
       type: object
@@ -8163,6 +9244,558 @@ components:
           description: File content
         valueFrom:
           $ref: '#/components/schemas/EnvVarValueFrom'
+
+    # -------------------------------------------------------------------------
+    # Resource family — shared
+    # -------------------------------------------------------------------------
+    ResourceSecretKeyRef:
+      type: object
+      description: Reference to a specific key in a Kubernetes Secret on the data plane.
+      required:
+        - name
+        - key
+      properties:
+        name:
+          type: string
+          description: Secret name (supports ${...} CEL templating in ResourceType outputs)
+          minLength: 1
+          example: analytics-shared-db-conn
+        key:
+          type: string
+          description: Key within the Secret
+          minLength: 1
+          example: password
+
+    ResourceConfigMapKeyRef:
+      type: object
+      description: Reference to a specific key in a Kubernetes ConfigMap on the data plane.
+      required:
+        - name
+        - key
+      properties:
+        name:
+          type: string
+          description: ConfigMap name (supports ${...} CEL templating in ResourceType outputs)
+          minLength: 1
+          example: analytics-shared-db-tls
+        key:
+          type: string
+          description: Key within the ConfigMap
+          minLength: 1
+          example: ca.crt
+
+    ResourceTypeOutput:
+      type: object
+      description: |
+        Single output declaration of a (Cluster)ResourceType. Exactly one of
+        value, secretKeyRef, or configMapKeyRef must be set. Output value, name,
+        and key fields support ${...} CEL templating evaluated against
+        metadata.*, parameters.*, environmentConfigs.*, and applied.<id>.status.*.
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Unique output name. Referenced by Workload.spec.dependencies.resources[].envBindings and fileBindings keys.
+          minLength: 1
+          example: host
+        value:
+          type: string
+          description: Literal or ${...} CEL expression. Use only for non-sensitive data; the resolved value transits to the control plane.
+          example: "${applied.claim.status.host}"
+        secretKeyRef:
+          $ref: '#/components/schemas/ResourceSecretKeyRef'
+        configMapKeyRef:
+          $ref: '#/components/schemas/ResourceConfigMapKeyRef'
+
+    ResourceTypeManifest:
+      type: object
+      description: |
+        Kubernetes resource template emitted by the (Cluster)ResourceType
+        provisioner on the data plane. The template body, includeWhen, and
+        readyWhen support ${...} CEL templating against metadata.*, parameters.*,
+        environmentConfigs.*, and dataplane.* (plus applied.<id>.* for readyWhen).
+      required:
+        - id
+        - template
+      properties:
+        id:
+          type: string
+          description: Unique entry identifier within the (Cluster)ResourceType. Referenced by readyWhen and outputs CEL via applied.<id>.status.*.
+          minLength: 1
+          example: claim
+        includeWhen:
+          type: string
+          description: Optional ${...}-wrapped CEL expression. When false, the entry is skipped entirely.
+          example: "${parameters.tlsEnabled}"
+        template:
+          type: object
+          description: Kubernetes resource body with ${...} CEL substitutions.
+          additionalProperties: true
+        readyWhen:
+          type: string
+          description: Optional ${...}-wrapped CEL expression. When set, drives the entry's contribution to ResourceReleaseBinding.status.conditions[ResourcesReady]; otherwise per-Kind health inference is used.
+          example: "${applied.claim.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}"
+
+    ResourceTypeSpec:
+      type: object
+      description: Desired state of a (Cluster)ResourceType.
+      required:
+        - resources
+      properties:
+        parameters:
+          $ref: '#/components/schemas/SchemaSection'
+        environmentConfigs:
+          $ref: '#/components/schemas/SchemaSection'
+        retainPolicy:
+          type: string
+          description: Default retention for ResourceReleaseBindings of this type. Per-env override available on the binding.
+          enum: [Delete, Retain]
+          default: Delete
+          example: Delete
+        outputs:
+          type: array
+          description: Outputs that workloads consume via dependencies.resources[].envBindings or fileBindings.
+          items:
+            $ref: '#/components/schemas/ResourceTypeOutput'
+        resources:
+          type: array
+          description: Kubernetes manifests the (Cluster)ResourceType provisioner emits on the data plane.
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ResourceTypeManifest'
+
+    # -------------------------------------------------------------------------
+    # ClusterResourceTypes
+    # -------------------------------------------------------------------------
+    ClusterResourceTypeList:
+      type: object
+      description: Paginated list of cluster resource types
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterResourceType'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ClusterResourceType:
+      type: object
+      description: |
+        ClusterResourceType resource.
+        Cluster-scoped sibling of ResourceType. Resources in any namespace can reference it.
+      required:
+        - metadata
+      properties:
+        apiVersion:
+          type: string
+          readOnly: true
+          description: API version of the resource
+          example: openchoreo.dev/v1alpha1
+        kind:
+          type: string
+          readOnly: true
+          description: Kind of the resource
+          example: ClusterResourceType
+        metadata:
+          $ref: '#/components/schemas/ObjectMeta'
+        spec:
+          $ref: '#/components/schemas/ResourceTypeSpec'
+        status:
+          readOnly: true
+          type: object
+          description: ClusterResourceType status (currently empty)
+
+    # -------------------------------------------------------------------------
+    # ResourceTypes
+    # -------------------------------------------------------------------------
+    ResourceTypeList:
+      type: object
+      description: Paginated list of resource types
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceType'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ResourceType:
+      type: object
+      description: |
+        ResourceType resource.
+        PE-published template scoped to a namespace. Developers reference it from Resource.spec.type.
+      required:
+        - metadata
+      properties:
+        apiVersion:
+          type: string
+          readOnly: true
+          description: API version of the resource
+          example: openchoreo.dev/v1alpha1
+        kind:
+          type: string
+          readOnly: true
+          description: Kind of the resource
+          example: ResourceType
+        metadata:
+          $ref: '#/components/schemas/ObjectMeta'
+        spec:
+          $ref: '#/components/schemas/ResourceTypeSpec'
+        status:
+          readOnly: true
+          type: object
+          description: ResourceType status (currently empty)
+
+    # -------------------------------------------------------------------------
+    # Resources
+    # -------------------------------------------------------------------------
+    # The OpenAPI schema name is `ResourceInstance` to avoid colliding with the
+    # existing authz `Resource` schema (used by `EvaluateRequest.resource`).
+    # The on-the-wire `kind` value remains `Resource` to match the Kubernetes
+    # CRD kind.
+    ResourceInstanceList:
+      type: object
+      description: Paginated list of resources
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceInstance'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ResourceInstance:
+      type: object
+      description: |
+        Resource.
+        Developer-facing intent for a managed-infrastructure dependency (database,
+        queue, cache, object storage). References a ResourceType or ClusterResourceType template.
+      required:
+        - metadata
+      properties:
+        apiVersion:
+          type: string
+          readOnly: true
+          description: API version of the resource
+          example: openchoreo.dev/v1alpha1
+        kind:
+          type: string
+          readOnly: true
+          description: Kind of the resource (always "Resource" on the wire; see schema name)
+          example: Resource
+        metadata:
+          $ref: '#/components/schemas/ObjectMeta'
+        spec:
+          $ref: '#/components/schemas/ResourceInstanceSpec'
+        status:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/ResourceInstanceStatus'
+
+    ResourceInstanceSpec:
+      type: object
+      description: Desired state of a Resource. spec.owner and spec.type are immutable after creation.
+      required:
+        - owner
+        - type
+      properties:
+        owner:
+          type: object
+          description: Identifies the project that owns this Resource.
+          required:
+            - projectName
+          properties:
+            projectName:
+              type: string
+              description: Parent project name
+              minLength: 1
+              example: analytics
+        type:
+          $ref: '#/components/schemas/ResourceTypeRef'
+        parameters:
+          type: object
+          description: Values for the parameter schema declared on the referenced (Cluster)ResourceType. Validated by the controller.
+          additionalProperties: true
+
+    ResourceInstanceStatus:
+      type: object
+      description: Observed state of a Resource.
+      properties:
+        observedGeneration:
+          type: integer
+          format: int64
+          description: Most recent generation observed by the controller
+        conditions:
+          type: array
+          description: Latest available observations of the Resource's state. Includes Ready and Finalizing.
+          items:
+            $ref: '#/components/schemas/Condition'
+        latestRelease:
+          type: object
+          description: Most recent ResourceRelease for this Resource. Used as the promote source for ResourceReleaseBinding pin advance.
+          required:
+            - name
+            - hash
+          properties:
+            name:
+              type: string
+              description: Name of the ResourceRelease resource
+              example: analytics-shared-db-abc123
+            hash:
+              type: string
+              description: Content hash of Resource.spec + (Cluster)ResourceType.spec captured at release time
+              example: abc123
+
+    ResourceTypeRef:
+      type: object
+      description: Reference to a ResourceType or ClusterResourceType template.
+      required:
+        - name
+      properties:
+        kind:
+          type: string
+          description: Resource type kind. Defaults to ResourceType (namespaced).
+          enum: [ResourceType, ClusterResourceType]
+          default: ResourceType
+        name:
+          type: string
+          description: Template name.
+          minLength: 1
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          example: mysql
+
+    # -------------------------------------------------------------------------
+    # ResourceReleases
+    # -------------------------------------------------------------------------
+    ResourceReleaseList:
+      type: object
+      description: Paginated list of resource releases
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceRelease'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ResourceRelease:
+      type: object
+      description: |
+        ResourceRelease resource.
+        Immutable snapshot of Resource.spec and the referenced (Cluster)ResourceType.spec
+        at the time it was cut. Created by the Resource controller; spec is immutable.
+      required:
+        - metadata
+      properties:
+        apiVersion:
+          type: string
+          readOnly: true
+          description: API version of the resource
+          example: openchoreo.dev/v1alpha1
+        kind:
+          type: string
+          readOnly: true
+          description: Kind of the resource
+          example: ResourceRelease
+        metadata:
+          $ref: '#/components/schemas/ObjectMeta'
+        spec:
+          $ref: '#/components/schemas/ResourceReleaseSpec'
+        status:
+          readOnly: true
+          type: object
+          description: ResourceRelease status (currently empty, immutable after creation)
+
+    ResourceReleaseSpec:
+      type: object
+      description: Desired state of a ResourceRelease. Immutable after creation.
+      required:
+        - owner
+        - resourceType
+      properties:
+        owner:
+          type: object
+          description: Identifies the resource and project this ResourceRelease belongs to.
+          required:
+            - projectName
+            - resourceName
+          properties:
+            projectName:
+              type: string
+              description: Parent project name
+              minLength: 1
+              example: analytics
+            resourceName:
+              type: string
+              description: Parent resource name
+              minLength: 1
+              example: analytics-shared-db
+        resourceType:
+          type: object
+          description: Frozen snapshot of the referenced (Cluster)ResourceType.
+          required:
+            - kind
+            - name
+            - spec
+          properties:
+            kind:
+              type: string
+              description: Source kind (ResourceType or ClusterResourceType)
+              enum: [ResourceType, ClusterResourceType]
+            name:
+              type: string
+              description: Source resource type name
+              minLength: 1
+              example: mysql
+            spec:
+              $ref: '#/components/schemas/ResourceTypeSpec'
+        parameters:
+          type: object
+          description: Snapshot of parameter values from Resource.spec at release time.
+          additionalProperties: true
+
+    # -------------------------------------------------------------------------
+    # ResourceReleaseBindings
+    # -------------------------------------------------------------------------
+    ResourceReleaseBindingList:
+      type: object
+      description: Paginated list of resource release bindings
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceReleaseBinding'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    ResourceReleaseBinding:
+      type: object
+      description: |
+        ResourceReleaseBinding resource.
+        Pins a ResourceRelease to an Environment and carries per-env config overrides.
+        Authored externally; not managed by the Resource controller.
+      required:
+        - metadata
+      properties:
+        apiVersion:
+          type: string
+          readOnly: true
+          description: API version of the resource
+          example: openchoreo.dev/v1alpha1
+        kind:
+          type: string
+          readOnly: true
+          description: Kind of the resource
+          example: ResourceReleaseBinding
+        metadata:
+          $ref: '#/components/schemas/ObjectMeta'
+        spec:
+          $ref: '#/components/schemas/ResourceReleaseBindingSpec'
+        status:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/ResourceReleaseBindingStatus'
+
+    ResourceReleaseBindingSpec:
+      type: object
+      description: |
+        Desired state of a ResourceReleaseBinding. spec.owner and spec.environment
+        are immutable after creation. spec.resourceRelease is the promote pin and is
+        advanced manually via `occ resource promote` or kubectl edit.
+      required:
+        - owner
+        - environment
+      properties:
+        owner:
+          type: object
+          description: Identifies the resource and project this binding belongs to.
+          required:
+            - projectName
+            - resourceName
+          properties:
+            projectName:
+              type: string
+              description: Parent project name
+              minLength: 1
+              example: analytics
+            resourceName:
+              type: string
+              description: Parent resource name
+              minLength: 1
+              example: analytics-shared-db
+        environment:
+          type: string
+          description: Target environment name. Immutable after creation.
+          minLength: 1
+          example: dev
+        resourceRelease:
+          type: string
+          description: Pinned ResourceRelease name. Advanced manually (e.g. via `occ resource promote`).
+          example: analytics-shared-db-abc123
+        retainPolicy:
+          type: string
+          description: Per-env override for retention. Falls back to ResourceType.spec.retainPolicy when unset.
+          enum: [Delete, Retain]
+          example: Delete
+        resourceTypeEnvironmentConfigs:
+          type: object
+          description: Per-environment values for ResourceType.spec.environmentConfigs.
+          additionalProperties: true
+
+    ResolvedResourceOutput:
+      type: object
+      description: |
+        Resolved output value populated by the binding controller after evaluating
+        the ResourceType output CEL against the applied DP-side objects. Exactly one
+        of value, secretKeyRef, or configMapKeyRef is set, matching the source
+        declaration on ResourceType.spec.outputs.
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Output name. Matches the declared output name on the referenced ResourceType.
+          minLength: 1
+          example: host
+        value:
+          type: string
+          description: Resolved literal value when the source output is declared with `value:`.
+          example: 10.0.0.5
+        secretKeyRef:
+          $ref: '#/components/schemas/ResourceSecretKeyRef'
+        configMapKeyRef:
+          $ref: '#/components/schemas/ResourceConfigMapKeyRef'
+
+    ResourceReleaseBindingStatus:
+      type: object
+      description: Observed state of a ResourceReleaseBinding.
+      properties:
+        conditions:
+          type: array
+          description: Latest available observations of the binding's state. Includes Synced, ResourcesReady, OutputsResolved, Ready (aggregate), and Finalizing.
+          items:
+            $ref: '#/components/schemas/Condition'
+        outputs:
+          type: array
+          description: Resolved outputs for this environment, populated from the underlying RenderedRelease.status by the binding controller.
+          items:
+            $ref: '#/components/schemas/ResolvedResourceOutput'
 
     # -------------------------------------------------------------------------
     # RenderedRelease
@@ -8444,11 +10077,11 @@ components:
           type: string
           description: Timestamp of the log entry in RFC3339 format
           format: date-time
-          example: '2024-01-10T12:34:56.789Z'
+          example: "2024-01-10T12:34:56.789Z"
         log:
           type: string
           description: Log message content
-          example: 'Starting application server on port 8080'
+          example: "Starting application server on port 8080"
 
     ResourcePodLogsResponse:
       type: object
@@ -8557,7 +10190,7 @@ components:
           description: List of actions this role permits
           items:
             type: string
-          example: ['project:create', 'project:view', 'project:delete']
+          example: ["project:create", "project:view", "project:delete"]
         description:
           type: string
           description: Human-readable description of the role
@@ -8611,7 +10244,7 @@ components:
           description: List of actions this role permits
           items:
             type: string
-          example: ['component:create', 'component:view']
+          example: ["component:create", "component:view"]
         description:
           type: string
           description: Human-readable description of the role
@@ -8795,6 +10428,34 @@ components:
           description: Component name
           example: api-service
 
+    AuthzCondition:
+      type: object
+      description: >
+        Action-scoped mapping condition attached to a role mapping inside a binding.
+        It constrains only the actions listed in the "actions" property and does not
+        enable or disable the entire mapping or binding; all other actions in the
+        mapping remain unaffected by this condition.
+      required:
+        - actions
+        - expression
+      properties:
+        actions:
+          type: array
+          description: >
+            List of actions this condition applies to. Supports exact match
+            (e.g. "releasebinding:create") and wildcards (e.g. "releasebinding:*").
+          minItems: 1
+          items:
+            type: string
+          example: ["releasebinding:create", "releasebinding:*"]
+        expression:
+          type: string
+          description: >
+            CEL expression that must evaluate to true for the action to be permitted.
+            Example: resource.environment in ["dev", "staging"]
+          minLength: 1
+          example: 'resource.environment in ["dev", "staging"]'
+
     AuthzRoleMapping:
       type: object
       description: Pairs a role reference with an optional scope
@@ -8805,6 +10466,14 @@ components:
           $ref: '#/components/schemas/AuthzRoleRef'
         scope:
           $ref: '#/components/schemas/AuthzScope'
+        conditions:
+          type: array
+          description: >
+            Per-role-mapping conditions that restrict specific actions within this role mapping in the binding.
+            Each condition only affects the actions listed in its "actions" property and does not
+            enable or disable the mapping or binding as a whole.
+          items:
+            $ref: '#/components/schemas/AuthzCondition'
 
     AuthzClusterScope:
       type: object
@@ -8840,6 +10509,14 @@ components:
                   example: ClusterAuthzRole
         scope:
           $ref: '#/components/schemas/AuthzClusterScope'
+        conditions:
+          type: array
+          description: >
+            Per-role-mapping conditions that restrict specific actions within this role mapping in the binding.
+            Each condition only affects the actions listed in its "actions" property and does not
+            enable or disable the mapping or binding as a whole.
+          items:
+            $ref: '#/components/schemas/AuthzCondition'
 
     Entitlement:
       type: object
@@ -8877,7 +10554,15 @@ components:
     AuthzContext:
       type: object
       description: Additional context for authorization
-      additionalProperties: true
+      properties:
+        resource:
+          type: object
+          description: Resource-level attributes for condition evaluation
+          properties:
+            environment:
+              type: string
+              description: Target deployment environment (e.g. "dev", "staging", "prod")
+              example: dev
 
     SubjectContext:
       type: object
@@ -8901,7 +10586,7 @@ components:
           description: Entitlement values
           items:
             type: string
-          example: ['admin-group', 'dev-group']
+          example: ["admin-group", "dev-group"]
 
     Resource:
       type: object
@@ -8959,6 +10644,23 @@ components:
               description: Reason for the decision
               example: User has admin role
 
+
+    ConditionAttribute:
+      type: object
+      description: An ABAC attribute available for CEL condition expressions on an action.
+      required:
+        - key
+        - description
+      properties:
+        key:
+          type: string
+          description: Full dotted path of the attribute (e.g. "resource.environment").
+          example: resource.environment
+        description:
+          type: string
+          description: Human-readable description of the attribute.
+          example: Environment associated with the resource
+
     ActionInfo:
       type: object
       description: An authorization action with its scope in the resource hierarchy.
@@ -8981,6 +10683,11 @@ components:
             - project
             - component
           example: component
+        conditions:
+          type: array
+          description: ABAC attributes available for CEL condition expressions on this action. Empty means no conditions are supported.
+          items:
+            $ref: '#/components/schemas/ConditionAttribute'
 
     ActionCapability:
       type: object
@@ -8997,6 +10704,18 @@ components:
           items:
             $ref: '#/components/schemas/CapabilityResource'
 
+    CapabilityConstraints:
+      type: object
+      description: CEL expressions constraining access for a given action and resource path. Multiple expressions are OR'd.
+      properties:
+        expressions:
+          type: array
+          description: CEL expressions; access is granted if any one evaluates to true
+          items:
+            type: string
+          minItems: 1
+          example: ['resource.environment == "prod"', 'resource.environment == "staging"']
+
     CapabilityResource:
       type: object
       description: Resource with permission details
@@ -9006,9 +10725,7 @@ components:
           description: Full resource path
           example: namespace/acme/project/payment
         constraints:
-          type: object
-          description: Additional instance-level restrictions
-          additionalProperties: true
+          $ref: '#/components/schemas/CapabilityConstraints'
 
     UserCapabilitiesResponse:
       type: object
@@ -9025,315 +10742,8 @@ components:
           type: string
           format: date-time
           description: Time when capabilities were evaluated
-          example: '2025-01-06T10:00:00Z'
+          example: "2025-01-06T10:00:00Z"
 
-    # -------------------------------------------------------------------------
-    # Legacy Authz Schemas (kept for legacy handler compatibility)
-    # -------------------------------------------------------------------------
-
-    Role:
-      type: object
-      description: Authorization role with permitted actions (legacy)
-      required:
-        - name
-        - actions
-      properties:
-        name:
-          type: string
-          description: Unique role name
-          example: admin
-        actions:
-          type: array
-          description: List of actions this role permits
-          items:
-            type: string
-          example: ['read', 'write', 'delete']
-        namespace:
-          type: string
-          description: Namespace for namespace-scoped roles, empty for cluster roles
-          example: my-namespace
-        description:
-          type: string
-          description: Human-readable description of the role
-          example: Full administrative access
-
-    UpdateRoleRequest:
-      type: object
-      description: Request to update a role's actions (legacy)
-      required:
-        - actions
-      properties:
-        actions:
-          type: array
-          description: New list of actions for the role
-          items:
-            type: string
-          example: ['read', 'write']
-
-    TargetPath:
-      type: object
-      description: Target resource path within a namespace (project/component only) (legacy)
-      properties:
-        project:
-          type: string
-          description: Project name
-          example: my-project
-        component:
-          type: string
-          description: Component name
-          example: api-service
-
-    RoleEntitlementMapping:
-      type: object
-      description: Mapping of a role to an entitlement within a scope (legacy)
-      required:
-        - name
-        - role
-        - entitlement
-        - hierarchy
-        - effect
-      properties:
-        name:
-          type: string
-          description: Unique mapping name
-          example: admin-binding
-        role:
-          $ref: '#/components/schemas/RoleRef'
-        entitlement:
-          $ref: '#/components/schemas/Entitlement'
-        hierarchy:
-          $ref: '#/components/schemas/ResourceHierarchy'
-        effect:
-          type: string
-          description: Policy effect (allow or deny)
-          enum: [allow, deny]
-          default: allow
-          example: allow
-        context:
-          $ref: '#/components/schemas/AuthzContext'
-
-    UpdateRoleMappingRequest:
-      type: object
-      description: Request to update a role mapping (legacy)
-      required:
-        - role
-        - entitlement
-        - hierarchy
-        - effect
-      properties:
-        role:
-          $ref: '#/components/schemas/RoleRef'
-        entitlement:
-          $ref: '#/components/schemas/Entitlement'
-        hierarchy:
-          $ref: '#/components/schemas/ResourceHierarchy'
-        effect:
-          type: string
-          description: Policy effect (allow or deny)
-          enum: [allow, deny]
-          default: allow
-          example: allow
-        context:
-          $ref: '#/components/schemas/AuthzContext'
-
-    ClusterRoleRef:
-      type: object
-      description: Reference to a cluster role by name only (legacy)
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          description: Cluster role name
-          example: admin
-
-    RoleRef:
-      type: object
-      description: Reference to a role by name and namespace (legacy)
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          description: Role name
-          example: developer
-        namespace:
-          type: string
-          description: Namespace for namespace-scoped roles, empty for cluster roles
-          example: my-namespace
-
-    CreateClusterRoleRequest:
-      type: object
-      description: Request to create a cluster-scoped role (legacy)
-      required:
-        - name
-        - actions
-      properties:
-        name:
-          type: string
-          description: Unique cluster role name
-          example: cluster-admin
-        actions:
-          type: array
-          description: List of actions this role permits
-          items:
-            type: string
-          example: ['read', 'write', 'delete']
-        description:
-          type: string
-          description: Human-readable description of the role
-          example: Full cluster administration access
-
-    UpdateClusterRoleRequest:
-      type: object
-      description: Request to update a cluster role (legacy)
-      required:
-        - actions
-      properties:
-        actions:
-          type: array
-          description: List of actions this role permits
-          items:
-            type: string
-          example: ['read', 'write']
-        description:
-          type: string
-          description: Human-readable description of the role
-          example: Updated cluster admin role
-
-    # NOTE: Legacy single-mapping endpoints. Multi-mapping is handled via the CRD API directly.
-    CreateClusterRoleBindingRequest:
-      type: object
-      description: Request to create a cluster-scoped role binding (legacy, single mapping only)
-      required:
-        - name
-        - entitlement
-        - role
-      properties:
-        name:
-          type: string
-          description: Unique cluster role binding name
-          example: admin-binding
-        entitlement:
-          $ref: '#/components/schemas/Entitlement'
-        role:
-          type: string
-          description: Cluster role name
-          example: admin
-        effect:
-          type: string
-          description: Policy effect (allow or deny)
-          enum: [allow, deny]
-          default: allow
-          example: allow
-
-    UpdateClusterRoleBindingRequest:
-      type: object
-      description: Request to update a cluster role binding (legacy, single mapping only)
-      required:
-        - entitlement
-        - role
-        - effect
-      properties:
-        entitlement:
-          $ref: '#/components/schemas/Entitlement'
-        role:
-          type: string
-          description: Cluster role name
-          example: admin
-        effect:
-          type: string
-          description: Policy effect (allow or deny)
-          enum: [allow, deny]
-          default: allow
-          example: allow
-
-    CreateNamespaceRoleRequest:
-      type: object
-      description: Request to create a namespace-scoped role (legacy)
-      required:
-        - name
-        - actions
-      properties:
-        name:
-          type: string
-          description: Unique namespace role name
-          example: developer
-        actions:
-          type: array
-          description: List of actions this role permits
-          items:
-            type: string
-          example: ['read', 'write']
-        description:
-          type: string
-          description: Human-readable description of the role
-          example: Developer access within namespace
-
-    UpdateNamespaceRoleRequest:
-      type: object
-      description: Request to update a namespace role (legacy)
-      required:
-        - actions
-      properties:
-        actions:
-          type: array
-          description: List of actions this role permits
-          items:
-            type: string
-          example: ['read', 'write']
-        description:
-          type: string
-          description: Human-readable description of the role
-          example: Updated developer role
-
-    # NOTE: Legacy single-mapping endpoints. Multi-mapping is handled via the CRD API directly.
-    CreateNamespaceRoleBindingRequest:
-      type: object
-      description: Request to create a namespace-scoped role binding (legacy, single mapping only)
-      required:
-        - name
-        - entitlement
-        - role
-      properties:
-        name:
-          type: string
-          description: Unique namespace role binding name
-          example: developer-binding
-        entitlement:
-          $ref: '#/components/schemas/Entitlement'
-        role:
-          $ref: '#/components/schemas/RoleRef'
-        targetPath:
-          $ref: '#/components/schemas/TargetPath'
-        effect:
-          type: string
-          description: Policy effect (allow or deny)
-          enum: [allow, deny]
-          default: allow
-          example: allow
-
-    UpdateNamespaceRoleBindingRequest:
-      type: object
-      description: Request to update a namespace role binding (legacy, single mapping only)
-      required:
-        - entitlement
-        - role
-        - targetPath
-        - effect
-      properties:
-        entitlement:
-          $ref: '#/components/schemas/Entitlement'
-        role:
-          $ref: '#/components/schemas/RoleRef'
-        targetPath:
-          $ref: '#/components/schemas/TargetPath'
-        effect:
-          type: string
-          description: Policy effect (allow or deny)
-          enum: [allow, deny]
-          default: allow
-          example: allow
 
     # -------------------------------------------------------------------------
     # Webhook Schemas
@@ -9359,7 +10769,7 @@ components:
           description: List of components affected by this webhook
           items:
             type: string
-          example: ['api-service', 'web-app']
+          example: ["api-service", "web-app"]
         triggeredBuilds:
           type: integer
           description: Number of builds triggered
@@ -9450,7 +10860,7 @@ components:
           type: string
           format: date-time
           description: When the secret reference was last processed
-          example: '2025-01-06T11:00:00Z'
+          example: "2025-01-06T11:00:00Z"
         secretStores:
           type: array
           description: Secret stores using this reference
@@ -9843,7 +11253,7 @@ components:
 
     TargetEnvironmentRef:
       type: object
-      description: Target environment reference with approval settings
+      description: Target environment reference
       required:
         - name
       properties:
@@ -9856,14 +11266,6 @@ components:
           type: string
           description: Target environment name
           example: staging
-        requiresApproval:
-          type: boolean
-          description: Whether promotion requires approval
-          example: false
-        isManualApprovalRequired:
-          type: boolean
-          description: Whether manual approval is required
-          example: true
 
     # -------------------------------------------------------------------------
     # Observability Alerts Notification Channel Schemas
@@ -10036,11 +11438,11 @@ components:
         subject:
           type: string
           description: Email subject line template using CEL expressions
-          example: '[${alert.severity}] - ${alert.name} Triggered'
+          example: "[${alert.severity}] - ${alert.name} Triggered"
         body:
           type: string
           description: Email body template using CEL expressions
-          example: 'Alert: ${alert.name} triggered at ${alert.startsAt}.'
+          example: "Alert: ${alert.name} triggered at ${alert.startsAt}."
 
     NotificationWebhookConfig:
       type: object
@@ -10181,6 +11583,9 @@ components:
           type: integer
           description: Number of items per page
 
+    # -------------------------------------------------------------------------
+    # Secrets
+    # -------------------------------------------------------------------------
     TargetPlaneRef:
       type: object
       description: Reference to the plane that hosts the secret data.
@@ -10238,46 +11643,45 @@ components:
           example:
             username: alice
             password: s3cret
+        labels:
+          type: object
+          description: |
+            Labels applied as Kubernetes labels on the underlying
+            SecretReference. Keys in the openchoreo.dev/ namespace are
+            reserved and rejected.
+          additionalProperties:
+            type: string
+          example:
+            team: payments
 
     UpdateSecretRequest:
       type: object
-      description: Request body for updating a secret
+      description: |
+        Request body for replacing a secret's data. The data map is the final
+        state; keys present in the existing secret but absent here are pruned.
       required:
         - data
       properties:
         data:
           type: object
-          description: New map of secret keys to plaintext values. Replaces all existing keys.
+          description: |
+            Map of secret keys to plaintext values. Required keys depend on
+            the secret's existing type.
           additionalProperties:
             type: string
           example:
             username: alice
-            password: r0tated
-
-    SecretResponse:
-      type: object
-      description: Secret resource. Values are never returned, only key names.
-      properties:
-        name:
-          type: string
-          description: Name of the secret
-          example: my-secret
-        namespace:
-          type: string
-          description: Namespace of the secret
-          example: my-namespace
-        secretType:
-          $ref: '#/components/schemas/SecretType'
-        targetPlane:
-          $ref: '#/components/schemas/TargetPlaneRef'
-        keys:
-          type: array
-          description: Sorted list of keys present in the secret data
-          items:
+            password: s3cret
+        labels:
+          type: object
+          description: |
+            Labels applied as Kubernetes labels on the underlying
+            SecretReference. The supplied map replaces all user-set labels;
+            keys in the openchoreo.dev/ namespace are reserved and rejected.
+          additionalProperties:
             type: string
           example:
-            - password
-            - username
+            team: payments
 
     Secret:
       type: object
@@ -10308,6 +11712,9 @@ components:
           additionalProperties:
             type: string
             format: byte
+          example:
+            username: YWxpY2U=
+            password: czNjcmV0
         immutable:
           type: boolean
           description: Whether the secret is immutable.

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -6016,7 +6016,7 @@ components:
         Multiple requirements are comma-separated and ANDed together.
       schema:
         type: string
-        example: "app=frontend,environment notin (staging,qa),tier!=backend,!deprecated"
+        example: 'app=frontend,environment notin (staging,qa),tier!=backend,!deprecated'
 
     LimitParam:
       name: limit
@@ -6050,7 +6050,7 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: "Invalid request: name is required"
+            error: 'Invalid request: name is required'
             code: BAD_REQUEST
             details:
               - field: name
@@ -6063,7 +6063,7 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: "Authentication required"
+            error: 'Authentication required'
             code: UNAUTHORIZED
 
     Forbidden:
@@ -6073,7 +6073,7 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: "You do not have permission to perform this operation"
+            error: 'You do not have permission to perform this operation'
             code: FORBIDDEN
 
     NotFound:
@@ -6116,7 +6116,7 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: "Internal server error"
+            error: 'Internal server error'
             code: INTERNAL_ERROR
 
     NotImplemented:
@@ -6126,7 +6126,7 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           example:
-            error: "Secret API is disabled on this server"
+            error: 'Secret API is disabled on this server'
             code: NOT_IMPLEMENTED
 
   # ===========================================================================
@@ -6213,12 +6213,12 @@ components:
           type: string
           format: date-time
           description: Creation timestamp
-          example: "2025-01-06T10:00:00Z"
+          example: '2025-01-06T10:00:00Z'
         deletionTimestamp:
           type: string
           format: date-time
           description: Timestamp when the resource was requested to be deleted
-          example: "2025-01-06T12:00:00Z"
+          example: '2025-01-06T12:00:00Z'
         deletionGracePeriodSeconds:
           type: integer
           format: int64
@@ -6241,8 +6241,8 @@ components:
         status:
           type: string
           description: Status of the condition
-          enum: ["True", "False", "Unknown"]
-          example: "True"
+          enum: ['True', 'False', 'Unknown']
+          example: 'True'
         observedGeneration:
           type: integer
           format: int64
@@ -6251,7 +6251,7 @@ components:
           type: string
           format: date-time
           description: Last time the condition transitioned
-          example: "2025-01-06T10:00:05Z"
+          example: '2025-01-06T10:00:05Z'
         reason:
           type: string
           description: Machine-readable reason for the condition
@@ -6259,7 +6259,7 @@ components:
         message:
           type: string
           description: Human-readable message
-          example: "Project is ready"
+          example: 'Project is ready'
 
     # -------------------------------------------------------------------------
     # Version
@@ -6291,7 +6291,7 @@ components:
         buildTime:
           type: string
           description: Build timestamp
-          example: "2025-01-06T10:00:00Z"
+          example: '2025-01-06T10:00:00Z'
         goOS:
           type: string
           description: Target operating system
@@ -6386,7 +6386,7 @@ components:
           minItems: 1
           items:
             type: string
-          example: ["openid", "profile", "email"]
+          example: ['openid', 'profile', 'email']
 
     # -------------------------------------------------------------------------
     # User Type Configuration
@@ -6463,7 +6463,7 @@ components:
             Opaque cursor for fetching the next page. Pass this value as the
             `cursor` query parameter in the next request. Absent when there
             are no more items.
-          example: "eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MzQ0N30="
+          example: 'eyJ2IjoibWV0YS5rOHMuaW8vdjEiLCJydiI6MzQ0N30='
         remainingCount:
           type: integer
           format: int64
@@ -6616,7 +6616,6 @@ components:
         pagination:
           $ref: '#/components/schemas/Pagination'
 
-
     # -------------------------------------------------------------------------
     # Components
     # -------------------------------------------------------------------------
@@ -6664,7 +6663,7 @@ components:
               default: ComponentType
             name:
               type: string
-              description: "Component type reference in format: {workloadType}/{componentTypeName}"
+              description: 'Component type reference in format: {workloadType}/{componentTypeName}'
               example: deployment/go-service
               pattern: '^(deployment|statefulset|cronjob|job|proxy)/[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         autoDeploy:
@@ -6766,12 +6765,12 @@ components:
           maxLength: 1024
         type:
           type: string
-          description: "DEPRECATED: Use componentType instead. Legacy component type field."
+          description: 'DEPRECATED: Use componentType instead. Legacy component type field.'
           example: service/go-service
           deprecated: true
         componentType:
           type: string
-          description: "Component type reference (format: {workloadType}/{componentTypeName})"
+          description: 'Component type reference (format: {workloadType}/{componentTypeName})'
           example: service/go-service
         autoDeploy:
           type: boolean
@@ -7728,11 +7727,11 @@ components:
                 default: dataplane
               includeWhen:
                 type: string
-                description: "CEL expression determining if this resource should be created"
+                description: 'CEL expression determining if this resource should be created'
                 pattern: '^\$\{[\s\S]+\}\s*$'
               forEach:
                 type: string
-                description: "CEL expression for generating multiple resources from a list"
+                description: 'CEL expression for generating multiple resources from a list'
                 pattern: '^\$\{[\s\S]+\}\s*$'
               var:
                 type: string
@@ -7818,10 +7817,10 @@ components:
                 default: dataplane
               includeWhen:
                 type: string
-                description: "CEL expression determining if this resource should be created"
+                description: 'CEL expression determining if this resource should be created'
               forEach:
                 type: string
-                description: "CEL expression for generating multiple resources from a list"
+                description: 'CEL expression for generating multiple resources from a list'
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -7840,7 +7839,7 @@ components:
             properties:
               forEach:
                 type: string
-                description: "CEL expression for repeating this patch"
+                description: 'CEL expression for repeating this patch'
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -7863,7 +7862,7 @@ components:
                     description: Resource type to patch
                   where:
                     type: string
-                    description: "CEL expression to filter which resources to patch"
+                    description: 'CEL expression to filter which resources to patch'
               targetPlane:
                 type: string
                 description: Target plane for this patch
@@ -8022,10 +8021,10 @@ components:
                 default: dataplane
               includeWhen:
                 type: string
-                description: "CEL expression determining if this resource should be created"
+                description: 'CEL expression determining if this resource should be created'
               forEach:
                 type: string
-                description: "CEL expression for generating multiple resources from a list"
+                description: 'CEL expression for generating multiple resources from a list'
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -8110,10 +8109,10 @@ components:
                 default: dataplane
               includeWhen:
                 type: string
-                description: "CEL expression determining if this resource should be created"
+                description: 'CEL expression determining if this resource should be created'
               forEach:
                 type: string
-                description: "CEL expression for generating multiple resources from a list"
+                description: 'CEL expression for generating multiple resources from a list'
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -8132,7 +8131,7 @@ components:
             properties:
               forEach:
                 type: string
-                description: "CEL expression for repeating this patch"
+                description: 'CEL expression for repeating this patch'
               var:
                 type: string
                 description: Loop variable name when using forEach
@@ -8155,7 +8154,7 @@ components:
                     description: Resource type to patch
                   where:
                     type: string
-                    description: "CEL expression to filter which resources to patch"
+                    description: 'CEL expression to filter which resources to patch'
               targetPlane:
                 type: string
                 description: Target plane for this patch
@@ -8194,7 +8193,7 @@ components:
       properties:
         rule:
           type: string
-          description: "CEL expression wrapped in ${...} that must evaluate to true"
+          description: 'CEL expression wrapped in ${...} that must evaluate to true'
           pattern: '^\$\{[\s\S]+\}\s*$'
         message:
           type: string
@@ -8694,12 +8693,12 @@ components:
           type: string
           format: date-time
           description: When the step started
-          example: "2025-01-06T10:00:00Z"
+          example: '2025-01-06T10:00:00Z'
         finishedAt:
           type: string
           format: date-time
           description: When the step finished
-          example: "2025-01-06T10:01:00Z"
+          example: '2025-01-06T10:01:00Z'
 
     WorkflowRunLogEntry:
       type: object
@@ -8711,11 +8710,11 @@ components:
           type: string
           format: date-time
           description: Log entry timestamp
-          example: "2025-01-06T10:00:00Z"
+          example: '2025-01-06T10:00:00Z'
         log:
           type: string
           description: Log message
-          example: "Step 1: Cloning repository..."
+          example: 'Step 1: Cloning repository...'
 
     WorkflowRunEventEntry:
       type: object
@@ -8730,7 +8729,7 @@ components:
           type: string
           format: date-time
           description: Event timestamp
-          example: "2025-01-06T10:00:00Z"
+          example: '2025-01-06T10:00:00Z'
         type:
           type: string
           description: Event type
@@ -8742,7 +8741,7 @@ components:
         message:
           type: string
           description: Human-readable description of the event
-          example: "Container main started"
+          example: 'Container main started'
 
     CreateWorkflowRunRequest:
       type: object
@@ -8760,8 +8759,8 @@ components:
           description: User-defined workflow parameters
           additionalProperties: true
           example:
-            database_url: "postgresql://localhost:5432/mydb"
-            migration_version: "v2.1.0"
+            database_url: 'postgresql://localhost:5432/mydb'
+            migration_version: 'v2.1.0'
 
     # -------------------------------------------------------------------------
     # Component Extended Schemas
@@ -9302,7 +9301,7 @@ components:
         value:
           type: string
           description: Literal or ${...} CEL expression. Use only for non-sensitive data; the resolved value transits to the control plane.
-          example: "${applied.claim.status.host}"
+          example: '${applied.claim.status.host}'
         secretKeyRef:
           $ref: '#/components/schemas/ResourceSecretKeyRef'
         configMapKeyRef:
@@ -9327,7 +9326,7 @@ components:
         includeWhen:
           type: string
           description: Optional ${...}-wrapped CEL expression. When false, the entry is skipped entirely.
-          example: "${parameters.tlsEnabled}"
+          example: '${parameters.tlsEnabled}'
         template:
           type: object
           description: Kubernetes resource body with ${...} CEL substitutions.
@@ -10077,11 +10076,11 @@ components:
           type: string
           description: Timestamp of the log entry in RFC3339 format
           format: date-time
-          example: "2024-01-10T12:34:56.789Z"
+          example: '2024-01-10T12:34:56.789Z'
         log:
           type: string
           description: Log message content
-          example: "Starting application server on port 8080"
+          example: 'Starting application server on port 8080'
 
     ResourcePodLogsResponse:
       type: object
@@ -10190,7 +10189,7 @@ components:
           description: List of actions this role permits
           items:
             type: string
-          example: ["project:create", "project:view", "project:delete"]
+          example: ['project:create', 'project:view', 'project:delete']
         description:
           type: string
           description: Human-readable description of the role
@@ -10244,7 +10243,7 @@ components:
           description: List of actions this role permits
           items:
             type: string
-          example: ["component:create", "component:view"]
+          example: ['component:create', 'component:view']
         description:
           type: string
           description: Human-readable description of the role
@@ -10447,7 +10446,7 @@ components:
           minItems: 1
           items:
             type: string
-          example: ["releasebinding:create", "releasebinding:*"]
+          example: ['releasebinding:create', 'releasebinding:*']
         expression:
           type: string
           description: >
@@ -10586,7 +10585,7 @@ components:
           description: Entitlement values
           items:
             type: string
-          example: ["admin-group", "dev-group"]
+          example: ['admin-group', 'dev-group']
 
     Resource:
       type: object
@@ -10643,7 +10642,6 @@ components:
               type: string
               description: Reason for the decision
               example: User has admin role
-
 
     ConditionAttribute:
       type: object
@@ -10714,7 +10712,11 @@ components:
           items:
             type: string
           minItems: 1
-          example: ['resource.environment == "prod"', 'resource.environment == "staging"']
+          example:
+            [
+              'resource.environment == "prod"',
+              'resource.environment == "staging"',
+            ]
 
     CapabilityResource:
       type: object
@@ -10742,8 +10744,7 @@ components:
           type: string
           format: date-time
           description: Time when capabilities were evaluated
-          example: "2025-01-06T10:00:00Z"
-
+          example: '2025-01-06T10:00:00Z'
 
     # -------------------------------------------------------------------------
     # Webhook Schemas
@@ -10769,7 +10770,7 @@ components:
           description: List of components affected by this webhook
           items:
             type: string
-          example: ["api-service", "web-app"]
+          example: ['api-service', 'web-app']
         triggeredBuilds:
           type: integer
           description: Number of builds triggered
@@ -10860,7 +10861,7 @@ components:
           type: string
           format: date-time
           description: When the secret reference was last processed
-          example: "2025-01-06T11:00:00Z"
+          example: '2025-01-06T11:00:00Z'
         secretStores:
           type: array
           description: Secret stores using this reference
@@ -11438,11 +11439,11 @@ components:
         subject:
           type: string
           description: Email subject line template using CEL expressions
-          example: "[${alert.severity}] - ${alert.name} Triggered"
+          example: '[${alert.severity}] - ${alert.name} Triggered'
         body:
           type: string
           description: Email body template using CEL expressions
-          example: "Alert: ${alert.name} triggered at ${alert.startsAt}."
+          example: 'Alert: ${alert.name} triggered at ${alert.startsAt}.'
 
     NotificationWebhookConfig:
       type: object

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -1080,7 +1080,11 @@ export interface paths {
      */
     put: operations['updateWorkflowRun'];
     post?: never;
-    delete?: never;
+    /**
+     * Delete workflow run
+     * @description Deletes a workflow run by name.
+     */
+    delete: operations['deleteWorkflowRun'];
     options?: never;
     head?: never;
     patch?: never;
@@ -1643,7 +1647,11 @@ export interface paths {
      */
     get: operations['listComponentReleases'];
     put?: never;
-    post?: never;
+    /**
+     * Create component release
+     * @description Creates a new component release within a namespace.
+     */
+    post: operations['createComponentRelease'];
     delete?: never;
     options?: never;
     head?: never;
@@ -1664,7 +1672,11 @@ export interface paths {
     get: operations['getComponentRelease'];
     put?: never;
     post?: never;
-    delete?: never;
+    /**
+     * Delete component release
+     * @description Deletes a component release by name.
+     */
+    delete: operations['deleteComponentRelease'];
     options?: never;
     head?: never;
     patch?: never;
@@ -1777,6 +1789,302 @@ export interface paths {
     put?: never;
     post?: never;
     delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/clusterresourcetypes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List cluster resource types
+     * @description Returns a list of cluster-scoped resource types.
+     */
+    get: operations['listClusterResourceTypes'];
+    put?: never;
+    /**
+     * Create cluster resource type
+     * @description Creates a new cluster-scoped resource type.
+     */
+    post: operations['createClusterResourceType'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/clusterresourcetypes/{crtName}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get a cluster resource type
+     * @description Returns details of a specific cluster-scoped resource type.
+     */
+    get: operations['getClusterResourceType'];
+    /**
+     * Update cluster resource type
+     * @description Replaces an existing cluster-scoped resource type (full update).
+     */
+    put: operations['updateClusterResourceType'];
+    post?: never;
+    /**
+     * Delete cluster resource type
+     * @description Deletes a cluster-scoped resource type by name.
+     */
+    delete: operations['deleteClusterResourceType'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/clusterresourcetypes/{crtName}/schema': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get cluster resource type schema
+     * @description Returns the parameter schema for a specific cluster-scoped resource type.
+     */
+    get: operations['getClusterResourceTypeSchema'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resourcetypes': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List resource types
+     * @description Returns a paginated list of resource types available in the namespace.
+     */
+    get: operations['listResourceTypes'];
+    put?: never;
+    /**
+     * Create resource type
+     * @description Creates a new resource type within a namespace.
+     */
+    post: operations['createResourceType'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resourcetypes/{rtName}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get resource type
+     * @description Returns details of a specific resource type.
+     */
+    get: operations['getResourceType'];
+    /**
+     * Update resource type
+     * @description Replaces an existing resource type (full update).
+     */
+    put: operations['updateResourceType'];
+    post?: never;
+    /**
+     * Delete resource type
+     * @description Deletes a resource type by name.
+     */
+    delete: operations['deleteResourceType'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resourcetypes/{rtName}/schema': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get resource type schema
+     * @description Returns the parameter schema for a specific resource type.
+     */
+    get: operations['getResourceTypeSchema'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resources': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List resources
+     * @description Returns a paginated list of resources within a namespace, optionally filtered by project.
+     */
+    get: operations['listResources'];
+    put?: never;
+    /**
+     * Create resource
+     * @description Creates a new resource within a namespace.
+     */
+    post: operations['createResource'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resources/{resourceName}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get resource
+     * @description Returns details of a specific resource.
+     */
+    get: operations['getResource'];
+    /**
+     * Update resource
+     * @description Replaces an existing resource (full update). Mutating spec.parameters cuts a new ResourceRelease via the Resource controller.
+     */
+    put: operations['updateResource'];
+    post?: never;
+    /**
+     * Delete resource
+     * @description Deletes a resource by name. The Resource finalizer blocks deletion until all owned ResourceReleaseBindings and ResourceReleases are cleaned up.
+     */
+    delete: operations['deleteResource'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resourcereleases': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List resource releases
+     * @description Returns a paginated list of resource releases within a namespace, optionally filtered by resource.
+     */
+    get: operations['listResourceReleases'];
+    put?: never;
+    /**
+     * Create resource release
+     * @description Creates a new resource release within a namespace. Normally cut by the Resource controller; exposed here for offline emit (e.g. `occ resource generate` in v1.2).
+     */
+    post: operations['createResourceRelease'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resourcereleases/{resourceReleaseName}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get resource release
+     * @description Returns details of a specific resource release.
+     */
+    get: operations['getResourceRelease'];
+    put?: never;
+    post?: never;
+    /**
+     * Delete resource release
+     * @description Deletes a resource release by name.
+     */
+    delete: operations['deleteResourceRelease'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resourcereleasebindings': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List resource release bindings
+     * @description Returns a paginated list of resource release bindings within a namespace, optionally filtered by resource.
+     */
+    get: operations['listResourceReleaseBindings'];
+    put?: never;
+    /**
+     * Create resource release binding
+     * @description Creates a new resource release binding within a namespace.
+     */
+    post: operations['createResourceReleaseBinding'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/namespaces/{namespaceName}/resourcereleasebindings/{resourceReleaseBindingName}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get resource release binding
+     * @description Returns details of a specific resource release binding.
+     */
+    get: operations['getResourceReleaseBinding'];
+    /**
+     * Update resource release binding
+     * @description Replaces an existing resource release binding (full update). Used to advance `spec.resourceRelease` (the promote flow) or change `spec.retainPolicy` / `spec.resourceTypeEnvironmentConfigs`. `spec.owner` and `spec.environment` are immutable.
+     */
+    put: operations['updateResourceReleaseBinding'];
+    post?: never;
+    /**
+     * Delete resource release binding
+     * @description Deletes a resource release binding by name. The binding finalizer either cascades the underlying RenderedRelease (retainPolicy=Delete) or holds (retainPolicy=Retain).
+     */
+    delete: operations['deleteResourceReleaseBinding'];
     options?: never;
     head?: never;
     patch?: never;
@@ -1976,8 +2284,11 @@ export interface paths {
     get: operations['getSecret'];
     /**
      * Update a secret
-     * @description Replaces the data of an existing secret. The secret type and target
-     *     plane cannot be changed; only the data keys and values.
+     * @description Replaces a secret's data with the supplied final state. Keys present
+     *     in the existing secret but absent from the request body are pruned
+     *     from the Kubernetes Secret, the PushSecret, and the SecretReference.
+     *     Returns 404 if the SecretReference does not exist or is not managed
+     *     by the Secret API. Secret type and target plane are immutable.
      */
     put: operations['updateSecret'];
     post?: never;
@@ -2013,7 +2324,9 @@ export interface components {
         | 'FORBIDDEN'
         | 'NOT_FOUND'
         | 'CONFLICT'
+        | 'UNPROCESSABLE_CONTENT'
         | 'INTERNAL_ERROR'
+        | 'NOT_IMPLEMENTED'
         | 'UNKNOWN_GIT_PROVIDER';
       /** @description Additional error details (e.g., validation errors) */
       details?: {
@@ -2065,10 +2378,16 @@ export interface components {
       creationTimestamp?: string;
       /**
        * Format: date-time
-       * @description Deletion timestamp (set when resource is being deleted)
-       * @example 2025-01-06T10:00:00Z
+       * @description Timestamp when the resource was requested to be deleted
+       * @example 2025-01-06T12:00:00Z
        */
       deletionTimestamp?: string;
+      /**
+       * Format: int64
+       * @description Number of seconds before the object is removed after deletion is requested
+       * @example 0
+       */
+      deletionGracePeriodSeconds?: number;
     };
     /** @description Kubernetes-style condition */
     Condition: {
@@ -2343,6 +2662,18 @@ export interface components {
       spec?: components['schemas']['ProjectSpec'];
       readonly status?: components['schemas']['ProjectStatus'];
     };
+    /** @description Request to patch a project */
+    PatchProjectRequest: {
+      /** @description Human-readable display name */
+      displayName?: string;
+      /** @description Human-readable description */
+      description?: string;
+      /**
+       * @description Name of the deployment pipeline resource
+       * @example default
+       */
+      deploymentPipeline?: string;
+    };
     /** @description Paginated list of projects */
     ProjectList: {
       items: components['schemas']['Project'][];
@@ -2438,51 +2769,6 @@ export interface components {
       spec?: components['schemas']['ComponentSpec'];
       readonly status?: components['schemas']['ComponentStatus'];
     };
-    /** @description Component workflow configuration */
-    ComponentWorkflowConfig: {
-      /**
-       * @description Kind of workflow (Workflow or ClusterWorkflow)
-       * @default Workflow
-       * @enum {string}
-       */
-      kind: 'Workflow' | 'ClusterWorkflow';
-      /**
-       * @description Workflow name
-       * @example docker-build
-       */
-      name?: string;
-      /** @description System-managed parameters (repository info) */
-      systemParameters?: {
-        repository?: {
-          /**
-           * @description Git repository URL
-           * @example https://github.com/org/repo.git
-           */
-          url?: string;
-          revision?: {
-            /**
-             * @description Git branch
-             * @example main
-             */
-            branch?: string;
-            /**
-             * @description Git commit SHA
-             * @example abc1234
-             */
-            commit?: string;
-          };
-          /**
-           * @description Path to application within repository
-           * @example ./services/api
-           */
-          appPath?: string;
-        };
-      };
-      /** @description User-defined workflow parameters */
-      parameters?: {
-        [key: string]: unknown;
-      };
-    };
     /** @description Request to create a new component */
     CreateComponentRequest: {
       /**
@@ -2508,7 +2794,7 @@ export interface components {
       type?: string;
       /**
        * @description Component type reference (format: {workloadType}/{componentTypeName})
-       * @example deployment/go-service
+       * @example service/go-service
        */
       componentType?: string;
       /**
@@ -2552,43 +2838,16 @@ export interface components {
     /** @description Workflow configuration for component creation */
     ComponentWorkflowInput: {
       /**
-       * @description Kind of workflow (Workflow or ClusterWorkflow)
-       * @default Workflow
+       * @description Kind of referenced workflow resource (Workflow or ClusterWorkflow)
+       * @default ClusterWorkflow
        * @enum {string}
        */
       kind: 'Workflow' | 'ClusterWorkflow';
       /**
-       * @description ComponentWorkflow resource name
+       * @description Workflow resource name
        * @example docker-build
        */
       name: string;
-      /** @description System parameters including repository configuration */
-      systemParameters: {
-        repository: {
-          /**
-           * @description Git repository URL
-           * @example https://github.com/org/repo.git
-           */
-          url: string;
-          revision: {
-            /**
-             * @description Git branch to build from
-             * @example main
-             */
-            branch: string;
-            /**
-             * @description Specific commit SHA (optional)
-             * @example abc1234
-             */
-            commit?: string;
-          };
-          /**
-           * @description Path to application within repository
-           * @example ./services/api
-           */
-          appPath: string;
-        };
-      };
       /** @description User-defined workflow parameters */
       parameters?: {
         [key: string]: unknown;
@@ -2887,6 +3146,11 @@ export interface components {
        * @example http://rca-agent.observability-plane.svc:8080
        */
       rcaAgentURL?: string;
+      /**
+       * @description Base URL of the FinOps Agent API in the observability plane cluster
+       * @example http://finops-agent.observability-plane.svc:8080
+       */
+      finOpsAgentURL?: string;
     };
     /** @description Observed state of an ObservabilityPlane */
     ObservabilityPlaneStatus: {
@@ -3051,6 +3315,11 @@ export interface components {
        * @example http://rca-agent.observability-plane.svc:8080
        */
       rcaAgentURL?: string;
+      /**
+       * @description Base URL of the FinOps Agent API in the observability plane cluster
+       * @example http://finops-agent.observability-plane.svc:8080
+       */
+      finOpsAgentURL?: string;
     };
     /** @description Observed state of a ClusterObservabilityPlane */
     ClusterObservabilityPlaneStatus: {
@@ -3278,25 +3547,25 @@ export interface components {
        */
       workloadType: 'deployment' | 'statefulset' | 'cronjob' | 'job' | 'proxy';
       /**
-       * @description List of allowed Workflow references for this component type
+       * @description List of allowed Workflow or ClusterWorkflow references for this component type
        * @example [
        *       {
-       *         "kind": "Workflow",
+       *         "kind": "ClusterWorkflow",
        *         "name": "docker-build"
        *       },
        *       {
-       *         "kind": "Workflow",
+       *         "kind": "ClusterWorkflow",
        *         "name": "buildpack-build"
        *       }
        *     ]
        */
       allowedWorkflows?: {
         /**
-         * @description Kind of the workflow reference. Currently only "Workflow" is supported.
-         * @default Workflow
+         * @description Kind of the workflow reference (Workflow or ClusterWorkflow)
+         * @default ClusterWorkflow
          * @enum {string}
          */
-        kind: 'Workflow';
+        kind: 'Workflow' | 'ClusterWorkflow';
         /** @description Name of the workflow resource */
         name: string;
       }[];
@@ -3515,6 +3784,7 @@ export interface components {
     };
     /** @description Desired state of a Workflow */
     WorkflowSpec: {
+      /** @description Reference to the WorkflowPlane or ClusterWorkflowPlane for this workflow's operations. Defaults to ClusterWorkflowPlane named "default" when omitted. */
       workflowPlaneRef?: components['schemas']['WorkflowPlaneRef'];
       parameters?: components['schemas']['SchemaSection'];
       /** @description Kubernetes resource template to render and apply for this workflow run. */
@@ -3605,7 +3875,7 @@ export interface components {
     };
     /** @description Desired state of a ClusterWorkflow */
     ClusterWorkflowSpec: {
-      /** @description Reference to the ClusterWorkflowPlane for this workflow's build operations. Defaults to the ClusterWorkflowPlane named "default" when omitted. */
+      /** @description Reference to the ClusterWorkflowPlane for this workflow's build operations. Defaults to ClusterWorkflowPlane named "default" when omitted. */
       workflowPlaneRef?: components['schemas']['ClusterWorkflowPlaneRef'];
       parameters?: components['schemas']['SchemaSection'];
       /** @description Kubernetes resource template to render and apply for this workflow run. */
@@ -3664,15 +3934,30 @@ export interface components {
       /** @description Time-to-live for this workflow run after completion (duration string like 10d1h30m). */
       ttlAfterCompletion?: string;
     };
-    /** @description Workflow configuration referencing the Workflow and providing schema values. */
-    WorkflowRunConfig: {
+    /** @description Workflow configuration for a component. Kind and name are mutable. */
+    ComponentWorkflowConfig: {
       /**
-       * @description Kind of workflow (Workflow or ClusterWorkflow)
-       * @default Workflow
+       * @description Kind of referenced workflow resource (Workflow or ClusterWorkflow)
+       * @default ClusterWorkflow
        * @enum {string}
        */
       kind: 'Workflow' | 'ClusterWorkflow';
-      /** @description Referenced Workflow name */
+      /** @description Referenced workflow resource name */
+      name: string;
+      /** @description Developer-provided parameters for the referenced workflow */
+      parameters?: {
+        [key: string]: unknown;
+      };
+    };
+    /** @description Workflow configuration referencing the Workflow and providing schema values. Kind and name are immutable after creation. */
+    WorkflowRunConfig: {
+      /**
+       * @description Kind of referenced workflow resource (Workflow or ClusterWorkflow)
+       * @default ClusterWorkflow
+       * @enum {string}
+       */
+      kind: 'Workflow' | 'ClusterWorkflow';
+      /** @description Referenced workflow resource name */
       name: string;
       /** @description Developer-provided parameters for the referenced workflow */
       parameters?: {
@@ -3813,8 +4098,22 @@ export interface components {
         [key: string]: unknown;
       };
     };
-    /** @description Request to patch a component */
+    /**
+     * @description Request to patch a component. All fields are optional. Each field follows partial-update
+     *     semantics: a field that is omitted from the request leaves the corresponding component
+     *     attribute unchanged. A provided field is applied as described below.
+     */
     PatchComponentRequest: {
+      /**
+       * @description Human-readable display name. When provided, replaces the existing display name.
+       *     Empty string is treated as "no change" (omit the field instead).
+       */
+      displayName?: string;
+      /**
+       * @description Human-readable description. When provided, replaces the existing description.
+       *     Empty string is treated as "no change" (omit the field instead).
+       */
+      description?: string;
       /**
        * @description Controls auto-deployment to default environment
        * @example true
@@ -3824,6 +4123,13 @@ export interface components {
       parameters?: {
         [key: string]: unknown;
       };
+      /**
+       * @description Trait instances attached to the component. When provided, replaces the entire
+       *     traits list (whole-list replace at the slice level). Pass an empty array to
+       *     clear all traits.
+       */
+      traits?: components['schemas']['ComponentTraitInput'][];
+      workflow?: components['schemas']['ComponentWorkflowInput'];
     };
     /** @description Trait attached to a component */
     ComponentTrait: {
@@ -3893,10 +4199,10 @@ export interface components {
       componentType: {
         [key: string]: unknown;
       };
-      /** @description Frozen trait specs at release time (keyed by trait name) */
+      /** @description Frozen trait specs at release time */
       traits?: {
         [key: string]: unknown;
-      };
+      }[];
       /** @description Snapshot of component parameters and trait configs */
       componentProfile?: {
         /** @description Component type parameters */
@@ -3993,6 +4299,40 @@ export interface components {
       conditions?: components['schemas']['Condition'][];
       /** @description Resolved invoke URLs for each named workload endpoint */
       endpoints?: components['schemas']['EndpointURLStatus'][];
+      /** @description Connections that have been successfully resolved */
+      resolvedConnections?: components['schemas']['ResolvedConnection'][];
+      /** @description Connections that could not be resolved */
+      pendingConnections?: components['schemas']['PendingConnection'][];
+    };
+    /** @description Holds the resolved URL for a single connection */
+    ResolvedConnection: {
+      /** @description Control plane namespace of the target component */
+      namespace: string;
+      /** @description Name of the project that owns the target component */
+      project: string;
+      /** @description Name of the target component */
+      component: string;
+      /** @description Name of the endpoint on the target component */
+      endpoint: string;
+      /**
+       * @description Visibility level at which the endpoint was resolved
+       * @enum {string}
+       */
+      visibility: 'project' | 'namespace' | 'internal' | 'external';
+      url: components['schemas']['EndpointURL'];
+    };
+    /** @description Represents a connection that could not be resolved */
+    PendingConnection: {
+      /** @description Control plane namespace of the target component */
+      namespace: string;
+      /** @description Name of the project that owns the target component */
+      project: string;
+      /** @description Name of the target component */
+      component: string;
+      /** @description Name of the endpoint on the target component */
+      endpoint: string;
+      /** @description Describes why the connection could not be resolved */
+      reason: string;
     };
     /** @description Resolved URLs for a single named workload endpoint */
     EndpointURLStatus: {
@@ -4094,6 +4434,375 @@ export interface components {
       /** @description File content */
       value?: string;
       valueFrom?: components['schemas']['EnvVarValueFrom'];
+    };
+    /** @description Reference to a specific key in a Kubernetes Secret on the data plane. */
+    ResourceSecretKeyRef: {
+      /**
+       * @description Secret name (supports ${...} CEL templating in ResourceType outputs)
+       * @example analytics-shared-db-conn
+       */
+      name: string;
+      /**
+       * @description Key within the Secret
+       * @example password
+       */
+      key: string;
+    };
+    /** @description Reference to a specific key in a Kubernetes ConfigMap on the data plane. */
+    ResourceConfigMapKeyRef: {
+      /**
+       * @description ConfigMap name (supports ${...} CEL templating in ResourceType outputs)
+       * @example analytics-shared-db-tls
+       */
+      name: string;
+      /**
+       * @description Key within the ConfigMap
+       * @example ca.crt
+       */
+      key: string;
+    };
+    /**
+     * @description Single output declaration of a (Cluster)ResourceType. Exactly one of
+     *     value, secretKeyRef, or configMapKeyRef must be set. Output value, name,
+     *     and key fields support ${...} CEL templating evaluated against
+     *     metadata.*, parameters.*, environmentConfigs.*, and applied.<id>.status.*.
+     */
+    ResourceTypeOutput: {
+      /**
+       * @description Unique output name. Referenced by Workload.spec.dependencies.resources[].envBindings and fileBindings keys.
+       * @example host
+       */
+      name: string;
+      /**
+       * @description Literal or ${...} CEL expression. Use only for non-sensitive data; the resolved value transits to the control plane.
+       * @example ${applied.claim.status.host}
+       */
+      value?: string;
+      secretKeyRef?: components['schemas']['ResourceSecretKeyRef'];
+      configMapKeyRef?: components['schemas']['ResourceConfigMapKeyRef'];
+    };
+    /**
+     * @description Kubernetes resource template emitted by the (Cluster)ResourceType
+     *     provisioner on the data plane. The template body, includeWhen, and
+     *     readyWhen support ${...} CEL templating against metadata.*, parameters.*,
+     *     environmentConfigs.*, and dataplane.* (plus applied.<id>.* for readyWhen).
+     */
+    ResourceTypeManifest: {
+      /**
+       * @description Unique entry identifier within the (Cluster)ResourceType. Referenced by readyWhen and outputs CEL via applied.<id>.status.*.
+       * @example claim
+       */
+      id: string;
+      /**
+       * @description Optional ${...}-wrapped CEL expression. When false, the entry is skipped entirely.
+       * @example ${parameters.tlsEnabled}
+       */
+      includeWhen?: string;
+      /** @description Kubernetes resource body with ${...} CEL substitutions. */
+      template: {
+        [key: string]: unknown;
+      };
+      /**
+       * @description Optional ${...}-wrapped CEL expression. When set, drives the entry's contribution to ResourceReleaseBinding.status.conditions[ResourcesReady]; otherwise per-Kind health inference is used.
+       * @example ${applied.claim.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}
+       */
+      readyWhen?: string;
+    };
+    /** @description Desired state of a (Cluster)ResourceType. */
+    ResourceTypeSpec: {
+      parameters?: components['schemas']['SchemaSection'];
+      environmentConfigs?: components['schemas']['SchemaSection'];
+      /**
+       * @description Default retention for ResourceReleaseBindings of this type. Per-env override available on the binding.
+       * @default Delete
+       * @example Delete
+       * @enum {string}
+       */
+      retainPolicy: 'Delete' | 'Retain';
+      /** @description Outputs that workloads consume via dependencies.resources[].envBindings or fileBindings. */
+      outputs?: components['schemas']['ResourceTypeOutput'][];
+      /** @description Kubernetes manifests the (Cluster)ResourceType provisioner emits on the data plane. */
+      resources: components['schemas']['ResourceTypeManifest'][];
+    };
+    /** @description Paginated list of cluster resource types */
+    ClusterResourceTypeList: {
+      items: components['schemas']['ClusterResourceType'][];
+      pagination: components['schemas']['Pagination'];
+    };
+    /**
+     * @description ClusterResourceType resource.
+     *     Cluster-scoped sibling of ResourceType. Resources in any namespace can reference it.
+     */
+    ClusterResourceType: {
+      /**
+       * @description API version of the resource
+       * @example openchoreo.dev/v1alpha1
+       */
+      readonly apiVersion?: string;
+      /**
+       * @description Kind of the resource
+       * @example ClusterResourceType
+       */
+      readonly kind?: string;
+      metadata: components['schemas']['ObjectMeta'];
+      spec?: components['schemas']['ResourceTypeSpec'];
+      /** @description ClusterResourceType status (currently empty) */
+      readonly status?: Record<string, never>;
+    };
+    /** @description Paginated list of resource types */
+    ResourceTypeList: {
+      items: components['schemas']['ResourceType'][];
+      pagination: components['schemas']['Pagination'];
+    };
+    /**
+     * @description ResourceType resource.
+     *     PE-published template scoped to a namespace. Developers reference it from Resource.spec.type.
+     */
+    ResourceType: {
+      /**
+       * @description API version of the resource
+       * @example openchoreo.dev/v1alpha1
+       */
+      readonly apiVersion?: string;
+      /**
+       * @description Kind of the resource
+       * @example ResourceType
+       */
+      readonly kind?: string;
+      metadata: components['schemas']['ObjectMeta'];
+      spec?: components['schemas']['ResourceTypeSpec'];
+      /** @description ResourceType status (currently empty) */
+      readonly status?: Record<string, never>;
+    };
+    /** @description Paginated list of resources */
+    ResourceInstanceList: {
+      items: components['schemas']['ResourceInstance'][];
+      pagination: components['schemas']['Pagination'];
+    };
+    /**
+     * @description Resource.
+     *     Developer-facing intent for a managed-infrastructure dependency (database,
+     *     queue, cache, object storage). References a ResourceType or ClusterResourceType template.
+     */
+    ResourceInstance: {
+      /**
+       * @description API version of the resource
+       * @example openchoreo.dev/v1alpha1
+       */
+      readonly apiVersion?: string;
+      /**
+       * @description Kind of the resource (always "Resource" on the wire; see schema name)
+       * @example Resource
+       */
+      readonly kind?: string;
+      metadata: components['schemas']['ObjectMeta'];
+      spec?: components['schemas']['ResourceInstanceSpec'];
+      readonly status?: components['schemas']['ResourceInstanceStatus'];
+    };
+    /** @description Desired state of a Resource. spec.owner and spec.type are immutable after creation. */
+    ResourceInstanceSpec: {
+      /** @description Identifies the project that owns this Resource. */
+      owner: {
+        /**
+         * @description Parent project name
+         * @example analytics
+         */
+        projectName: string;
+      };
+      type: components['schemas']['ResourceTypeRef'];
+      /** @description Values for the parameter schema declared on the referenced (Cluster)ResourceType. Validated by the controller. */
+      parameters?: {
+        [key: string]: unknown;
+      };
+    };
+    /** @description Observed state of a Resource. */
+    ResourceInstanceStatus: {
+      /**
+       * Format: int64
+       * @description Most recent generation observed by the controller
+       */
+      observedGeneration?: number;
+      /** @description Latest available observations of the Resource's state. Includes Ready and Finalizing. */
+      conditions?: components['schemas']['Condition'][];
+      /** @description Most recent ResourceRelease for this Resource. Used as the promote source for ResourceReleaseBinding pin advance. */
+      latestRelease?: {
+        /**
+         * @description Name of the ResourceRelease resource
+         * @example analytics-shared-db-abc123
+         */
+        name: string;
+        /**
+         * @description Content hash of Resource.spec + (Cluster)ResourceType.spec captured at release time
+         * @example abc123
+         */
+        hash: string;
+      };
+    };
+    /** @description Reference to a ResourceType or ClusterResourceType template. */
+    ResourceTypeRef: {
+      /**
+       * @description Resource type kind. Defaults to ResourceType (namespaced).
+       * @default ResourceType
+       * @enum {string}
+       */
+      kind: 'ResourceType' | 'ClusterResourceType';
+      /**
+       * @description Template name.
+       * @example mysql
+       */
+      name: string;
+    };
+    /** @description Paginated list of resource releases */
+    ResourceReleaseList: {
+      items: components['schemas']['ResourceRelease'][];
+      pagination: components['schemas']['Pagination'];
+    };
+    /**
+     * @description ResourceRelease resource.
+     *     Immutable snapshot of Resource.spec and the referenced (Cluster)ResourceType.spec
+     *     at the time it was cut. Created by the Resource controller; spec is immutable.
+     */
+    ResourceRelease: {
+      /**
+       * @description API version of the resource
+       * @example openchoreo.dev/v1alpha1
+       */
+      readonly apiVersion?: string;
+      /**
+       * @description Kind of the resource
+       * @example ResourceRelease
+       */
+      readonly kind?: string;
+      metadata: components['schemas']['ObjectMeta'];
+      spec?: components['schemas']['ResourceReleaseSpec'];
+      /** @description ResourceRelease status (currently empty, immutable after creation) */
+      readonly status?: Record<string, never>;
+    };
+    /** @description Desired state of a ResourceRelease. Immutable after creation. */
+    ResourceReleaseSpec: {
+      /** @description Identifies the resource and project this ResourceRelease belongs to. */
+      owner: {
+        /**
+         * @description Parent project name
+         * @example analytics
+         */
+        projectName: string;
+        /**
+         * @description Parent resource name
+         * @example analytics-shared-db
+         */
+        resourceName: string;
+      };
+      /** @description Frozen snapshot of the referenced (Cluster)ResourceType. */
+      resourceType: {
+        /**
+         * @description Source kind (ResourceType or ClusterResourceType)
+         * @enum {string}
+         */
+        kind: 'ResourceType' | 'ClusterResourceType';
+        /**
+         * @description Source resource type name
+         * @example mysql
+         */
+        name: string;
+        spec: components['schemas']['ResourceTypeSpec'];
+      };
+      /** @description Snapshot of parameter values from Resource.spec at release time. */
+      parameters?: {
+        [key: string]: unknown;
+      };
+    };
+    /** @description Paginated list of resource release bindings */
+    ResourceReleaseBindingList: {
+      items: components['schemas']['ResourceReleaseBinding'][];
+      pagination: components['schemas']['Pagination'];
+    };
+    /**
+     * @description ResourceReleaseBinding resource.
+     *     Pins a ResourceRelease to an Environment and carries per-env config overrides.
+     *     Authored externally; not managed by the Resource controller.
+     */
+    ResourceReleaseBinding: {
+      /**
+       * @description API version of the resource
+       * @example openchoreo.dev/v1alpha1
+       */
+      readonly apiVersion?: string;
+      /**
+       * @description Kind of the resource
+       * @example ResourceReleaseBinding
+       */
+      readonly kind?: string;
+      metadata: components['schemas']['ObjectMeta'];
+      spec?: components['schemas']['ResourceReleaseBindingSpec'];
+      readonly status?: components['schemas']['ResourceReleaseBindingStatus'];
+    };
+    /**
+     * @description Desired state of a ResourceReleaseBinding. spec.owner and spec.environment
+     *     are immutable after creation. spec.resourceRelease is the promote pin and is
+     *     advanced manually via `occ resource promote` or kubectl edit.
+     */
+    ResourceReleaseBindingSpec: {
+      /** @description Identifies the resource and project this binding belongs to. */
+      owner: {
+        /**
+         * @description Parent project name
+         * @example analytics
+         */
+        projectName: string;
+        /**
+         * @description Parent resource name
+         * @example analytics-shared-db
+         */
+        resourceName: string;
+      };
+      /**
+       * @description Target environment name. Immutable after creation.
+       * @example dev
+       */
+      environment: string;
+      /**
+       * @description Pinned ResourceRelease name. Advanced manually (e.g. via `occ resource promote`).
+       * @example analytics-shared-db-abc123
+       */
+      resourceRelease?: string;
+      /**
+       * @description Per-env override for retention. Falls back to ResourceType.spec.retainPolicy when unset.
+       * @example Delete
+       * @enum {string}
+       */
+      retainPolicy?: 'Delete' | 'Retain';
+      /** @description Per-environment values for ResourceType.spec.environmentConfigs. */
+      resourceTypeEnvironmentConfigs?: {
+        [key: string]: unknown;
+      };
+    };
+    /**
+     * @description Resolved output value populated by the binding controller after evaluating
+     *     the ResourceType output CEL against the applied DP-side objects. Exactly one
+     *     of value, secretKeyRef, or configMapKeyRef is set, matching the source
+     *     declaration on ResourceType.spec.outputs.
+     */
+    ResolvedResourceOutput: {
+      /**
+       * @description Output name. Matches the declared output name on the referenced ResourceType.
+       * @example host
+       */
+      name: string;
+      /**
+       * @description Resolved literal value when the source output is declared with `value:`.
+       * @example 10.0.0.5
+       */
+      value?: string;
+      secretKeyRef?: components['schemas']['ResourceSecretKeyRef'];
+      configMapKeyRef?: components['schemas']['ResourceConfigMapKeyRef'];
+    };
+    /** @description Observed state of a ResourceReleaseBinding. */
+    ResourceReleaseBindingStatus: {
+      /** @description Latest available observations of the binding's state. Includes Synced, ResourcesReady, OutputsResolved, Ready (aggregate), and Finalizing. */
+      conditions?: components['schemas']['Condition'][];
+      /** @description Resolved outputs for this environment, populated from the underlying RenderedRelease.status by the binding controller. */
+      outputs?: components['schemas']['ResolvedResourceOutput'][];
     };
     /**
      * @description RenderedRelease resource.
@@ -4534,10 +5243,28 @@ export interface components {
        */
       component?: string;
     };
+    /** @description Action-scoped mapping condition attached to a role mapping inside a binding. It constrains only the actions listed in the "actions" property and does not enable or disable the entire mapping or binding; all other actions in the mapping remain unaffected by this condition. */
+    AuthzCondition: {
+      /**
+       * @description List of actions this condition applies to. Supports exact match (e.g. "releasebinding:create") and wildcards (e.g. "releasebinding:*").
+       * @example [
+       *       "releasebinding:create",
+       *       "releasebinding:*"
+       *     ]
+       */
+      actions: string[];
+      /**
+       * @description CEL expression that must evaluate to true for the action to be permitted. Example: resource.environment in ["dev", "staging"]
+       * @example resource.environment in ["dev", "staging"]
+       */
+      expression: string;
+    };
     /** @description Pairs a role reference with an optional scope */
     AuthzRoleMapping: {
       roleRef: components['schemas']['AuthzRoleRef'];
       scope?: components['schemas']['AuthzScope'];
+      /** @description Per-role-mapping conditions that restrict specific actions within this role mapping in the binding. Each condition only affects the actions listed in its "actions" property and does not enable or disable the mapping or binding as a whole. */
+      conditions?: components['schemas']['AuthzCondition'][];
     };
     /** @description Target resource scope for cluster-scoped bindings (namespace/project/component) */
     AuthzClusterScope: {
@@ -4567,6 +5294,8 @@ export interface components {
         kind?: 'ClusterAuthzRole';
       };
       scope?: components['schemas']['AuthzClusterScope'];
+      /** @description Per-role-mapping conditions that restrict specific actions within this role mapping in the binding. Each condition only affects the actions listed in its "actions" property and does not enable or disable the mapping or binding as a whole. */
+      conditions?: components['schemas']['AuthzCondition'][];
     };
     /** @description Entitlement with claim and value */
     Entitlement: {
@@ -4601,7 +5330,14 @@ export interface components {
     };
     /** @description Additional context for authorization */
     AuthzContext: {
-      [key: string]: unknown;
+      /** @description Resource-level attributes for condition evaluation */
+      resource?: {
+        /**
+         * @description Target deployment environment (e.g. "dev", "staging", "prod")
+         * @example dev
+         */
+        environment?: string;
+      };
     };
     /** @description Authenticated subject context */
     SubjectContext: {
@@ -4666,6 +5402,19 @@ export interface components {
         reason?: string;
       };
     };
+    /** @description An ABAC attribute available for CEL condition expressions on an action. */
+    ConditionAttribute: {
+      /**
+       * @description Full dotted path of the attribute (e.g. "resource.environment").
+       * @example resource.environment
+       */
+      key: string;
+      /**
+       * @description Human-readable description of the attribute.
+       * @example Environment associated with the resource
+       */
+      description: string;
+    };
     /** @description An authorization action with its scope in the resource hierarchy. */
     ActionInfo: {
       /**
@@ -4679,6 +5428,8 @@ export interface components {
        * @enum {string}
        */
       lowestScope: 'cluster' | 'namespace' | 'project' | 'component';
+      /** @description ABAC attributes available for CEL condition expressions on this action. Empty means no conditions are supported. */
+      conditions?: components['schemas']['ConditionAttribute'][];
     };
     /** @description Capabilities for a specific action */
     ActionCapability: {
@@ -4687,6 +5438,17 @@ export interface components {
       /** @description Resources where action is denied */
       denied?: components['schemas']['CapabilityResource'][];
     };
+    /** @description CEL expressions constraining access for a given action and resource path. Multiple expressions are OR'd. */
+    CapabilityConstraints: {
+      /**
+       * @description CEL expressions; access is granted if any one evaluates to true
+       * @example [
+       *       "resource.environment == \"prod\"",
+       *       "resource.environment == \"staging\""
+       *     ]
+       */
+      expressions?: string[];
+    };
     /** @description Resource with permission details */
     CapabilityResource: {
       /**
@@ -4694,10 +5456,7 @@ export interface components {
        * @example namespace/acme/project/payment
        */
       path?: string;
-      /** @description Additional instance-level restrictions */
-      constraints?: {
-        [key: string]: unknown;
-      };
+      constraints?: components['schemas']['CapabilityConstraints'];
     };
     /** @description User authorization profile response */
     UserCapabilitiesResponse: {
@@ -4712,254 +5471,6 @@ export interface components {
        * @example 2025-01-06T10:00:00Z
        */
       evaluatedAt?: string;
-    };
-    /** @description Authorization role with permitted actions (legacy) */
-    Role: {
-      /**
-       * @description Unique role name
-       * @example admin
-       */
-      name: string;
-      /**
-       * @description List of actions this role permits
-       * @example [
-       *       "read",
-       *       "write",
-       *       "delete"
-       *     ]
-       */
-      actions: string[];
-      /**
-       * @description Namespace for namespace-scoped roles, empty for cluster roles
-       * @example my-namespace
-       */
-      namespace?: string;
-      /**
-       * @description Human-readable description of the role
-       * @example Full administrative access
-       */
-      description?: string;
-    };
-    /** @description Request to update a role's actions (legacy) */
-    UpdateRoleRequest: {
-      /**
-       * @description New list of actions for the role
-       * @example [
-       *       "read",
-       *       "write"
-       *     ]
-       */
-      actions: string[];
-    };
-    /** @description Target resource path within a namespace (project/component only) (legacy) */
-    TargetPath: {
-      /**
-       * @description Project name
-       * @example my-project
-       */
-      project?: string;
-      /**
-       * @description Component name
-       * @example api-service
-       */
-      component?: string;
-    };
-    /** @description Mapping of a role to an entitlement within a scope (legacy) */
-    RoleEntitlementMapping: {
-      /**
-       * @description Unique mapping name
-       * @example admin-binding
-       */
-      name: string;
-      role: components['schemas']['RoleRef'];
-      entitlement: components['schemas']['Entitlement'];
-      hierarchy: components['schemas']['ResourceHierarchy'];
-      /**
-       * @description Policy effect (allow or deny)
-       * @default allow
-       * @example allow
-       * @enum {string}
-       */
-      effect: 'allow' | 'deny';
-      context?: components['schemas']['AuthzContext'];
-    };
-    /** @description Request to update a role mapping (legacy) */
-    UpdateRoleMappingRequest: {
-      role: components['schemas']['RoleRef'];
-      entitlement: components['schemas']['Entitlement'];
-      hierarchy: components['schemas']['ResourceHierarchy'];
-      /**
-       * @description Policy effect (allow or deny)
-       * @default allow
-       * @example allow
-       * @enum {string}
-       */
-      effect: 'allow' | 'deny';
-      context?: components['schemas']['AuthzContext'];
-    };
-    /** @description Reference to a cluster role by name only (legacy) */
-    ClusterRoleRef: {
-      /**
-       * @description Cluster role name
-       * @example admin
-       */
-      name: string;
-    };
-    /** @description Reference to a role by name and namespace (legacy) */
-    RoleRef: {
-      /**
-       * @description Role name
-       * @example developer
-       */
-      name: string;
-      /**
-       * @description Namespace for namespace-scoped roles, empty for cluster roles
-       * @example my-namespace
-       */
-      namespace?: string;
-    };
-    /** @description Request to create a cluster-scoped role (legacy) */
-    CreateClusterRoleRequest: {
-      /**
-       * @description Unique cluster role name
-       * @example cluster-admin
-       */
-      name: string;
-      /**
-       * @description List of actions this role permits
-       * @example [
-       *       "read",
-       *       "write",
-       *       "delete"
-       *     ]
-       */
-      actions: string[];
-      /**
-       * @description Human-readable description of the role
-       * @example Full cluster administration access
-       */
-      description?: string;
-    };
-    /** @description Request to update a cluster role (legacy) */
-    UpdateClusterRoleRequest: {
-      /**
-       * @description List of actions this role permits
-       * @example [
-       *       "read",
-       *       "write"
-       *     ]
-       */
-      actions: string[];
-      /**
-       * @description Human-readable description of the role
-       * @example Updated cluster admin role
-       */
-      description?: string;
-    };
-    /** @description Request to create a cluster-scoped role binding (legacy, single mapping only) */
-    CreateClusterRoleBindingRequest: {
-      /**
-       * @description Unique cluster role binding name
-       * @example admin-binding
-       */
-      name: string;
-      entitlement: components['schemas']['Entitlement'];
-      /**
-       * @description Cluster role name
-       * @example admin
-       */
-      role: string;
-      /**
-       * @description Policy effect (allow or deny)
-       * @default allow
-       * @example allow
-       * @enum {string}
-       */
-      effect: 'allow' | 'deny';
-    };
-    /** @description Request to update a cluster role binding (legacy, single mapping only) */
-    UpdateClusterRoleBindingRequest: {
-      entitlement: components['schemas']['Entitlement'];
-      /**
-       * @description Cluster role name
-       * @example admin
-       */
-      role: string;
-      /**
-       * @description Policy effect (allow or deny)
-       * @default allow
-       * @example allow
-       * @enum {string}
-       */
-      effect: 'allow' | 'deny';
-    };
-    /** @description Request to create a namespace-scoped role (legacy) */
-    CreateNamespaceRoleRequest: {
-      /**
-       * @description Unique namespace role name
-       * @example developer
-       */
-      name: string;
-      /**
-       * @description List of actions this role permits
-       * @example [
-       *       "read",
-       *       "write"
-       *     ]
-       */
-      actions: string[];
-      /**
-       * @description Human-readable description of the role
-       * @example Developer access within namespace
-       */
-      description?: string;
-    };
-    /** @description Request to update a namespace role (legacy) */
-    UpdateNamespaceRoleRequest: {
-      /**
-       * @description List of actions this role permits
-       * @example [
-       *       "read",
-       *       "write"
-       *     ]
-       */
-      actions: string[];
-      /**
-       * @description Human-readable description of the role
-       * @example Updated developer role
-       */
-      description?: string;
-    };
-    /** @description Request to create a namespace-scoped role binding (legacy, single mapping only) */
-    CreateNamespaceRoleBindingRequest: {
-      /**
-       * @description Unique namespace role binding name
-       * @example developer-binding
-       */
-      name: string;
-      entitlement: components['schemas']['Entitlement'];
-      role: components['schemas']['RoleRef'];
-      targetPath?: components['schemas']['TargetPath'];
-      /**
-       * @description Policy effect (allow or deny)
-       * @default allow
-       * @example allow
-       * @enum {string}
-       */
-      effect: 'allow' | 'deny';
-    };
-    /** @description Request to update a namespace role binding (legacy, single mapping only) */
-    UpdateNamespaceRoleBindingRequest: {
-      entitlement: components['schemas']['Entitlement'];
-      role: components['schemas']['RoleRef'];
-      targetPath: components['schemas']['TargetPath'];
-      /**
-       * @description Policy effect (allow or deny)
-       * @default allow
-       * @example allow
-       * @enum {string}
-       */
-      effect: 'allow' | 'deny';
     };
     /** @description Response after processing a webhook event */
     WebhookEventResponse: {
@@ -5289,7 +5800,7 @@ export interface components {
       /** @description Target environments for promotion */
       targetEnvironmentRefs: components['schemas']['TargetEnvironmentRef'][];
     };
-    /** @description Target environment reference with approval settings */
+    /** @description Target environment reference */
     TargetEnvironmentRef: {
       /**
        * @description Kind of environment resource
@@ -5302,16 +5813,6 @@ export interface components {
        * @example staging
        */
       name: string;
-      /**
-       * @description Whether promotion requires approval
-       * @example false
-       */
-      requiresApproval?: boolean;
-      /**
-       * @description Whether manual approval is required
-       * @example true
-       */
-      isManualApprovalRequired?: boolean;
     };
     /** @description Paginated list of observability alerts notification channels */
     ObservabilityAlertsNotificationChannelList: {
@@ -5580,42 +6081,45 @@ export interface components {
       data: {
         [key: string]: string;
       };
+      /**
+       * @description Labels applied as Kubernetes labels on the underlying
+       *     SecretReference. Keys in the openchoreo.dev/ namespace are
+       *     reserved and rejected.
+       * @example {
+       *       "team": "payments"
+       *     }
+       */
+      labels?: {
+        [key: string]: string;
+      };
     };
-    /** @description Request body for updating a secret */
+    /**
+     * @description Request body for replacing a secret's data. The data map is the final
+     *     state; keys present in the existing secret but absent here are pruned.
+     */
     UpdateSecretRequest: {
       /**
-       * @description New map of secret keys to plaintext values. Replaces all existing keys.
+       * @description Map of secret keys to plaintext values. Required keys depend on
+       *     the secret's existing type.
        * @example {
        *       "username": "alice",
-       *       "password": "r0tated"
+       *       "password": "s3cret"
        *     }
        */
       data: {
         [key: string]: string;
       };
-    };
-    /** @description Secret resource. Values are never returned, only key names. */
-    SecretResponse: {
       /**
-       * @description Name of the secret
-       * @example my-secret
+       * @description Labels applied as Kubernetes labels on the underlying
+       *     SecretReference. The supplied map replaces all user-set labels;
+       *     keys in the openchoreo.dev/ namespace are reserved and rejected.
+       * @example {
+       *       "team": "payments"
+       *     }
        */
-      name?: string;
-      /**
-       * @description Namespace of the secret
-       * @example my-namespace
-       */
-      namespace?: string;
-      secretType?: components['schemas']['SecretType'];
-      targetPlane?: components['schemas']['TargetPlaneRef'];
-      /**
-       * @description Sorted list of keys present in the secret data
-       * @example [
-       *       "password",
-       *       "username"
-       *     ]
-       */
-      keys?: string[];
+      labels?: {
+        [key: string]: string;
+      };
     };
     /**
      * @description Kubernetes Secret. Wire shape matches `corev1.Secret`: `data` is a map
@@ -5631,6 +6135,10 @@ export interface components {
       /**
        * @description Map of secret keys to base64-encoded values. Matches the
        *     Kubernetes Secret `data` field semantics.
+       * @example {
+       *       "username": "YWxpY2U=",
+       *       "password": "czNjcmV0"
+       *     }
        */
       data?: {
         [key: string]: string;
@@ -5682,7 +6190,7 @@ export interface components {
         'application/json': components['schemas']['ErrorResponse'];
       };
     };
-    /** @description Insufficient permissions to access the resource */
+    /** @description Insufficient permissions to perform the operation */
     Forbidden: {
       headers: {
         [name: string]: unknown;
@@ -5690,7 +6198,7 @@ export interface components {
       content: {
         /**
          * @example {
-         *       "error": "You do not have permission to access this resource",
+         *       "error": "You do not have permission to perform this operation",
          *       "code": "FORBIDDEN"
          *     }
          */
@@ -5727,6 +6235,27 @@ export interface components {
         'application/json': components['schemas']['ErrorResponse'];
       };
     };
+    /** @description Request body is well-formed but failed validation */
+    UnprocessableContent: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        /**
+         * @example {
+         *       "error": "spec.outputs[0].value: undeclared reference to 'applied'",
+         *       "code": "UNPROCESSABLE_CONTENT",
+         *       "details": [
+         *         {
+         *           "field": "spec.outputs[0].value",
+         *           "message": "undeclared reference to 'applied'"
+         *         }
+         *       ]
+         *     }
+         */
+        'application/json': components['schemas']['ErrorResponse'];
+      };
+    };
     /** @description Internal server error */
     InternalError: {
       headers: {
@@ -5737,6 +6266,21 @@ export interface components {
          * @example {
          *       "error": "Internal server error",
          *       "code": "INTERNAL_ERROR"
+         *     }
+         */
+        'application/json': components['schemas']['ErrorResponse'];
+      };
+    };
+    /** @description Feature is disabled on this server */
+    NotImplemented: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        /**
+         * @example {
+         *       "error": "Secret API is disabled on this server",
+         *       "code": "NOT_IMPLEMENTED"
          *     }
          */
         'application/json': components['schemas']['ErrorResponse'];
@@ -5796,6 +6340,18 @@ export interface components {
     ReleaseBindingNameParam: string;
     /** @description Component release name */
     ComponentReleaseNameParam: string;
+    /** @description ClusterResourceType name */
+    ClusterResourceTypeNameParam: string;
+    /** @description ResourceType name */
+    ResourceTypeNameParam: string;
+    /** @description Resource name */
+    ResourceNameParam: string;
+    /** @description Resource release name */
+    ResourceReleaseNameParam: string;
+    /** @description Filter resources by resource name (matches spec.owner.resourceName) */
+    ResourceQueryParam: string;
+    /** @description Resource release binding name */
+    ResourceReleaseBindingNameParam: string;
     /** @description Role name */
     RoleNameParam: string;
     /** @description Role mapping ID */
@@ -5992,6 +6548,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6051,6 +6608,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6152,6 +6710,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6216,6 +6775,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6321,6 +6881,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6396,6 +6957,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6460,6 +7022,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6562,6 +7125,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6626,6 +7190,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6728,6 +7293,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6792,6 +7358,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6894,6 +7461,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -6958,6 +7526,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7054,6 +7623,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7114,6 +7684,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7208,6 +7779,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7268,6 +7840,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7362,6 +7935,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7422,6 +7996,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7516,6 +8091,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7576,6 +8152,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7697,6 +8274,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7757,6 +8335,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7884,6 +8463,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -7948,6 +8528,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8079,6 +8660,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8143,6 +8725,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8268,6 +8851,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8328,6 +8912,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8455,6 +9040,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8519,6 +9105,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8652,6 +9239,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8712,6 +9300,34 @@ export interface operations {
         };
       };
       400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteWorkflowRun: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Workflow run name */
+        runName: components['parameters']['WorkflowRunNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Workflow run deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
@@ -8873,6 +9489,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -8963,6 +9580,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9013,6 +9631,7 @@ export interface operations {
       };
       400: components['responses']['BadRequest'];
       401: components['responses']['Unauthorized'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9113,6 +9732,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9172,6 +9792,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9267,6 +9888,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9327,6 +9949,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9427,6 +10050,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9491,6 +10115,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9595,6 +10220,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9660,6 +10286,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9746,6 +10373,7 @@ export interface operations {
       };
       400: components['responses']['BadRequest'];
       401: components['responses']['Unauthorized'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9821,6 +10449,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9884,6 +10513,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -9989,6 +10619,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10052,6 +10683,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10128,6 +10760,39 @@ export interface operations {
       500: components['responses']['InternalError'];
     };
   };
+  createComponentRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ComponentRelease'];
+      };
+    };
+    responses: {
+      /** @description Component release created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ComponentRelease'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
+      500: components['responses']['InternalError'];
+    };
+  };
   getComponentRelease: {
     parameters: {
       query?: never;
@@ -10150,6 +10815,33 @@ export interface operations {
         content: {
           'application/json': components['schemas']['ComponentRelease'];
         };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteComponentRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Component release name */
+        componentReleaseName: components['parameters']['ComponentReleaseNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Component release deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
@@ -10232,6 +10924,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10295,6 +10988,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10429,6 +11123,850 @@ export interface operations {
       500: components['responses']['InternalError'];
     };
   };
+  listClusterResourceTypes: {
+    parameters: {
+      query?: {
+        /**
+         * @description A label selector to filter resources using Kubernetes label selector syntax.
+         *     Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+         *     Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+         *     Supports existence checks: "key" (label exists), "!key" (label does not exist).
+         *     Multiple requirements are comma-separated and ANDed together.
+         */
+        labelSelector?: components['parameters']['LabelSelectorParam'];
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of cluster resource types */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ClusterResourceTypeList'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  createClusterResourceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ClusterResourceType'];
+      };
+    };
+    responses: {
+      /** @description Cluster resource type created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ClusterResourceType'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  getClusterResourceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ClusterResourceType name */
+        crtName: components['parameters']['ClusterResourceTypeNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Cluster resource type details */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ClusterResourceType'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  updateClusterResourceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ClusterResourceType name */
+        crtName: components['parameters']['ClusterResourceTypeNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ClusterResourceType'];
+      };
+    };
+    responses: {
+      /** @description Cluster resource type updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ClusterResourceType'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteClusterResourceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ClusterResourceType name */
+        crtName: components['parameters']['ClusterResourceTypeNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description ClusterResourceType deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  getClusterResourceTypeSchema: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ClusterResourceType name */
+        crtName: components['parameters']['ClusterResourceTypeNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Cluster resource type schema */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SchemaResponse'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  listResourceTypes: {
+    parameters: {
+      query?: {
+        /**
+         * @description A label selector to filter resources using Kubernetes label selector syntax.
+         *     Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+         *     Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+         *     Supports existence checks: "key" (label exists), "!key" (label does not exist).
+         *     Multiple requirements are comma-separated and ANDed together.
+         */
+        labelSelector?: components['parameters']['LabelSelectorParam'];
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of resource types */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceTypeList'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  createResourceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResourceType'];
+      };
+    };
+    responses: {
+      /** @description Resource type created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceType'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  getResourceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description ResourceType name */
+        rtName: components['parameters']['ResourceTypeNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource type details */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceType'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  updateResourceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description ResourceType name */
+        rtName: components['parameters']['ResourceTypeNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResourceType'];
+      };
+    };
+    responses: {
+      /** @description Resource type updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceType'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteResourceType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description ResourceType name */
+        rtName: components['parameters']['ResourceTypeNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource type deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  getResourceTypeSchema: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description ResourceType name */
+        rtName: components['parameters']['ResourceTypeNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource type schema */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SchemaResponse'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  listResources: {
+    parameters: {
+      query?: {
+        /** @description Filter resources by project name */
+        project?: components['parameters']['ProjectQueryParam'];
+        /**
+         * @description A label selector to filter resources using Kubernetes label selector syntax.
+         *     Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+         *     Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+         *     Supports existence checks: "key" (label exists), "!key" (label does not exist).
+         *     Multiple requirements are comma-separated and ANDed together.
+         */
+        labelSelector?: components['parameters']['LabelSelectorParam'];
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of resources */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceInstanceList'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  createResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResourceInstance'];
+      };
+    };
+    responses: {
+      /** @description Resource created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceInstance'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  getResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Resource name */
+        resourceName: components['parameters']['ResourceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource details */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceInstance'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  updateResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Resource name */
+        resourceName: components['parameters']['ResourceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResourceInstance'];
+      };
+    };
+    responses: {
+      /** @description Resource updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceInstance'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Resource name */
+        resourceName: components['parameters']['ResourceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  listResourceReleases: {
+    parameters: {
+      query?: {
+        /** @description Filter resources by resource name (matches spec.owner.resourceName) */
+        resource?: components['parameters']['ResourceQueryParam'];
+        /**
+         * @description A label selector to filter resources using Kubernetes label selector syntax.
+         *     Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+         *     Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+         *     Supports existence checks: "key" (label exists), "!key" (label does not exist).
+         *     Multiple requirements are comma-separated and ANDed together.
+         */
+        labelSelector?: components['parameters']['LabelSelectorParam'];
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of resource releases */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceReleaseList'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  createResourceRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResourceRelease'];
+      };
+    };
+    responses: {
+      /** @description Resource release created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceRelease'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  getResourceRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Resource release name */
+        resourceReleaseName: components['parameters']['ResourceReleaseNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource release details */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceRelease'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteResourceRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Resource release name */
+        resourceReleaseName: components['parameters']['ResourceReleaseNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource release deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  listResourceReleaseBindings: {
+    parameters: {
+      query?: {
+        /** @description Filter resources by resource name (matches spec.owner.resourceName) */
+        resource?: components['parameters']['ResourceQueryParam'];
+        /**
+         * @description A label selector to filter resources using Kubernetes label selector syntax.
+         *     Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+         *     Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+         *     Supports existence checks: "key" (label exists), "!key" (label does not exist).
+         *     Multiple requirements are comma-separated and ANDed together.
+         */
+        labelSelector?: components['parameters']['LabelSelectorParam'];
+        /** @description Maximum number of items to return per page */
+        limit?: components['parameters']['LimitParam'];
+        /**
+         * @description Opaque pagination cursor from a previous response.
+         *     Pass the `nextCursor` value from pagination metadata to fetch the next page.
+         */
+        cursor?: components['parameters']['CursorParam'];
+      };
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of resource release bindings */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceReleaseBindingList'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  createResourceReleaseBinding: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResourceReleaseBinding'];
+      };
+    };
+    responses: {
+      /** @description Resource release binding created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceReleaseBinding'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      409: components['responses']['Conflict'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  getResourceReleaseBinding: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Resource release binding name */
+        resourceReleaseBindingName: components['parameters']['ResourceReleaseBindingNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource release binding details */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceReleaseBinding'];
+        };
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  updateResourceReleaseBinding: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Resource release binding name */
+        resourceReleaseBindingName: components['parameters']['ResourceReleaseBindingNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResourceReleaseBinding'];
+      };
+    };
+    responses: {
+      /** @description Resource release binding updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ResourceReleaseBinding'];
+        };
+      };
+      400: components['responses']['BadRequest'];
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
+  deleteResourceReleaseBinding: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Namespace name */
+        namespaceName: components['parameters']['NamespaceNameParam'];
+        /** @description Resource release binding name */
+        resourceReleaseBindingName: components['parameters']['ResourceReleaseBindingNameParam'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource release binding deleted successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components['responses']['Unauthorized'];
+      403: components['responses']['Forbidden'];
+      404: components['responses']['NotFound'];
+      500: components['responses']['InternalError'];
+    };
+  };
   listDeploymentPipelines: {
     parameters: {
       query?: {
@@ -10501,6 +12039,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10564,6 +12103,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10666,6 +12206,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10729,6 +12270,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10814,6 +12356,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
     };
   };
@@ -10877,6 +12420,7 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       500: components['responses']['InternalError'];
+      501: components['responses']['NotImplemented'];
     };
   };
   createSecret: {
@@ -10901,14 +12445,16 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['SecretResponse'];
+          'application/json': components['schemas']['Secret'];
         };
       };
       400: components['responses']['BadRequest'];
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       409: components['responses']['Conflict'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
+      501: components['responses']['NotImplemented'];
     };
   };
   getSecret: {
@@ -10938,6 +12484,7 @@ export interface operations {
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
       500: components['responses']['InternalError'];
+      501: components['responses']['NotImplemented'];
     };
   };
   updateSecret: {
@@ -10964,14 +12511,16 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['SecretResponse'];
+          'application/json': components['schemas']['Secret'];
         };
       };
       400: components['responses']['BadRequest'];
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
+      501: components['responses']['NotImplemented'];
     };
   };
   deleteSecret: {
@@ -10999,7 +12548,9 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+      422: components['responses']['UnprocessableContent'];
       500: components['responses']['InternalError'];
+      501: components['responses']['NotImplemented'];
     };
   };
 }

--- a/plugins/catalog-backend-module-openchoreo/src/kinds/DeploymentPipelineEntityV1alpha1.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/kinds/DeploymentPipelineEntityV1alpha1.ts
@@ -12,14 +12,6 @@ export interface TargetEnvironmentRef {
    */
   name: string;
   /**
-   * Whether promotion to this environment requires approval
-   */
-  requiresApproval?: boolean;
-  /**
-   * Whether manual approval is required (as opposed to automated approval)
-   */
-  isManualApprovalRequired?: boolean;
-  /**
    * Index signature for JSON compatibility
    */
   [key: string]: JsonValue | undefined;

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.test.ts
@@ -151,7 +151,7 @@ const k8sPipeline = {
     promotionPaths: [
       {
         sourceEnvironmentRef: 'dev',
-        targetEnvironmentRefs: [{ name: 'staging', requiresApproval: true }],
+        targetEnvironmentRefs: [{ name: 'staging' }],
       },
     ],
   },

--- a/plugins/catalog-backend-module-openchoreo/src/utils/entityTranslation.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/utils/entityTranslation.ts
@@ -1365,8 +1365,6 @@ export function translateNewDeploymentPipelineToEntity(
       targetEnvironments:
         path.targetEnvironmentRefs?.map(target => ({
           name: target.name,
-          requiresApproval: target.requiresApproval,
-          isManualApprovalRequired: target.isManualApprovalRequired,
         })) || [],
     })) || [];
 

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
@@ -135,7 +135,7 @@ const k8sPipeline = {
     promotionPaths: [
       {
         sourceEnvironmentRef: 'dev',
-        targetEnvironmentRefs: [{ name: 'staging', requiresApproval: true }],
+        targetEnvironmentRefs: [{ name: 'staging' }],
       },
     ],
   },
@@ -435,13 +435,11 @@ describe('EnvironmentInfoService', () => {
         promotionPaths: [
           {
             sourceEnvironmentRef: 'dev',
-            targetEnvironmentRefs: [
-              { name: 'staging', requiresApproval: false },
-            ],
+            targetEnvironmentRefs: [{ name: 'staging' }],
           },
           {
             sourceEnvironmentRef: 'staging',
-            targetEnvironmentRefs: [{ name: 'prod', requiresApproval: true }],
+            targetEnvironmentRefs: [{ name: 'prod' }],
           },
         ],
       },

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -426,8 +426,6 @@ export class EnvironmentInfoService implements EnvironmentService {
       transformedEnv.promotionTargets = promotionTargets.map((ref: any) => ({
         name: ref.name,
         resourceName: ref.resourceName,
-        requiresApproval: ref.requiresApproval,
-        isManualApprovalRequired: ref.isManualApprovalRequired,
       }));
     }
 

--- a/plugins/openchoreo-backend/src/services/ProjectService/ProjectInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/ProjectService/ProjectInfoService.test.ts
@@ -60,7 +60,7 @@ const k8sPipeline = {
     promotionPaths: [
       {
         sourceEnvironmentRef: 'dev',
-        targetEnvironmentRefs: [{ name: 'staging', requiresApproval: true }],
+        targetEnvironmentRefs: [{ name: 'staging' }],
       },
     ],
   },

--- a/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.test.ts
+++ b/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.test.ts
@@ -203,15 +203,11 @@ describe('SecretsService', () => {
   });
 
   describe('createSecret', () => {
-    it('POSTs the request body and returns the response', async () => {
-      const created = {
-        name: 'db-creds',
-        namespace: 'test-ns',
-        secretType: 'Opaque',
-        targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
-        keys: ['DB_HOST', 'DB_USER'],
-      };
-      mockPOST.mockResolvedValueOnce(createOkResponse(created));
+    it('POSTs the request body and projects the K8s Secret response', async () => {
+      // The new API returns the K8s Secret shape. targetPlane is not on the
+      // response (it lives on the SecretReference); the BFF leaves the field
+      // undefined and the UI refreshes via list.
+      mockPOST.mockResolvedValueOnce(createOkResponse(dbCredsSecret));
 
       const result = await createService().createSecret(
         'test-ns',
@@ -224,7 +220,13 @@ describe('SecretsService', () => {
         'token',
       );
 
-      expect(result).toEqual(created);
+      expect(result).toEqual({
+        name: 'db-creds',
+        namespace: 'test-ns',
+        secretType: 'Opaque',
+        targetPlane: undefined,
+        keys: ['DB_HOST', 'DB_USER'],
+      });
       expect(mockPOST).toHaveBeenCalledWith(
         '/api/v1alpha1/namespaces/{namespaceName}/secrets',
         expect.objectContaining({
@@ -252,15 +254,8 @@ describe('SecretsService', () => {
   });
 
   describe('updateSecret', () => {
-    it('PUTs the request body and returns the response', async () => {
-      const updated = {
-        name: 'db-creds',
-        namespace: 'test-ns',
-        secretType: 'Opaque',
-        targetPlane: { kind: 'DataPlane', name: 'dp-prod' },
-        keys: ['DB_HOST', 'DB_USER'],
-      };
-      mockPUT.mockResolvedValueOnce(createOkResponse(updated));
+    it('PUTs the request body and projects the K8s Secret response', async () => {
+      mockPUT.mockResolvedValueOnce(createOkResponse(dbCredsSecret));
 
       const result = await createService().updateSecret(
         'test-ns',
@@ -269,7 +264,13 @@ describe('SecretsService', () => {
         'token',
       );
 
-      expect(result).toEqual(updated);
+      expect(result).toEqual({
+        name: 'db-creds',
+        namespace: 'test-ns',
+        secretType: 'Opaque',
+        targetPlane: undefined,
+        keys: ['DB_HOST', 'DB_USER'],
+      });
       expect(mockPUT).toHaveBeenCalledWith(
         '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}',
         expect.objectContaining({

--- a/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.ts
+++ b/plugins/openchoreo-backend/src/services/SecretsService/SecretsService.ts
@@ -8,7 +8,6 @@ import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
 
 export type SecretType = OpenChoreoComponents['schemas']['SecretType'];
 export type TargetPlaneRef = OpenChoreoComponents['schemas']['TargetPlaneRef'];
-export type SecretResponse = OpenChoreoComponents['schemas']['SecretResponse'];
 export type CreateSecretRequest =
   OpenChoreoComponents['schemas']['CreateSecretRequest'];
 export type UpdateSecretRequest =
@@ -17,6 +16,19 @@ type SecretReference = OpenChoreoComponents['schemas']['SecretReference'];
 type ListSecretsResponse =
   OpenChoreoComponents['schemas']['ListSecretsResponse'];
 type SecretObject = OpenChoreoComponents['schemas']['Secret'];
+
+/**
+ * Flat projection of a K8s Secret joined with its SecretReference for
+ * targetPlane. The BFF returns this shape so frontend consumers don't need
+ * to know about the K8s metadata/spec wrapper or the separate reference.
+ */
+export interface SecretResponse {
+  name: string;
+  namespace: string;
+  secretType?: SecretType;
+  targetPlane?: TargetPlaneRef;
+  keys: string[];
+}
 
 export interface SecretsListResponse {
   items: SecretResponse[];
@@ -85,16 +97,7 @@ export class SecretsService {
       const items: SecretResponse[] = secrets.map(secret => {
         const name = secret.metadata?.name ?? '';
         const ref = refByName.get(name);
-        const keys = Object.keys(secret.data ?? {}).sort((a, b) =>
-          a.localeCompare(b),
-        );
-        return {
-          name,
-          namespace: secret.metadata?.namespace ?? namespaceName,
-          secretType: toSecretType(secret.type),
-          targetPlane: ref?.spec?.targetPlane,
-          keys,
-        };
+        return projectSecret(secret, ref, name, namespaceName);
       });
 
       this.logger.debug(
@@ -159,14 +162,8 @@ export class SecretsService {
       }
 
       const data = (secret.data ?? {}) as Record<string, string>;
-      const keys = Object.keys(data).sort((a, b) => a.localeCompare(b));
-
       return {
-        name: secret.metadata?.name ?? secretName,
-        namespace: secret.metadata?.namespace ?? namespaceName,
-        secretType: toSecretType(secret.type),
-        targetPlane: ref.spec?.targetPlane,
-        keys,
+        ...projectSecret(secret, ref, secretName, namespaceName),
         data,
       };
     } catch (err) {
@@ -193,20 +190,27 @@ export class SecretsService {
         logger: this.logger,
       });
 
-      const { data, error, response } = await client.POST(
+      const postRes = await client.POST(
         '/api/v1alpha1/namespaces/{namespaceName}/secrets',
         {
           params: { path: { namespaceName } },
           body,
         },
       );
-
-      assertApiResponse({ data, error, response }, 'create secret');
+      assertApiResponse(postRes, 'create secret');
 
       this.logger.debug(
         `Successfully created secret ${body.secretName} in namespace: ${namespaceName}`,
       );
-      return data as SecretResponse;
+      // targetPlane is not on the K8s Secret response; the only frontend
+      // consumer awaits this call for completion and refreshes via list,
+      // so we leave the optional field undefined to avoid an extra GET.
+      return projectSecret(
+        postRes.data as SecretObject,
+        undefined,
+        body.secretName,
+        namespaceName,
+      );
     } catch (err) {
       this.logger.error(
         `Failed to create secret ${body.secretName} in ${namespaceName}: ${err}`,
@@ -232,20 +236,25 @@ export class SecretsService {
         logger: this.logger,
       });
 
-      const { data, error, response } = await client.PUT(
+      const putRes = await client.PUT(
         '/api/v1alpha1/namespaces/{namespaceName}/secrets/{secretName}',
         {
           params: { path: { namespaceName, secretName } },
           body,
         },
       );
-
-      assertApiResponse({ data, error, response }, 'update secret');
+      assertApiResponse(putRes, 'update secret');
 
       this.logger.debug(
         `Successfully updated secret ${secretName} in namespace: ${namespaceName}`,
       );
-      return data as SecretResponse;
+      // See createSecret: targetPlane is left undefined here too.
+      return projectSecret(
+        putRes.data as SecretObject,
+        undefined,
+        secretName,
+        namespaceName,
+      );
     } catch (err) {
       this.logger.error(
         `Failed to update secret ${secretName} in ${namespaceName}: ${err}`,
@@ -304,4 +313,23 @@ function toSecretType(raw: string | undefined): SecretType | undefined {
     return raw as SecretType;
   }
   return undefined;
+}
+
+/**
+ * Project a K8s Secret + SecretReference into the flat BFF response shape.
+ * `targetPlane` comes from the reference; everything else from the Secret.
+ */
+function projectSecret(
+  secret: SecretObject,
+  ref: SecretReference | undefined,
+  fallbackName: string,
+  fallbackNamespace: string,
+): SecretResponse {
+  return {
+    name: secret.metadata?.name ?? fallbackName,
+    namespace: secret.metadata?.namespace ?? fallbackNamespace,
+    secretType: toSecretType(secret.type),
+    targetPlane: ref?.spec?.targetPlane,
+    keys: Object.keys(secret.data ?? {}).sort((a, b) => a.localeCompare(b)),
+  };
 }

--- a/plugins/openchoreo-backend/src/services/transformers/transformers.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/transformers.test.ts
@@ -496,7 +496,6 @@ describe('transformDeploymentPipeline', () => {
             {
               kind: 'Environment' as const,
               name: 'staging',
-              requiresApproval: true,
             },
           ],
         },

--- a/plugins/openchoreo-backend/src/types.ts
+++ b/plugins/openchoreo-backend/src/types.ts
@@ -81,8 +81,6 @@ export interface Environment {
   promotionTargets?: {
     name: string;
     resourceName?: string;
-    requiresApproval?: boolean;
-    isManualApprovalRequired?: boolean;
   }[];
 }
 

--- a/plugins/openchoreo-common/src/types/bff-types.ts
+++ b/plugins/openchoreo-common/src/types/bff-types.ts
@@ -82,8 +82,6 @@ export interface PromotionPath {
 
 export interface TargetEnvironmentRef {
   name: string;
-  requiresApproval?: boolean;
-  isManualApprovalRequired?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/openchoreo-react/src/components/PipelineFlowVisualization/dag/PipelineEdge.tsx
+++ b/plugins/openchoreo-react/src/components/PipelineFlowVisualization/dag/PipelineEdge.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
 import { usePipelineStyles } from './pipelineStyles';
 import type { PipelineEdge as PipelineEdgeType } from './pipelineTypes';
 
@@ -9,18 +8,6 @@ interface PipelineEdgeProps {
 
 export const PipelineEdge: FC<PipelineEdgeProps> = ({ edge }) => {
   const classes = usePipelineStyles();
-
-  const approvalIconPosition =
-    edge.requiresApproval && edge.lines.length > 0
-      ? (() => {
-          const midIndex = Math.floor(edge.lines.length / 2);
-          const midLine = edge.lines[midIndex];
-          return {
-            x: (midLine.x1 + midLine.x2) / 2,
-            y: (midLine.y1 + midLine.y2) / 2,
-          };
-        })()
-      : null;
 
   const lastLine = edge.lines[edge.lines.length - 1];
 
@@ -37,11 +24,7 @@ export const PipelineEdge: FC<PipelineEdgeProps> = ({ edge }) => {
         return (
           <div
             key={i}
-            className={
-              edge.requiresApproval
-                ? classes.edgeLineApproval
-                : classes.edgeLine
-            }
+            className={classes.edgeLine}
             style={{
               width: length,
               left: midX - length / 2,
@@ -60,18 +43,6 @@ export const PipelineEdge: FC<PipelineEdgeProps> = ({ edge }) => {
             top: lastLine.y2 - 4,
           }}
         />
-      )}
-
-      {approvalIconPosition && (
-        <div
-          className={classes.approvalIcon}
-          style={{
-            left: approvalIconPosition.x - 8,
-            top: approvalIconPosition.y - 8,
-          }}
-        >
-          <LockOutlinedIcon style={{ fontSize: 12 }} />
-        </div>
       )}
     </>
   );

--- a/plugins/openchoreo-react/src/components/PipelineFlowVisualization/dag/pipelineLayoutUtils.ts
+++ b/plugins/openchoreo-react/src/components/PipelineFlowVisualization/dag/pipelineLayoutUtils.ts
@@ -27,13 +27,13 @@ export const MINI_SETUP_NODE_HEIGHT = 140;
 /** Minimal env shape used by buildEnvPipelineNodes */
 export interface EnvPipelineInput {
   name: string;
-  promotionTargets?: { name: string; requiresApproval?: boolean }[];
+  promotionTargets?: { name: string }[];
 }
 
-/** A promotion path in canonical form (source name + target {name, requiresApproval?}) */
+/** A promotion path in canonical form (source name + target names) */
 export interface PathPipelineInput {
   source: string;
-  targets: { name: string; requiresApproval?: boolean }[];
+  targets: { name: string }[];
 }
 
 /**
@@ -44,10 +44,7 @@ export interface PathPipelineInput {
 export function buildEnvPipelineNodes<T extends EnvPipelineInput>(
   environments: T[],
 ): PipelineNode<T>[] {
-  const incomingMap = new Map<
-    string,
-    { from: string; requiresApproval?: boolean }[]
-  >();
+  const incomingMap = new Map<string, string[]>();
   for (const env of environments) {
     incomingMap.set(env.name, []);
   }
@@ -57,10 +54,7 @@ export function buildEnvPipelineNodes<T extends EnvPipelineInput>(
     for (const target of env.promotionTargets) {
       const incoming = incomingMap.get(target.name);
       if (incoming) {
-        incoming.push({
-          from: env.name,
-          requiresApproval: target.requiresApproval,
-        });
+        incoming.push(env.name);
       }
     }
   }
@@ -73,10 +67,7 @@ export function buildEnvPipelineNodes<T extends EnvPipelineInput>(
     const incoming = incomingMap.get(env.name) ?? [];
     const parents =
       incoming.length > 0
-        ? incoming.map(i => ({
-            id: i.from,
-            requiresApproval: i.requiresApproval,
-          }))
+        ? incoming.map(from => ({ id: from }))
         : [{ id: SETUP_NODE_ID }];
     nodes.push({ id: env.name, isSetup: false, parents, data: env });
   }
@@ -89,15 +80,13 @@ export function buildEnvPipelineNodes<T extends EnvPipelineInput>(
  * used by the chip-strip mini-DAG inside PipelineFlowVisualization.
  *
  * Multiple paths sharing a source are merged. Multiple paths with the
- * same (source, target) pair de-duplicate to a single edge; if any
- * declares requiresApproval, the merged edge inherits that flag.
+ * same (source, target) pair de-duplicate to a single edge.
  */
 export function buildPathPipelineNodes(
   paths: PathPipelineInput[],
 ): PipelineNode<{ name: string }>[] {
   const allEnvs = new Set<string>();
-  // edgeKey -> requiresApproval (sticky-true)
-  const incomingByTarget = new Map<string, Map<string, boolean | undefined>>();
+  const incomingByTarget = new Map<string, Set<string>>();
 
   for (const path of paths) {
     if (!path.source) continue;
@@ -105,10 +94,8 @@ export function buildPathPipelineNodes(
     for (const target of path.targets) {
       if (!target.name) continue;
       allEnvs.add(target.name);
-      const incoming = incomingByTarget.get(target.name) ?? new Map();
-      const prior = incoming.get(path.source);
-      const merged = prior || target.requiresApproval;
-      incoming.set(path.source, merged);
+      const incoming = incomingByTarget.get(target.name) ?? new Set();
+      incoming.add(path.source);
       incomingByTarget.set(target.name, incoming);
     }
   }
@@ -117,10 +104,7 @@ export function buildPathPipelineNodes(
   for (const name of allEnvs) {
     const incoming = incomingByTarget.get(name);
     const parents = incoming
-      ? Array.from(incoming.entries()).map(([from, requiresApproval]) => ({
-          id: from,
-          requiresApproval,
-        }))
+      ? Array.from(incoming).map(from => ({ id: from }))
       : [];
     nodes.push({ id: name, isSetup: false, parents, data: { name } });
   }
@@ -191,7 +175,6 @@ export interface ComputeLayoutOptions {
 
 /**
  * Run dagre layout to compute positions for all pipeline nodes and edges.
- * `requiresApproval` flows from the node's parent metadata onto each edge.
  */
 export function computePipelineLayout<T>(
   pipelineNodes: PipelineNode<T>[],
@@ -227,14 +210,9 @@ export function computePipelineLayout<T>(
     graph.setNode(node.id, { width, height });
   }
 
-  // Track requiresApproval per edge from node parent metadata.
-  const approvalByEdge = new Map<string, boolean | undefined>();
-  const edgeKey = (from: string, to: string) => `${from}->${to}`;
-
   for (const node of pipelineNodes) {
     for (const parent of node.parents) {
       graph.setEdge(parent.id, node.id);
-      approvalByEdge.set(edgeKey(parent.id, node.id), parent.requiresApproval);
     }
   }
 
@@ -275,7 +253,6 @@ export function computePipelineLayout<T>(
       from: edgeInfo.v,
       to: edgeInfo.w,
       lines: computeLines(fromNode, toNode),
-      requiresApproval: approvalByEdge.get(edgeKey(edgeInfo.v, edgeInfo.w)),
     });
   }
 

--- a/plugins/openchoreo-react/src/components/PipelineFlowVisualization/dag/pipelineStyles.ts
+++ b/plugins/openchoreo-react/src/components/PipelineFlowVisualization/dag/pipelineStyles.ts
@@ -30,13 +30,6 @@ export const usePipelineStyles = makeStyles(theme => ({
     zIndex: 0,
     pointerEvents: 'none',
   },
-  edgeLineApproval: {
-    position: 'absolute',
-    borderTop: `1.5px dashed ${theme.palette.warning.main}`,
-    transformOrigin: 'center',
-    zIndex: 0,
-    pointerEvents: 'none',
-  },
   arrowHead: {
     position: 'absolute',
     width: 0,
@@ -45,19 +38,6 @@ export const usePipelineStyles = makeStyles(theme => ({
     borderBottom: '4px solid transparent',
     borderLeft: `6px solid ${theme.palette.grey[400]}`,
     zIndex: 0,
-    pointerEvents: 'none',
-  },
-  approvalIcon: {
-    position: 'absolute',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 16,
-    height: 16,
-    borderRadius: '50%',
-    backgroundColor: theme.palette.warning.light,
-    color: theme.palette.warning.dark,
-    zIndex: 1,
     pointerEvents: 'none',
   },
 }));

--- a/plugins/openchoreo-react/src/components/PipelineFlowVisualization/dag/pipelineTypes.ts
+++ b/plugins/openchoreo-react/src/components/PipelineFlowVisualization/dag/pipelineTypes.ts
@@ -9,7 +9,6 @@ export interface EdgeLine {
 /** A parent reference with optional edge metadata */
 export interface PipelineParent {
   id: string;
-  requiresApproval?: boolean;
 }
 
 /** A node in the pipeline DAG */
@@ -33,7 +32,6 @@ export interface PipelineEdge {
   from: string;
   to: string;
   lines: EdgeLine[];
-  requiresApproval?: boolean;
 }
 
 /** The complete computed pipeline layout */

--- a/plugins/openchoreo/src/components/DeploymentPipelineOverview/DeploymentPipelineVisualization.tsx
+++ b/plugins/openchoreo/src/components/DeploymentPipelineOverview/DeploymentPipelineVisualization.tsx
@@ -12,16 +12,8 @@ import { useDeploymentPipelineOverviewStyles } from './styles';
 interface RawPromotionPath {
   sourceEnvironment?: string;
   sourceEnvironmentRef?: string | { name?: string };
-  targetEnvironments?: Array<{
-    name: string;
-    requiresApproval?: boolean;
-    isManualApprovalRequired?: boolean;
-  }>;
-  targetEnvironmentRefs?: Array<{
-    name: string;
-    requiresApproval?: boolean;
-    isManualApprovalRequired?: boolean;
-  }>;
+  targetEnvironments?: Array<{ name: string }>;
+  targetEnvironmentRefs?: Array<{ name: string }>;
 }
 
 export const DeploymentPipelineVisualization = () => {
@@ -47,10 +39,7 @@ export const DeploymentPipelineVisualization = () => {
         path.targetEnvironments ?? path.targetEnvironmentRefs ?? [];
       const targets = rawTargets
         .filter(t => !!t.name)
-        .map(t => ({
-          name: t.name,
-          requiresApproval: t.requiresApproval ?? t.isManualApprovalRequired,
-        }));
+        .map(t => ({ name: t.name }));
       return { source, targets };
     });
 

--- a/plugins/openchoreo/src/components/EnvironmentOverview/useEnvironmentPipelines.ts
+++ b/plugins/openchoreo/src/components/EnvironmentOverview/useEnvironmentPipelines.ts
@@ -65,22 +65,14 @@ export function useEnvironmentPipelines(): UseEnvironmentPipelinesResult {
             // Catalog entity may use either the old (string) or new (object) shape:
             sourceEnvironment?: string;
             sourceEnvironmentRef?: string | { name?: string };
-            targetEnvironments?: Array<{
-              name: string;
-              requiresApproval?: boolean;
-              isManualApprovalRequired?: boolean;
-            }>;
-            targetEnvironmentRefs?: Array<{
-              name: string;
-              requiresApproval?: boolean;
-              isManualApprovalRequired?: boolean;
-            }>;
+            targetEnvironments?: Array<{ name: string }>;
+            targetEnvironmentRefs?: Array<{ name: string }>;
           }>;
         };
         if (!rawSpec?.promotionPaths) continue;
 
         // Normalize to a single shape:
-        // { source: string, targets: { name, requiresApproval? }[] }[]
+        // { source: string, targets: { name }[] }[]
         const normalized = rawSpec.promotionPaths.map(path => {
           const source =
             path.sourceEnvironment ??
@@ -92,11 +84,7 @@ export function useEnvironmentPipelines(): UseEnvironmentPipelinesResult {
             path.targetEnvironments ?? path.targetEnvironmentRefs ?? [];
           const targets = rawTargets
             .filter(t => !!t.name)
-            .map(t => ({
-              name: t.name,
-              requiresApproval:
-                t.requiresApproval ?? t.isManualApprovalRequired,
-            }));
+            .map(t => ({ name: t.name }));
           return { source, targets };
         });
 

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentData.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentData.ts
@@ -39,8 +39,6 @@ export interface Environment {
   promotionTargets?: {
     name: string;
     resourceName?: string;
-    requiresApproval?: boolean;
-    isManualApprovalRequired?: boolean;
   }[];
 }
 

--- a/plugins/openchoreo/src/components/Environments/hooks/usePromotionAction.test.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/usePromotionAction.test.ts
@@ -58,10 +58,7 @@ describe('usePromotionAction', () => {
       usePromotionAction({
         environmentName: 'dev',
         deploymentStatus: 'Ready',
-        promotionTargets: [
-          { name: 'staging' },
-          { name: 'prod', requiresApproval: true },
-        ],
+        promotionTargets: [{ name: 'staging' }, { name: 'prod' }],
         isAlreadyPromoted: () => false,
         promotionTracker: tracker(),
         suspendTracker: tracker(),
@@ -72,9 +69,7 @@ describe('usePromotionAction', () => {
     );
     expect(result.current.promotionActions).toHaveLength(2);
     expect(result.current.promotionActions[0].label).toBe('Promote to staging');
-    expect(result.current.promotionActions[1].label).toBe(
-      'Promote to prod (Approval Required)',
-    );
+    expect(result.current.promotionActions[1].label).toBe('Promote to prod');
     expect(result.current.primaryPromotion?.target.name).toBe('staging');
   });
 

--- a/plugins/openchoreo/src/components/Environments/hooks/usePromotionAction.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/usePromotionAction.ts
@@ -7,7 +7,6 @@ import type { ItemActionTracker } from '../types';
 export interface PromotionTargetInfo {
   name: string;
   resourceName?: string;
-  requiresApproval?: boolean;
 }
 
 export interface PromotionTargetAction {
@@ -56,9 +55,9 @@ export interface UsePromotionActionResult {
 
 /**
  * Centralizes the per-target promotion + undeploy/redeploy decision tree
- * (label / disabled / approval-required / "already promoted" / in-flight)
- * so the full-card EnvironmentActions row, the mini node primary action,
- * and the detail panel can all derive identical button state.
+ * (label / disabled / "already promoted" / in-flight) so the full-card
+ * EnvironmentActions row, the mini node primary action, and the detail
+ * panel can all derive identical button state.
  */
 export function usePromotionAction({
   environmentName,
@@ -102,9 +101,7 @@ export function usePromotionAction({
           } else if (promoting) {
             label = 'Promoting...';
           } else {
-            label = `Promote to ${target.name}${
-              target.requiresApproval ? ' (Approval Required)' : ''
-            }`;
+            label = `Promote to ${target.name}`;
           }
           return {
             target,

--- a/plugins/openchoreo/src/components/Projects/hooks/useDeploymentPipeline.ts
+++ b/plugins/openchoreo/src/components/Projects/hooks/useDeploymentPipeline.ts
@@ -70,13 +70,7 @@ export const useDeploymentPipeline = () => {
             }
             const targets = (path.targetEnvironmentRefs ?? [])
               .filter(t => !!t.name)
-              .map(t => ({
-                name: t.name,
-                requiresApproval:
-                  t.requiresApproval ??
-                  (t as { isManualApprovalRequired?: boolean })
-                    .isManualApprovalRequired,
-              }));
+              .map(t => ({ name: t.name }));
             for (const target of targets) {
               if (!addedEnvs.has(target.name)) {
                 environments.push(target.name);


### PR DESCRIPTION
## Purpose

Syncs the openchoreo-api typed client to upstream/main (61 PRs since 2026-03-02). Picks up new endpoints and adapts consumers to two upstream breaking changes.

## Approach

- Sync `openchoreo-api.yaml` from openchoreo `upstream/main` and regenerate the typed client
- Adapt consumers to two upstream breaking changes:
  - DeploymentPipeline approval fields removed (openchoreo/openchoreo#2651) — drop the dead field reads and remove the lock-icon UI plumbing
  - Secret API response shape changed to K8s `Secret` (openchoreo/openchoreo#3457) — fix `SecretsService.create/update`, which used to cast the K8s response as the old flat shape without converting it.

## Checklist

- [x] Tests added or updated (unit, integration, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified approval metadata handling in deployment pipelines and environment configurations.

* **UI Changes**
  * Removed approval status indicators and lock icons from pipeline flow visualizations.
  * Updated promotion action labels to remove approval requirement suffixes.

* **API Changes**
  * Streamlined target environment references to include only environment names.
  * Refactored `SecretsService` response structure for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/540)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->