### PR TITLE
feat: introduce capability to apply finOps agent recommendations automatically

### DIFF
--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -66,6 +66,7 @@ export {
   openchoreoTracesViewPermission,
   openchoreoRcaViewPermission,
   openchoreoRcaUpdatePermission,
+  openchoreoFinopsUpdatePermission,
   openchoreoTraitsViewPermission,
   openchoreoTraitCreatePermission,
   openchoreoComponentTypeCreatePermission,

--- a/plugins/openchoreo-common/src/permissions.ts
+++ b/plugins/openchoreo-common/src/permissions.ts
@@ -780,6 +780,16 @@ export const openchoreoRcaUpdatePermission = createPermission({
 });
 
 /**
+ * Permission to update FinOps reports for a project (apply/dismiss recommendations).
+ * Resource-based: requires the specific project context.
+ */
+export const openchoreoFinopsUpdatePermission = createPermission({
+  name: 'openchoreo.finops.update',
+  attributes: { action: 'update' },
+  resourceType: OPENCHOREO_RESOURCE_TYPE_PROJECT,
+});
+
+/**
  * Permission to view traits for a component.
  * Resource-based: requires the specific component context.
  */
@@ -855,6 +865,7 @@ export const openchoreoPermissions = [
   openchoreoTracesViewPermission,
   openchoreoRcaViewPermission,
   openchoreoRcaUpdatePermission,
+  openchoreoFinopsUpdatePermission,
   openchoreoTraitsViewPermission,
   openchoreoAlertsViewPermission,
   openchoreoIncidentsViewPermission,
@@ -953,6 +964,7 @@ export const OPENCHOREO_PERMISSION_TO_ACTION: Record<string, string> = {
   'openchoreo.traces.view': 'traces:view',
   'openchoreo.rca.view': 'rcareport:view',
   'openchoreo.rca.update': 'rcareport:update',
+  'openchoreo.finops.update': 'finopsreport:update',
   'openchoreo.traits.view': 'trait:view',
   'openchoreo.trait.create': 'trait:create',
   'openchoreo.componenttype.create': 'componenttype:create',

--- a/plugins/openchoreo-observability/src/api/FinOpsAgentApi.test.ts
+++ b/plugins/openchoreo-observability/src/api/FinOpsAgentApi.test.ts
@@ -1,0 +1,116 @@
+import { FinOpsAgentClient } from './FinOpsAgentApi';
+
+const mockResolveUrls = jest.fn();
+
+jest.mock('./ObserverUrlCache', () => ({
+  ObserverUrlCache: jest.fn().mockImplementation(() => ({
+    resolveUrls: mockResolveUrls,
+  })),
+}));
+
+const mockFetchApi = { fetch: jest.fn() };
+const mockDiscoveryApi = { getBaseUrl: jest.fn() };
+
+function createClient() {
+  return new FinOpsAgentClient({
+    discoveryApi: mockDiscoveryApi as any,
+    fetchApi: mockFetchApi as any,
+  });
+}
+
+const routing = { namespaceName: 'dev', environmentName: 'development' };
+
+describe('FinOpsAgentClient.updateActionStatuses', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveUrls.mockResolvedValue({
+      finopsAgentUrl: 'http://finops-agent',
+    });
+    mockFetchApi.fetch.mockResolvedValue({ ok: true } as Response);
+  });
+
+  it('calls the correct PUT endpoint', async () => {
+    await createClient().updateActionStatuses('rep-1', routing, {
+      appliedIndices: [0],
+    });
+
+    expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+      'http://finops-agent/api/v1alpha1/reports/rep-1',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+
+  it('sends appliedIndices in the request body as JSON', async () => {
+    await createClient().updateActionStatuses('rep-1', routing, {
+      appliedIndices: [0, 2],
+    });
+
+    const [, opts] = mockFetchApi.fetch.mock.calls[0];
+    expect(JSON.parse(opts.body)).toEqual({ appliedIndices: [0, 2] });
+  });
+
+  it('sends dismissedIndices in the request body as JSON', async () => {
+    await createClient().updateActionStatuses('rep-1', routing, {
+      dismissedIndices: [1],
+    });
+
+    const [, opts] = mockFetchApi.fetch.mock.calls[0];
+    expect(JSON.parse(opts.body)).toEqual({ dismissedIndices: [1] });
+  });
+
+  it('includes the x-openchoreo-direct header', async () => {
+    await createClient().updateActionStatuses('rep-1', routing, {});
+
+    const [, opts] = mockFetchApi.fetch.mock.calls[0];
+    expect(opts.headers['x-openchoreo-direct']).toBe('true');
+  });
+
+  it('URL-encodes the report ID', async () => {
+    await createClient().updateActionStatuses('report/with/slashes', routing, {
+      appliedIndices: [0],
+    });
+
+    const [url] = mockFetchApi.fetch.mock.calls[0];
+    expect(url).toContain('report%2Fwith%2Fslashes');
+  });
+
+  it('resolves the URL using the routing namespace and environment', async () => {
+    await createClient().updateActionStatuses('rep-1', routing, {});
+
+    expect(mockResolveUrls).toHaveBeenCalledWith('dev', 'development');
+  });
+
+  it('throws when the finops service is not configured', async () => {
+    mockResolveUrls.mockResolvedValue({ finopsAgentUrl: undefined });
+
+    await expect(
+      createClient().updateActionStatuses('rep-1', routing, {}),
+    ).rejects.toThrow('FinOps service is not configured');
+  });
+
+  it('throws with the error detail from a non-OK response', async () => {
+    mockFetchApi.fetch.mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({ detail: 'Invalid action indices' }),
+    } as any);
+
+    await expect(
+      createClient().updateActionStatuses('rep-1', routing, {
+        appliedIndices: [99],
+      }),
+    ).rejects.toThrow('Invalid action indices');
+  });
+
+  it('falls back to statusText when response body has no detail field', async () => {
+    mockFetchApi.fetch.mockResolvedValue({
+      ok: false,
+      statusText: 'Service Unavailable',
+      json: () => Promise.resolve({}),
+    } as any);
+
+    await expect(
+      createClient().updateActionStatuses('rep-1', routing, {}),
+    ).rejects.toThrow('Update report failed: Service Unavailable');
+  });
+});

--- a/plugins/openchoreo-observability/src/api/FinOpsAgentApi.ts
+++ b/plugins/openchoreo-observability/src/api/FinOpsAgentApi.ts
@@ -1,0 +1,67 @@
+import {
+  createApiRef,
+  DiscoveryApi,
+  FetchApi,
+} from '@backstage/core-plugin-api';
+import { ObserverUrlCache } from './ObserverUrlCache';
+
+export interface FinOpsRoutingContext {
+  namespaceName: string;
+  environmentName: string;
+}
+
+export interface FinOpsAgentApi {
+  updateActionStatuses(
+    reportId: string,
+    routing: FinOpsRoutingContext,
+    update: { appliedIndices?: number[]; dismissedIndices?: number[] },
+  ): Promise<void>;
+}
+
+export const finopsAgentApiRef = createApiRef<FinOpsAgentApi>({
+  id: 'plugin.openchoreo-finops-agent.service',
+});
+
+export class FinOpsAgentClient implements FinOpsAgentApi {
+  private readonly fetchApi: FetchApi;
+  private readonly urlCache: ObserverUrlCache;
+
+  constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi }) {
+    this.fetchApi = options.fetchApi;
+    this.urlCache = new ObserverUrlCache(options);
+  }
+
+  async updateActionStatuses(
+    reportId: string,
+    routing: FinOpsRoutingContext,
+    update: { appliedIndices?: number[]; dismissedIndices?: number[] },
+  ): Promise<void> {
+    const { finopsAgentUrl } = await this.urlCache.resolveUrls(
+      routing.namespaceName,
+      routing.environmentName,
+    );
+
+    if (!finopsAgentUrl) {
+      throw new Error('FinOps service is not configured');
+    }
+
+    const response = await this.fetchApi.fetch(
+      `${finopsAgentUrl}/api/v1alpha1/reports/${encodeURIComponent(reportId)}`,
+      {
+        method: 'PUT',
+        body: JSON.stringify(update),
+        headers: {
+          'Content-Type': 'application/json',
+          'x-openchoreo-direct': 'true',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(
+        error.detail || `Update report failed: ${response.statusText}`,
+      );
+    }
+  }
+}

--- a/plugins/openchoreo-observability/src/api/index.ts
+++ b/plugins/openchoreo-observability/src/api/index.ts
@@ -12,3 +12,10 @@ export {
   type ChatRequest,
   type StreamEvent,
 } from './RCAAgentApi';
+
+export {
+  finopsAgentApiRef,
+  FinOpsAgentClient,
+  type FinOpsAgentApi,
+  type FinOpsRoutingContext,
+} from './FinOpsAgentApi';

--- a/plugins/openchoreo-observability/src/components/CostAnalysis/CostAnalysisReport.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostAnalysis/CostAnalysisReport.test.tsx
@@ -1,7 +1,9 @@
 import { screen } from '@testing-library/react';
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { CostAnalysisReport } from './CostAnalysisReport';
+import { finopsAgentApiRef } from '../../api/FinOpsAgentApi';
+import { discoveryApiRef } from '@backstage/core-plugin-api';
 
 const mockUseRcaPermission = jest.fn();
 jest.mock('@openchoreo/backstage-plugin-react', () => ({
@@ -76,11 +78,30 @@ function setupDefaultMocks() {
   });
 }
 
+const mockFinopsAgentApi = {
+  updateActionStatuses: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockDiscoveryApi = {
+  getBaseUrl: jest
+    .fn()
+    .mockResolvedValue(
+      'http://localhost:7007/api/openchoreo-observability-backend',
+    ),
+};
+
 async function renderReport(routePath = '/r1') {
   return renderInTestApp(
-    <EntityProvider entity={defaultEntity}>
-      <CostAnalysisReport />
-    </EntityProvider>,
+    <TestApiProvider
+      apis={[
+        [finopsAgentApiRef, mockFinopsAgentApi],
+        [discoveryApiRef, mockDiscoveryApi],
+      ]}
+    >
+      <EntityProvider entity={defaultEntity}>
+        <CostAnalysisReport />
+      </EntityProvider>
+    </TestApiProvider>,
     { routeEntries: [routePath] },
   );
 }

--- a/plugins/openchoreo-observability/src/components/CostAnalysis/CostAnalysisReport.tsx
+++ b/plugins/openchoreo-observability/src/components/CostAnalysis/CostAnalysisReport.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Box, Typography } from '@material-ui/core';
 import { Progress } from '@backstage/core-components';
@@ -14,6 +15,8 @@ import {
 } from '../../hooks';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { CostAnalysisReportView } from './CostAnalysisReportView';
+import { useApi, discoveryApiRef } from '@backstage/core-plugin-api';
+import { finopsAgentApiRef } from '../../api/FinOpsAgentApi';
 
 const CostAnalysisReportContent = () => {
   const { reportId } = useParams<{ reportId?: string }>();
@@ -22,6 +25,8 @@ const CostAnalysisReportContent = () => {
   const { filters } = useFilters();
   const namespace = entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
   const projectName = entity.metadata.name as string;
+  const finopsAgentApi = useApi(finopsAgentApiRef);
+  const discoveryApi = useApi(discoveryApiRef);
 
   // Get environments to ensure we have environment data
   const { environments } = useGetEnvironmentsByNamespace(
@@ -34,7 +39,28 @@ const CostAnalysisReportContent = () => {
     report: detailedReport,
     loading,
     error,
+    refresh,
   } = useFinOpsReport(reportId, environment?.name, entity);
+
+  const [backendBaseUrl, setBackendBaseUrl] = useState<string | undefined>();
+  const [discoveryError, setDiscoveryError] = useState<string | undefined>();
+  useEffect(() => {
+    discoveryApi
+      .getBaseUrl('openchoreo-observability-backend')
+      .then(setBackendBaseUrl)
+      .catch((err: unknown) => {
+        // eslint-disable-next-line no-console
+        console.error(
+          'Failed to discover openchoreo-observability-backend:',
+          err,
+        );
+        setDiscoveryError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to connect to the observability backend.',
+        );
+      });
+  }, [discoveryApi]);
 
   if (loading) {
     return <Progress />;
@@ -58,6 +84,16 @@ const CostAnalysisReportContent = () => {
       <Box mt={2} mb={2}>
         <Alert severity={severity}>
           <Typography variant="body1">{errorMessage}</Typography>
+        </Alert>
+      </Box>
+    );
+  }
+
+  if (discoveryError) {
+    return (
+      <Box mt={2} mb={2}>
+        <Alert severity="error">
+          <Typography variant="body1">{discoveryError}</Typography>
         </Alert>
       </Box>
     );
@@ -90,6 +126,13 @@ const CostAnalysisReportContent = () => {
       }`
     : undefined;
 
+  const chatContext = {
+    backendBaseUrl,
+    namespaceName: namespace || '',
+    environmentName: environmentName || '',
+    finopsAgentApi,
+  };
+
   return (
     <CostAnalysisReportView
       report={detailedReport}
@@ -97,6 +140,8 @@ const CostAnalysisReportContent = () => {
       onBack={handleBack}
       componentUrl={componentUrl}
       metricsUrl={metricsUrl}
+      chatContext={chatContext}
+      onRecommendationApplied={refresh}
     />
   );
 };

--- a/plugins/openchoreo-observability/src/components/CostAnalysis/CostAnalysisReportView.tsx
+++ b/plugins/openchoreo-observability/src/components/CostAnalysis/CostAnalysisReportView.tsx
@@ -14,6 +14,8 @@ import TrendingUpOutlinedIcon from '@material-ui/icons/TrendingUpOutlined';
 import AssignmentOutlinedIcon from '@material-ui/icons/AssignmentOutlined';
 import { FinOpsReportDetailed } from '../../types';
 import { FormattedText } from '../RCA/RCAReport/FormattedText';
+import { FinOpsApplyButton } from './FinOpsApplyButton';
+import type { FinOpsAgentApi } from '../../api/FinOpsAgentApi';
 
 const useStyles = makeStyles(theme => ({
   header: {
@@ -118,12 +120,21 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+interface FinOpsApplyChatContextProp {
+  backendBaseUrl?: string;
+  namespaceName: string;
+  environmentName: string;
+  finopsAgentApi: FinOpsAgentApi;
+}
+
 interface CostAnalysisReportViewProps {
   report: FinOpsReportDetailed;
   reportId: string;
   onBack: () => void;
   componentUrl?: string;
   metricsUrl?: string;
+  chatContext?: FinOpsApplyChatContextProp;
+  onRecommendationApplied?: () => void;
 }
 
 export const CostAnalysisReportView = ({
@@ -132,6 +143,8 @@ export const CostAnalysisReportView = ({
   onBack,
   componentUrl,
   metricsUrl,
+  chatContext,
+  onRecommendationApplied,
 }: CostAnalysisReportViewProps) => {
   const classes = useStyles();
 
@@ -612,6 +625,21 @@ export const CostAnalysisReportView = ({
                     }
                   />
                 </Typography>
+                {(() => {
+                  const action = costAnalysis.recommended_actions?.[0];
+                  if (!action?.change || !chatContext) return null;
+                  return (
+                    <Box mt={2}>
+                      <FinOpsApplyButton
+                        reportId={reportId}
+                        actionIndex={0}
+                        action={action}
+                        chatContext={chatContext}
+                        onApplied={onRecommendationApplied}
+                      />
+                    </Box>
+                  );
+                })()}
               </InfoCard>
             </Grid>
           )}

--- a/plugins/openchoreo-observability/src/components/CostAnalysis/FinOpsApplyButton.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostAnalysis/FinOpsApplyButton.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { FinOpsApplyButton } from './FinOpsApplyButton';
+import type { FinOpsRemediationAction } from '../../types';
+
+// Mock the shared apply utility
+jest.mock('../../utils/applyResourceChange', () => ({
+  applyResourceChange: jest.fn(),
+}));
+
+import { applyResourceChange } from '../../utils/applyResourceChange';
+
+const mockApplyResourceChange = applyResourceChange as jest.MockedFunction<
+  typeof applyResourceChange
+>;
+
+// Mock the permission hook
+const mockUseFinopsUpdatePermission = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useFinopsUpdatePermission: () => mockUseFinopsUpdatePermission(),
+}));
+
+// Mock Backstage fetchApiRef (used inside FinOpsApplyButton via useApi)
+const mockFetch = jest.fn();
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: () => ({ fetch: mockFetch }),
+  fetchApiRef: {},
+}));
+
+const mockFinopsAgentApi = {
+  updateActionStatuses: jest.fn(),
+};
+
+const chatContext = {
+  backendBaseUrl: 'http://backend',
+  namespaceName: 'dev',
+  environmentName: 'development',
+  finopsAgentApi: mockFinopsAgentApi,
+};
+
+const revisedAction: FinOpsRemediationAction = {
+  description: 'Right-size CPU and memory requests',
+  rationale: 'CPU utilization is low',
+  status: 'revised',
+  change: {
+    release_binding: 'my-service-development',
+    fields: [
+      {
+        json_pointer:
+          '/spec/componentTypeEnvironmentConfigs/resources/requests/cpu',
+        value: '50m',
+      },
+    ],
+  },
+};
+
+function renderButton(
+  action: FinOpsRemediationAction = revisedAction,
+  props?: Partial<Parameters<typeof FinOpsApplyButton>[0]>,
+) {
+  return render(
+    <FinOpsApplyButton
+      reportId="report-123"
+      actionIndex={0}
+      action={action}
+      chatContext={chatContext}
+      onApplied={jest.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe('FinOpsApplyButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseFinopsUpdatePermission.mockReturnValue({
+      canUpdateFinops: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+    mockApplyResourceChange.mockResolvedValue(undefined);
+    mockFinopsAgentApi.updateActionStatuses.mockResolvedValue(undefined);
+  });
+
+  describe('initial states from server status', () => {
+    it('shows Apply Recommendation button for a revised action', () => {
+      renderButton();
+      expect(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows Applied (disabled) for a server-side applied action', () => {
+      renderButton({ ...revisedAction, status: 'applied' });
+      const btn = screen.getByRole('button', { name: /applied/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it('shows Dismissed (disabled) for a server-side dismissed action', () => {
+      renderButton({ ...revisedAction, status: 'dismissed' });
+      const btn = screen.getByRole('button', { name: /dismissed/i });
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  describe('permission gating', () => {
+    it('disables the button when canUpdateFinops is false', () => {
+      mockUseFinopsUpdatePermission.mockReturnValue({
+        canUpdateFinops: false,
+        loading: false,
+        deniedTooltip: 'No permission',
+      });
+      renderButton();
+      expect(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      ).toBeDisabled();
+    });
+
+    it('disables the button while permission is loading', () => {
+      mockUseFinopsUpdatePermission.mockReturnValue({
+        canUpdateFinops: false,
+        loading: true,
+        deniedTooltip: '',
+      });
+      renderButton();
+      expect(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      ).toBeDisabled();
+    });
+
+    it('disables the button when action.change is null', () => {
+      renderButton({ ...revisedAction, change: null });
+      expect(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe('successful apply flow', () => {
+    it('calls applyResourceChange with correct arguments', async () => {
+      renderButton();
+      fireEvent.click(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockApplyResourceChange).toHaveBeenCalledWith({
+          backendBaseUrl: 'http://backend',
+          fetchApi: expect.any(Object),
+          namespaceName: 'dev',
+          change: revisedAction.change,
+        }),
+      );
+    });
+
+    it('calls finopsAgentApi.updateActionStatuses with appliedIndices', async () => {
+      renderButton();
+      fireEvent.click(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockFinopsAgentApi.updateActionStatuses).toHaveBeenCalledWith(
+          'report-123',
+          { namespaceName: 'dev', environmentName: 'development' },
+          { appliedIndices: [0] },
+        ),
+      );
+    });
+
+    it('shows Applied button after successful apply', async () => {
+      renderButton();
+      fireEvent.click(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /applied/i })).toBeDisabled(),
+      );
+    });
+
+    it('calls onApplied callback after successful apply', async () => {
+      const onApplied = jest.fn();
+      renderButton(revisedAction, { onApplied });
+      fireEvent.click(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      );
+
+      await waitFor(() => expect(onApplied).toHaveBeenCalledTimes(1));
+    });
+
+    it('still shows Applied even if updateActionStatuses fails (non-fatal)', async () => {
+      mockFinopsAgentApi.updateActionStatuses.mockRejectedValue(
+        new Error('network'),
+      );
+      renderButton();
+      fireEvent.click(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /applied/i })).toBeDisabled(),
+      );
+    });
+  });
+
+  describe('failure flow', () => {
+    it('shows Retry button and error message when applyResourceChange throws', async () => {
+      mockApplyResourceChange.mockRejectedValue(
+        new Error('Release binding not found'),
+      );
+      renderButton();
+      fireEvent.click(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      );
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /retry/i }),
+        ).toBeInTheDocument(),
+      );
+      expect(screen.getByText(/Release binding not found/)).toBeInTheDocument();
+    });
+
+    it('does not call onApplied when applyResourceChange fails', async () => {
+      mockApplyResourceChange.mockRejectedValue(new Error('oops'));
+      const onApplied = jest.fn();
+      renderButton(revisedAction, { onApplied });
+      fireEvent.click(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      );
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /retry/i }),
+        ).toBeInTheDocument(),
+      );
+      expect(onApplied).not.toHaveBeenCalled();
+    });
+
+    it('retries when the Retry button is clicked', async () => {
+      mockApplyResourceChange
+        .mockRejectedValueOnce(new Error('first failure'))
+        .mockResolvedValueOnce(undefined);
+
+      renderButton();
+      fireEvent.click(
+        screen.getByRole('button', { name: /apply recommendation/i }),
+      );
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /retry/i }),
+        ).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /applied/i })).toBeDisabled(),
+      );
+      expect(mockApplyResourceChange).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostAnalysis/FinOpsApplyButton.tsx
+++ b/plugins/openchoreo-observability/src/components/CostAnalysis/FinOpsApplyButton.tsx
@@ -1,0 +1,157 @@
+import { useState, useCallback } from 'react';
+import { Button, Box, LinearProgress, Tooltip } from '@material-ui/core';
+import CheckIcon from '@material-ui/icons/Check';
+import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
+import { Alert } from '@material-ui/lab';
+import { useApi, fetchApiRef } from '@backstage/core-plugin-api';
+import { useFinopsUpdatePermission } from '@openchoreo/backstage-plugin-react';
+import type { FinOpsAgentApi } from '../../api/FinOpsAgentApi';
+import type { FinOpsRemediationAction } from '../../types';
+import { applyResourceChange } from '../../utils/applyResourceChange';
+
+interface FinOpsApplyChatContext {
+  backendBaseUrl?: string;
+  namespaceName: string;
+  environmentName: string;
+  finopsAgentApi: FinOpsAgentApi;
+}
+
+interface FinOpsApplyButtonProps {
+  reportId: string;
+  actionIndex: number;
+  action: FinOpsRemediationAction;
+  chatContext: FinOpsApplyChatContext;
+  onApplied?: () => void;
+}
+
+type ApplyStatus = 'idle' | 'applying' | 'success' | 'failed';
+
+export const FinOpsApplyButton = ({
+  reportId,
+  actionIndex,
+  action,
+  chatContext,
+  onApplied,
+}: FinOpsApplyButtonProps) => {
+  const fetchApi = useApi(fetchApiRef);
+  const {
+    canUpdateFinops,
+    loading: permissionLoading,
+    deniedTooltip,
+  } = useFinopsUpdatePermission();
+
+  const initialStatus: ApplyStatus =
+    action.status === 'applied' ? 'success' : 'idle';
+  const [status, setStatus] = useState<ApplyStatus>(initialStatus);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleApply = useCallback(async () => {
+    if (!chatContext.backendBaseUrl || !action.change) return;
+
+    setStatus('applying');
+    setErrorMsg('');
+
+    try {
+      await applyResourceChange({
+        backendBaseUrl: chatContext.backendBaseUrl,
+        fetchApi,
+        namespaceName: chatContext.namespaceName,
+        change: action.change,
+      });
+
+      try {
+        await chatContext.finopsAgentApi.updateActionStatuses(
+          reportId,
+          {
+            namespaceName: chatContext.namespaceName,
+            environmentName: chatContext.environmentName,
+          },
+          { appliedIndices: [actionIndex] },
+        );
+      } catch {
+        // Non-fatal: the binding was patched; status recording failed
+      }
+
+      setStatus('success');
+      onApplied?.();
+    } catch (err) {
+      setErrorMsg(
+        err instanceof Error ? err.message : 'Failed to apply recommendation',
+      );
+      setStatus('failed');
+    }
+  }, [chatContext, fetchApi, reportId, actionIndex, action.change, onApplied]);
+
+  if (action.status === 'applied' || status === 'success') {
+    return (
+      <Button
+        variant="outlined"
+        size="small"
+        disabled
+        startIcon={<CheckIcon />}
+      >
+        Applied
+      </Button>
+    );
+  }
+
+  if (action.status === 'dismissed') {
+    return (
+      <Button variant="outlined" size="small" disabled>
+        Dismissed
+      </Button>
+    );
+  }
+
+  if (status === 'applying') {
+    return (
+      <Box display="flex" flexDirection="column" style={{ gap: 8 }}>
+        <Button variant="outlined" size="small" disabled>
+          Applying...
+        </Button>
+        <LinearProgress style={{ borderRadius: 2 }} />
+      </Box>
+    );
+  }
+
+  if (status === 'failed') {
+    return (
+      <Box display="flex" flexDirection="column" style={{ gap: 8 }}>
+        <Button
+          variant="outlined"
+          color="secondary"
+          size="small"
+          startIcon={<ErrorOutlineIcon />}
+          onClick={handleApply}
+        >
+          Retry
+        </Button>
+        <Alert severity="error" style={{ fontSize: '0.8rem' }}>
+          {errorMsg}
+        </Alert>
+      </Box>
+    );
+  }
+
+  const missingConfig = !chatContext.backendBaseUrl || !action.change;
+  const disabled = permissionLoading || !canUpdateFinops || missingConfig;
+  const tooltipTitle = missingConfig
+    ? 'Apply is unavailable: required configuration is missing'
+    : deniedTooltip;
+
+  return (
+    <Tooltip title={tooltipTitle}>
+      <span>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          onClick={handleApply}
+          disabled={disabled}
+        >
+          Apply Recommendation
+        </Button>
+      </span>
+    </Tooltip>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/PatchTabContent.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/PatchTabContent.tsx
@@ -23,6 +23,11 @@ import type {
   FileChange,
   FieldChange,
 } from '../../../../api/RCAAgentApi';
+import {
+  applyJsonPointer,
+  applyEnvChange,
+  applyFileChange,
+} from '../../../../utils/applyResourceChange';
 
 interface ChatContext {
   namespaceName: string;
@@ -58,69 +63,6 @@ export function allActionsResolved(
         action.status === 'applied' || action.status === 'dismissed',
     )
   );
-}
-
-const ALLOWED_OVERRIDE_CATEGORIES = new Set([
-  'workloadOverrides',
-  'traitEnvironmentConfigs',
-  'componentTypeEnvironmentConfigs',
-]);
-
-function applyJsonPointer(doc: any, pointer: string, value: any): void {
-  const keys = pointer.replace(/^\//, '').split('/');
-  if (
-    keys.length < 3 ||
-    keys[0] !== 'spec' ||
-    !ALLOWED_OVERRIDE_CATEGORIES.has(keys[1])
-  ) {
-    throw new Error(`Invalid pointer: '${pointer}'`);
-  }
-  let current = doc;
-  for (const key of keys.slice(0, -1)) {
-    if (
-      current[key] === null ||
-      current[key] === undefined ||
-      typeof current[key] !== 'object'
-    ) {
-      current[key] = {};
-    }
-    current = current[key];
-  }
-  const last = keys.at(-1)!;
-  current[last] = value;
-}
-
-function applyEnvChange(doc: any, key: string, value: string): void {
-  const env: { key: string; value: string }[] =
-    doc.spec?.workloadOverrides?.container?.env ?? [];
-  const existing = env.find(e => e.key === key);
-  if (existing) {
-    existing.value = value;
-  } else {
-    env.push({ key, value });
-    doc.spec ??= {};
-    doc.spec.workloadOverrides ??= {};
-    doc.spec.workloadOverrides.container ??= {};
-    doc.spec.workloadOverrides.container.env = env;
-  }
-}
-
-function applyFileChange(
-  doc: any,
-  key: string,
-  mountPath: string,
-  value: string,
-): void {
-  const files: { key: string; value: string; mountPath: string }[] =
-    doc.spec?.workloadOverrides?.container?.files ?? [];
-  const existing = files.find(f => f.key === key && f.mountPath === mountPath);
-  if (existing) {
-    existing.value = value;
-  } else {
-    throw new Error(
-      `File mount '${key}' at '${mountPath}' not found in binding`,
-    );
-  }
 }
 
 type PrimitiveValue = string | number | boolean;

--- a/plugins/openchoreo-observability/src/plugin.ts
+++ b/plugins/openchoreo-observability/src/plugin.ts
@@ -12,6 +12,7 @@ import {
   ObservabilityClient,
 } from './api/ObservabilityApi';
 import { rcaAgentApiRef, RCAAgentClient } from './api/RCAAgentApi';
+import { finopsAgentApiRef, FinOpsAgentClient } from './api/FinOpsAgentApi';
 
 const openchoreoObservabilityPlugin = createPlugin({
   id: 'openchoreo-observability',
@@ -36,6 +37,15 @@ const openchoreoObservabilityPlugin = createPlugin({
       },
       factory: ({ discoveryApi, fetchApi }) =>
         new RCAAgentClient({ discoveryApi, fetchApi }),
+    }),
+    createApiFactory({
+      api: finopsAgentApiRef,
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new FinOpsAgentClient({ discoveryApi, fetchApi }),
     }),
   ],
 });

--- a/plugins/openchoreo-observability/src/types.ts
+++ b/plugins/openchoreo-observability/src/types.ts
@@ -209,6 +209,7 @@ export interface FinOpsReport {
   overprovisioning: OverprovisioningAssessment;
   summary: string;
   investigation_path: InvestigationStep[];
+  recommended_actions?: FinOpsRemediationAction[];
 }
 
 export interface CostBreakdown {
@@ -243,6 +244,24 @@ export interface ResourceRecommendation {
   memory_request: string;
   memory_limit: string;
   rationale: string;
+  release_binding?: string | null;
+}
+
+export interface FinOpsFieldChange {
+  json_pointer: string;
+  value: string | number | boolean;
+}
+
+export interface FinOpsResourceChange {
+  release_binding: string;
+  fields: FinOpsFieldChange[];
+}
+
+export interface FinOpsRemediationAction {
+  description: string;
+  rationale: string;
+  status: 'revised' | 'applied' | 'dismissed';
+  change: FinOpsResourceChange | null;
 }
 
 export interface InvestigationStep {

--- a/plugins/openchoreo-observability/src/utils/applyResourceChange.test.ts
+++ b/plugins/openchoreo-observability/src/utils/applyResourceChange.test.ts
@@ -1,0 +1,351 @@
+// structuredClone is not available in all test environments
+if (typeof structuredClone === 'undefined') {
+  (global as any).structuredClone = <T>(obj: T): T =>
+    JSON.parse(JSON.stringify(obj));
+}
+
+import {
+  applyJsonPointer,
+  applyEnvChange,
+  applyFileChange,
+  applyResourceChange,
+} from './applyResourceChange';
+
+// ---------------------------------------------------------------------------
+// applyJsonPointer
+// ---------------------------------------------------------------------------
+
+describe('applyJsonPointer', () => {
+  it('sets a value at a valid spec/componentTypeEnvironmentConfigs pointer', () => {
+    const doc: any = {};
+    applyJsonPointer(
+      doc,
+      '/spec/componentTypeEnvironmentConfigs/resources/requests/cpu',
+      '50m',
+    );
+    expect(
+      doc.spec.componentTypeEnvironmentConfigs.resources.requests.cpu,
+    ).toBe('50m');
+  });
+
+  it('sets a value at a valid spec/workloadOverrides pointer', () => {
+    const doc: any = {};
+    applyJsonPointer(doc, '/spec/workloadOverrides/container/replicas', 2);
+    expect(doc.spec.workloadOverrides.container.replicas).toBe(2);
+  });
+
+  it('sets a value at a valid spec/traitEnvironmentConfigs pointer', () => {
+    const doc: any = {};
+    applyJsonPointer(doc, '/spec/traitEnvironmentConfigs/my-trait/timeout', 30);
+    expect(doc.spec.traitEnvironmentConfigs['my-trait'].timeout).toBe(30);
+  });
+
+  it('overwrites an existing value', () => {
+    const doc: any = {
+      spec: {
+        componentTypeEnvironmentConfigs: {
+          resources: { requests: { cpu: '200m' } },
+        },
+      },
+    };
+    applyJsonPointer(
+      doc,
+      '/spec/componentTypeEnvironmentConfigs/resources/requests/cpu',
+      '50m',
+    );
+    expect(
+      doc.spec.componentTypeEnvironmentConfigs.resources.requests.cpu,
+    ).toBe('50m');
+  });
+
+  it('initialises null intermediate nodes to objects', () => {
+    const doc: any = { spec: { componentTypeEnvironmentConfigs: null } };
+    applyJsonPointer(
+      doc,
+      '/spec/componentTypeEnvironmentConfigs/resources/requests/cpu',
+      '10m',
+    );
+    expect(
+      doc.spec.componentTypeEnvironmentConfigs.resources.requests.cpu,
+    ).toBe('10m');
+  });
+
+  it('throws for pointer with fewer than 3 segments', () => {
+    expect(() =>
+      applyJsonPointer({}, '/spec/componentTypeEnvironmentConfigs', 'x'),
+    ).toThrow('Invalid pointer');
+  });
+
+  it('throws for pointer not starting with /spec/', () => {
+    expect(() => applyJsonPointer({}, '/metadata/name/foo', 'x')).toThrow(
+      'Invalid pointer',
+    );
+  });
+
+  it('throws for pointer with a disallowed spec category', () => {
+    expect(() => applyJsonPointer({}, '/spec/containers/0/image', 'x')).toThrow(
+      'Invalid pointer',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyEnvChange
+// ---------------------------------------------------------------------------
+
+describe('applyEnvChange', () => {
+  it('adds a new env var when the key does not exist', () => {
+    const doc: any = {};
+    applyEnvChange(doc, 'FOO', 'bar');
+    expect(doc.spec.workloadOverrides.container.env).toEqual([
+      { key: 'FOO', value: 'bar' },
+    ]);
+  });
+
+  it('updates an existing env var', () => {
+    const doc: any = {
+      spec: {
+        workloadOverrides: {
+          container: {
+            env: [{ key: 'FOO', value: 'old' }],
+          },
+        },
+      },
+    };
+    applyEnvChange(doc, 'FOO', 'new');
+    expect(doc.spec.workloadOverrides.container.env).toEqual([
+      { key: 'FOO', value: 'new' },
+    ]);
+  });
+
+  it('appends without touching unrelated env vars', () => {
+    const doc: any = {
+      spec: {
+        workloadOverrides: { container: { env: [{ key: 'A', value: '1' }] } },
+      },
+    };
+    applyEnvChange(doc, 'B', '2');
+    expect(doc.spec.workloadOverrides.container.env).toHaveLength(2);
+    expect(doc.spec.workloadOverrides.container.env[1]).toEqual({
+      key: 'B',
+      value: '2',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyFileChange
+// ---------------------------------------------------------------------------
+
+describe('applyFileChange', () => {
+  it('updates value of an existing file mount', () => {
+    const doc: any = {
+      spec: {
+        workloadOverrides: {
+          container: {
+            files: [
+              { key: 'config.yaml', mountPath: '/etc/app', value: 'old' },
+            ],
+          },
+        },
+      },
+    };
+    applyFileChange(doc, 'config.yaml', '/etc/app', 'new');
+    expect(doc.spec.workloadOverrides.container.files[0].value).toBe('new');
+  });
+
+  it('throws when the mount is not found', () => {
+    const doc: any = {
+      spec: { workloadOverrides: { container: { files: [] } } },
+    };
+    expect(() => applyFileChange(doc, 'missing.yaml', '/etc/app', 'v')).toThrow(
+      "File mount 'missing.yaml'",
+    );
+  });
+
+  it('throws when key matches but mountPath differs', () => {
+    const doc: any = {
+      spec: {
+        workloadOverrides: {
+          container: {
+            files: [{ key: 'config.yaml', mountPath: '/etc/a', value: 'v' }],
+          },
+        },
+      },
+    };
+    expect(() => applyFileChange(doc, 'config.yaml', '/etc/b', 'new')).toThrow(
+      "File mount 'config.yaml'",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyResourceChange (integration: GET → mutate → PUT)
+// ---------------------------------------------------------------------------
+
+describe('applyResourceChange', () => {
+  const mockFetchApi = { fetch: jest.fn() };
+  const baseUrl = 'http://backend';
+  const namespaceName = 'dev';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function makeGetResponse(data: object) {
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(data),
+    } as Response);
+  }
+
+  function makePutResponse(ok = true) {
+    return Promise.resolve({
+      ok,
+      statusText: ok ? 'OK' : 'Internal Server Error',
+    } as Response);
+  }
+
+  it('GETs, applies field changes, and PUTs the updated binding', async () => {
+    const binding = {
+      metadata: { name: 'my-binding' },
+      spec: {},
+    };
+    mockFetchApi.fetch
+      .mockResolvedValueOnce(makeGetResponse(binding))
+      .mockResolvedValueOnce(makePutResponse());
+
+    await applyResourceChange({
+      backendBaseUrl: baseUrl,
+      fetchApi: mockFetchApi as any,
+      namespaceName,
+      change: {
+        release_binding: 'my-binding',
+        fields: [
+          {
+            json_pointer:
+              '/spec/componentTypeEnvironmentConfigs/resources/requests/cpu',
+            value: '50m',
+          },
+          {
+            json_pointer:
+              '/spec/componentTypeEnvironmentConfigs/resources/requests/memory',
+            value: '128Mi',
+          },
+        ],
+      },
+    });
+
+    // GET called with correct URL
+    expect(mockFetchApi.fetch).toHaveBeenNthCalledWith(
+      1,
+      `${baseUrl}/release-binding?namespaceName=dev&bindingName=my-binding`,
+    );
+
+    // PUT called with mutated spec
+    const [putUrl, putOpts] = mockFetchApi.fetch.mock.calls[1];
+    expect(putUrl).toBe(
+      `${baseUrl}/release-binding?namespaceName=dev&bindingName=my-binding`,
+    );
+    expect(putOpts.method).toBe('PUT');
+    const body = JSON.parse(putOpts.body);
+    expect(
+      body.spec.componentTypeEnvironmentConfigs.resources.requests.cpu,
+    ).toBe('50m');
+    expect(
+      body.spec.componentTypeEnvironmentConfigs.resources.requests.memory,
+    ).toBe('128Mi');
+  });
+
+  it('does not mutate the original binding object', async () => {
+    const binding = { metadata: { name: 'b' }, spec: {} };
+    mockFetchApi.fetch
+      .mockResolvedValueOnce(makeGetResponse(binding))
+      .mockResolvedValueOnce(makePutResponse());
+
+    await applyResourceChange({
+      backendBaseUrl: baseUrl,
+      fetchApi: mockFetchApi as any,
+      namespaceName,
+      change: {
+        release_binding: 'b',
+        fields: [
+          {
+            json_pointer: '/spec/componentTypeEnvironmentConfigs/x',
+            value: '1',
+          },
+        ],
+      },
+    });
+
+    // original binding.spec is still empty
+    expect(binding.spec).toEqual({});
+  });
+
+  it('throws with a 404 message when GET returns 404', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as Response);
+
+    await expect(
+      applyResourceChange({
+        backendBaseUrl: baseUrl,
+        fetchApi: mockFetchApi as any,
+        namespaceName,
+        change: { release_binding: 'missing-binding' },
+      }),
+    ).rejects.toThrow("Release binding 'missing-binding' not found");
+  });
+
+  it('throws with a generic message on non-404 GET failure', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as Response);
+
+    await expect(
+      applyResourceChange({
+        backendBaseUrl: baseUrl,
+        fetchApi: mockFetchApi as any,
+        namespaceName,
+        change: { release_binding: 'b' },
+      }),
+    ).rejects.toThrow('Failed to get release binding: Internal Server Error');
+  });
+
+  it('throws when PUT fails', async () => {
+    const binding = { metadata: {}, spec: {} };
+    mockFetchApi.fetch
+      .mockResolvedValueOnce(makeGetResponse(binding))
+      .mockResolvedValueOnce(makePutResponse(false));
+
+    await expect(
+      applyResourceChange({
+        backendBaseUrl: baseUrl,
+        fetchApi: mockFetchApi as any,
+        namespaceName,
+        change: { release_binding: 'b' },
+      }),
+    ).rejects.toThrow('Failed to update release binding');
+  });
+
+  it('URL-encodes namespace and binding name', async () => {
+    mockFetchApi.fetch
+      .mockResolvedValueOnce(makeGetResponse({ metadata: {}, spec: {} }))
+      .mockResolvedValueOnce(makePutResponse());
+
+    await applyResourceChange({
+      backendBaseUrl: baseUrl,
+      fetchApi: mockFetchApi as any,
+      namespaceName: 'my namespace',
+      change: { release_binding: 'my binding' },
+    });
+
+    const getUrl = mockFetchApi.fetch.mock.calls[0][0] as string;
+    expect(getUrl).toContain('namespaceName=my%20namespace');
+    expect(getUrl).toContain('bindingName=my%20binding');
+  });
+});

--- a/plugins/openchoreo-observability/src/utils/applyResourceChange.ts
+++ b/plugins/openchoreo-observability/src/utils/applyResourceChange.ts
@@ -1,0 +1,130 @@
+import type { FetchApi } from '@backstage/core-plugin-api';
+
+type PrimitiveValue = string | number | boolean;
+
+export interface FieldChangeDef {
+  json_pointer: string;
+  value: PrimitiveValue;
+}
+
+export interface ResourceChangeDef {
+  release_binding: string;
+  fields?: FieldChangeDef[];
+  env?: Array<{ key: string; value: string }>;
+  files?: Array<{ key: string; mount_path: string; value: string }>;
+}
+
+const ALLOWED_OVERRIDE_CATEGORIES = new Set([
+  'workloadOverrides',
+  'traitEnvironmentConfigs',
+  'componentTypeEnvironmentConfigs',
+]);
+
+export function applyJsonPointer(doc: any, pointer: string, value: any): void {
+  const keys = pointer.replace(/^\//, '').split('/');
+  if (
+    keys.length < 3 ||
+    keys[0] !== 'spec' ||
+    !ALLOWED_OVERRIDE_CATEGORIES.has(keys[1])
+  ) {
+    throw new Error(`Invalid pointer: '${pointer}'`);
+  }
+  let current = doc;
+  for (const key of keys.slice(0, -1)) {
+    if (
+      current[key] === null ||
+      current[key] === undefined ||
+      typeof current[key] !== 'object'
+    ) {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+  const last = keys.at(-1)!;
+  current[last] = value;
+}
+
+export function applyEnvChange(doc: any, key: string, value: string): void {
+  const env: { key: string; value: string }[] =
+    doc.spec?.workloadOverrides?.container?.env ?? [];
+  const existing = env.find(e => e.key === key);
+  if (existing) {
+    existing.value = value;
+  } else {
+    env.push({ key, value });
+    doc.spec ??= {};
+    doc.spec.workloadOverrides ??= {};
+    doc.spec.workloadOverrides.container ??= {};
+    doc.spec.workloadOverrides.container.env = env;
+  }
+}
+
+export function applyFileChange(
+  doc: any,
+  key: string,
+  mountPath: string,
+  value: string,
+): void {
+  const files: { key: string; value: string; mountPath: string }[] =
+    doc.spec?.workloadOverrides?.container?.files ?? [];
+  const existing = files.find(f => f.key === key && f.mountPath === mountPath);
+  if (existing) {
+    existing.value = value;
+  } else {
+    throw new Error(
+      `File mount '${key}' at '${mountPath}' not found in binding`,
+    );
+  }
+}
+
+/**
+ * GET a release binding, apply the given changes, and PUT it back.
+ * Used by the finops apply button for deterministic field-only patches
+ * (no user-editable overrides).
+ */
+export async function applyResourceChange(opts: {
+  backendBaseUrl: string;
+  fetchApi: FetchApi;
+  namespaceName: string;
+  change: ResourceChangeDef;
+}): Promise<void> {
+  const { backendBaseUrl, fetchApi, namespaceName, change } = opts;
+
+  const bindingUrl = `${backendBaseUrl}/release-binding?namespaceName=${encodeURIComponent(
+    namespaceName,
+  )}&bindingName=${encodeURIComponent(change.release_binding)}`;
+
+  const getResponse = await fetchApi.fetch(bindingUrl);
+  if (!getResponse.ok) {
+    const detail =
+      getResponse.status === 404
+        ? `Release binding '${change.release_binding}' not found`
+        : `Failed to get release binding: ${getResponse.statusText}`;
+    throw new Error(detail);
+  }
+
+  const binding = await getResponse.json();
+  const updated = structuredClone(binding);
+
+  for (const e of change.env ?? []) {
+    applyEnvChange(updated, e.key, e.value);
+  }
+  for (const f of change.files ?? []) {
+    applyFileChange(updated, f.key, f.mount_path, f.value);
+  }
+  for (const f of change.fields ?? []) {
+    applyJsonPointer(updated, f.json_pointer, f.value);
+  }
+
+  const putResponse = await fetchApi.fetch(bindingUrl, {
+    method: 'PUT',
+    body: JSON.stringify({ metadata: updated.metadata, spec: updated.spec }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!putResponse.ok) {
+    throw new Error(
+      `Failed to update release binding: ${putResponse.statusText}`,
+    );
+  }
+}

--- a/plugins/openchoreo-react/src/hooks/useFinopsUpdatePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useFinopsUpdatePermission.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react';
+import { useFinopsUpdatePermission } from './useFinopsUpdatePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test', namespace: 'default' },
+    },
+  }),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/test',
+}));
+
+describe('useFinopsUpdatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns canUpdateFinops=true when permission is allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    const { result } = renderHook(() => useFinopsUpdatePermission());
+
+    expect(result.current.canUpdateFinops).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBe('openchoreo.finops.update');
+  });
+
+  it('returns canUpdateFinops=false and a tooltip when denied', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+    const { result } = renderHook(() => useFinopsUpdatePermission());
+
+    expect(result.current.canUpdateFinops).toBe(false);
+    expect(result.current.deniedTooltip).toBeTruthy();
+  });
+
+  it('returns empty tooltip while loading even when not allowed', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+    const { result } = renderHook(() => useFinopsUpdatePermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('passes the entity resource ref to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useFinopsUpdatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceRef: 'component:default/test' }),
+    );
+  });
+
+  it('passes the finops update permission to usePermission', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useFinopsUpdatePermission());
+
+    expect(mockUsePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permission: expect.objectContaining({
+          name: 'openchoreo.finops.update',
+        }),
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useFinopsUpdatePermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useFinopsUpdatePermission.ts
@@ -1,0 +1,36 @@
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { usePermission } from '@backstage/plugin-permission-react';
+import { openchoreoFinopsUpdatePermission } from '@openchoreo/backstage-plugin-common';
+
+export interface UseFinopsUpdatePermissionResult {
+  /** Whether the user has permission to apply/dismiss FinOps recommendations */
+  canUpdateFinops: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+  /** Tooltip message to show when permission is denied (empty string when allowed/loading) */
+  deniedTooltip: string;
+  /** The permission name identifier */
+  permissionName: string;
+}
+
+export const useFinopsUpdatePermission =
+  (): UseFinopsUpdatePermissionResult => {
+    const { entity } = useEntity();
+    const { allowed, loading } = usePermission({
+      permission: openchoreoFinopsUpdatePermission,
+      resourceRef: stringifyEntityRef(entity),
+    });
+
+    const deniedTooltip =
+      !allowed && !loading
+        ? 'You do not have permission to apply FinOps recommendations.'
+        : '';
+
+    return {
+      canUpdateFinops: allowed,
+      loading,
+      deniedTooltip,
+      permissionName: openchoreoFinopsUpdatePermission.name,
+    };
+  };

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -263,6 +263,10 @@ export {
   type UseRcaUpdatePermissionResult,
 } from './hooks/useRcaUpdatePermission';
 export {
+  useFinopsUpdatePermission,
+  type UseFinopsUpdatePermissionResult,
+} from './hooks/useFinopsUpdatePermission';
+export {
   useTraitsPermission,
   type UseTraitsPermissionResult,
 } from './hooks/useTraitsPermission';


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/3441

At the moment, the FinOps agent provides request and limit recommendations for CPU and memory and the user has to configure them in the component manually. To make the user experience better, this PR introduces an "Apply recommendation" button in the cost analysis report which when clicked, applies the recommendation automatically by patching the ReleaseBinding

## Approach
- Shared patch utility: Extracted JSON-pointer/env-var/file-mount mutation helpers from PatchTabContent.tsx into a shared util so it can be used by both the SRE agent and the FinOps agent
- FinOpsAgentApi.ts: New API client that resolves the finops-agent URL via ObserverUrlCache and calls PUT /api/v1alpha1/reports/{reportId} with appliedIndices. Registered as a Backstage API factory.
- Permission: Added openchoreoFinopsUpdatePermission (finopsreport:update) to openchoreo-common and a useFinopsUpdatePermission hook to openchoreo-react.
- Types & wiring: Extended FinOpsReport with recommended_actions and ResourceRecommendation with release_binding. 


Before applying the recommendation
<img width="1701" height="463" alt="Screenshot 2026-05-15 at 08 48 02" src="https://github.com/user-attachments/assets/37af653d-65fa-41ed-8778-f126087832af" />

After applying the recommendation
<img width="1699" height="444" alt="Screenshot 2026-05-15 at 08 48 21" src="https://github.com/user-attachments/assets/8218b069-cd31-413e-aa7a-99886ab1e9fd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply FinOps cost-optimization recommendations directly from cost analysis reports with progressive UI states (applying, applied, dismissed, retry).
  * Persist and track applied/dismissed recommendation statuses across sessions and show server-derived states.
  * Permission-gated apply flow with clear denial messaging and loading handling.
  * Improved error handling and user-facing messages for apply and discovery failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/542)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->