### PR TITLE
fix: trigger metrics fetch on initial observability page load

### DIFF
--- a/plugins/openchoreo-observability/src/components/Metrics/ObservabilityMetricsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Metrics/ObservabilityMetricsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import {
   Grid,
   Card,
@@ -72,40 +72,16 @@ const ObservabilityMetricsContent = () => {
   } = useMetrics(filters, entity, namespace as string, project as string);
   const resourceMetrics = metrics as ResourceMetrics;
 
-  // Track previous filter values to detect changes
-  const previousFiltersRef = useRef({
-    environment: filters.environment?.name,
-    timeRange: filters.timeRange,
-  });
-
   // Fetch metrics when filters change
   useEffect(() => {
-    const currentFilters = {
-      environment: filters.environment?.name,
-      timeRange: filters.timeRange,
-    };
-
-    const filtersChanged =
-      JSON.stringify(previousFiltersRef.current) !==
-      JSON.stringify(currentFilters);
-
-    if (
-      filters.environment &&
-      filters.timeRange &&
-      canViewMetricsForEnv &&
-      filtersChanged
-    ) {
+    if (filters.environment && filters.timeRange && canViewMetricsForEnv) {
       fetchMetrics(true);
     }
-
-    previousFiltersRef.current = currentFilters;
   }, [
     filters.environment,
     filters.timeRange,
     fetchMetrics,
     canViewMetricsForEnv,
-    envPermissionLoading,
-    envPermissionDenied,
   ]);
 
   const handleFiltersChange = (newFilters: Partial<typeof filters>) => {


### PR DESCRIPTION
## Summary

Metrics page sometimes loads empty until the user clicks Refresh or changes a filter. The `useEffect` used a `previousFiltersRef` initialized from live first-render filter values, so when the page mounted with `env` already resolved (URL carries `?env=...`, or environments resolve from cache) the first diff was a no-op and the fetch was skipped.

`useMetrics` already guards on env + timeRange internally, so the manual diff was redundant. Drop the ref; let the effect's dep array (`env`, `timeRange`, `canViewMetricsForEnv`, `fetchMetrics`) trigger the fetch.

Side effect: changing the custom date range now refetches automatically instead of needing Refresh.

`HTTPMetricsSection` is untouched — separate component, separate ref, cilium gate intact.

## Test plan

- [x] CPU / memory cards populate on initial mount with `?env=...` in the URL.
- [x] Initial mount with no URL `env` (auto-select path).
- [x] Env / time-range / custom date changes all refetch.
- [x] HTTP metrics cards still hide when cilium disabled and fetch independently when enabled.
- [x] Per-env permission denial still hides cards and skips fetch.