### PR TITLE
fix(release-diff): swap orientation, fix scroll, rename promote action

### DIFF
--- a/plugins/openchoreo-react/src/components/YamlDiffViewer/YamlDiffViewer.tsx
+++ b/plugins/openchoreo-react/src/components/YamlDiffViewer/YamlDiffViewer.tsx
@@ -48,17 +48,22 @@ const useStyles = makeStyles<Theme, StyleProps>(theme => ({
     whiteSpace: 'nowrap',
   },
   container: ({ height, isDark }) => ({
-    height,
     fontSize: '0.75rem',
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius,
     overflow: 'hidden',
     backgroundColor: isDark ? '#1e1e1e' : '#fafafa',
-    '& .cm-mergeView, & .cm-mergeViewEditors': {
-      height: '100%',
+    // Per CodeMirror's MergeView docs: views are not scrollable by default —
+    // the .cm-mergeView itself must have a height and `overflow: auto` to
+    // become the scroller. Both panes are children of .cm-mergeView, so they
+    // scroll together as one unit. CM's baseTheme forces inner .cm-scroller
+    // to height:auto + overflow:visible when nested in a .cm-mergeView, so
+    // we don't override those.
+    '& .cm-mergeView': {
+      height,
+      overflow: 'auto',
     },
     '& .cm-editor': {
-      height: '100%',
       backgroundColor: 'transparent',
     },
     '& .cm-scroller': {

--- a/plugins/openchoreo/src/components/Environments/EnvironmentOverridesPage.tsx
+++ b/plugins/openchoreo/src/components/Environments/EnvironmentOverridesPage.tsx
@@ -708,7 +708,7 @@ export const EnvironmentOverridesPage = ({
               disabled={saving || deleting}
               style={{ marginRight: 8 }}
             >
-              View diff
+              View release diff
             </Button>
           </span>
         </Tooltip>

--- a/plugins/openchoreo/src/components/Environments/components/ComponentReleaseDiffDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/ComponentReleaseDiffDialog.tsx
@@ -74,25 +74,29 @@ export const ComponentReleaseDiffDialog = ({
     setOriginal(null);
     setModified(null);
 
+    // Diff orientation: LHS shows the target env's *current* release ("before"),
+    // RHS shows the upstream env's incoming release ("after"). The dialog title's
+    // `upstreamEnv → targetEnv` arrow still reflects promotion direction, not
+    // LHS → RHS.
     const fetches: Array<Promise<unknown>> = [];
-    if (upstreamReleaseName) {
-      fetches.push(
-        api.fetchComponentRelease(entity, upstreamReleaseName).then(res => {
-          if (cancelled) return;
-          if (!res?.success || !res.data) {
-            setError(`Couldn't fetch ${upstreamEnvName}'s release manifest.`);
-            return;
-          }
-          setOriginal(YAML.stringify(res.data));
-        }),
-      );
-    }
     if (releaseName) {
       fetches.push(
         api.fetchComponentRelease(entity, releaseName).then(res => {
           if (cancelled) return;
           if (!res?.success || !res.data) {
             setError(`Couldn't fetch ${environmentName}'s release manifest.`);
+            return;
+          }
+          setOriginal(YAML.stringify(res.data));
+        }),
+      );
+    }
+    if (upstreamReleaseName) {
+      fetches.push(
+        api.fetchComponentRelease(entity, upstreamReleaseName).then(res => {
+          if (cancelled) return;
+          if (!res?.success || !res.data) {
+            setError(`Couldn't fetch ${upstreamEnvName}'s release manifest.`);
             return;
           }
           setModified(YAML.stringify(res.data));
@@ -146,28 +150,28 @@ export const ComponentReleaseDiffDialog = ({
           <YamlDiffViewer
             original={original}
             modified={modified}
-            originalLabel={`${upstreamEnvName} (${upstreamReleaseName})`}
-            modifiedLabel={`${environmentName} (${releaseName})`}
+            originalLabel={`${environmentName} (${releaseName})`}
+            modifiedLabel={`${upstreamEnvName} (${upstreamReleaseName})`}
             height="60vh"
           />
         )}
-        {previewMode === 'source-only' && original && (
+        {previewMode === 'source-only' && modified && (
           <>
             <Typography variant="body2" color="textSecondary" gutterBottom>
               <strong>{environmentName}</strong> has no release yet — this is
               the manifest that will be created from{' '}
               <strong>{upstreamEnvName}</strong>.
             </Typography>
-            <YamlViewer value={original} maxHeight="60vh" showLineNumbers />
+            <YamlViewer value={modified} maxHeight="60vh" showLineNumbers />
           </>
         )}
-        {previewMode === 'target-only' && modified && (
+        {previewMode === 'target-only' && original && (
           <>
             <Typography variant="body2" color="textSecondary" gutterBottom>
               <strong>{upstreamEnvName}</strong> has no release to compare;
               showing <strong>{environmentName}</strong>'s current manifest.
             </Typography>
-            <YamlViewer value={modified} maxHeight="60vh" showLineNumbers />
+            <YamlViewer value={original} maxHeight="60vh" showLineNumbers />
           </>
         )}
       </DialogContent>


### PR DESCRIPTION
  Three small fixes to the release-diff experience:

  - Swap LHS/RHS in ComponentReleaseDiffDialog so the target env's current release is the "before" (left) and the upstream's incoming release is the "after" (right). Matches how reviewers actually read promotion diffs. The dialog title arrow still reflects promotion direction. Both callers (drift chip on the env detail panel and the promote action on the overrides page) pick up the new orientation automatically.

  - YamlDiffViewer: move height + overflow:auto onto .cm-mergeView per CodeMirror MergeView docs so both panes scroll as one unit instead of scrolling independently and breaking line alignment.

  - Rename the promote-flow button "View diff" -> "View release diff" to match the wording already used by the drift-chip button.


Before

<img width="1728" height="865" alt="Screenshot 2026-05-16 at 10 05 30" src="https://github.com/user-attachments/assets/e26843ee-58d1-4d34-9bf9-e17f33017ded" />

https://github.com/user-attachments/assets/cd982b57-10a5-4241-8fdb-7d2b9da31bd7

After


https://github.com/user-attachments/assets/bd095be4-e08e-40a4-8024-abe5c8058d13



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated button label in environment promote flow to "View release diff" for clarity.
  * Reoriented YAML diff viewer: target environment's current release now displays on the left, upstream environment's incoming release on the right.

* **Style**
  * Improved scrolling behavior in diff viewer for better usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->