### PR TITLE
fix: set credentials include for direct-mode cross-origin fetches

### DIFF
--- a/packages/app/src/apis/OpenChoreoFetchApi.test.ts
+++ b/packages/app/src/apis/OpenChoreoFetchApi.test.ts
@@ -80,6 +80,14 @@ describe('OpenChoreoFetchApi', () => {
       expect(headers.get('Authorization')).toBe('Bearer backstage-token');
     });
 
+    it('does not set credentials in normal mode', async () => {
+      const api = createApi();
+      await api.fetch('http://example.com');
+
+      const init = mockFetch.mock.calls[0][1];
+      expect(init.credentials).toBeUndefined();
+    });
+
     it('continues without IDP token when oauthApi throws', async () => {
       mockOauthApi.getAccessToken.mockRejectedValue(new Error('no token'));
       const api = createApi();
@@ -113,6 +121,16 @@ describe('OpenChoreoFetchApi', () => {
       const headers = mockFetch.mock.calls[0][1].headers as Headers;
       expect(headers.get('Authorization')).toBe('Bearer idp-token');
       expect(mockIdentityApi.getCredentials).not.toHaveBeenCalled();
+    });
+
+    it('sets credentials to include in direct mode', async () => {
+      const api = createApi();
+      await api.fetch('http://example.com', {
+        headers: { 'x-openchoreo-direct': 'true' },
+      });
+
+      const init = mockFetch.mock.calls[0][1];
+      expect(init.credentials).toBe('include');
     });
 
     it('skips IDP token when auth is disabled in direct mode', async () => {

--- a/packages/app/src/apis/OpenChoreoFetchApi.ts
+++ b/packages/app/src/apis/OpenChoreoFetchApi.ts
@@ -89,6 +89,6 @@ export class OpenChoreoFetchApi implements FetchApi {
       }
     }
 
-    return fetch(input, { ...init, headers });
+    return fetch(input, { ...init, headers, ...(isDirect && { credentials: 'include' as RequestCredentials }) });
   }
 }

--- a/packages/app/src/apis/OpenChoreoFetchApi.ts
+++ b/packages/app/src/apis/OpenChoreoFetchApi.ts
@@ -89,6 +89,10 @@ export class OpenChoreoFetchApi implements FetchApi {
       }
     }
 
-    return fetch(input, { ...init, headers, ...(isDirect && { credentials: 'include' as RequestCredentials }) });
+    return fetch(input, {
+      ...init,
+      headers,
+      ...(isDirect && { credentials: 'include' as RequestCredentials }),
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Set credentials: 'include' in OpenChoreoFetchApi when in direct mode
- Ensures cookies (from auth proxies, zero-trust gateways, etc.) are sent on cross-origin requests to Observer, RCA, FinOps, and Perch

Fixes #557

## Test plan
- Updated existing OpenChoreoFetchApi unit tests to verify credentials is set in direct mode and omitted in normal mode
- yarn test packages/app --testPathPattern=OpenChoreoFetchApi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced API request credential handling to conditionally include credentials based on request mode, improving authentication compatibility.

* **Tests**
  * Added test coverage for API credential behavior across normal and direct request modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->