### PR TITLE
fix(authz): stop component-segment denies from hiding sibling Resources in catalog

### DIFF
--- a/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCatalogEntityCapability.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCatalogEntityCapability.test.ts
@@ -272,6 +272,74 @@ describe('matchesCatalogEntityCapability.apply', () => {
     });
   });
 
+  describe('Resource entities (project-sibling of Component)', () => {
+    it('uses PROJECT annotation (not PROJECT_ID) for project scope', () => {
+      const entity = makeEntity('Resource', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'payments',
+      });
+      expect(
+        apply(entity, {
+          resource: {
+            action: 'resource:view',
+            allowedPaths: ['ns/acme/project/payments'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('project-level deny hides the Resource (Project → Resource cascade)', () => {
+      const entity = makeEntity('Resource', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'payments',
+      });
+      expect(
+        apply(entity, {
+          resource: {
+            action: 'resource:view',
+            allowedPaths: ['*'],
+            deniedPaths: ['ns/acme/project/payments'],
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('component-segment deny does NOT cascade to a sibling Resource', () => {
+      // Regression: a deny on `component/orders-api` used to broaden to
+      // project-wide and hide every Resource under `payments`.
+      const entity = makeEntity('Resource', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'payments',
+      });
+      expect(
+        apply(entity, {
+          resource: {
+            action: 'resource:view',
+            allowedPaths: ['*'],
+            deniedPaths: ['ns/acme/project/payments/component/orders-api'],
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('rejects component-segment allow path for Resource', () => {
+      const entity = makeEntity('Resource', {
+        [CHOREO_ANNOTATIONS.NAMESPACE]: 'acme',
+        [CHOREO_ANNOTATIONS.PROJECT]: 'payments',
+      });
+      expect(
+        apply(entity, {
+          resource: {
+            action: 'resource:view',
+            allowedPaths: ['ns/acme/project/payments/component/orders-api'],
+            deniedPaths: [],
+          },
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe('cluster-scoped entities', () => {
     it('allows ClusterDataplane only when global wildcard "*" is allowed', () => {
       const entity = makeEntity('ClusterDataplane', {});
@@ -462,6 +530,66 @@ describe('matchesCatalogEntityCapability.toQuery', () => {
     const result = toQuery({}, ['clusterdataplane']) as any;
     expect(result).toEqual({
       not: { key: 'kind', values: ['clusterdataplane'] },
+    });
+  });
+
+  describe('Resource kind (project-sibling of Component)', () => {
+    it('keys project-level filter off PROJECT annotation', () => {
+      const result = toQuery({
+        resource: {
+          action: 'resource:view',
+          allowedPaths: ['ns/acme/project/payments'],
+          deniedPaths: [],
+        },
+      }) as any;
+
+      const serialized = JSON.stringify(result);
+      expect(serialized).toContain(CHOREO_ANNOTATIONS.PROJECT);
+      expect(serialized).toContain('payments');
+      // PROJECT_ID is System-only; Resource must not use it.
+      expect(serialized).not.toContain(CHOREO_ANNOTATIONS.PROJECT_ID);
+    });
+
+    it('does NOT broaden a component-segment deny to a project-wide exclusion', () => {
+      // Regression: with wildcard allow + a component-segment deny that
+      // merged in via caps['*'], the previous buildScopeFilter dropped the
+      // component segment and excluded every Resource in the project.
+      const result = toQuery({
+        resource: {
+          action: 'resource:view',
+          allowedPaths: ['*'],
+          deniedPaths: ['ns/acme/project/payments/component/orders-api'],
+        },
+      }) as any;
+
+      // With the fix, the component-segment path is filtered out by
+      // isPathValidForLevel for entityLevel='resource', so the resource
+      // kind ends up as a plain wildcard kind filter — no deny exclusion.
+      expect(result.anyOf).toContainEqual({
+        key: 'kind',
+        values: ['resource'],
+      });
+      // And critically, the project annotation must not appear in any
+      // not-clause that would strip resources under `payments`.
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain('"payments"');
+    });
+
+    it('project-level deny still excludes all Resources in the project', () => {
+      const result = toQuery({
+        resource: {
+          action: 'resource:view',
+          allowedPaths: ['*'],
+          deniedPaths: ['ns/acme/project/payments'],
+        },
+      }) as any;
+
+      const serialized = JSON.stringify(result);
+      // Both the project annotation and value should appear inside a
+      // negated clause — i.e. the cascade fires for the parent project.
+      expect(serialized).toContain(CHOREO_ANNOTATIONS.PROJECT);
+      expect(serialized).toContain('payments');
+      expect(serialized).toContain('"not"');
     });
   });
 });

--- a/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCatalogEntityCapability.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/rules/matchesCatalogEntityCapability.ts
@@ -99,13 +99,18 @@ function parseCapabilityPath(path: string): CatalogParsedPath | null {
 /**
  * Entity level type for path specificity checking.
  * - domain/namespace-scoped: namespace-level only (no project/component paths)
- * - system: project-level (no component paths)
+ * - system: project-level (no component paths), keyed by PROJECT_ID annotation
+ * - resource: project-level (no component paths), keyed by PROJECT annotation.
+ *   Resources are siblings of Components under a Project — a deny on a sibling
+ *   Component must not cascade to Resources, but a deny on the parent Project
+ *   must.
  * - component: any level
  * - cluster-scoped: only global wildcard "*" path
  */
 type EntityLevel =
   | 'domain'
   | 'system'
+  | 'resource'
   | 'component'
   | 'namespace-scoped'
   | 'cluster-scoped';
@@ -115,7 +120,7 @@ const KIND_TO_ENTITY_LEVEL: Record<string, EntityLevel> = {
   domain: 'domain',
   system: 'system',
   component: 'component',
-  resource: 'component',
+  resource: 'resource',
   dataplane: 'namespace-scoped',
   workflowplane: 'namespace-scoped',
   observabilityplane: 'namespace-scoped',
@@ -186,8 +191,11 @@ function matchesScope(
     }
   }
 
-  // System entities: path must NOT have component
-  if (entityLevel === 'system') {
+  // System and Resource entities: path must NOT have component. A
+  // component-segment path describes a sibling Component, not the entity
+  // itself — letting it through would let a Component-scoped deny strip a
+  // sibling Resource (or a System) from the catalog.
+  if (entityLevel === 'system' || entityLevel === 'resource') {
     if (parsed.component) {
       return false; // Path is more specific than entity level
     }
@@ -255,7 +263,7 @@ function isPathValidForLevel(path: string, entityLevel: EntityLevel): boolean {
     return !parsed.project && !parsed.component;
   }
 
-  if (entityLevel === 'system') {
+  if (entityLevel === 'system' || entityLevel === 'resource') {
     return !parsed.component;
   }
 
@@ -405,6 +413,15 @@ export const matchesCatalogEntityCapability = createCatalogPermissionRule({
       scope = {
         ns: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE],
         project: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT_ID],
+      };
+    } else if (entityLevel === 'resource') {
+      // Resources are sibling-to-Component under a Project. Like System we
+      // stop at project granularity, but unlike System we key off PROJECT
+      // (the project name) since that is the annotation the Resource
+      // translator emits — PROJECT_ID is System-only.
+      scope = {
+        ns: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE],
+        project: entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT],
       };
     } else {
       scope = {


### PR DESCRIPTION
## Purpose

Writing a deny policy against a specific Component was hiding every Resource in the same Project from the Backstage catalog, even though the OpenChoreo API correctly listed those Resources for the same user token. Resources are siblings of Components under a Project — a Component-scoped deny must not cascade to its siblings, while a Project-scoped deny still must. 
This PR fixes this issue by introducing a new entity level `resource`


## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resources now supported as first-class, project-scoped entities in permission policies.

* **Bug Fixes**
  * Project-level deny rules properly cascade to hide all matching Resources.
  * Component-segment deny rules no longer incorrectly broaden to project-wide restrictions.
  * Component-scoped capability paths now properly rejected for Resource-level matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->