### PR TITLE
ci(release): run yarn tsc before build:all

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: TypeScript compile
+        # Backstage's per-package builder reads `.d.ts` files from
+        # `dist-types/` during `build:all`. Without a prior `yarn tsc` the
+        # build fails with "No declaration files found at ../../dist-types/...".
+        # Mirrors the order used by build-and-test.yml.
+        run: yarn tsc
+
       - name: Build all workspaces
         # `changeset publish` runs each workspace's `prepack`, which invokes
         # `backstage-cli package prepack` — that rewrites `workspace:^` deps to


### PR DESCRIPTION
 Backstage's per-package builder needs .d.ts files in dist-types/
  to exist before build:all; without them the release job fails with
  "No declaration files found at ../../dist-types/...". Mirrors the
  order already used by build-and-test.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process to ensure TypeScript type declarations are properly compiled and available during the packaging step, improving build reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->