### PR TITLE
fix(release): publish-pipeline + Deploy-tab observability dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,20 +68,25 @@ jobs:
         run: yarn tsc
 
       - name: Build all workspaces
-        # `changeset publish` runs each workspace's `prepack`, which invokes
-        # `backstage-cli package prepack` — that rewrites `workspace:^` deps to
-        # concrete versions and assumes `dist/` exists. Build everything first.
+        # `yarn npm publish` runs each workspace's `prepack` (which invokes
+        # `backstage-cli package prepack` to populate `dist/` entry points)
+        # and rewrites `workspace:^` deps to concrete versions at pack time.
+        # `npm publish` (and `changeset publish`, which shells out to it for
+        # non-pnpm repos) leaks `workspace:^` strings into the tarball, so we
+        # use Yarn Berry's native publish instead. Build first so `dist/`
+        # exists before prepack reads it.
         run: yarn build:all
 
       - name: Publish to GitHub Packages
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TAG=latest
           if [ "${IS_PRERELEASE}" = "true" ]; then
-            yarn changeset publish --tag next
-          else
-            yarn release:publish
+            TAG=next
           fi
+          yarn workspaces foreach --all --no-private --topological --verbose \
+            npm publish --tolerate-republish --access public --tag "${TAG}"
 
       - name: Login to GitHub container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/README.md
+++ b/README.md
@@ -499,9 +499,11 @@ Releases are tag-driven. Pushing a `v*.*.*` tag triggers the [release workflow](
 
 5. **CI publishes**. The release workflow:
    - Retags the existing Docker image (built earlier on the `main` push) to `vX.Y.Z` in GHCR.
-   - Runs `yarn install --immutable && yarn build:all && yarn release:publish` to publish npm packages to GitHub Packages.
+   - Runs `yarn install --immutable && yarn tsc && yarn build:all`, then `yarn workspaces foreach --all --no-private --topological --verbose npm publish --tolerate-republish --access public --tag <latest|next>` to publish npm packages to GitHub Packages.
    - On **stable** tags (`vX.Y.Z`) publishes under the `latest` npm dist-tag.
    - On **prerelease** tags (`vX.Y.Z-rc.N`, `vX.Y.Z-test.N`, etc. — any tag containing a hyphen) publishes under the `next` dist-tag, leaving `latest` untouched.
+
+`yarn npm publish` (not `npm publish` or `changeset publish`) is required so that Yarn Berry rewrites `workspace:^` deps to concrete versions at pack time. `npm publish` and `changeset publish` (which shells out to `npm publish` on non-pnpm repos) leak `workspace:^` strings into the tarball and break installs for external consumers.
 
 ### Verifying a release
 
@@ -510,24 +512,33 @@ yarn npm info @openchoreo/backstage-plugin --registry=https://npm.pkg.github.com
 yarn npm info @openchoreo/backstage-design-system --registry=https://npm.pkg.github.com
 ```
 
-Both should show the new version. Confirm under `dist-tags` that stable releases moved `latest` and prereleases moved `next`.
+Both should show the new version. Confirm under `dist-tags` that stable releases moved `latest` and prereleases moved `next`. To confirm `workspace:^` rewriting worked, inspect the `dependencies` field of any published `@openchoreo/*` package — every version specifier should be a concrete range (e.g. `^1.1.0`), never `workspace:^`.
 
 ### Re-running a tag
 
-`changeset publish` is idempotent — re-running the workflow on an already-published tag skips packages whose versions already exist on the registry and exits cleanly. Useful when a transient failure leaves some packages published and others not.
+The publish step is idempotent — `--tolerate-republish` makes `yarn npm publish` skip packages whose versions already exist on the registry and exit cleanly. Useful when a transient failure leaves some packages published and others not.
 
 ### One-time local dry run
 
-Before the first real release, validate the publish path locally:
+Before the first real release, validate the publish path locally. Yarn Berry's `yarn npm publish` does not accept a `--dry-run` flag, so the equivalent offline check is `yarn pack` on every public workspace — `yarn pack` runs the same workspace-protocol rewriter that `yarn npm publish` does, just stopping before the upload:
 
 ```bash
-export YARN_NPM_AUTH_TOKEN=<a classic PAT with write:packages on the openchoreo org>
 yarn install --immutable
+yarn tsc
 yarn build:all
-yarn changeset publish --dry-run
+yarn workspaces foreach --all --no-private --topological --verbose pack
 ```
 
-Output should list exactly the 13 public `@openchoreo/*` packages targeting `https://npm.pkg.github.com`. No `"private": true` package should appear.
+Then confirm a sample tarball has no `workspace:` leaks in its `dependencies`:
+
+```bash
+cd plugins/openchoreo
+tar -xzf package.tgz package/package.json -O | \
+  python3 -c "import json,sys; d=json.load(sys.stdin).get('dependencies',{}); leaks={k:v for k,v in d.items() if str(v).startswith('workspace:')}; print('workspace: leaks:', leaks if leaks else 'NONE')"
+rm package.tgz
+```
+
+Expected output: `workspace: leaks: NONE`. Repeat for any other plugin to spot-check. `yarn pack` writes a `package.tgz` next to each workspace's `package.json`; clean them up with `find packages plugins -maxdepth 2 -name package.tgz -delete` when done.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier:write": "prettier --write .",
     "new": "backstage-cli new",
     "release:version": "changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' && yarn install",
-    "release:publish": "changeset publish"
+    "release:publish": "yarn workspaces foreach --all --no-private --topological --verbose npm publish --tolerate-republish --access public --tag latest"
   },
   "workspaces": {
     "packages": [

--- a/plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { useApi, createApiRef } from '@backstage/core-plugin-api';
+import { useApiHolder, createApiRef } from '@backstage/core-plugin-api';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import type { Environment } from './useEnvironmentData';
 
@@ -42,7 +42,11 @@ export function useIncidentsSummary(
   environments: Environment[],
 ): Map<string, IncidentsSummary> {
   const { entity } = useEntity();
-  const observabilityApi = useApi(observabilityApiRef);
+  // Observability is optional. When @openchoreo/backstage-plugin-openchoreo-observability
+  // is not installed in the host app, no API factory is registered for this ref and
+  // `useApi()` would throw NotImplementedError. `useApiHolder().get()` returns undefined
+  // instead, letting the Deploy tab render without incident chips.
+  const observabilityApi = useApiHolder().get(observabilityApiRef);
   const [summaries, setSummaries] = useState<Map<string, IncidentsSummary>>(
     new Map(),
   );
@@ -56,6 +60,11 @@ export function useIncidentsSummary(
 
   const fetchIncidents = useCallback(async () => {
     const currentRequestId = ++requestIdRef.current;
+
+    if (!observabilityApi) {
+      setSummaries(new Map());
+      return;
+    }
 
     if (!componentName || !projectName || !namespaceName) {
       setSummaries(new Map());

--- a/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { useApi, createApiRef } from '@backstage/core-plugin-api';
+import { useApi, useApiHolder, createApiRef } from '@backstage/core-plugin-api';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { openChoreoClientApiRef } from '../../../api/OpenChoreoClientApi';
 import { calculateTimeRange } from '../../../api/runtimeLogs';
@@ -50,7 +50,11 @@ interface LogsSummaryState {
 export function useLogsSummary() {
   const { entity } = useEntity();
   const client = useApi(openChoreoClientApiRef);
-  const observabilityApi = useApi(observabilityApiRef);
+  // Optional — see note in useIncidentsSummary.ts. When the observability plugin is not
+  // installed, useApiHolder().get() returns undefined and we short-circuit fetchData below
+  // by setting observabilityDisabled: true (the same state the backend sets when the
+  // cluster has observability turned off).
+  const observabilityApi = useApiHolder().get(observabilityApiRef);
 
   const [state, setState] = useState<LogsSummaryState>({
     errorCount: 0,
@@ -63,6 +67,15 @@ export function useLogsSummary() {
   });
 
   const fetchData = useCallback(async () => {
+    if (!observabilityApi) {
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        error: null,
+        observabilityDisabled: true,
+      }));
+      return;
+    }
     try {
       // Get environments
       const environments: Environment[] = await client.getEnvironments(entity);


### PR DESCRIPTION
## Purpose

  Two related bugs were blocking external installs of `@openchoreo/*@1.1.0` per the docs:

  1. **Publish pipeline leaked `workspace:^` into tarballs.** `changeset publish` shells out to
  `npm publish` for non-pnpm repos, and `npm publish` does not rewrite Yarn Berry's `workspace:`
  protocol. 13 of 17 published `@openchoreo/*@1.1.0` packages contained literal `workspace:^`
  strings in `dependencies`. External `yarn add @openchoreo/backstage-plugin@^1.1.0` failed with
  `Workspace not found`.

  2. **Deploy tab hard-required the observability plugin.** Following the install guide through
  Section 4 (Core) only, opening any component's Deploy tab threw `NotImplementedError: No
  implementation available for apiRef{plugin.openchoreo-observability.service}`. The hooks
  consuming observability already documented the intent that it be optional ("without requiring a
  package dependency") but used `useApi()` (throws) instead of `useApiHolder().get()` (returns
  undefined).

<img width="1727" height="902" alt="image" src="https://github.com/user-attachments/assets/3e729366-b10f-4abb-9515-84f7ae5ebb67" />

  ## Goals

  - Get every `@openchoreo/*` package installable via `yarn add` against the published registry,
  with concrete version ranges in `dependencies`.
  - Make the Core Deploy tab render correctly without §5 Observability installed, matching the
  install guide's promise that "Section 4 is the only mandatory install."

  ## Approach

  **Commit 1 — `fix(release): publish with yarn npm publish to rewrite workspace deps`**

  Replace `changeset publish` with `yarn workspaces foreach --all --no-private --topological
  --verbose npm publish --tolerate-republish --access public --tag <latest|next>`. Yarn Berry's
  native publish rewrites `workspace:^` to concrete versions at pack time, independent of
  `.npmrc:ignore-scripts=true`. `--tolerate-republish` preserves the previous idempotent-on-retry
  behaviour. `changeset version` (in `prepare-next-version.yml`) is untouched — only the publish
  step moves.

  Files changed:
  - `package.json` — `release:publish` script
  - `.github/workflows/release.yml` — publish step + comment
  - `README.md` — release-procedure docs (incl. `yarn pack`-based local dry-run, since `yarn npm
  publish --dry-run` is not supported)

  Verified locally: `yarn workspaces foreach pack` across all 22 public workspaces produced 22
  clean tarballs with zero `workspace:` leaks. The `@openchoreo/*@1.1.0` packages were
  subsequently deleted from GitHub Packages and republished manually with the fixed command —
  `yarn add @openchoreo/backstage-plugin@^1.1.0` now succeeds end-to-end.

  **Commit 2 — `fix(openchoreo): make observability dependency optional in Deploy tab`**

  Switch both consumers of `observabilityApiRef` in `@openchoreo/backstage-plugin` from `useApi()`
   to `useApiHolder().get()` and short-circuit each fetch when the API is undefined.

  Files changed:
  - `plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts` — returns an
  empty `Map` when observability isn't registered. `PipelineCanvas` already optional-chains
  `incidentsSummaries.get(name)?.activeCount`, so the Deploy tab now renders environment tiles
  cleanly without incident chips.
  - `plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts` — sets
  `observabilityDisabled: true`. `RuntimeHealthCard` already routes that state to a friendly empty
   card (the same branch it uses when the backend reports observability is off cluster-side).

  No UI changes — only the throw is gone.

  ## User stories

  - As an external Backstage operator integrating OpenChoreo, I can `yarn add
  @openchoreo/backstage-plugin@^1.1.0` and have it resolve.
  - As an operator who installs only the Core plugin set (no Observability), every Component's
  Deploy tab loads without runtime errors.

  ## Release note

  Fixed: `@openchoreo/*` packages no longer publish with `workspace:^` strings in `dependencies`.
  Fixed: Core Deploy tab no longer requires
  `@openchoreo/backstage-plugin-openchoreo-observability` — installs of just the Core plugin set
  work end-to-end.

  ## Documentation

  Release-procedure changes are in this PR's `README.md` diff. The OpenChoreo install guide is
  being updated separately to flag Section 4's previously-implicit dependency on Section 5
  (resolved by this PR) and other gaps surfaced during install testing.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI publish workflow to reliably publish workspace packages with consistent tags and idempotent republishing.

* **Documentation**
  * Updated release docs with the new publish process, verification steps for dist-tags and concrete dependency versions, and updated local dry-run guidance.

* **Bug Fixes**
  * UI now gracefully handles missing observability capabilities, avoiding errors and clearing related summaries/logs when the observability integration isn’t available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->