### PR TITLE
fix(authz): gate Resource Deploy actions on env-scoped permissions

### DIFF
--- a/plugins/openchoreo-react/src/hooks/useResourcePromoteToEnvPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useResourcePromoteToEnvPermission.test.ts
@@ -1,0 +1,140 @@
+import { renderHook } from '@testing-library/react';
+import { useResourcePromoteToEnvPermission } from './useResourcePromoteToEnvPermission';
+
+const mockCreate = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock('./useResourceReleaseBindingCreatePermission', () => ({
+  useResourceReleaseBindingCreatePermission: (env?: string) => mockCreate(env),
+}));
+jest.mock('./useResourceReleaseBindingUpdatePermission', () => ({
+  useResourceReleaseBindingUpdatePermission: (env?: string) => mockUpdate(env),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useResourcePromoteToEnvPermission', () => {
+  it('allows when both create and update permissions are allowed', () => {
+    mockCreate.mockReturnValue({
+      canCreate: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+    mockUpdate.mockReturnValue({
+      canUpdate: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+
+    const { result } = renderHook(() =>
+      useResourcePromoteToEnvPermission('production'),
+    );
+
+    expect(result.current.canPromote).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('forwards the target env name to both underlying hooks', () => {
+    mockCreate.mockReturnValue({
+      canCreate: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+    mockUpdate.mockReturnValue({
+      canUpdate: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+
+    renderHook(() => useResourcePromoteToEnvPermission('production'));
+
+    expect(mockCreate).toHaveBeenCalledWith('production');
+    expect(mockUpdate).toHaveBeenCalledWith('production');
+  });
+
+  it('denies and surfaces the create-denied tooltip when only create is denied', () => {
+    mockCreate.mockReturnValue({
+      canCreate: false,
+      loading: false,
+      deniedTooltip: 'no deploy to production',
+    });
+    mockUpdate.mockReturnValue({
+      canUpdate: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+
+    const { result } = renderHook(() =>
+      useResourcePromoteToEnvPermission('production'),
+    );
+
+    expect(result.current.canPromote).toBe(false);
+    expect(result.current.deniedTooltip).toBe('no deploy to production');
+  });
+
+  it('denies and surfaces the update-denied tooltip when only update is denied', () => {
+    mockCreate.mockReturnValue({
+      canCreate: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+    mockUpdate.mockReturnValue({
+      canUpdate: false,
+      loading: false,
+      deniedTooltip: 'no update on production',
+    });
+
+    const { result } = renderHook(() =>
+      useResourcePromoteToEnvPermission('production'),
+    );
+
+    expect(result.current.canPromote).toBe(false);
+    expect(result.current.deniedTooltip).toBe('no update on production');
+  });
+
+  it('uses a generic message when both are denied', () => {
+    mockCreate.mockReturnValue({
+      canCreate: false,
+      loading: false,
+      deniedTooltip: 'no deploy',
+    });
+    mockUpdate.mockReturnValue({
+      canUpdate: false,
+      loading: false,
+      deniedTooltip: 'no update',
+    });
+
+    const { result } = renderHook(() =>
+      useResourcePromoteToEnvPermission('production'),
+    );
+
+    expect(result.current.canPromote).toBe(false);
+    expect(result.current.deniedTooltip).toBe(
+      'You do not have permission to promote to production',
+    );
+  });
+
+  it('reports loading when either half is loading', () => {
+    mockCreate.mockReturnValue({
+      canCreate: false,
+      loading: true,
+      deniedTooltip: '',
+    });
+    mockUpdate.mockReturnValue({
+      canUpdate: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+
+    const { result } = renderHook(() =>
+      useResourcePromoteToEnvPermission('production'),
+    );
+
+    expect(result.current.loading).toBe(true);
+    // Tooltip suppressed while loading.
+    expect(result.current.deniedTooltip).toBe('');
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useResourcePromoteToEnvPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useResourcePromoteToEnvPermission.ts
@@ -1,0 +1,51 @@
+import { useResourceReleaseBindingCreatePermission } from './useResourceReleaseBindingCreatePermission';
+import { useResourceReleaseBindingUpdatePermission } from './useResourceReleaseBindingUpdatePermission';
+
+/**
+ * Result of the useResourcePromoteToEnvPermission hook.
+ */
+export interface UseResourcePromoteToEnvPermissionResult {
+  /** Whether the user has permission to promote to the target environment */
+  canPromote: boolean;
+  /** Whether either permission check is still loading */
+  loading: boolean;
+  /** Tooltip explaining which half (or both) is denied; empty when allowed/loading */
+  deniedTooltip: string;
+}
+
+/**
+ * Composite permission hook for the per-target Promote action on a Resource.
+ *
+ * Mirrors `usePromoteToEnvPermission` for Components. Promoting to an
+ * environment creates a new ResourceReleaseBinding (or advances the existing
+ * one) AND mutates lifecycle state, so it requires BOTH
+ * `resourcereleasebinding:create` AND `resourcereleasebinding:update` on the
+ * target environment. Either being denied disables the button; the tooltip
+ * surfaces which half is missing.
+ *
+ * Must be used within an EntityProvider context. `targetEnvironment` should
+ * be the Kubernetes resource name (e.g. "production"), not the display name
+ * ("Production"), so the ABAC `resource.environment` CEL check matches.
+ */
+export const useResourcePromoteToEnvPermission = (
+  targetEnvironment: string,
+): UseResourcePromoteToEnvPermissionResult => {
+  const create = useResourceReleaseBindingCreatePermission(targetEnvironment);
+  const update = useResourceReleaseBindingUpdatePermission(targetEnvironment);
+
+  const loading = create.loading || update.loading;
+  const canPromote = create.canCreate && update.canUpdate;
+
+  let deniedTooltip = '';
+  if (!canPromote && !loading) {
+    if (!create.canCreate && !update.canUpdate) {
+      deniedTooltip = `You do not have permission to promote to ${targetEnvironment}`;
+    } else if (!create.canCreate) {
+      deniedTooltip = create.deniedTooltip;
+    } else {
+      deniedTooltip = update.deniedTooltip;
+    }
+  }
+
+  return { canPromote, loading, deniedTooltip };
+};

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -366,6 +366,10 @@ export {
   type UsePromoteToEnvPermissionResult,
 } from './hooks/usePromoteToEnvPermission';
 export {
+  useResourcePromoteToEnvPermission,
+  type UseResourcePromoteToEnvPermissionResult,
+} from './hooks/useResourcePromoteToEnvPermission';
+export {
   useReleaseBindingPermission,
   type UseReleaseBindingPermissionResult,
 } from './hooks/useReleaseBindingPermission';

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironmentDetailPanel.test.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironmentDetailPanel.test.tsx
@@ -15,9 +15,14 @@ jest.mock('@openchoreo/backstage-design-system', () => ({
 
 const mockUpdatePerm = jest.fn();
 const mockDeletePerm = jest.fn();
+const mockPromotePerm = jest.fn();
 jest.mock('@openchoreo/backstage-plugin-react', () => ({
-  useResourceReleaseBindingUpdatePermission: () => mockUpdatePerm(),
-  useResourceReleaseBindingDeletePermission: () => mockDeletePerm(),
+  formatRelativeTime: () => 'just now',
+  useResourceReleaseBindingUpdatePermission: (env?: string) =>
+    mockUpdatePerm(env),
+  useResourceReleaseBindingDeletePermission: (env?: string) =>
+    mockDeletePerm(env),
+  useResourcePromoteToEnvPermission: (env: string) => mockPromotePerm(env),
 }));
 
 function makeCtx(
@@ -63,6 +68,11 @@ beforeEach(() => {
   });
   mockDeletePerm.mockReturnValue({
     canDelete: true,
+    loading: false,
+    deniedTooltip: '',
+  });
+  mockPromotePerm.mockReturnValue({
+    canPromote: true,
     loading: false,
     deniedTooltip: '',
   });
@@ -304,7 +314,7 @@ describe('ResourceEnvironmentDetailPanel', () => {
     expect(screen.queryByRole('button', { name: /view all/i })).toBeNull();
   });
 
-  it('shows Promoting... while a forward promote is in flight', () => {
+  it('shows Promoting... while a promote is in flight', () => {
     const dev = {
       name: 'dev',
       bindingName: 'b-dev',
@@ -318,5 +328,83 @@ describe('ResourceEnvironmentDetailPanel', () => {
       pendingAction: { env: 'staging', kind: 'promote' },
     });
     expect(screen.getByText('Promoting...')).toBeInTheDocument();
+  });
+
+  // ABAC-aware permission gating. Bug observed in live cluster: a developer
+  // role with `resource.environment != 'default/production'` CEL gating
+  // saw Configure overrides + Promote enabled on the prod panel because
+  // (1) the env display name was being passed instead of resourceName, and
+  // (2) the panel Promote button didn't check promote perm at all.
+  describe('permission gating', () => {
+    const prodEnv = {
+      name: 'Production',
+      resourceName: 'production',
+      bindingName: 'b-prod',
+      resourceRelease: 'rel-1',
+      retainPolicy: 'Delete' as const,
+      status: 'Ready' as const,
+      latestRelease: 'rel-1',
+    };
+
+    it('passes env.resourceName to update perm hook, not the display name', () => {
+      renderPanel(prodEnv);
+      // ABAC CEL on the cluster matches against the K8s name "production",
+      // not the display name "Production".
+      expect(mockUpdatePerm).toHaveBeenCalledWith('production');
+    });
+
+    it('passes env.resourceName to delete perm hook, not the display name', () => {
+      renderPanel(prodEnv);
+      expect(mockDeletePerm).toHaveBeenCalledWith('production');
+    });
+
+    it('falls back to env.name when resourceName is absent', () => {
+      // Component-side compatibility: not all entries carry resourceName.
+      renderPanel({
+        name: 'dev',
+        bindingName: 'b-dev',
+        resourceRelease: 'rel-1',
+        retainPolicy: 'Delete',
+        status: 'Ready',
+        latestRelease: 'rel-1',
+      });
+      expect(mockUpdatePerm).toHaveBeenCalledWith('dev');
+      expect(mockDeletePerm).toHaveBeenCalledWith('dev');
+    });
+
+    it('disables the panel Promote button when target env denies promote perm', () => {
+      mockPromotePerm.mockReturnValue({
+        canPromote: false,
+        loading: false,
+        deniedTooltip: 'You do not have permission to promote to production',
+      });
+      const staging = {
+        name: 'staging',
+        bindingName: 'b-staging',
+        resourceRelease: 'rel-abc',
+        retainPolicy: 'Delete' as const,
+        status: 'Ready' as const,
+        promotionTargets: [{ name: 'Production', resourceName: 'production' }],
+      };
+      renderPanel(staging, {
+        environments: [staging, { ...prodEnv, resourceRelease: 'rel-old' }],
+      });
+      expect(screen.getByRole('button', { name: /^promote$/i })).toBeDisabled();
+    });
+
+    it('queries promote perm using the target resourceName, not the display name', () => {
+      const staging = {
+        name: 'staging',
+        bindingName: 'b-staging',
+        resourceRelease: 'rel-abc',
+        retainPolicy: 'Delete' as const,
+        status: 'Ready' as const,
+        promotionTargets: [{ name: 'Production', resourceName: 'production' }],
+      };
+      renderPanel(staging, {
+        environments: [staging, { ...prodEnv, resourceRelease: 'rel-old' }],
+      });
+      expect(mockPromotePerm).toHaveBeenCalledWith('production');
+    });
   });
 });

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironmentDetailPanel.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironmentDetailPanel.tsx
@@ -25,6 +25,7 @@ import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import { StatusBadge } from '@openchoreo/backstage-design-system';
 import {
   formatRelativeTime,
+  useResourcePromoteToEnvPermission,
   useResourceReleaseBindingDeletePermission,
   useResourceReleaseBindingUpdatePermission,
 } from '@openchoreo/backstage-plugin-react';
@@ -97,9 +98,11 @@ function ResourceEnvironmentDetailContent({ env, onClose }: ContentProps) {
   const hasOutputs = outputCount > 0;
   const badgeStatus = deriveResourceEnvBadgeStatus(env);
 
-  // Promote eligibility (forward-promote semantic, same as the env card):
-  // shows when this env has a binding + release + at least one
-  // promotion target that doesn't already have this release.
+  // Promote eligibility: shows when this env has a binding + release + at
+  // least one promotion target that doesn't already have this release. Promote
+  // copies this env's release pin forward to the next env's binding; the
+  // pipeline-defined `promotionTargets` enforces ordering (prod has no
+  // targets, so the button never appears on the terminal env).
   const promotionTargets = env.promotionTargets ?? [];
   const eligibleTargets = env.resourceRelease
     ? promotionTargets.filter(t => {
@@ -109,12 +112,12 @@ function ResourceEnvironmentDetailContent({ env, onClose }: ContentProps) {
     : [];
   const allTargetsInSync =
     promotionTargets.length > 0 && eligibleTargets.length === 0;
-  const isPromotingForward = promotionTargets.some(
+  const isPromoting = promotionTargets.some(
     t =>
       pendingAction?.kind === 'promote' &&
       pendingAction.env === (t.resourceName ?? t.name),
   );
-  const showForwardPromote =
+  const showPromote =
     hasBinding &&
     Boolean(env.resourceRelease) &&
     env.status === 'Ready' &&
@@ -136,8 +139,12 @@ function ResourceEnvironmentDetailContent({ env, onClose }: ContentProps) {
     [notification],
   );
 
-  const updatePerm = useResourceReleaseBindingUpdatePermission(env.name);
-  const deletePerm = useResourceReleaseBindingDeletePermission(env.name);
+  // ABAC env-aware perms key on the K8s resource name (e.g. "production"),
+  // not the display name ("Production") — that's what the cluster's
+  // `resource.environment` CEL matches against.
+  const envResourceName = env.resourceName ?? env.name;
+  const updatePerm = useResourceReleaseBindingUpdatePermission(envResourceName);
+  const deletePerm = useResourceReleaseBindingDeletePermission(envResourceName);
 
   const isUndeploying =
     pendingAction?.env === (env.resourceName ?? env.name) &&
@@ -318,11 +325,11 @@ function ResourceEnvironmentDetailContent({ env, onClose }: ContentProps) {
                   Actions
                 </Typography>
                 <Box className={classes.actionsRow}>
-                  {showForwardPromote && (
-                    <ForwardPromoteButton
+                  {showPromote && (
+                    <PromotePrimaryAction
                       allTargetsInSync={allTargetsInSync}
                       eligibleTargets={eligibleTargets}
-                      isPromotingForward={isPromotingForward}
+                      isPromoting={isPromoting}
                       onPromoteSingle={handlePromoteSingle}
                     />
                   )}
@@ -462,19 +469,19 @@ function ResourceEnvironmentDetailContent({ env, onClose }: ContentProps) {
   );
 }
 
-interface ForwardPromoteButtonProps {
+interface PromotePrimaryActionProps {
   allTargetsInSync: boolean;
-  eligibleTargets: Array<{ name: string }>;
-  isPromotingForward: boolean;
+  eligibleTargets: Array<{ name: string; resourceName?: string }>;
+  isPromoting: boolean;
   onPromoteSingle: () => void;
 }
 
-function ForwardPromoteButton({
+function PromotePrimaryAction({
   allTargetsInSync,
   eligibleTargets,
-  isPromotingForward,
+  isPromoting,
   onPromoteSingle,
-}: ForwardPromoteButtonProps) {
+}: PromotePrimaryActionProps) {
   if (allTargetsInSync) {
     return (
       <Button size="small" variant="contained" disabled>
@@ -488,21 +495,57 @@ function ForwardPromoteButton({
   const target = eligibleTargets[0];
   if (!target) return null;
   return (
-    <Tooltip title={`Promote to ${target.name}`}>
+    <PromotePrimaryButton
+      target={target}
+      isPromoting={isPromoting}
+      onPromoteSingle={onPromoteSingle}
+    />
+  );
+}
+
+interface PromotePrimaryButtonProps {
+  target: { name: string; resourceName?: string };
+  isPromoting: boolean;
+  onPromoteSingle: () => void;
+}
+
+/**
+ * Single-target Promote button on the panel. Calls
+ * `useResourcePromoteToEnvPermission(target)` so disabled state honors both
+ * `resourcereleasebinding:create` and `resourcereleasebinding:update` ABAC
+ * on the target env. Mirrors the Component-side `PromotePrimaryButton` in
+ * `PromotePrimaryAction.tsx`.
+ *
+ * Mounted only when there is a real target to promote to so the hook
+ * receives a stable argument (hooks can't be called conditionally).
+ */
+function PromotePrimaryButton({
+  target,
+  isPromoting,
+  onPromoteSingle,
+}: PromotePrimaryButtonProps) {
+  const targetEnvName = target.resourceName ?? target.name;
+  const { canPromote, loading, deniedTooltip } =
+    useResourcePromoteToEnvPermission(targetEnvName);
+  const disabled = isPromoting || loading || !canPromote;
+  const tooltip =
+    !canPromote && !loading ? deniedTooltip : `Promote to ${target.name}`;
+  return (
+    <Tooltip title={tooltip}>
       <span>
         <Button
           size="small"
           variant="contained"
           color="primary"
           onClick={onPromoteSingle}
-          disabled={isPromotingForward}
+          disabled={disabled}
           startIcon={
-            isPromotingForward ? (
+            isPromoting ? (
               <CircularProgress size={14} color="inherit" />
             ) : undefined
           }
         >
-          {isPromotingForward ? 'Promoting...' : 'Promote'}
+          {isPromoting ? 'Promoting...' : 'Promote'}
         </Button>
       </span>
     </Tooltip>

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironments.test.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironments.test.tsx
@@ -38,6 +38,11 @@ jest.mock('@openchoreo/backstage-plugin-react', () => ({
     loading: false,
     deniedTooltip: '',
   }),
+  useResourcePromoteToEnvPermission: () => ({
+    canPromote: true,
+    loading: false,
+    deniedTooltip: '',
+  }),
   // The canvas internals are exercised in their own test; here we stub the
   // graph layout so jsdom doesn't need to mount the real dagre + zoom infra.
   // Mirror the real buildEnvPipelineNodes shape: prepend a synthetic setup

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceMiniEnvironmentNode.test.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceMiniEnvironmentNode.test.tsx
@@ -13,9 +13,29 @@ jest.mock('@openchoreo/backstage-design-system', () => ({
   ),
 }));
 
+const mockPromotePerm = jest.fn();
+const mockUpdatePerm = jest.fn();
 jest.mock('@openchoreo/backstage-plugin-react', () => ({
   formatRelativeTime: () => 'just now',
+  useResourcePromoteToEnvPermission: (env: string) => mockPromotePerm(env),
+  useResourceReleaseBindingUpdatePermission: (env?: string) =>
+    mockUpdatePerm(env),
 }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default to allowed so existing tests keep passing; gating tests override.
+  mockPromotePerm.mockReturnValue({
+    canPromote: true,
+    loading: false,
+    deniedTooltip: '',
+  });
+  mockUpdatePerm.mockReturnValue({
+    canUpdate: true,
+    loading: false,
+    deniedTooltip: '',
+  });
+});
 
 function bound(): ResourceEnvironment {
   return {
@@ -368,6 +388,110 @@ describe('ResourceMiniEnvironmentNode', () => {
         );
         expect(onPromote).toHaveBeenCalledWith('stagingB', 'rel-abc');
       });
+    });
+  });
+
+  // ABAC env-aware permission gating. The Resource Deploy tab honors the same
+  // `resource.environment` CEL constraints as Component side; without these
+  // checks a developer with `releasebinding:update` allowed on non-prod envs
+  // saw an enabled "Promote to Production" button that 403'd on click.
+  // Mirrors MiniEnvironmentNode.test.tsx coverage for Components.
+  describe('permission gating', () => {
+    const devToProd: ResourceEnvironment = {
+      ...bound(),
+      promotionTargets: [{ name: 'Production', resourceName: 'production' }],
+    };
+    const prodBehind: ResourceEnvironment = {
+      name: 'Production',
+      resourceName: 'production',
+      resourceRelease: 'rel-old',
+    };
+
+    it('queries promote permission using the target resourceName, not the display name', () => {
+      renderTile(devToProd, false, () => {}, {
+        environments: [devToProd, prodBehind],
+      });
+      // ABAC matches on the lowercase RFC 1123 name; passing the display
+      // name ("Production") lets the prod-deny CEL slip through.
+      expect(mockPromotePerm).toHaveBeenCalledWith('production');
+    });
+
+    it('disables the single-target Promote button when promote perm is denied', () => {
+      mockPromotePerm.mockReturnValue({
+        canPromote: false,
+        loading: false,
+        deniedTooltip: 'You do not have permission to promote to production',
+      });
+      renderTile(devToProd, false, () => {}, {
+        environments: [devToProd, prodBehind],
+      });
+      const button = screen.getByRole('button', {
+        name: /promote dev to production/i,
+      });
+      expect(button).toBeDisabled();
+    });
+
+    it('disables a multi-target promote MenuItem when its target denies promote perm', () => {
+      const devToTwo: ResourceEnvironment = {
+        ...bound(),
+        promotionTargets: [
+          { name: 'staging', resourceName: 'staging' },
+          { name: 'Production', resourceName: 'production' },
+        ],
+      };
+      const stagingBehind: ResourceEnvironment = {
+        name: 'staging',
+        resourceName: 'staging',
+        resourceRelease: 'rel-old',
+      };
+      // Only deny on production; staging stays allowed so the row-by-row
+      // gating assertion is meaningful.
+      mockPromotePerm.mockImplementation((env: string) =>
+        env === 'production'
+          ? {
+              canPromote: false,
+              loading: false,
+              deniedTooltip: 'denied',
+            }
+          : {
+              canPromote: true,
+              loading: false,
+              deniedTooltip: '',
+            },
+      );
+      renderTile(devToTwo, false, () => {}, {
+        environments: [devToTwo, stagingBehind, prodBehind],
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^promote dev$/i }));
+      expect(
+        screen.getByRole('menuitem', { name: /promote to production/i }),
+      ).toHaveAttribute('aria-disabled', 'true');
+      expect(
+        screen.getByRole('menuitem', { name: /promote to staging/i }),
+      ).not.toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('queries Configure overrides permission with the env resourceName', () => {
+      const prodEnv: ResourceEnvironment = {
+        ...bound(),
+        name: 'Production',
+        resourceName: 'production',
+      };
+      renderTile(prodEnv);
+      expect(mockUpdatePerm).toHaveBeenCalledWith('production');
+    });
+
+    it('disables Configure overrides when binding-update perm is denied', () => {
+      mockUpdatePerm.mockReturnValue({
+        canUpdate: false,
+        loading: false,
+        deniedTooltip: 'no update',
+      });
+      renderTile(bound());
+      fireEvent.click(screen.getByRole('button', { name: /actions for dev/i }));
+      expect(
+        screen.getByRole('menuitem', { name: /configure overrides/i }),
+      ).toHaveAttribute('aria-disabled', 'true');
     });
   });
 });

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceMiniEnvironmentNode.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceMiniEnvironmentNode.tsx
@@ -23,7 +23,11 @@ import SettingsOutlinedIcon from '@material-ui/icons/SettingsOutlined';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 import { StatusBadge } from '@openchoreo/backstage-design-system';
-import { formatRelativeTime } from '@openchoreo/backstage-plugin-react';
+import {
+  formatRelativeTime,
+  useResourcePromoteToEnvPermission,
+  useResourceReleaseBindingUpdatePermission,
+} from '@openchoreo/backstage-plugin-react';
 import type { ResourceEnvironment } from '../../api/OpenChoreoClientApi';
 import { useResourceMiniEnvironmentNodeStyles } from './styles';
 import { useResourceEnvironmentsContext } from './ResourceEnvironmentsContext';
@@ -57,15 +61,21 @@ export const ResourceMiniEnvironmentNode = ({
 
   const hasBinding = Boolean(env.bindingName);
   const hasRelease = Boolean(env.resourceRelease);
+  // ABAC env-aware perm for Configure overrides on THIS env. Use the
+  // K8s resource name (not the display name) so `resource.environment`
+  // CEL on the cluster matches the expected lowercase RFC 1123 form.
+  const envResourceName = env.resourceName ?? env.name;
+  const updatePerm = useResourceReleaseBindingUpdatePermission(envResourceName);
   const badgeStatus = deriveResourceEnvBadgeStatus(env);
   const relativeDeployed = env.lastDeployed
     ? formatRelativeTime(env.lastDeployed)
     : null;
 
-  // Card-level Promote pushes this env's release FORWARD to the next env
-  // in the pipeline (mirrors Component). Distinct from the detail panel's
-  // Promote, which advances this binding to the latest ResourceRelease
-  // when the Resource spec has drifted ahead.
+  // Card Promote copies this env's release pin forward to the next env's
+  // binding (mirrors Component). The pipeline-defined `promotionTargets`
+  // enforces ordering: prod has no targets, so the button never appears on
+  // the terminal env. There is no skip-the-pipeline "jump to latest"
+  // operation by design.
   const promotionTargets = env.promotionTargets ?? [];
   const hasPromotionTargets = promotionTargets.length > 0;
   const eligibleTargets = hasRelease
@@ -75,7 +85,7 @@ export const ResourceMiniEnvironmentNode = ({
       })
     : [];
   const isReady = env.status === 'Ready';
-  const isPromotingForward = promotionTargets.some(
+  const isPromoting = promotionTargets.some(
     t =>
       pendingAction?.kind === 'promote' &&
       pendingAction.env === (t.resourceName ?? t.name),
@@ -159,17 +169,13 @@ export const ResourceMiniEnvironmentNode = ({
     }
     if (promotionTargets.length === 1) {
       return (
-        <Button
-          size="small"
-          variant="contained"
-          color="primary"
+        <PromotePrimaryButton
+          envName={env.name}
+          target={eligibleTargets[0]}
+          isPromoting={isPromoting}
           className={classes.primaryButton}
           onClick={handlePromoteSingle}
-          disabled={isPromotingForward}
-          aria-label={`Promote ${env.name} to ${eligibleTargets[0].name}`}
-        >
-          {isPromotingForward ? 'Promoting...' : 'Promote'}
-        </Button>
+        />
       );
     }
     return (
@@ -180,11 +186,11 @@ export const ResourceMiniEnvironmentNode = ({
         className={classes.primaryButton}
         endIcon={<ArrowDropDownIcon fontSize="small" />}
         onClick={openPromoteMenu}
-        disabled={isPromotingForward}
+        disabled={isPromoting}
         aria-haspopup="true"
         aria-label={`Promote ${env.name}`}
       >
-        {isPromotingForward ? 'Promoting...' : 'Promote'}
+        {isPromoting ? 'Promoting...' : 'Promote'}
       </Button>
     );
   };
@@ -317,10 +323,30 @@ export const ResourceMiniEnvironmentNode = ({
           </span>
         </Tooltip>
         <Divider />
-        <MenuItem onClick={handleConfigureOverrides} disabled={!hasBinding}>
-          <SettingsOutlinedIcon fontSize="small" style={{ marginRight: 8 }} />
-          Configure overrides
-        </MenuItem>
+        <Tooltip
+          title={
+            hasBinding && !updatePerm.loading && !updatePerm.canUpdate
+              ? updatePerm.deniedTooltip
+              : ''
+          }
+          placement="left"
+          PopperProps={{ disablePortal: true }}
+        >
+          <span>
+            <MenuItem
+              onClick={handleConfigureOverrides}
+              disabled={
+                !hasBinding || updatePerm.loading || !updatePerm.canUpdate
+              }
+            >
+              <SettingsOutlinedIcon
+                fontSize="small"
+                style={{ marginRight: 8 }}
+              />
+              Configure overrides
+            </MenuItem>
+          </span>
+        </Tooltip>
       </Menu>
 
       {/* Per-target promote menu, only mounted when the env has more than
@@ -336,28 +362,118 @@ export const ResourceMiniEnvironmentNode = ({
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         onClick={e => e.stopPropagation()}
       >
-        {promotionTargets.map(target => {
-          const promoted = isTargetAlreadyPromoted(target.name);
-          const inFlight = isTargetInFlight(target.resourceName ?? target.name);
-          let label: string;
-          if (promoted) {
-            label = `Promoted to ${target.name}`;
-          } else if (inFlight) {
-            label = `Promoting to ${target.name}...`;
-          } else {
-            label = `Promote to ${target.name}`;
-          }
-          return (
-            <MenuItem
-              key={target.name}
-              onClick={() => handlePromoteTo(target)}
-              disabled={promoted || inFlight}
-            >
-              {label}
-            </MenuItem>
-          );
-        })}
+        {promotionTargets.map(target => (
+          <PromoteMenuItemRow
+            key={target.name}
+            target={target}
+            promoted={isTargetAlreadyPromoted(target.name)}
+            inFlight={isTargetInFlight(target.resourceName ?? target.name)}
+            onClick={() => handlePromoteTo(target)}
+          />
+        ))}
       </Menu>
     </Box>
   );
 };
+
+interface PromoteTarget {
+  name: string;
+  resourceName?: string;
+}
+
+interface PromotePrimaryButtonProps {
+  envName: string;
+  target: PromoteTarget;
+  isPromoting: boolean;
+  className?: string;
+  onClick: (e: ReactMouseEvent<HTMLButtonElement>) => void;
+}
+
+/**
+ * Single-target Promote button on the env card. Calls
+ * `useResourcePromoteToEnvPermission(target)` so disabled state honors both
+ * `resourcereleasebinding:create` and `resourcereleasebinding:update` ABAC
+ * on the target env. Mirrors the Component-side `PromotePrimaryButton` in
+ * `MiniEnvironmentNode.tsx`.
+ */
+function PromotePrimaryButton({
+  envName,
+  target,
+  isPromoting,
+  className,
+  onClick,
+}: PromotePrimaryButtonProps) {
+  const targetEnvName = target.resourceName ?? target.name;
+  const { canPromote, loading, deniedTooltip } =
+    useResourcePromoteToEnvPermission(targetEnvName);
+  const disabled = isPromoting || loading || !canPromote;
+  const tooltip = !canPromote && !loading ? deniedTooltip : '';
+  return (
+    <Tooltip
+      title={tooltip}
+      disableHoverListener={!tooltip}
+      PopperProps={{ disablePortal: true }}
+    >
+      <span>
+        <Button
+          size="small"
+          variant="contained"
+          color="primary"
+          className={className}
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={`Promote ${envName} to ${target.name}`}
+        >
+          {isPromoting ? 'Promoting...' : 'Promote'}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+}
+
+interface PromoteMenuItemRowProps {
+  target: PromoteTarget;
+  promoted: boolean;
+  inFlight: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Single MenuItem inside the multi-target promote dropdown. Same ABAC story
+ * as the single-target button — one hook call per target row.
+ */
+function PromoteMenuItemRow({
+  target,
+  promoted,
+  inFlight,
+  onClick,
+}: PromoteMenuItemRowProps) {
+  const targetEnvName = target.resourceName ?? target.name;
+  const { canPromote, loading, deniedTooltip } =
+    useResourcePromoteToEnvPermission(targetEnvName);
+  let label: string;
+  if (promoted) {
+    label = `Promoted to ${target.name}`;
+  } else if (inFlight) {
+    label = `Promoting to ${target.name}...`;
+  } else {
+    label = `Promote to ${target.name}`;
+  }
+  const permDenied = !loading && !canPromote;
+  const disabled = promoted || inFlight || loading || !canPromote;
+  const tooltip = permDenied ? deniedTooltip : '';
+  return (
+    <Tooltip
+      title={tooltip}
+      disableHoverListener={!tooltip}
+      placement="left"
+      PopperProps={{ disablePortal: true }}
+    >
+      <span>
+        <MenuItem disabled={disabled} onClick={onClick}>
+          {label}
+        </MenuItem>
+      </span>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Purpose

The Resource Deploy tab in Backstage did not honor ABAC env-scoped permissions, so a developer with a deny on `resourcereleasebinding:*` for production saw enabled Promote / Configure overrides / Remove deployment buttons that would 403 on click. Components were already gated; Resources had not been wired up.

Live-reproduced on k3d as `developer@openchoreo.dev` with the standard `developer-binding` CEL `resource.environment != 'default/production'`.

## Approach

- Add `useResourcePromoteToEnvPermission` composite hook that gates both `resourcereleasebinding:create` and `resourcereleasebinding:update` on the target env, mirroring the Component-side `usePromoteToEnvPermission`.
- Gate the inline Promote button, the multi-target picker row, and the Configure overrides menu item in `ResourceMiniEnvironmentNode` by the target / current env permission.
- Wire the same Promote gate into the panel's primary Promote action.
- Fix `ResourceEnvironmentDetailPanel` to pass `env.resourceName` (not the display name) to the env-scoped perm hooks so the ABAC `resource.environment` CEL matches the K8s name.
- Rename `ForwardPromoteButton` → `PromotePrimaryAction` to match Component-side naming. Drop a stale comment that documented an unshipped "advance-to-latest" Promote variant; the design was retired in slice 4 polish (`f2b05e38`) in favor of the forward-only model that enforces pipeline order.

## Related Issues

Related: openchoreo/openchoreo#3107, openchoreo/openchoreo#3336

## Checklist
- [x] Tests added or updated (unit, integration, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission checks for resource promotion to environments, ensuring promote actions are gated based on user access control.
  * Enhanced UI to display appropriate disabled states and permission denial messages when users lack authorization to promote resources.

* **Tests**
  * Added comprehensive test coverage for promotion permission validation and component behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->