### PR TITLE
feat: add runtime observability toggle in CellDiagram

### DIFF
--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx
@@ -322,7 +322,7 @@ describe('CellDiagram', () => {
 
     expect(
       document.querySelector(
-        '[data-tooltip*="Cilium module is not setup in all environments"]',
+        '[data-tooltip*="Observability is unavailable in all environments. Configure the Cilium module to enable observability."]',
       ),
     ).not.toBeNull();
   });
@@ -370,9 +370,7 @@ describe('CellDiagram', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          /Observability is unavailable: Cilium module is not set up/i,
-        ),
+        screen.getByText(/Observability is unavailable in the/i),
       ).toBeInTheDocument();
     });
   });

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx
@@ -11,7 +11,9 @@ jest.mock('@backstage/plugin-catalog-react', () => ({
 
 jest.mock('@backstage/core-plugin-api', () => ({
   useApi: jest.fn(),
-  createApiRef: () => ({ id: 'mock-api-ref' }),
+  createApiRef: (def: { id: string }) => ({ id: def?.id ?? 'mock-api-ref' }),
+  discoveryApiRef: { id: 'discovery' },
+  fetchApiRef: { id: 'fetch' },
 }));
 
 jest.mock('@backstage/core-components', () => ({
@@ -19,9 +21,16 @@ jest.mock('@backstage/core-components', () => ({
 }));
 
 jest.mock('@wso2/cell-diagram', () => ({
-  CellDiagram: ({ project }: any) => (
-    <div data-testid="cell-diagram-view">{project?.id}</div>
+  CellDiagram: ({ project, defaultDiagramLayer }: any) => (
+    <div data-testid="cell-diagram-view" data-layer={defaultDiagramLayer}>
+      {project?.id}
+    </div>
   ),
+  DiagramLayer: {
+    ARCHITECTURE: 'architecture',
+    OBSERVABILITY: 'observability',
+    DIFF: 'diff',
+  },
 }));
 
 jest.mock('@openchoreo/backstage-design-system', () => ({
@@ -30,7 +39,10 @@ jest.mock('@openchoreo/backstage-design-system', () => ({
 
 jest.mock('@material-ui/core/styles', () => ({
   useTheme: () => ({
-    palette: { background: { paper: '#fff' } },
+    palette: {
+      background: { paper: '#fff' },
+      warning: { light: '#ffd', contrastText: '#000' },
+    },
   }),
 }));
 
@@ -41,6 +53,32 @@ jest.mock('@material-ui/core/Box', () => ({ children, ...rest }: any) => (
 jest.mock('@material-ui/core/FormControl', () => ({ children }: any) => (
   <div>{children}</div>
 ));
+jest.mock(
+  '@material-ui/core/FormControlLabel',
+  () =>
+    ({ control, label }: any) =>
+      (
+        <label>
+          {control}
+          {label}
+        </label>
+      ),
+);
+jest.mock(
+  '@material-ui/core/Switch',
+  () =>
+    ({ checked, onChange, disabled, inputProps }: any) =>
+      (
+        <input
+          type="checkbox"
+          role="switch"
+          aria-label={inputProps?.['aria-label']}
+          checked={!!checked}
+          disabled={!!disabled}
+          onChange={e => onChange?.({ target: { checked: e.target.checked } })}
+        />
+      ),
+);
 jest.mock('@material-ui/core/InputLabel', () => ({ children }: any) => (
   <label>{children}</label>
 ));
@@ -50,10 +88,12 @@ jest.mock('@material-ui/core/MenuItem', () => ({ children, value }: any) => (
 jest.mock(
   '@material-ui/core/Select',
   () =>
-    ({ children, onChange, value, disabled }: any) =>
+    ({ children, onChange, value, disabled, labelId }: any) =>
       (
         <select
-          data-testid="select"
+          data-testid={
+            labelId === 'cell-diagram-env-label' ? 'env-select' : 'select'
+          }
           onChange={e => onChange?.({ target: { value: e.target.value } })}
           value={value}
           disabled={disabled}
@@ -62,8 +102,8 @@ jest.mock(
         </select>
       ),
 );
-jest.mock('@material-ui/core/Tooltip', () => ({ children }: any) => (
-  <div>{children}</div>
+jest.mock('@material-ui/core/Tooltip', () => ({ children, title }: any) => (
+  <div data-tooltip={typeof title === 'string' ? title : ''}>{children}</div>
 ));
 jest.mock(
   '@material-ui/core/Typography',
@@ -79,7 +119,7 @@ jest.mock(
   () =>
     ({ children, onClick, disabled }: any) =>
       (
-        <button onClick={onClick} disabled={disabled}>
+        <button aria-label="refresh" onClick={onClick} disabled={disabled}>
           {children}
         </button>
       ),
@@ -102,15 +142,54 @@ const mockEntity = {
   spec: {},
 };
 
+const mkEnvEntity = (name: string, dp: string | undefined = 'dp-cilium') => ({
+  metadata: {
+    name,
+    namespace: 'test-ns',
+    annotations: dp
+      ? {
+          'openchoreo.io/namespace': 'test-ns',
+          'openchoreo.io/data-plane-ref': dp,
+          'openchoreo.io/data-plane-ref-kind': 'DataPlane',
+        }
+      : { 'openchoreo.io/namespace': 'test-ns' },
+  },
+});
+
 const mockCatalogApi = {
   getEntities: jest.fn().mockResolvedValue({
-    items: [{ metadata: { name: 'dev' } }, { metadata: { name: 'prod' } }],
+    items: [mkEnvEntity('dev'), mkEnvEntity('prod')],
   }),
+};
+
+const mockDiscoveryApi = {
+  getBaseUrl: jest
+    .fn()
+    .mockResolvedValue('http://localhost/observability-backend'),
+};
+
+let mockFetchApi: { fetch: jest.Mock };
+const setNetPolResponses = (
+  providerByDpName: Record<string, string | undefined>,
+) => {
+  mockFetchApi = {
+    fetch: jest.fn().mockImplementation(async (url: string) => {
+      const u = new URL(url);
+      const dpName = u.searchParams.get('dpName') ?? '';
+      const provider = providerByDpName[dpName];
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ networkPolicyProvider: provider ?? null }),
+      };
+    }),
+  };
 };
 
 function setupMockClient(
   overrides: Partial<{
     getCellDiagramInfo: jest.Mock;
+    fetchDeploymentPipeline: jest.Mock;
   }> = {},
 ) {
   const mockClient = {
@@ -119,10 +198,21 @@ function setupMockClient(
       components: [],
       connections: [],
     }),
+    fetchDeploymentPipeline: jest.fn().mockResolvedValue({
+      name: 'default-pipeline',
+      promotionPaths: [
+        {
+          sourceEnvironmentRef: 'dev',
+          targetEnvironmentRefs: [{ name: 'prod' }],
+        },
+      ],
+    }),
     ...overrides,
   };
   useApi.mockImplementation((ref: { id: string }) => {
     if (ref.id === 'catalog') return mockCatalogApi;
+    if (ref.id === 'discovery') return mockDiscoveryApi;
+    if (ref.id === 'fetch') return mockFetchApi;
     return mockClient;
   });
   return mockClient;
@@ -132,12 +222,14 @@ beforeEach(() => {
   jest.clearAllMocks();
   useEntity.mockReturnValue({ entity: mockEntity });
   mockCatalogApi.getEntities.mockResolvedValue({
-    items: [{ metadata: { name: 'dev' } }, { metadata: { name: 'prod' } }],
+    items: [mkEnvEntity('dev'), mkEnvEntity('prod')],
   });
+  // Default: both envs use a Cilium-enabled DataPlane
+  setNetPolResponses({ 'dp-cilium': 'cilium' });
 });
 
 describe('CellDiagram', () => {
-  it('renders the cell diagram after loading environments and data', async () => {
+  it('renders the cell diagram and defaults Runtime Observability OFF', async () => {
     const mockClient = setupMockClient();
 
     await act(async () => {
@@ -145,32 +237,71 @@ describe('CellDiagram', () => {
     });
 
     await waitFor(() => {
-      expect(mockCatalogApi.getEntities).toHaveBeenCalledWith(
-        expect.objectContaining({
-          filter: { kind: 'Environment', 'metadata.namespace': 'test-ns' },
-        }),
-      );
-      expect(mockClient.getCellDiagramInfo).toHaveBeenCalled();
+      expect(screen.getByTestId('cell-diagram-view')).toBeInTheDocument();
+    });
+
+    // Toggle is rendered and OFF
+    const toggle = screen.getByRole('switch', {
+      name: /runtime observability/i,
+    });
+    expect(toggle).not.toBeChecked();
+
+    // Env/time-range selects and refresh hidden while OFF
+    expect(screen.queryByTestId('env-select')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /refresh/i }),
+    ).not.toBeInTheDocument();
+
+    // The initial fetch must omit environmentName/startTime/endTime
+    expect(mockClient.getCellDiagramInfo).toHaveBeenCalledWith(
+      expect.anything(),
+      { environmentName: undefined, startTime: undefined, endTime: undefined },
+    );
+  });
+
+  it('reveals filters and refetches with env/time range when toggle is turned ON', async () => {
+    const mockClient = setupMockClient();
+
+    await act(async () => {
+      render(<CellDiagram />);
     });
 
     await waitFor(() => {
       expect(screen.getByTestId('cell-diagram-view')).toBeInTheDocument();
     });
-  });
 
-  it('shows Progress while data loads', async () => {
-    // make getCellDiagramInfo never resolve so we stay in loading state
-    setupMockClient({
-      getCellDiagramInfo: jest.fn(() => new Promise(() => {})),
+    const toggle = screen.getByRole('switch', {
+      name: /runtime observability/i,
     });
 
-    render(<CellDiagram />);
+    await act(async () => {
+      await userEvent.click(toggle);
+    });
 
-    // Initial render shows Progress (cellDiagramData is undefined)
-    expect(screen.getByTestId('progress')).toBeInTheDocument();
+    // Env + time-range selects + refresh now visible
+    expect(screen.getByTestId('env-select')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /refresh/i }),
+    ).toBeInTheDocument();
+
+    // Latest call must include the env and the time range
+    await waitFor(() => {
+      const lastCall =
+        mockClient.getCellDiagramInfo.mock.calls[
+          mockClient.getCellDiagramInfo.mock.calls.length - 1
+        ];
+      expect(lastCall[1]).toEqual(
+        expect.objectContaining({
+          environmentName: 'dev',
+          startTime: expect.any(String),
+          endTime: expect.any(String),
+        }),
+      );
+    });
   });
 
-  it('renders environment selector with returned environments', async () => {
+  it('disables the toggle and shows tooltip when no env supports Cilium', async () => {
+    setNetPolResponses({ 'dp-cilium': 'calico' });
     setupMockClient();
 
     await act(async () => {
@@ -181,12 +312,72 @@ describe('CellDiagram', () => {
       expect(screen.getByTestId('cell-diagram-view')).toBeInTheDocument();
     });
 
-    // Both env options should be present in the selector
-    expect(screen.getByText('dev')).toBeInTheDocument();
-    expect(screen.getByText('prod')).toBeInTheDocument();
+    // The hook resolves async — wait for the disabled state to settle
+    await waitFor(() => {
+      const toggle = screen.getByRole('switch', {
+        name: /runtime observability/i,
+      });
+      expect(toggle).toBeDisabled();
+    });
+
+    expect(
+      document.querySelector(
+        '[data-tooltip*="Cilium module is not setup in all environments"]',
+      ),
+    ).not.toBeNull();
   });
 
-  it('shows no-traffic hint when project has no observations', async () => {
+  it('shows per-env warning when selected env lacks Cilium', async () => {
+    setNetPolResponses({ 'dp-cilium': 'cilium', 'dp-no-cilium': 'calico' });
+    mockCatalogApi.getEntities.mockResolvedValue({
+      items: [
+        mkEnvEntity('dev', 'dp-cilium'),
+        mkEnvEntity('staging', 'dp-no-cilium'),
+      ],
+    });
+    setupMockClient({
+      fetchDeploymentPipeline: jest.fn().mockResolvedValue({
+        name: 'default-pipeline',
+        promotionPaths: [
+          {
+            sourceEnvironmentRef: 'dev',
+            targetEnvironmentRefs: [{ name: 'staging' }],
+          },
+        ],
+      }),
+    });
+
+    await act(async () => {
+      render(<CellDiagram />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cell-diagram-view')).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByRole('switch', {
+      name: /runtime observability/i,
+    });
+    await act(async () => {
+      await userEvent.click(toggle);
+    });
+
+    // Switch env from dev → staging
+    const envSelect = screen.getByTestId('env-select');
+    await act(async () => {
+      await userEvent.selectOptions(envSelect, 'staging');
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /Observability is unavailable: Cilium module is not set up/i,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows no-traffic hint when observations are empty and toggle is on', async () => {
     setupMockClient({
       getCellDiagramInfo: jest.fn().mockResolvedValue({
         id: 'my-project',
@@ -211,11 +402,22 @@ describe('CellDiagram', () => {
     });
 
     await waitFor(() => {
+      expect(screen.getByTestId('cell-diagram-view')).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByRole('switch', {
+      name: /runtime observability/i,
+    });
+    await act(async () => {
+      await userEvent.click(toggle);
+    });
+
+    await waitFor(() => {
       expect(screen.getByText(/No HTTP traffic/i)).toBeInTheDocument();
     });
   });
 
-  it('does not show no-traffic hint when observations are present', async () => {
+  it('hides no-traffic hint when observations are present', async () => {
     setupMockClient({
       getCellDiagramInfo: jest.fn().mockResolvedValue({
         id: 'my-project',
@@ -244,6 +446,13 @@ describe('CellDiagram', () => {
       render(<CellDiagram />);
     });
 
+    const toggle = screen.getByRole('switch', {
+      name: /runtime observability/i,
+    });
+    await act(async () => {
+      await userEvent.click(toggle);
+    });
+
     await waitFor(() => {
       expect(screen.getByTestId('cell-diagram-view')).toBeInTheDocument();
     });
@@ -251,7 +460,99 @@ describe('CellDiagram', () => {
     expect(screen.queryByText(/No HTTP traffic/i)).not.toBeInTheDocument();
   });
 
-  it('increments refresh nonce when Refresh button is clicked', async () => {
+  it('defaults the diagram layer to observability when runtime data has observations', async () => {
+    setupMockClient({
+      getCellDiagramInfo: jest.fn().mockResolvedValue({
+        id: 'my-project',
+        components: [
+          {
+            id: 'svc',
+            services: {
+              main: {
+                deploymentMetadata: {
+                  gateways: {
+                    internet: {
+                      isExposed: true,
+                      observations: [{ requestCount: 10 }],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        connections: [],
+      }),
+    });
+
+    await act(async () => {
+      render(<CellDiagram />);
+    });
+
+    // Toggle OFF → architecture
+    await waitFor(() => {
+      expect(screen.getByTestId('cell-diagram-view')).toHaveAttribute(
+        'data-layer',
+        'architecture',
+      );
+    });
+
+    const toggle = screen.getByRole('switch', {
+      name: /runtime observability/i,
+    });
+    await act(async () => {
+      await userEvent.click(toggle);
+    });
+
+    // Toggle ON + observations present → observability
+    await waitFor(() => {
+      expect(screen.getByTestId('cell-diagram-view')).toHaveAttribute(
+        'data-layer',
+        'observability',
+      );
+    });
+  });
+
+  it('keeps architecture layer when toggle is on but no observations yet', async () => {
+    setupMockClient({
+      getCellDiagramInfo: jest.fn().mockResolvedValue({
+        id: 'my-project',
+        components: [
+          {
+            id: 'svc',
+            services: {
+              main: {
+                deploymentMetadata: {
+                  gateways: { internet: { observations: [] } },
+                },
+              },
+            },
+          },
+        ],
+        connections: [],
+      }),
+    });
+
+    await act(async () => {
+      render(<CellDiagram />);
+    });
+
+    const toggle = screen.getByRole('switch', {
+      name: /runtime observability/i,
+    });
+    await act(async () => {
+      await userEvent.click(toggle);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cell-diagram-view')).toHaveAttribute(
+        'data-layer',
+        'architecture',
+      );
+    });
+  });
+
+  it('increments refresh nonce when Refresh button is clicked (toggle on)', async () => {
     const mockClient = setupMockClient();
 
     await act(async () => {
@@ -262,14 +563,26 @@ describe('CellDiagram', () => {
       expect(screen.getByTestId('cell-diagram-view')).toBeInTheDocument();
     });
 
-    const refreshButton = screen.getByRole('button');
+    const toggle = screen.getByRole('switch', {
+      name: /runtime observability/i,
+    });
+    await act(async () => {
+      await userEvent.click(toggle);
+    });
 
+    const callsAfterToggle = mockClient.getCellDiagramInfo.mock.calls.length;
+
+    const refreshButton = await screen.findByRole('button', {
+      name: /refresh/i,
+    });
     await act(async () => {
       await userEvent.click(refreshButton);
     });
 
     await waitFor(() => {
-      expect(mockClient.getCellDiagramInfo).toHaveBeenCalledTimes(2);
+      expect(mockClient.getCellDiagramInfo.mock.calls.length).toBeGreaterThan(
+        callsAfterToggle,
+      );
     });
   });
 });

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -241,7 +241,7 @@ export const CellDiagram = () => {
         }}
       >
         {toggleDisabled ? (
-          <Tooltip title="Observability is unavailable. Cilium module is not setup in all environments.">
+          <Tooltip title="Observability is unavailable in all environments. Configure the Cilium module to enable observability.">
             <span>{toggleControl}</span>
           </Tooltip>
         ) : (
@@ -336,8 +336,9 @@ export const CellDiagram = () => {
                     borderRadius: 4,
                   }}
                 >
-                  Observability is unavailable: Cilium module is not set up in{' '}
-                  <strong>{environment}</strong> environment.
+                  Observability is unavailable in the{' '}
+                  <strong>{environment}</strong> environment. Configure the
+                  Cilium module to enable observability.
                 </Typography>
               )}
 

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -133,7 +133,11 @@ export const CellDiagram = () => {
   }, [runtimeEnabled]);
 
   useEffect(() => {
-    if (environmentsLoading) return undefined;
+    if (environmentsLoading) {
+      setCellDiagramData(undefined);
+      setLoading(false);
+      return undefined;
+    }
     let cancelled = false;
     setLoading(true);
     const observabilityActive =
@@ -182,6 +186,12 @@ export const CellDiagram = () => {
     !environmentsLoading &&
     environments.length > 0 &&
     !anyEnvHasRuntimeObservability;
+
+  useEffect(() => {
+    if (toggleDisabled && runtimeEnabled) {
+      setRuntimeEnabled(false);
+    }
+  }, [toggleDisabled, runtimeEnabled]);
 
   const toggleControl = (
     <FormControlLabel

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -133,11 +133,6 @@ export const CellDiagram = () => {
   }, [runtimeEnabled]);
 
   useEffect(() => {
-    if (environmentsLoading) {
-      setCellDiagramData(undefined);
-      setLoading(false);
-      return undefined;
-    }
     let cancelled = false;
     setLoading(true);
     const observabilityActive =
@@ -169,7 +164,6 @@ export const CellDiagram = () => {
     client,
     environment,
     range,
-    environmentsLoading,
     runtimeEnabled,
     selectedEnvHasRuntimeObservability,
   ]);
@@ -201,7 +195,7 @@ export const CellDiagram = () => {
           checked={runtimeEnabled}
           onChange={e => setRuntimeEnabled(e.target.checked)}
           color="primary"
-          disabled={toggleDisabled}
+          disabled={toggleDisabled || environmentsLoading}
           inputProps={{ 'aria-label': 'Runtime Observability' }}
         />
       }

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -132,11 +132,17 @@ export const CellDiagram = () => {
     }
   }, [runtimeEnabled]);
 
+  const observabilityActive =
+    runtimeEnabled && selectedEnvHasRuntimeObservability;
+  // When observability is off, environment/time-range don't affect the result, so they must not be in
+  // the useEffect's dependancies. Use a memoized key that only changes when relevant values change.
+  const diagramFetchKey = observabilityActive
+    ? `obs|${environment}|${range?.startTime ?? ''}|${range?.endTime ?? ''}`
+    : 'arch';
+
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    const observabilityActive =
-      runtimeEnabled && selectedEnvHasRuntimeObservability;
     const fetchData = async () => {
       try {
         const data = await client.getCellDiagramInfo(entity, {
@@ -159,14 +165,8 @@ export const CellDiagram = () => {
     return () => {
       cancelled = true;
     };
-  }, [
-    entity,
-    client,
-    environment,
-    range,
-    runtimeEnabled,
-    selectedEnvHasRuntimeObservability,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entity, client, diagramFetchKey]);
 
   const showEmptyHint =
     runtimeEnabled &&

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -1,22 +1,33 @@
-import { lazy, memo, Suspense, useEffect, useMemo, useState } from 'react';
+import {
+  lazy,
+  memo,
+  Suspense,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Progress } from '@backstage/core-components';
 import Box from '@material-ui/core/Box';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import IconButton from '@material-ui/core/IconButton';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
+import Switch from '@material-ui/core/Switch';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import RefreshIcon from '@material-ui/icons/Refresh';
-import { useEntity, catalogApiRef } from '@backstage/plugin-catalog-react';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import { useApi } from '@backstage/core-plugin-api';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { useTheme } from '@material-ui/core/styles';
 import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
-import { Project } from '@wso2/cell-diagram';
+import { DiagramLayer, Project } from '@wso2/cell-diagram';
 import { useChoreoTokens } from '@openchoreo/backstage-design-system';
+import { useCellEnvironments } from './useCellEnvironments';
 
 const CellView = lazy(() =>
   import('@wso2/cell-diagram').then(module => ({
@@ -68,47 +79,36 @@ function hasObservations(project: Project | undefined): boolean {
 export const CellDiagram = () => {
   const { entity } = useEntity();
   const [cellDiagramData, setCellDiagramData] = useState<Project>();
-  const [environments, setEnvironments] = useState<string[]>([]);
   const [environment, setEnvironment] = useState<string>('');
-  const [environmentsLoaded, setEnvironmentsLoaded] = useState(false);
   const [timeRange, setTimeRange] = useState<string>('1h');
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [loading, setLoading] = useState(false);
   const [hasFetchedOnce, setHasFetchedOnce] = useState(false);
+  const [runtimeEnabled, setRuntimeEnabled] = useState(false);
   const client = useApi(openChoreoClientApiRef);
-  const catalogApi = useApi(catalogApiRef);
   const { mode } = useChoreoTokens();
   const theme = useTheme();
   const controlBg = theme.palette.background.paper;
 
-  // Load environments once per entity from the Backstage catalog
+  const projectName = entity.metadata.name;
+  const namespaceName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
+  const { environments, loading: environmentsLoading } = useCellEnvironments(
+    projectName,
+    namespaceName,
+  );
+
   useEffect(() => {
-    let cancelled = false;
-    const namespace =
-      entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
-    if (!namespace) {
-      setEnvironmentsLoaded(true);
-      return undefined;
-    }
-    catalogApi
-      .getEntities({
-        filter: { kind: 'Environment', 'metadata.namespace': namespace },
-        fields: ['metadata.name'],
-      })
-      .then(({ items }) => {
-        if (cancelled) return;
-        const names = items.map(e => e.metadata.name);
-        setEnvironments(names);
-        setEnvironment(names[0] ?? '');
-        setEnvironmentsLoaded(true);
-      })
-      .catch(() => {
-        if (!cancelled) setEnvironmentsLoaded(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [entity, catalogApi]);
+    setEnvironment(environments[0]?.name ?? '');
+  }, [environments]);
+
+  const anyEnvHasRuntimeObservability = useMemo(
+    () => environments.some(e => e.hasRuntimeObservability),
+    [environments],
+  );
+  const selectedEnvHasRuntimeObservability =
+    environments.find(e => e.name === environment)?.hasRuntimeObservability ??
+    false;
 
   // Compute startTime/endTime/step from selected range. Recomputes when refreshNonce changes
   // so the refresh button advances "now" in the window.
@@ -124,16 +124,28 @@ export const CellDiagram = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timeRange, refreshNonce]);
 
+  const prevRuntimeRef = useRef(runtimeEnabled);
   useEffect(() => {
-    if (!environmentsLoaded) return undefined;
+    if (prevRuntimeRef.current !== runtimeEnabled) {
+      prevRuntimeRef.current = runtimeEnabled;
+      setCellDiagramData(undefined);
+    }
+  }, [runtimeEnabled]);
+
+  useEffect(() => {
+    if (environmentsLoading) return undefined;
     let cancelled = false;
     setLoading(true);
+    const observabilityActive =
+      runtimeEnabled && selectedEnvHasRuntimeObservability;
     const fetchData = async () => {
       try {
         const data = await client.getCellDiagramInfo(entity, {
-          environmentName: environment || undefined,
-          startTime: range?.startTime,
-          endTime: range?.endTime,
+          environmentName: observabilityActive
+            ? environment || undefined
+            : undefined,
+          startTime: observabilityActive ? range?.startTime : undefined,
+          endTime: observabilityActive ? range?.endTime : undefined,
         });
         if (cancelled) return;
         setCellDiagramData(data as Project);
@@ -148,13 +160,49 @@ export const CellDiagram = () => {
     return () => {
       cancelled = true;
     };
-  }, [entity, client, environment, range, environmentsLoaded]);
+  }, [
+    entity,
+    client,
+    environment,
+    range,
+    environmentsLoading,
+    runtimeEnabled,
+    selectedEnvHasRuntimeObservability,
+  ]);
 
   const showEmptyHint =
+    runtimeEnabled &&
+    selectedEnvHasRuntimeObservability &&
     hasFetchedOnce &&
     !loading &&
     cellDiagramData &&
     !hasObservations(cellDiagramData);
+
+  const toggleDisabled =
+    !environmentsLoading &&
+    environments.length > 0 &&
+    !anyEnvHasRuntimeObservability;
+
+  const toggleControl = (
+    <FormControlLabel
+      style={{ margin: 0 }}
+      control={
+        <Switch
+          checked={runtimeEnabled}
+          onChange={e => setRuntimeEnabled(e.target.checked)}
+          color="primary"
+          disabled={toggleDisabled}
+          inputProps={{ 'aria-label': 'Runtime Observability' }}
+        />
+      }
+      label={
+        <Typography variant="body2" style={{ fontWeight: 500 }}>
+          Runtime Observability
+        </Typography>
+      }
+      labelPlacement="start"
+    />
+  );
 
   return (
     <Box
@@ -174,122 +222,166 @@ export const CellDiagram = () => {
           position: 'absolute',
           top: 16,
           left: 24,
+          right: 24,
           zIndex: 10,
           display: 'flex',
+          flexWrap: 'wrap',
           alignItems: 'center',
+          gap: 12,
         }}
       >
-        <FormControl
-          variant="outlined"
-          size="small"
-          style={{
-            minWidth: 200,
-            marginRight: 12,
-            backgroundColor: controlBg,
-            borderRadius: 4,
-          }}
-        >
-          <InputLabel id="cell-diagram-env-label">Environment</InputLabel>
-          <Select
-            labelId="cell-diagram-env-label"
-            value={environment}
-            label="Environment"
-            onChange={e => setEnvironment(e.target.value as string)}
-            disabled={environments.length === 0}
-          >
-            {environments.length === 0 && (
-              <MenuItem value="" disabled>
-                No environments
-              </MenuItem>
-            )}
-            {environments.map(env => (
-              <MenuItem key={env} value={env}>
-                {env}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        {toggleDisabled ? (
+          <Tooltip title="Observability is unavailable. Cilium module is not setup in all environments.">
+            <span>{toggleControl}</span>
+          </Tooltip>
+        ) : (
+          toggleControl
+        )}
 
-        <FormControl
-          variant="outlined"
-          size="small"
-          style={{
-            minWidth: 180,
-            marginRight: 8,
-            backgroundColor: controlBg,
-            borderRadius: 4,
-          }}
-        >
-          <InputLabel id="cell-diagram-range-label">Time range</InputLabel>
-          <Select
-            labelId="cell-diagram-range-label"
-            value={timeRange}
-            label="Time range"
-            onChange={e => setTimeRange(e.target.value as string)}
-          >
-            {TIME_RANGES.map(r => (
-              <MenuItem key={r.value} value={r.value}>
-                {r.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-
-        <Tooltip title="Refresh">
-          <span>
-            <IconButton
+        {runtimeEnabled && (
+          <>
+            <FormControl
+              variant="outlined"
               size="small"
-              onClick={() => setRefreshNonce(n => n + 1)}
-              disabled={loading || !environmentsLoaded}
               style={{
+                minWidth: 200,
                 backgroundColor: controlBg,
                 borderRadius: 4,
-                marginRight: 12,
               }}
             >
-              {loading ? (
-                <CircularProgress size={18} />
-              ) : (
-                <RefreshIcon fontSize="small" />
-              )}
-            </IconButton>
-          </span>
-        </Tooltip>
+              <InputLabel id="cell-diagram-env-label">Environment</InputLabel>
+              <Select
+                labelId="cell-diagram-env-label"
+                value={environment}
+                label="Environment"
+                onChange={e => setEnvironment(e.target.value as string)}
+                disabled={environments.length === 0}
+              >
+                {environments.length === 0 && (
+                  <MenuItem value="" disabled>
+                    No environments
+                  </MenuItem>
+                )}
+                {environments.map(env => (
+                  <MenuItem key={env.name} value={env.name}>
+                    {env.displayName ?? env.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
 
-        {showEmptyHint && (
-          <Typography
-            variant="caption"
-            style={{
-              padding: '6px 12px',
-              backgroundColor: controlBg,
-              borderRadius: 4,
-              opacity: 0.8,
-            }}
-          >
-            No HTTP traffic in selected range
-          </Typography>
+            <FormControl
+              variant="outlined"
+              size="small"
+              style={{
+                minWidth: 180,
+                backgroundColor: controlBg,
+                borderRadius: 4,
+              }}
+            >
+              <InputLabel id="cell-diagram-range-label">Time range</InputLabel>
+              <Select
+                labelId="cell-diagram-range-label"
+                value={timeRange}
+                label="Time range"
+                onChange={e => setTimeRange(e.target.value as string)}
+              >
+                {TIME_RANGES.map(r => (
+                  <MenuItem key={r.value} value={r.value}>
+                    {r.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Tooltip title="Refresh">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => setRefreshNonce(n => n + 1)}
+                  disabled={loading || environmentsLoading}
+                  style={{
+                    backgroundColor: controlBg,
+                    borderRadius: 4,
+                  }}
+                >
+                  {loading ? (
+                    <CircularProgress size={18} />
+                  ) : (
+                    <RefreshIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </span>
+            </Tooltip>
+
+            {environment &&
+              !selectedEnvHasRuntimeObservability &&
+              !environmentsLoading && (
+                <Typography
+                  variant="body2"
+                  style={{
+                    padding: '6px 12px',
+                    backgroundColor: theme.palette.warning.light,
+                    color: theme.palette.warning.contrastText,
+                    borderRadius: 4,
+                  }}
+                >
+                  Observability is unavailable: Cilium module is not set up in{' '}
+                  <strong>{environment}</strong> environment.
+                </Typography>
+              )}
+
+            {showEmptyHint && (
+              <Typography
+                variant="caption"
+                style={{
+                  padding: '6px 12px',
+                  backgroundColor: controlBg,
+                  borderRadius: 4,
+                  opacity: 0.8,
+                }}
+              >
+                No HTTP traffic in selected range
+              </Typography>
+            )}
+          </>
         )}
       </Box>
 
-      <Typography
-        variant="caption"
-        style={{
-          position: 'absolute',
-          bottom: 16,
-          right: 16,
-          zIndex: 10,
-          padding: '4px 10px',
-          backgroundColor: controlBg,
-          borderRadius: 4,
-          opacity: 0.6,
-        }}
-      >
-        Runtime visibility is limited to HTTP traffic. TCP/UDP traffic is not
-        observed.
-      </Typography>
+      {runtimeEnabled && (
+        <Typography
+          variant="caption"
+          style={{
+            position: 'absolute',
+            bottom: 16,
+            right: 16,
+            zIndex: 10,
+            padding: '4px 10px',
+            backgroundColor: controlBg,
+            borderRadius: 4,
+            opacity: 0.6,
+          }}
+        >
+          Runtime visibility is limited to HTTP traffic. TCP/UDP traffic is not
+          observed.
+        </Typography>
+      )}
       {cellDiagramData ? (
         <Suspense fallback={<Progress />}>
-          <MemoCellView project={cellDiagramData} mode={mode} />
+          {(() => {
+            const targetLayer =
+              runtimeEnabled && hasObservations(cellDiagramData)
+                ? DiagramLayer.OBSERVABILITY
+                : DiagramLayer.ARCHITECTURE;
+            return (
+              <MemoCellView
+                key={targetLayer}
+                project={cellDiagramData}
+                mode={mode}
+                defaultDiagramLayer={targetLayer}
+              />
+            );
+          })()}
         </Suspense>
       ) : (
         <Progress />

--- a/plugins/openchoreo/src/components/CellDiagram/useCellEnvironments.ts
+++ b/plugins/openchoreo/src/components/CellDiagram/useCellEnvironments.ts
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react';
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
+
+export interface CellEnvironment {
+  name: string;
+  displayName?: string;
+  namespace: string;
+  dataPlaneRef?: { kind?: string; name?: string };
+  /** True when the env's DataPlane reports `networkpolicyprovider=cilium`. */
+  hasRuntimeObservability: boolean;
+}
+
+export interface UseCellEnvironmentsResult {
+  environments: CellEnvironment[];
+  loading: boolean;
+}
+
+/**
+ * Resolves the project's environments in deployment-pipeline order, hydrated
+ * from the catalog and flagged with `hasRuntimeObservability` per the
+ * environment's DataPlane network-policy provider.
+ */
+export const useCellEnvironments = (
+  projectName: string | undefined,
+  namespaceName: string | undefined,
+): UseCellEnvironmentsResult => {
+  const client = useApi(openChoreoClientApiRef);
+  const catalogApi = useApi(catalogApiRef);
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const [environments, setEnvironments] = useState<CellEnvironment[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!projectName || !namespaceName) {
+      setEnvironments([]);
+      setLoading(false);
+      return undefined;
+    }
+    setLoading(true);
+
+    (async () => {
+      try {
+        const pipeline = await client.fetchDeploymentPipeline(
+          projectName,
+          namespaceName,
+        );
+
+        const orderedEnvNames: string[] = [];
+        const seen = new Set<string>();
+        const paths: Array<{
+          sourceEnvironmentRef?: unknown;
+          targetEnvironmentRefs?: Array<{ name?: string }>;
+        }> = pipeline?.promotionPaths ?? [];
+        for (const path of paths) {
+          const sourceName =
+            typeof path.sourceEnvironmentRef === 'string'
+              ? path.sourceEnvironmentRef
+              : (path.sourceEnvironmentRef as { name?: string } | undefined)
+                  ?.name ?? '';
+          if (sourceName && !seen.has(sourceName)) {
+            orderedEnvNames.push(sourceName);
+            seen.add(sourceName);
+          }
+          for (const target of path.targetEnvironmentRefs ?? []) {
+            if (target?.name && !seen.has(target.name)) {
+              orderedEnvNames.push(target.name);
+              seen.add(target.name);
+            }
+          }
+        }
+
+        if (orderedEnvNames.length === 0) {
+          if (!cancelled) setEnvironments([]);
+          return;
+        }
+
+        const { items } = await catalogApi.getEntities({
+          filter: { kind: 'Environment', 'metadata.namespace': namespaceName },
+          fields: [
+            'metadata.name',
+            'metadata.namespace',
+            'metadata.title',
+            'metadata.annotations',
+          ],
+        });
+        if (cancelled) return;
+
+        const byName = new Map(items.map(e => [e.metadata.name, e]));
+        const baseEnvs = orderedEnvNames.map(name => {
+          const entry = byName.get(name);
+          const ann = entry?.metadata.annotations ?? {};
+          return {
+            name,
+            displayName: entry?.metadata.title ?? name,
+            namespace: ann[CHOREO_ANNOTATIONS.NAMESPACE] ?? namespaceName,
+            dataPlaneRef: {
+              name: ann['openchoreo.io/data-plane-ref'],
+              kind: ann[CHOREO_ANNOTATIONS.DATA_PLANE_REF_KIND] ?? 'DataPlane',
+            },
+          };
+        });
+
+        const baseUrl = await discoveryApi.getBaseUrl(
+          'openchoreo-observability-backend',
+        );
+        const enriched = await Promise.all(
+          baseEnvs.map(async env => {
+            if (!env.namespace || !env.dataPlaneRef.name) {
+              return { ...env, hasRuntimeObservability: false };
+            }
+            try {
+              const params = new URLSearchParams({
+                namespaceName: env.namespace,
+                dpName: env.dataPlaneRef.name,
+                dpKind: env.dataPlaneRef.kind ?? 'DataPlane',
+              });
+              const res = await fetchApi.fetch(
+                `${baseUrl}/dataplane-netpol-provider?${params.toString()}`,
+              );
+              if (!res.ok) return { ...env, hasRuntimeObservability: false };
+              const data = await res.json();
+              return {
+                ...env,
+                hasRuntimeObservability:
+                  data?.networkPolicyProvider === 'cilium',
+              };
+            } catch {
+              return { ...env, hasRuntimeObservability: false };
+            }
+          }),
+        );
+
+        if (!cancelled) setEnvironments(enriched);
+      } catch {
+        if (!cancelled) setEnvironments([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectName, namespaceName, client, catalogApi, discoveryApi, fetchApi]);
+
+  return { environments, loading };
+};

--- a/plugins/openchoreo/src/components/CellDiagram/useCellEnvironments.ts
+++ b/plugins/openchoreo/src/components/CellDiagram/useCellEnvironments.ts
@@ -8,6 +8,10 @@ import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
 
+// Cap each network-policy probe so a single hanging DataPlane doesn't
+// indefinitely block the diagram from rendering.
+const NETPOL_TIMEOUT_MS = 8000;
+
 export interface CellEnvironment {
   name: string;
   displayName?: string;
@@ -117,6 +121,11 @@ export const useCellEnvironments = (
             if (!env.namespace || !env.dataPlaneRef.name) {
               return { ...env, hasRuntimeObservability: false };
             }
+            const controller = new AbortController();
+            const timeout = setTimeout(
+              () => controller.abort(),
+              NETPOL_TIMEOUT_MS,
+            );
             try {
               const params = new URLSearchParams({
                 namespaceName: env.namespace,
@@ -125,6 +134,7 @@ export const useCellEnvironments = (
               });
               const res = await fetchApi.fetch(
                 `${baseUrl}/dataplane-netpol-provider?${params.toString()}`,
+                { signal: controller.signal },
               );
               if (!res.ok) return { ...env, hasRuntimeObservability: false };
               const data = await res.json();
@@ -135,6 +145,8 @@ export const useCellEnvironments = (
               };
             } catch {
               return { ...env, hasRuntimeObservability: false };
+            } finally {
+              clearTimeout(timeout);
             }
           }),
         );


### PR DESCRIPTION
## Purpose
Related: https://github.com/openchoreo/openchoreo/issues/3563

This pull request significantly expands and refactors the test suite for the `CellDiagram` component, introducing more comprehensive coverage of runtime observability features, environment support, and UI state. It also introduces a new `useCellEnvironments` hook in the main component, simplifying environment and capability management. The changes include improved mocking for dependencies, new test utilities, and enhanced checks for Cilium support and diagram layer selection.

**Key changes include:**

### Test Suite Enhancements

* Expanded test coverage for the `CellDiagram` component to include runtime observability toggle behavior, environment filtering, Cilium support checks, diagram layer selection, and refresh logic. Tests now verify UI state, toggle enablement/disablement, tooltips, and per-environment warnings. [[1]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L135-R304) [[2]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L184-R380) [[3]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R404-R420) [[4]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R449-R555) [[5]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L265-R585)

* Added new test utilities and mocks for APIs, including dynamic creation of environment entities, simulation of network policy provider responses, and support for additional Backstage APIs (`discoveryApiRef`, `fetchApiRef`). [[1]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L14-R33) [[2]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R145-R192)

* Enhanced mocking of Material-UI components to better simulate UI interactions, such as switches, tooltips, and select elements, including aria-labels and data attributes for more precise queries. [[1]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R56-R81) [[2]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L53-R96) [[3]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L65-R106) [[4]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L82-R122) [[5]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L33-R45)

### Component Refactorings

* Introduced the `useCellEnvironments` hook in `CellDiagram.tsx`, replacing manual environment loading logic and centralizing environment capability checks (e.g., Cilium support). This streamlines state management and improves clarity.

* Updated imports and usage to leverage new types and constants (e.g., `DiagramLayer`, `useCellEnvironments`), and removed direct dependency on `catalogApiRef` in favor of the new hook. [[1]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695L1-R30) [[2]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695L71-R111)

### Observability and Diagram Layer Logic

* Added logic to conditionally enable or disable runtime observability features based on environment support for Cilium, with appropriate tooltips and warnings in the UI. [[1]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L184-R380) [[2]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R404-R420)

* Enhanced diagram layer selection to default to the "observability" layer when runtime data is available, and to "architecture" otherwise, ensuring the UI accurately reflects available data.

---

**References:**  
Test Suite Enhancements: [[1]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L135-R304) [[2]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L184-R380) [[3]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R404-R420) [[4]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R449-R555) [[5]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L265-R585) [[6]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L14-R33) [[7]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R145-R192) [[8]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R56-R81) [[9]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L53-R96) [[10]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L65-R106) [[11]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L82-R122) [[12]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L33-R45)  
Component Refactorings: [[1]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695L71-R111) [[2]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695L1-R30)  
Observability and Diagram Layer Logic: [[1]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L184-R380) [[2]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R404-R420) [[3]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R449-R555)

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
https://github.com/user-attachments/assets/6eee83f1-a6f9-4e84-98db-4c4c4245a482

<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/337c4d45-67cf-42a8-b378-0a532afbac0e" />



## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime observability toggle with environment selector, time-range and refresh shown only when enabled
  * Automatic per-environment detection of observability with warnings, disabled toggle and tooltips when unavailable
  * Diagram clears stale data when toggling and switches between architecture and observability based on toggle + actual observations
  * Environment list now derived from the deployment pipeline with per-environment observability status

* **Tests**
  * Expanded tests covering toggle, environment selection, refresh/refetch behavior, per-environment warnings, "No HTTP traffic" hints, and diagram-layer logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->