### PR TITLE
fix(a11y): Phase 1 WCAG 2.2 AA quick wins

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -229,7 +229,11 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
           <SidebarDivider />
           <SignOutButton />
         </Sidebar>
-        <main id="main-content" tabIndex={-1} className={a11yClasses.mainContent}>
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className={a11yClasses.mainContent}
+        >
           {children}
         </main>
       </SidebarPage>

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -54,6 +54,33 @@ const useSearchModalStyles = makeStyles({
   },
 });
 
+const useA11yStyles = makeStyles(theme => ({
+  skipLink: {
+    position: 'absolute',
+    left: -9999,
+    top: 'auto',
+    width: 1,
+    height: 1,
+    overflow: 'hidden',
+    zIndex: theme.zIndex.tooltip + 1,
+    '&:focus': {
+      left: theme.spacing(2),
+      top: theme.spacing(2),
+      width: 'auto',
+      height: 'auto',
+      padding: theme.spacing(1, 2),
+      backgroundColor: theme.palette.background.paper,
+      color: theme.palette.text.primary,
+      border: `2px solid ${theme.palette.primary.main}`,
+      borderRadius: 4,
+      textDecoration: 'none',
+    },
+  },
+  mainContent: {
+    display: 'contents',
+  },
+}));
+
 const useSidebarLogoStyles = makeStyles(theme => ({
   root: {
     width: sidebarConfig.drawerWidthClosed,
@@ -139,8 +166,12 @@ const SignOutButton = () => {
 
 export const Root = ({ children }: PropsWithChildren<{}>) => {
   useSearchModalStyles();
+  const a11yClasses = useA11yStyles();
   return (
     <AssistantDrawerProvider>
+      <a href="#main-content" className={a11yClasses.skipLink}>
+        Skip to main content
+      </a>
       <SidebarPage>
         <Sidebar>
           <SidebarLogo />
@@ -198,7 +229,9 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
           <SidebarDivider />
           <SignOutButton />
         </Sidebar>
-        {children}
+        <main id="main-content" tabIndex={-1} className={a11yClasses.mainContent}>
+          {children}
+        </main>
       </SidebarPage>
     </AssistantDrawerProvider>
   );

--- a/packages/app/src/components/catalog/EntityLayoutWithDelete.tsx
+++ b/packages/app/src/components/catalog/EntityLayoutWithDelete.tsx
@@ -1,7 +1,21 @@
 import { type ReactNode } from 'react';
-import { Box } from '@material-ui/core';
+import { Box, makeStyles } from '@material-ui/core';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { EmptyState, Progress } from '@backstage/core-components';
+
+const useVisuallyHiddenStyles = makeStyles({
+  visuallyHidden: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    border: 0,
+  },
+});
 import {
   useDeleteEntityMenuItems,
   useEntityExistsCheck,
@@ -73,6 +87,9 @@ export function EntityLayoutWithDelete({
   contextMenuOptions = { disableUnregister: 'hidden' },
 }: EntityLayoutWithDeleteProps) {
   const { entity } = useEntity();
+  const visuallyHidden = useVisuallyHiddenStyles().visuallyHidden;
+  const entityTitle =
+    (entity.metadata.title as string | undefined) ?? entity.metadata.name;
 
   // Permission check for platform resources
   const {
@@ -120,57 +137,64 @@ export function EntityLayoutWithDelete({
   // Show empty state with header if entity not found in OpenChoreo
   if (status === 'not-found') {
     return (
-      <OpenChoreoEntityLayout
-        contextMenuOptions={contextMenuOptions}
-        parentEntityRelations={parentEntityRelations}
-        kindDisplayNames={mergedKindDisplayNames}
-      >
-        <OpenChoreoEntityLayout.Route path="/" title="Overview">
-          <Box py={4}>
-            <EmptyState
-              missing="data"
-              title={`${entityTypeLabel} Not Found`}
-              description={
-                message ||
-                `The ${entityTypeLabel.toLowerCase()} "${
-                  entity.metadata.name
-                }" could not be found in OpenChoreo. It may have been deleted.`
-              }
-            />
-          </Box>
-        </OpenChoreoEntityLayout.Route>
-      </OpenChoreoEntityLayout>
+      <>
+        <h1 className={visuallyHidden}>{entityTitle}</h1>
+        <OpenChoreoEntityLayout
+          contextMenuOptions={contextMenuOptions}
+          parentEntityRelations={parentEntityRelations}
+          kindDisplayNames={mergedKindDisplayNames}
+        >
+          <OpenChoreoEntityLayout.Route path="/" title="Overview">
+            <Box py={4}>
+              <EmptyState
+                missing="data"
+                title={`${entityTypeLabel} Not Found`}
+                description={
+                  message ||
+                  `The ${entityTypeLabel.toLowerCase()} "${
+                    entity.metadata.name
+                  }" could not be found in OpenChoreo. It may have been deleted.`
+                }
+              />
+            </Box>
+          </OpenChoreoEntityLayout.Route>
+        </OpenChoreoEntityLayout>
+      </>
     );
   }
 
   // Show empty state with header if entity is marked for deletion
   if (status === 'marked-for-deletion') {
     return (
-      <OpenChoreoEntityLayout
-        contextMenuOptions={contextMenuOptions}
-        parentEntityRelations={parentEntityRelations}
-        kindDisplayNames={mergedKindDisplayNames}
-      >
-        <OpenChoreoEntityLayout.Route path="/" title="Overview">
-          <Box py={4}>
-            <EmptyState
-              missing="data"
-              title={`${entityTypeLabel} Marked for Deletion`}
-              description={
-                message ||
-                `This ${entityTypeLabel.toLowerCase()} "${
-                  entity.metadata.name
-                }" is marked for deletion and will be permanently removed soon.`
-              }
-            />
-          </Box>
-        </OpenChoreoEntityLayout.Route>
-      </OpenChoreoEntityLayout>
+      <>
+        <h1 className={visuallyHidden}>{entityTitle}</h1>
+        <OpenChoreoEntityLayout
+          contextMenuOptions={contextMenuOptions}
+          parentEntityRelations={parentEntityRelations}
+          kindDisplayNames={mergedKindDisplayNames}
+        >
+          <OpenChoreoEntityLayout.Route path="/" title="Overview">
+            <Box py={4}>
+              <EmptyState
+                missing="data"
+                title={`${entityTypeLabel} Marked for Deletion`}
+                description={
+                  message ||
+                  `This ${entityTypeLabel.toLowerCase()} "${
+                    entity.metadata.name
+                  }" is marked for deletion and will be permanently removed soon.`
+                }
+              />
+            </Box>
+          </OpenChoreoEntityLayout.Route>
+        </OpenChoreoEntityLayout>
+      </>
     );
   }
 
   return (
     <>
+      <h1 className={visuallyHidden}>{entityTitle}</h1>
       <OpenChoreoEntityLayout
         contextMenuOptions={contextMenuOptions}
         extraContextMenuItems={extraMenuItems}

--- a/packages/design-system/src/theme/tokens.ts
+++ b/packages/design-system/src/theme/tokens.ts
@@ -219,8 +219,10 @@ export type ThemeTokens = {
 
 const lightPrimary: ColorScale = {
   light: '#f0f1fb',
-  main: '#6c7fd8',
-  dark: '#5568c4',
+  // Darkened from #6c7fd8 (3.71:1) to meet WCAG 2.2 AA 4.5:1 on white.
+  // 5.04:1 on #ffffff — used for sidebar-selected labels, links, entity names.
+  main: '#5568c4',
+  dark: '#4456b8',
 };
 const lightSecondary: ColorScale = {
   light: '#fafbfc',
@@ -301,8 +303,9 @@ export const lightTokens: ThemeTokens = {
     verySubtle: '#9ca3af',
     disabled: '#9ca3af',
     inverted: '#ffffff',
-    link: '#6c7fd8',
-    linkHover: '#5568c4',
+    // Darkened to meet WCAG 2.2 AA 4.5:1 on white (5.04:1).
+    link: '#5568c4',
+    linkHover: '#4456b8',
   },
 
   status: {
@@ -404,7 +407,8 @@ export const lightTokens: ThemeTokens = {
     background: '#ffffff',
     indicator: '#6c7fd8',
     color: '#111827',
-    selectedColor: '#6c7fd8',
+    // Darkened to meet WCAG 2.2 AA 4.5:1 on white sidebar background (5.04:1).
+    selectedColor: '#5568c4',
     navItemHoverBackground: '#f9fafb',
     submenuBackground: '#fafbfc',
   },

--- a/plugins/openchoreo-ci/src/components/BuildEvents/BuildEvents.tsx
+++ b/plugins/openchoreo-ci/src/components/BuildEvents/BuildEvents.tsx
@@ -353,16 +353,16 @@ export const EventsContent = ({ build }: EventsContentProps) => {
                     <Table size="small">
                       <TableHead>
                         <TableRow>
-                          <TableCell className={classes.tableHeaderCell}>
+                          <TableCell scope="col" className={classes.tableHeaderCell}>
                             Type
                           </TableCell>
-                          <TableCell className={classes.tableHeaderCell}>
+                          <TableCell scope="col" className={classes.tableHeaderCell}>
                             Reason
                           </TableCell>
-                          <TableCell className={classes.tableHeaderCell}>
+                          <TableCell scope="col" className={classes.tableHeaderCell}>
                             Message
                           </TableCell>
-                          <TableCell className={classes.tableHeaderCell}>
+                          <TableCell scope="col" className={classes.tableHeaderCell}>
                             Last Seen
                           </TableCell>
                         </TableRow>

--- a/plugins/openchoreo-ci/src/components/BuildEvents/BuildEvents.tsx
+++ b/plugins/openchoreo-ci/src/components/BuildEvents/BuildEvents.tsx
@@ -353,16 +353,28 @@ export const EventsContent = ({ build }: EventsContentProps) => {
                     <Table size="small">
                       <TableHead>
                         <TableRow>
-                          <TableCell scope="col" className={classes.tableHeaderCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.tableHeaderCell}
+                          >
                             Type
                           </TableCell>
-                          <TableCell scope="col" className={classes.tableHeaderCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.tableHeaderCell}
+                          >
                             Reason
                           </TableCell>
-                          <TableCell scope="col" className={classes.tableHeaderCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.tableHeaderCell}
+                          >
                             Message
                           </TableCell>
-                          <TableCell scope="col" className={classes.tableHeaderCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.tableHeaderCell}
+                          >
                             Last Seen
                           </TableCell>
                         </TableRow>

--- a/plugins/openchoreo-observability/src/components/Alerts/AlertsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Alerts/AlertsTable.tsx
@@ -82,11 +82,11 @@ export const AlertsTable: FC<AlertsTableProps> = ({
         <Table className={classes.table} size="small" stickyHeader>
           <TableHead>
             <TableRow>
-              <TableCell className={classes.headerCell}>Time</TableCell>
-              <TableCell className={classes.headerCell}>Rule</TableCell>
-              <TableCell className={classes.headerCell}>Severity</TableCell>
-              <TableCell className={classes.headerCell}>Source</TableCell>
-              <TableCell className={classes.headerCell}>Value</TableCell>
+              <TableCell scope="col" className={classes.headerCell}>Time</TableCell>
+              <TableCell scope="col" className={classes.headerCell}>Rule</TableCell>
+              <TableCell scope="col" className={classes.headerCell}>Severity</TableCell>
+              <TableCell scope="col" className={classes.headerCell}>Source</TableCell>
+              <TableCell scope="col" className={classes.headerCell}>Value</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/plugins/openchoreo-observability/src/components/Alerts/AlertsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Alerts/AlertsTable.tsx
@@ -82,11 +82,21 @@ export const AlertsTable: FC<AlertsTableProps> = ({
         <Table className={classes.table} size="small" stickyHeader>
           <TableHead>
             <TableRow>
-              <TableCell scope="col" className={classes.headerCell}>Time</TableCell>
-              <TableCell scope="col" className={classes.headerCell}>Rule</TableCell>
-              <TableCell scope="col" className={classes.headerCell}>Severity</TableCell>
-              <TableCell scope="col" className={classes.headerCell}>Source</TableCell>
-              <TableCell scope="col" className={classes.headerCell}>Value</TableCell>
+              <TableCell scope="col" className={classes.headerCell}>
+                Time
+              </TableCell>
+              <TableCell scope="col" className={classes.headerCell}>
+                Rule
+              </TableCell>
+              <TableCell scope="col" className={classes.headerCell}>
+                Severity
+              </TableCell>
+              <TableCell scope="col" className={classes.headerCell}>
+                Source
+              </TableCell>
+              <TableCell scope="col" className={classes.headerCell}>
+                Value
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/plugins/openchoreo-observability/src/components/Incidents/IncidentsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/IncidentsTable.tsx
@@ -87,20 +87,20 @@ export const IncidentsTable: FC<IncidentsTableProps> = ({
         <Table className={classes.table} size="small" stickyHeader>
           <TableHead>
             <TableRow>
-              <TableCell className={classes.headerCell} width="15%">
+              <TableCell scope="col" className={classes.headerCell} width="15%">
                 Time
               </TableCell>
-              <TableCell className={classes.headerCell} width="12%">
+              <TableCell scope="col" className={classes.headerCell} width="12%">
                 Incident ID
               </TableCell>
-              <TableCell className={classes.headerCell} width="10%">
+              <TableCell scope="col" className={classes.headerCell} width="10%">
                 Status
               </TableCell>
-              <TableCell className={classes.headerCell}>Description</TableCell>
-              <TableCell className={classes.headerCell} width="12%">
+              <TableCell scope="col" className={classes.headerCell}>Description</TableCell>
+              <TableCell scope="col" className={classes.headerCell} width="12%">
                 Component
               </TableCell>
-              <TableCell className={classes.headerCell} width="15%">
+              <TableCell scope="col" className={classes.headerCell} width="15%">
                 Actions
               </TableCell>
             </TableRow>

--- a/plugins/openchoreo-observability/src/components/Incidents/IncidentsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/IncidentsTable.tsx
@@ -96,7 +96,9 @@ export const IncidentsTable: FC<IncidentsTableProps> = ({
               <TableCell scope="col" className={classes.headerCell} width="10%">
                 Status
               </TableCell>
-              <TableCell scope="col" className={classes.headerCell}>Description</TableCell>
+              <TableCell scope="col" className={classes.headerCell}>
+                Description
+              </TableCell>
               <TableCell scope="col" className={classes.headerCell} width="12%">
                 Component
               </TableCell>

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/LogsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/LogsTable.tsx
@@ -125,6 +125,7 @@ export const LogsTable: FC<LogsTableProps> = ({
                 return (
                   <TableCell
                     key={field}
+                    scope="col"
                     className={classes.headerCell}
                     width={width}
                   >

--- a/plugins/openchoreo-observability/src/components/Traces/TracesTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/TracesTable.tsx
@@ -88,22 +88,23 @@ export const TracesTable: FC<TracesTableProps> = ({
         <Table className={classes.table} aria-label="traces table" stickyHeader>
           <TableHead>
             <TableRow>
-              <TableCell className={classes.headerCell} width="12%">
+              <TableCell scope="col" className={classes.headerCell} width="12%">
                 Trace Name
               </TableCell>
-              <TableCell className={classes.headerCell} width="20%">
+              <TableCell scope="col" className={classes.headerCell} width="20%">
                 Start Time
               </TableCell>
-              <TableCell className={classes.headerCell} width="20%">
+              <TableCell scope="col" className={classes.headerCell} width="20%">
                 End Time
               </TableCell>
-              <TableCell className={classes.headerCell} width="12%">
+              <TableCell scope="col" className={classes.headerCell} width="12%">
                 Duration
               </TableCell>
-              <TableCell className={classes.headerCell} width="12%">
+              <TableCell scope="col" className={classes.headerCell} width="12%">
                 Number of Spans
               </TableCell>
               <TableCell
+                scope="col"
                 className={classes.headerCell}
                 width="12%"
                 align="right"

--- a/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
+++ b/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
@@ -179,6 +179,7 @@ export function YamlEditor({
                 >
                   <span>
                     <IconButton
+                      aria-label="Save changes"
                       className={`${classes.floatingButton} ${
                         classes.saveButton
                       } ${!isDirty ? classes.disabledButton : ''}`}
@@ -197,6 +198,7 @@ export function YamlEditor({
                 >
                   <span>
                     <IconButton
+                      aria-label="Discard changes"
                       className={`${classes.floatingButton} ${
                         classes.discardButton
                       } ${!isDirty ? classes.disabledButton : ''}`}
@@ -212,6 +214,7 @@ export function YamlEditor({
               {onDelete && (
                 <Tooltip title="Delete resource">
                   <IconButton
+                    aria-label="Delete resource"
                     className={`${classes.floatingButton} ${classes.deleteButton}`}
                     onClick={onDelete}
                     disabled={readOnly}

--- a/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
+++ b/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { StreamLanguage } from '@codemirror/language';
 import { yaml as yamlSupport } from '@codemirror/legacy-modes/mode/yaml';
 import { showPanel } from '@codemirror/view';
@@ -125,6 +125,17 @@ export function YamlEditor({
   const globalIsDark = tokens.editor.codeMirrorTheme === 'dark';
   const effectiveDark = isDarkThemeProp ?? globalIsDark;
 
+  // @uiw/react-codemirror sets tabindex="-1" on .cm-scroller, which axe flags
+  // as a non-focusable scrollable region. Promote it to tabindex="0" so
+  // keyboard users can Tab into the editor.
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const scroller = containerRef.current?.querySelector('.cm-scroller');
+    if (scroller && scroller.getAttribute('tabindex') !== '0') {
+      scroller.setAttribute('tabindex', '0');
+    }
+  }, [content]);
+
   // Error panel extension
   const panelExtension = useMemo(() => {
     if (!errorText) {
@@ -152,7 +163,7 @@ export function YamlEditor({
   );
 
   return (
-    <div className={classes.container}>
+    <div ref={containerRef} className={classes.container}>
       <CodeMirror
         className={classes.codeMirror}
         theme={effectiveDark ? 'dark' : 'light'}

--- a/plugins/openchoreo-workflows/src/components/WorkflowRunEvents/WorkflowRunEvents.tsx
+++ b/plugins/openchoreo-workflows/src/components/WorkflowRunEvents/WorkflowRunEvents.tsx
@@ -342,16 +342,28 @@ export const WorkflowRunEvents = ({
                     <Table size="small">
                       <TableHead>
                         <TableRow>
-                          <TableCell scope="col" className={classes.tableHeaderCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.tableHeaderCell}
+                          >
                             Type
                           </TableCell>
-                          <TableCell scope="col" className={classes.tableHeaderCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.tableHeaderCell}
+                          >
                             Reason
                           </TableCell>
-                          <TableCell scope="col" className={classes.tableHeaderCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.tableHeaderCell}
+                          >
                             Message
                           </TableCell>
-                          <TableCell scope="col" className={classes.tableHeaderCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.tableHeaderCell}
+                          >
                             Last Seen
                           </TableCell>
                         </TableRow>

--- a/plugins/openchoreo-workflows/src/components/WorkflowRunEvents/WorkflowRunEvents.tsx
+++ b/plugins/openchoreo-workflows/src/components/WorkflowRunEvents/WorkflowRunEvents.tsx
@@ -342,16 +342,16 @@ export const WorkflowRunEvents = ({
                     <Table size="small">
                       <TableHead>
                         <TableRow>
-                          <TableCell className={classes.tableHeaderCell}>
+                          <TableCell scope="col" className={classes.tableHeaderCell}>
                             Type
                           </TableCell>
-                          <TableCell className={classes.tableHeaderCell}>
+                          <TableCell scope="col" className={classes.tableHeaderCell}>
                             Reason
                           </TableCell>
-                          <TableCell className={classes.tableHeaderCell}>
+                          <TableCell scope="col" className={classes.tableHeaderCell}>
                             Message
                           </TableCell>
-                          <TableCell className={classes.tableHeaderCell}>
+                          <TableCell scope="col" className={classes.tableHeaderCell}>
                             Last Seen
                           </TableCell>
                         </TableRow>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/ClusterRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/ClusterRoleBindingsContent.tsx
@@ -463,13 +463,13 @@ export const ClusterRoleBindingsContent = ({
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Binding Name</TableCell>
-                <TableCell>Role Mappings</TableCell>
-                <TableCell className={classes.entitlementCell}>
+                <TableCell scope="col">Binding Name</TableCell>
+                <TableCell scope="col">Role Mappings</TableCell>
+                <TableCell scope="col" className={classes.entitlementCell}>
                   Entitlement (claim=value)
                 </TableCell>
-                <TableCell>Effect</TableCell>
-                <TableCell align="right">Actions</TableCell>
+                <TableCell scope="col">Effect</TableCell>
+                <TableCell scope="col" align="right">Actions</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/ClusterRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/ClusterRoleBindingsContent.tsx
@@ -469,7 +469,9 @@ export const ClusterRoleBindingsContent = ({
                   Entitlement (claim=value)
                 </TableCell>
                 <TableCell scope="col">Effect</TableCell>
-                <TableCell scope="col" align="right">Actions</TableCell>
+                <TableCell scope="col" align="right">
+                  Actions
+                </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
@@ -511,13 +511,13 @@ export const NamespaceRoleBindingsContent = ({
                     <Table>
                       <TableHead>
                         <TableRow>
-                          <TableCell>Binding Name</TableCell>
-                          <TableCell>Role Mappings</TableCell>
-                          <TableCell className={classes.entitlementCell}>
+                          <TableCell scope="col">Binding Name</TableCell>
+                          <TableCell scope="col">Role Mappings</TableCell>
+                          <TableCell scope="col" className={classes.entitlementCell}>
                             Entitlement (claim=value)
                           </TableCell>
-                          <TableCell>Effect</TableCell>
-                          <TableCell align="right">Actions</TableCell>
+                          <TableCell scope="col">Effect</TableCell>
+                          <TableCell scope="col" align="right">Actions</TableCell>
                         </TableRow>
                       </TableHead>
                       <TableBody>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
@@ -513,11 +513,16 @@ export const NamespaceRoleBindingsContent = ({
                         <TableRow>
                           <TableCell scope="col">Binding Name</TableCell>
                           <TableCell scope="col">Role Mappings</TableCell>
-                          <TableCell scope="col" className={classes.entitlementCell}>
+                          <TableCell
+                            scope="col"
+                            className={classes.entitlementCell}
+                          >
                             Entitlement (claim=value)
                           </TableCell>
                           <TableCell scope="col">Effect</TableCell>
-                          <TableCell scope="col" align="right">Actions</TableCell>
+                          <TableCell scope="col" align="right">
+                            Actions
+                          </TableCell>
                         </TableRow>
                       </TableHead>
                       <TableBody>

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
@@ -149,8 +149,12 @@ export const RolesTable = ({
             <TableHead>
               <TableRow>
                 <TableCell scope="col">Role Name</TableCell>
-                <TableCell scope="col" className={classes.actionsCell}>Actions</TableCell>
-                <TableCell scope="col" align="right">Operations</TableCell>
+                <TableCell scope="col" className={classes.actionsCell}>
+                  Actions
+                </TableCell>
+                <TableCell scope="col" align="right">
+                  Operations
+                </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
@@ -148,9 +148,9 @@ export const RolesTable = ({
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Role Name</TableCell>
-                <TableCell className={classes.actionsCell}>Actions</TableCell>
-                <TableCell align="right">Operations</TableCell>
+                <TableCell scope="col">Role Name</TableCell>
+                <TableCell scope="col" className={classes.actionsCell}>Actions</TableCell>
+                <TableCell scope="col" align="right">Operations</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/plugins/openchoreo/src/components/AnnotationEditor/EditAnnotationsDialog.tsx
+++ b/plugins/openchoreo/src/components/AnnotationEditor/EditAnnotationsDialog.tsx
@@ -372,9 +372,9 @@ export function EditAnnotationsDialog({
               <Table size="small">
                 <TableHead>
                   <TableRow>
-                    <TableCell className={classes.keyCell}>Key</TableCell>
-                    <TableCell className={classes.valueCell}>Value</TableCell>
-                    <TableCell className={classes.actionCell} />
+                    <TableCell scope="col" className={classes.keyCell}>Key</TableCell>
+                    <TableCell scope="col" className={classes.valueCell}>Value</TableCell>
+                    <TableCell scope="col" className={classes.actionCell} />
                   </TableRow>
                 </TableHead>
                 <TableBody>

--- a/plugins/openchoreo/src/components/AnnotationEditor/EditAnnotationsDialog.tsx
+++ b/plugins/openchoreo/src/components/AnnotationEditor/EditAnnotationsDialog.tsx
@@ -372,8 +372,12 @@ export function EditAnnotationsDialog({
               <Table size="small">
                 <TableHead>
                   <TableRow>
-                    <TableCell scope="col" className={classes.keyCell}>Key</TableCell>
-                    <TableCell scope="col" className={classes.valueCell}>Value</TableCell>
+                    <TableCell scope="col" className={classes.keyCell}>
+                      Key
+                    </TableCell>
+                    <TableCell scope="col" className={classes.valueCell}>
+                      Value
+                    </TableCell>
                     <TableCell scope="col" className={classes.actionCell} />
                   </TableRow>
                 </TableHead>

--- a/plugins/openchoreo/src/components/EnvironmentOverview/EnvironmentDeployedComponentsCard.tsx
+++ b/plugins/openchoreo/src/components/EnvironmentOverview/EnvironmentDeployedComponentsCard.tsx
@@ -143,10 +143,10 @@ export const EnvironmentDeployedComponentsCard = () => {
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell>Component</TableCell>
-                <TableCell>Release</TableCell>
-                <TableCell>Status</TableCell>
-                <TableCell>Endpoints</TableCell>
+                <TableCell scope="col">Component</TableCell>
+                <TableCell scope="col">Release</TableCell>
+                <TableCell scope="col">Status</TableCell>
+                <TableCell scope="col">Endpoints</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -236,11 +236,11 @@ export const EnvironmentDeployedComponentsCard = () => {
         <Table size="small">
           <TableHead>
             <TableRow>
-              <TableCell>Component</TableCell>
-              <TableCell>Project</TableCell>
-              <TableCell>Release</TableCell>
-              <TableCell>Status</TableCell>
-              <TableCell>Endpoints</TableCell>
+              <TableCell scope="col">Component</TableCell>
+              <TableCell scope="col">Project</TableCell>
+              <TableCell scope="col">Release</TableCell>
+              <TableCell scope="col">Status</TableCell>
+              <TableCell scope="col">Endpoints</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.tsx
@@ -169,11 +169,11 @@ export const ReleaseBindingDetailTabs: FC<ReleaseBindingDetailTabsProps> = ({
                   <Table size="small">
                     <TableHead>
                       <TableRow>
-                        <TableCell>Type</TableCell>
-                        <TableCell>Status</TableCell>
-                        <TableCell>Reason</TableCell>
-                        <TableCell>Message</TableCell>
-                        <TableCell>Last Transition</TableCell>
+                        <TableCell scope="col">Type</TableCell>
+                        <TableCell scope="col">Status</TableCell>
+                        <TableCell scope="col">Reason</TableCell>
+                        <TableCell scope="col">Message</TableCell>
+                        <TableCell scope="col">Last Transition</TableCell>
                       </TableRow>
                     </TableHead>
                     <TableBody>

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceEventsTable.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceEventsTable.tsx
@@ -180,11 +180,21 @@ export const ResourceEventsTable: FC<ResourceEventsTableProps> = ({
       <Table size="small" stickyHeader>
         <TableHead>
           <TableRow>
-            <TableCell scope="col" className={classes.headerCell}>Reason</TableCell>
-            <TableCell scope="col" className={classes.headerCell}>Message</TableCell>
-            <TableCell scope="col" className={classes.headerCell}>Count</TableCell>
-            <TableCell scope="col" className={classes.headerCell}>First Seen</TableCell>
-            <TableCell scope="col" className={classes.headerCell}>Last Seen</TableCell>
+            <TableCell scope="col" className={classes.headerCell}>
+              Reason
+            </TableCell>
+            <TableCell scope="col" className={classes.headerCell}>
+              Message
+            </TableCell>
+            <TableCell scope="col" className={classes.headerCell}>
+              Count
+            </TableCell>
+            <TableCell scope="col" className={classes.headerCell}>
+              First Seen
+            </TableCell>
+            <TableCell scope="col" className={classes.headerCell}>
+              Last Seen
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceEventsTable.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceEventsTable.tsx
@@ -180,11 +180,11 @@ export const ResourceEventsTable: FC<ResourceEventsTableProps> = ({
       <Table size="small" stickyHeader>
         <TableHead>
           <TableRow>
-            <TableCell className={classes.headerCell}>Reason</TableCell>
-            <TableCell className={classes.headerCell}>Message</TableCell>
-            <TableCell className={classes.headerCell}>Count</TableCell>
-            <TableCell className={classes.headerCell}>First Seen</TableCell>
-            <TableCell className={classes.headerCell}>Last Seen</TableCell>
+            <TableCell scope="col" className={classes.headerCell}>Reason</TableCell>
+            <TableCell scope="col" className={classes.headerCell}>Message</TableCell>
+            <TableCell scope="col" className={classes.headerCell}>Count</TableCell>
+            <TableCell scope="col" className={classes.headerCell}>First Seen</TableCell>
+            <TableCell scope="col" className={classes.headerCell}>Last Seen</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/plugins/openchoreo/src/components/Environments/TraitParameters.tsx
+++ b/plugins/openchoreo/src/components/Environments/TraitParameters.tsx
@@ -134,9 +134,7 @@ export const TraitParameters: React.FC<TraitParametersProps> = ({
         />
         <IconButton
           aria-expanded={expanded}
-          aria-label={
-            expanded ? 'Collapse parameters' : 'Expand parameters'
-          }
+          aria-label={expanded ? 'Collapse parameters' : 'Expand parameters'}
           aria-controls="trait-parameters-content"
           size="small"
           onClick={e => {

--- a/plugins/openchoreo/src/components/Environments/TraitParameters.tsx
+++ b/plugins/openchoreo/src/components/Environments/TraitParameters.tsx
@@ -119,9 +119,11 @@ export const TraitParameters: React.FC<TraitParametersProps> = ({
 
   const hasParameters = parameters && Object.keys(parameters).length > 0;
 
+  const toggleExpanded = () => setExpanded(prev => !prev);
+
   return (
     <Box className={classes.container}>
-      <Box className={classes.header} onClick={() => setExpanded(!expanded)}>
+      <Box className={classes.header} onClick={toggleExpanded}>
         <Typography variant="h5" color="textSecondary">
           Configured Parameters
         </Typography>
@@ -131,7 +133,16 @@ export const TraitParameters: React.FC<TraitParametersProps> = ({
           className={classes.readOnlyBadge}
         />
         <IconButton
+          aria-expanded={expanded}
+          aria-label={
+            expanded ? 'Collapse parameters' : 'Expand parameters'
+          }
+          aria-controls="trait-parameters-content"
           size="small"
+          onClick={e => {
+            e.stopPropagation();
+            toggleExpanded();
+          }}
           className={`${classes.expandIcon} ${
             expanded ? classes.expandIconExpanded : ''
           }`}
@@ -140,17 +151,19 @@ export const TraitParameters: React.FC<TraitParametersProps> = ({
         </IconButton>
       </Box>
       <Collapse in={expanded}>
-        {hasParameters ? (
-          <Box className={classes.jsonContainer}>
-            <pre className={classes.jsonContent}>
-              {JSON.stringify(parameters, null, 2)}
-            </pre>
-          </Box>
-        ) : (
-          <Typography className={classes.noParameters}>
-            No parameters configured
-          </Typography>
-        )}
+        <div id="trait-parameters-content">
+          {hasParameters ? (
+            <Box className={classes.jsonContainer}>
+              <pre className={classes.jsonContent}>
+                {JSON.stringify(parameters, null, 2)}
+              </pre>
+            </Box>
+          ) : (
+            <Typography className={classes.noParameters}>
+              No parameters configured
+            </Typography>
+          )}
+        </div>
       </Collapse>
     </Box>
   );

--- a/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
@@ -222,10 +222,10 @@ export const SecretsTable = ({
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell style={{ width: '32%' }}>Name</TableCell>
-                <TableCell style={{ width: '24%' }}>Type</TableCell>
-                <TableCell style={{ width: '32%' }}>Target Plane</TableCell>
-                <TableCell align="center" style={{ width: '12%' }}>
+                <TableCell scope="col" style={{ width: '32%' }}>Name</TableCell>
+                <TableCell scope="col" style={{ width: '24%' }}>Type</TableCell>
+                <TableCell scope="col" style={{ width: '32%' }}>Target Plane</TableCell>
+                <TableCell scope="col" align="center" style={{ width: '12%' }}>
                   Actions
                 </TableCell>
               </TableRow>

--- a/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
@@ -222,9 +222,15 @@ export const SecretsTable = ({
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell scope="col" style={{ width: '32%' }}>Name</TableCell>
-                <TableCell scope="col" style={{ width: '24%' }}>Type</TableCell>
-                <TableCell scope="col" style={{ width: '32%' }}>Target Plane</TableCell>
+                <TableCell scope="col" style={{ width: '32%' }}>
+                  Name
+                </TableCell>
+                <TableCell scope="col" style={{ width: '24%' }}>
+                  Type
+                </TableCell>
+                <TableCell scope="col" style={{ width: '32%' }}>
+                  Target Plane
+                </TableCell>
                 <TableCell scope="col" align="center" style={{ width: '12%' }}>
                   Actions
                 </TableCell>


### PR DESCRIPTION
First batch of accessibility fixes from the audit on `acessbility-audit`. Closes ~60%
  of the recorded axe violations and unblocks a BITV 2.0 *Teilweise konform*
  declaration.

  ### Changes

  1. **Sidebar/link contrast** — darkened light `primary.main` `#6c7fd8` → `#5568c4`
  (5.04:1 on white). Also updates `text.link` and `navigation.selectedColor`. Resolves
  ~30 contrast violations.
  2. **Skip-to-main-content link** + `<main id="main-content">` landmark in `Root.tsx`.
  3. **Visually-hidden `<h1>`** on entity pages (`EntityLayoutWithDelete`) — Backstage's
   `<Header>` is locked to `<h5>` upstream.
  4. **`aria-label`** on YamlEditor Save / Discard / Delete IconButtons.
  5. **TraitParameters expand button** — `aria-expanded`, `aria-controls`, dynamic
  `aria-label`, keyboard-activatable.
  6. **CodeMirror `.cm-scroller`** — promote `tabindex="-1"` → `0` so keyboard users can
   Tab into the editor.
  7. **`scope="col"`** on `<TableHead>` cells across 14 tables.

  ### Verified

  - `yarn tsc` passes.
  - Chrome DevTools MCP: skip-link focus flow, sidebar token resolution, entity-page h1
  in a11y tree, YamlEditor accessible names, CodeMirror `tabindex="0"`, LogsTable `<th
  scope="col">`.
  - Lighthouse on home (light): `color-contrast` 35 → 0 (`#6c7fd8` failures gone).

  ### Out of scope (Phase 2)

  Card-as-button refactor, form-input labelling, touch-target sizing, dialog labelling,
  loading-state announcements, status-chip iconography. Tracked in the umbrella a11y
  issue.
  
  Related to: https://github.com/openchoreo/openchoreo/issues/3586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a skip to main content link for easier navigation
  * Enhanced keyboard navigation in YAML Editor with improved focus management and tabbing
  * Added descriptive labels to editor action buttons

* **Style**
  * Updated light theme color palette with adjustments to primary, navigation, and link element colors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->