### PR TITLE
fix(setup): scalable env badges and visible chip styling

### DIFF
--- a/plugins/openchoreo/src/components/Environments/components/DeployReleasePanel.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/DeployReleasePanel.tsx
@@ -181,6 +181,7 @@ export const DeployReleasePanel = ({
         releases={releases}
         selectedReleaseName={selectedReleaseName}
         deployments={deployments}
+        firstEnvironmentName={firstEnvironmentName}
         loading={releasesLoading}
       />
 

--- a/plugins/openchoreo/src/components/Environments/components/DeployedEnvBadges.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/DeployedEnvBadges.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DeployedEnvBadges } from './DeployedEnvBadges';
+
+describe('DeployedEnvBadges', () => {
+  it('renders nothing when envs is empty', () => {
+    const { container } = render(<DeployedEnvBadges envs={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a single primary chip and no overflow when one env', () => {
+    render(<DeployedEnvBadges envs={['Development']} />);
+    expect(screen.getByText('Deployed to:')).toBeInTheDocument();
+    expect(screen.getByText('Development')).toBeInTheDocument();
+    expect(screen.queryByText(/\+\d+ more/)).not.toBeInTheDocument();
+  });
+
+  it('promotes the matching primaryEnv to the front and collapses the rest into "+N more"', async () => {
+    const user = userEvent.setup();
+    render(
+      <DeployedEnvBadges
+        envs={[
+          'staging-eu',
+          'staging-us',
+          'Development',
+          'production-eu',
+          'production-us',
+        ]}
+        primaryEnv="development"
+      />,
+    );
+
+    // Primary chip is the case-insensitive match for primaryEnv, in original casing.
+    expect(screen.getByText('Development')).toBeInTheDocument();
+
+    // The four remaining envs collapse into one overflow chip.
+    const more = screen.getByText('+4 more');
+    expect(more).toBeInTheDocument();
+
+    // Hidden envs are not visible until hover.
+    expect(screen.queryByText('staging-eu')).not.toBeInTheDocument();
+
+    await user.hover(more);
+    expect(await screen.findByText('staging-eu')).toBeInTheDocument();
+    expect(screen.getByText('staging-us')).toBeInTheDocument();
+    expect(screen.getByText('production-eu')).toBeInTheDocument();
+    expect(screen.getByText('production-us')).toBeInTheDocument();
+  });
+
+  it('falls back to the first env when primaryEnv does not match', () => {
+    render(
+      <DeployedEnvBadges
+        envs={['staging-eu', 'production-eu']}
+        primaryEnv="development"
+      />,
+    );
+    expect(screen.getByText('staging-eu')).toBeInTheDocument();
+    expect(screen.getByText('+1 more')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/components/DeployedEnvBadges.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/DeployedEnvBadges.tsx
@@ -1,0 +1,108 @@
+import { useMemo } from 'react';
+import { Box, Chip, Tooltip, Typography } from '@material-ui/core';
+import { alpha, makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(theme => ({
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.75),
+    color: theme.palette.text.secondary,
+    fontSize: 12,
+    minWidth: 0,
+  },
+  label: {
+    flexShrink: 0,
+  },
+  chip: {
+    height: 20,
+    fontSize: 11,
+    maxWidth: '100%',
+    backgroundColor: alpha(theme.palette.primary.main, 0.15),
+    color: theme.palette.primary.main,
+    fontWeight: 500,
+    border: `1px solid ${alpha(theme.palette.primary.main, 0.3)}`,
+  },
+  moreChip: {
+    height: 20,
+    fontSize: 11,
+    borderColor: theme.palette.divider,
+    color: theme.palette.text.secondary,
+  },
+  tooltipList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+  },
+}));
+
+export interface DeployedEnvBadgesProps {
+  /** Envs this release is currently bound to (original casing preserved). */
+  envs: string[];
+  /**
+   * When set and matches an env in `envs` (case-insensitive), render that env
+   * as the primary chip. Falls back to the first env otherwise.
+   */
+  primaryEnv?: string;
+}
+
+/**
+ * Compact "Deployed to: [<primary>] [+N more ▾]" row used by the release
+ * picker and browser. The overflow chip's tooltip lists every hidden env so
+ * nothing is lost when a release is bound to many environments.
+ */
+export const DeployedEnvBadges = ({
+  envs,
+  primaryEnv,
+}: DeployedEnvBadgesProps) => {
+  const classes = useStyles();
+
+  const { primary, hidden } = useMemo(() => {
+    if (envs.length === 0) return { primary: null, hidden: [] as string[] };
+    const target = primaryEnv?.toLowerCase();
+    const primaryIndex = target
+      ? envs.findIndex(e => e.toLowerCase() === target)
+      : -1;
+    const idx = primaryIndex >= 0 ? primaryIndex : 0;
+    return {
+      primary: envs[idx],
+      hidden: envs.filter((_, i) => i !== idx),
+    };
+  }, [envs, primaryEnv]);
+
+  if (!primary) return null;
+
+  return (
+    <Box className={classes.row}>
+      <Typography
+        variant="caption"
+        color="textSecondary"
+        className={classes.label}
+      >
+        Deployed to:
+      </Typography>
+      <Chip label={primary} size="small" className={classes.chip} />
+      {hidden.length > 0 && (
+        <Tooltip
+          title={
+            <Box className={classes.tooltipList}>
+              {hidden.map(env => (
+                <Typography key={env} variant="caption" display="block">
+                  {env}
+                </Typography>
+              ))}
+            </Box>
+          }
+        >
+          <Chip
+            label={`+${hidden.length} more`}
+            size="small"
+            variant="outlined"
+            className={classes.moreChip}
+          />
+        </Tooltip>
+      )}
+    </Box>
+  );
+};

--- a/plugins/openchoreo/src/components/Environments/components/ReleaseBrowserDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/ReleaseBrowserDialog.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
-  Chip,
   CircularProgress,
   Dialog,
   DialogActions,
@@ -34,6 +33,7 @@ import YAML from 'yaml';
 import type { ComponentRelease } from '@openchoreo/backstage-plugin-common';
 import { openChoreoClientApiRef } from '../../../api/OpenChoreoClientApi';
 import type { ReleaseDeployments } from './ReleasePicker';
+import { DeployedEnvBadges } from './DeployedEnvBadges';
 
 const useStyles = makeStyles(theme => ({
   titleBar: {
@@ -99,10 +99,6 @@ const useStyles = makeStyles(theme => ({
     gap: theme.spacing(0.75),
     color: theme.palette.text.secondary,
     fontSize: 12,
-  },
-  chip: {
-    height: 20,
-    fontSize: 11,
   },
   detailHeader: {
     display: 'flex',
@@ -555,16 +551,13 @@ export const ReleaseBrowserDialog = ({
                             <Box className={classes.listItemMeta}>
                               {created && <span>{created}</span>}
                               {image && <span>img: {shortenImage(image)}</span>}
-                              {deployedIn.map(env => (
-                                <Chip
-                                  key={env}
-                                  label={`current in ${env}`}
-                                  size="small"
-                                  color="primary"
-                                  className={classes.chip}
-                                />
-                              ))}
                             </Box>
+                            {deployedIn.length > 0 && (
+                              <DeployedEnvBadges
+                                envs={deployedIn}
+                                primaryEnv={environmentName}
+                              />
+                            )}
                           </Box>
                         }
                       />
@@ -589,17 +582,12 @@ export const ReleaseBrowserDialog = ({
                       <Typography variant="h6">
                         {highlighted.metadata?.name}
                       </Typography>
-                      {(
-                        deployments[highlighted.metadata?.name ?? ''] ?? []
-                      ).map(env => (
-                        <Chip
-                          key={env}
-                          label={`current in ${env}`}
-                          size="small"
-                          color="primary"
-                          className={classes.chip}
-                        />
-                      ))}
+                      <DeployedEnvBadges
+                        envs={
+                          deployments[highlighted.metadata?.name ?? ''] ?? []
+                        }
+                        primaryEnv={environmentName}
+                      />
                     </Box>
                     <ToggleButtonGroup
                       size="small"

--- a/plugins/openchoreo/src/components/Environments/components/ReleasePicker.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/ReleasePicker.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
-import { Box, Chip, Typography } from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { Skeleton } from '@material-ui/lab';
 import type { ComponentRelease } from '@openchoreo/backstage-plugin-common';
+import { DeployedEnvBadges } from './DeployedEnvBadges';
 
 const useStyles = makeStyles(theme => ({
   summaryRow: {
@@ -28,10 +29,6 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     gap: theme.spacing(0.75),
   },
-  chip: {
-    height: 20,
-    fontSize: 11,
-  },
   empty: {
     color: theme.palette.text.secondary,
     fontStyle: 'italic',
@@ -46,6 +43,8 @@ export interface ReleasePickerProps {
   selectedReleaseName: string | null;
   /** Environments where each release is currently deployed. Used for badges. */
   deployments?: ReleaseDeployments;
+  /** First (lowest) env name — used to highlight the most relevant chip. */
+  firstEnvironmentName?: string;
   loading?: boolean;
 }
 
@@ -80,6 +79,7 @@ export const ReleasePicker = ({
   releases,
   selectedReleaseName,
   deployments = {},
+  firstEnvironmentName,
   loading,
 }: ReleasePickerProps) => {
   const classes = useStyles();
@@ -117,16 +117,13 @@ export const ReleasePicker = ({
         <Box className={classes.meta}>
           {created && <span>{created}</span>}
           {image && <span>img: {shortenImage(image)}</span>}
-          {deployedIn.map(env => (
-            <Chip
-              key={env}
-              label={`current in ${env}`}
-              size="small"
-              color="primary"
-              className={classes.chip}
-            />
-          ))}
         </Box>
+      )}
+      {selected && deployedIn.length > 0 && (
+        <DeployedEnvBadges
+          envs={deployedIn}
+          primaryEnv={firstEnvironmentName}
+        />
       )}
     </Box>
   );


### PR DESCRIPTION
  Collapse per-env chips into "Deployed to: <primary> [+N more]" with a
  hover tooltip listing the rest. Use alpha(primary, 0.15) background so
  the chip stays visible on light themes.

Related issue: https://github.com/openchoreo/openchoreo/issues/3567


Before:

<img width="395" height="698" alt="Screenshot 2026-05-25 at 11 41 53" src="https://github.com/user-attachments/assets/21b8cf02-9717-499e-849c-bfb9aa1dea0b" />
<img width="1307" height="698" alt="Screenshot 2026-05-25 at 11 42 03" src="https://github.com/user-attachments/assets/cf950abb-29b7-4cc0-abc3-95b32a724bcf" />


After

<img width="395" height="695" alt="Screenshot 2026-05-25 at 11 53 20" src="https://github.com/user-attachments/assets/e736520c-f321-48a8-a38f-fd1882cf19c2" />
<img width="1291" height="660" alt="Screenshot 2026-05-25 at 11 53 38" src="https://github.com/user-attachments/assets/d5890048-22e6-49c1-8e24-9c128c15f1b5" />

<img width="398" height="698" alt="Screenshot 2026-05-25 at 11 45 35" src="https://github.com/user-attachments/assets/1c43cfc9-164d-4adc-bc48-38aa1ed2b589" />
<img width="1299" height="670" alt="Screenshot 2026-05-25 at 11 45 58" src="https://github.com/user-attachments/assets/311f808c-7b2a-4fd8-aac9-1fece2946990" />
