### PR TITLE
fix: enhance CellDiagram to handle empty states and API errors

### DIFF
--- a/plugins/openchoreo-backend/src/services/CellDiagramService/CellDiagramInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/CellDiagramService/CellDiagramInfoService.test.ts
@@ -128,7 +128,7 @@ describe('CellDiagramInfoService', () => {
       expect(result!.components[0].id).toBe('api');
     });
 
-    it('returns undefined when no components found', async () => {
+    it('returns an empty project when no components found (so the UI can render an empty diagram instead of spinning forever)', async () => {
       mockGET.mockResolvedValueOnce(
         createOkResponse({ items: [], pagination: {} }),
       );
@@ -142,7 +142,10 @@ describe('CellDiagramInfoService', () => {
         'token',
       );
 
-      expect(result).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result!.id).toBe('proj');
+      expect(result!.components).toEqual([]);
+      expect(result!.connections).toEqual([]);
     });
 
     it('returns undefined on API error', async () => {

--- a/plugins/openchoreo-backend/src/services/CellDiagramService/CellDiagramInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/CellDiagramService/CellDiagramInfoService.ts
@@ -213,8 +213,10 @@ export class CellDiagramInfoService implements CellDiagramService {
       ]);
 
       if (!componentItems.length) {
-        this.logger.warn('No components found in API response');
-        return undefined;
+        this.logger.info(
+          `No components in project '${projectName}'; returning empty cell diagram`,
+        );
+        return this.buildProject(projectName, namespaceName, []);
       }
 
       // Build a map from component name to workload spec

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx
@@ -37,6 +37,20 @@ jest.mock('@openchoreo/backstage-design-system', () => ({
   useChoreoTokens: () => ({ mode: 'light' }),
 }));
 
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  EmptyState: ({ title, description, action }: any) => (
+    <div data-testid="empty-state">
+      <div>{title}</div>
+      {description && <div>{description}</div>}
+      {action && (
+        <button onClick={action.onClick} aria-label={action.label}>
+          {action.label}
+        </button>
+      )}
+    </div>
+  ),
+}));
+
 jest.mock('@material-ui/core/styles', () => ({
   useTheme: () => ({
     palette: {
@@ -195,7 +209,9 @@ function setupMockClient(
   const mockClient = {
     getCellDiagramInfo: jest.fn().mockResolvedValue({
       id: 'my-project',
-      components: [],
+      // Default has one component so the toggle renders; the "no components" path
+      // is hidden in the empty state and is exercised by a dedicated test below.
+      components: [{ id: 'svc-a', label: 'svc-a', services: {} }],
       connections: [],
     }),
     fetchDeploymentPipeline: jest.fn().mockResolvedValue({
@@ -582,5 +598,62 @@ describe('CellDiagram', () => {
         callsAfterToggle,
       );
     });
+  });
+
+  it('shows a "No components yet" empty state (and skips the cell diagram lib) when the project has no components', async () => {
+    setupMockClient({
+      getCellDiagramInfo: jest.fn().mockResolvedValue({
+        id: 'my-project',
+        components: [],
+        connections: [],
+      }),
+    });
+
+    await act(async () => {
+      render(<CellDiagram />);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('cell-diagram-no-components'),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/no components yet/i)).toBeInTheDocument();
+    // The cell-diagram lib is intentionally not rendered for empty projects —
+    // otherwise the standalone octagon outline looks awkward around the message.
+    expect(screen.queryByTestId('cell-diagram-view')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state with Retry when the fetch fails (instead of an infinite spinner)', async () => {
+    const mockClient = setupMockClient({
+      getCellDiagramInfo: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValue({
+          id: 'my-project',
+          components: [{ id: 'svc-a', label: 'svc-a', services: {} }],
+          connections: [],
+        }),
+    });
+
+    await act(async () => {
+      render(<CellDiagram />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('cell-diagram-view')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('progress')).not.toBeInTheDocument();
+
+    const retry = screen.getByRole('button', { name: /retry/i });
+    await act(async () => {
+      await userEvent.click(retry);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cell-diagram-view')).toBeInTheDocument();
+    });
+    expect(mockClient.getCellDiagramInfo).toHaveBeenCalledTimes(2);
   });
 });

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -27,6 +27,7 @@ import { useTheme } from '@material-ui/core/styles';
 import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
 import { DiagramLayer, Project } from '@wso2/cell-diagram';
 import { useChoreoTokens } from '@openchoreo/backstage-design-system';
+import { EmptyState } from '@openchoreo/backstage-plugin-react';
 import { useCellEnvironments } from './useCellEnvironments';
 
 const CellView = lazy(() =>
@@ -136,9 +137,11 @@ export const CellDiagram = () => {
     runtimeEnabled && selectedEnvHasRuntimeObservability;
   // When observability is off, environment/time-range don't affect the result, so they must not be in
   // the useEffect's dependancies. Use a memoized key that only changes when relevant values change.
+  // refreshNonce is included in the arch key so the Retry button can re-trigger the fetch even when
+  // observability is off (in obs mode it already flows through `range`).
   const diagramFetchKey = observabilityActive
     ? `obs|${environment}|${range?.startTime ?? ''}|${range?.endTime ?? ''}`
-    : 'arch';
+    : `arch|${refreshNonce}`;
 
   useEffect(() => {
     let cancelled = false;
@@ -154,11 +157,13 @@ export const CellDiagram = () => {
         });
         if (cancelled) return;
         setCellDiagramData(data as Project);
-        setHasFetchedOnce(true);
       } catch {
-        // swallow — diagram falls back to undefined
+        // swallow — empty-state with Retry surfaces failure in the UI
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+          setHasFetchedOnce(true);
+        }
       }
     };
     fetchData();
@@ -208,6 +213,9 @@ export const CellDiagram = () => {
     />
   );
 
+  const hasNoComponents =
+    !!cellDiagramData && (cellDiagramData.components?.length ?? 0) === 0;
+
   return (
     <Box
       sx={{
@@ -221,139 +229,143 @@ export const CellDiagram = () => {
         position: 'relative',
       }}
     >
-      <Box
-        style={{
-          position: 'absolute',
-          top: 16,
-          left: 24,
-          right: 24,
-          zIndex: 10,
-          display: 'flex',
-          flexWrap: 'wrap',
-          alignItems: 'center',
-          gap: 12,
-        }}
-      >
-        {toggleDisabled ? (
-          <Tooltip title="Observability is unavailable in all environments. Configure the Cilium module to enable observability.">
-            <span>{toggleControl}</span>
-          </Tooltip>
-        ) : (
-          toggleControl
-        )}
-
-        {runtimeEnabled && (
-          <>
-            <FormControl
-              variant="outlined"
-              size="small"
-              style={{
-                minWidth: 200,
-                backgroundColor: controlBg,
-                borderRadius: 4,
-              }}
-            >
-              <InputLabel id="cell-diagram-env-label">Environment</InputLabel>
-              <Select
-                labelId="cell-diagram-env-label"
-                value={environment}
-                label="Environment"
-                onChange={e => setEnvironment(e.target.value as string)}
-                disabled={environments.length === 0}
-              >
-                {environments.length === 0 && (
-                  <MenuItem value="" disabled>
-                    No environments
-                  </MenuItem>
-                )}
-                {environments.map(env => (
-                  <MenuItem key={env.name} value={env.name}>
-                    {env.displayName ?? env.name}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-
-            <FormControl
-              variant="outlined"
-              size="small"
-              style={{
-                minWidth: 180,
-                backgroundColor: controlBg,
-                borderRadius: 4,
-              }}
-            >
-              <InputLabel id="cell-diagram-range-label">Time range</InputLabel>
-              <Select
-                labelId="cell-diagram-range-label"
-                value={timeRange}
-                label="Time range"
-                onChange={e => setTimeRange(e.target.value as string)}
-              >
-                {TIME_RANGES.map(r => (
-                  <MenuItem key={r.value} value={r.value}>
-                    {r.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-
-            <Tooltip title="Refresh">
-              <span>
-                <IconButton
-                  size="small"
-                  onClick={() => setRefreshNonce(n => n + 1)}
-                  disabled={loading || environmentsLoading}
-                  style={{
-                    backgroundColor: controlBg,
-                    borderRadius: 4,
-                  }}
-                >
-                  {loading ? (
-                    <CircularProgress size={18} />
-                  ) : (
-                    <RefreshIcon fontSize="small" />
-                  )}
-                </IconButton>
-              </span>
+      {!hasNoComponents && (
+        <Box
+          style={{
+            position: 'absolute',
+            top: 16,
+            left: 24,
+            right: 24,
+            zIndex: 10,
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            gap: 12,
+          }}
+        >
+          {toggleDisabled ? (
+            <Tooltip title="Observability is unavailable in all environments. Configure the Cilium module to enable observability.">
+              <span>{toggleControl}</span>
             </Tooltip>
+          ) : (
+            toggleControl
+          )}
 
-            {environment &&
-              !selectedEnvHasRuntimeObservability &&
-              !environmentsLoading && (
-                <Typography
-                  variant="body2"
-                  style={{
-                    padding: '6px 12px',
-                    backgroundColor: theme.palette.warning.light,
-                    color: theme.palette.warning.contrastText,
-                    borderRadius: 4,
-                  }}
-                >
-                  Observability is unavailable in the{' '}
-                  <strong>{environment}</strong> environment. Configure the
-                  Cilium module to enable observability.
-                </Typography>
-              )}
-
-            {showEmptyHint && (
-              <Typography
-                variant="caption"
+          {runtimeEnabled && (
+            <>
+              <FormControl
+                variant="outlined"
+                size="small"
                 style={{
-                  padding: '6px 12px',
+                  minWidth: 200,
                   backgroundColor: controlBg,
                   borderRadius: 4,
-                  opacity: 0.8,
                 }}
               >
-                No HTTP traffic in selected range
-              </Typography>
-            )}
-          </>
-        )}
-      </Box>
+                <InputLabel id="cell-diagram-env-label">Environment</InputLabel>
+                <Select
+                  labelId="cell-diagram-env-label"
+                  value={environment}
+                  label="Environment"
+                  onChange={e => setEnvironment(e.target.value as string)}
+                  disabled={environments.length === 0}
+                >
+                  {environments.length === 0 && (
+                    <MenuItem value="" disabled>
+                      No environments
+                    </MenuItem>
+                  )}
+                  {environments.map(env => (
+                    <MenuItem key={env.name} value={env.name}>
+                      {env.displayName ?? env.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
 
-      {runtimeEnabled && (
+              <FormControl
+                variant="outlined"
+                size="small"
+                style={{
+                  minWidth: 180,
+                  backgroundColor: controlBg,
+                  borderRadius: 4,
+                }}
+              >
+                <InputLabel id="cell-diagram-range-label">
+                  Time range
+                </InputLabel>
+                <Select
+                  labelId="cell-diagram-range-label"
+                  value={timeRange}
+                  label="Time range"
+                  onChange={e => setTimeRange(e.target.value as string)}
+                >
+                  {TIME_RANGES.map(r => (
+                    <MenuItem key={r.value} value={r.value}>
+                      {r.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => setRefreshNonce(n => n + 1)}
+                    disabled={loading || environmentsLoading}
+                    style={{
+                      backgroundColor: controlBg,
+                      borderRadius: 4,
+                    }}
+                  >
+                    {loading ? (
+                      <CircularProgress size={18} />
+                    ) : (
+                      <RefreshIcon fontSize="small" />
+                    )}
+                  </IconButton>
+                </span>
+              </Tooltip>
+
+              {environment &&
+                !selectedEnvHasRuntimeObservability &&
+                !environmentsLoading && (
+                  <Typography
+                    variant="body2"
+                    style={{
+                      padding: '6px 12px',
+                      backgroundColor: theme.palette.warning.light,
+                      color: theme.palette.warning.contrastText,
+                      borderRadius: 4,
+                    }}
+                  >
+                    Observability is unavailable in the{' '}
+                    <strong>{environment}</strong> environment. Configure the
+                    Cilium module to enable observability.
+                  </Typography>
+                )}
+
+              {showEmptyHint && (
+                <Typography
+                  variant="caption"
+                  style={{
+                    padding: '6px 12px',
+                    backgroundColor: controlBg,
+                    borderRadius: 4,
+                    opacity: 0.8,
+                  }}
+                >
+                  No HTTP traffic in selected range
+                </Typography>
+              )}
+            </>
+          )}
+        </Box>
+      )}
+
+      {runtimeEnabled && !hasNoComponents && (
         <Typography
           variant="caption"
           style={{
@@ -371,7 +383,7 @@ export const CellDiagram = () => {
           observed.
         </Typography>
       )}
-      {cellDiagramData ? (
+      {cellDiagramData && (cellDiagramData.components?.length ?? 0) > 0 && (
         <Suspense fallback={<Progress />}>
           {(() => {
             const targetLayer =
@@ -388,8 +400,42 @@ export const CellDiagram = () => {
             );
           })()}
         </Suspense>
-      ) : (
-        <Progress />
+      )}
+      {cellDiagramData && (cellDiagramData.components?.length ?? 0) === 0 && (
+        <Box
+          data-testid="cell-diagram-no-components"
+          style={{
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <EmptyState
+            title="No components yet"
+            description="This project does not have any components. Create one to see it on the cell diagram."
+          />
+        </Box>
+      )}
+      {!cellDiagramData && loading && <Progress />}
+      {!cellDiagramData && !loading && (
+        <Box
+          style={{
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <EmptyState
+            title="Failed to load cell diagram"
+            description="Could not load project information. Try again in a moment."
+            action={{
+              label: 'Retry',
+              onClick: () => setRefreshNonce(n => n + 1),
+            }}
+          />
+        </Box>
       )}
     </Box>
   );

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -383,7 +383,7 @@ export const CellDiagram = () => {
           observed.
         </Typography>
       )}
-      {cellDiagramData && (cellDiagramData.components?.length ?? 0) > 0 && (
+      {cellDiagramData && !hasNoComponents && (
         <Suspense fallback={<Progress />}>
           {(() => {
             const targetLayer =
@@ -401,7 +401,7 @@ export const CellDiagram = () => {
           })()}
         </Suspense>
       )}
-      {cellDiagramData && (cellDiagramData.components?.length ?? 0) === 0 && (
+      {hasNoComponents && (
         <Box
           data-testid="cell-diagram-no-components"
           style={{
@@ -417,8 +417,8 @@ export const CellDiagram = () => {
           />
         </Box>
       )}
-      {!cellDiagramData && loading && <Progress />}
-      {!cellDiagramData && !loading && (
+      {!cellDiagramData && (loading || !hasFetchedOnce) && <Progress />}
+      {!cellDiagramData && hasFetchedOnce && !loading && (
         <Box
           style={{
             height: '100%',


### PR DESCRIPTION
## Purpose

Related: https://github.com/openchoreo/openchoreo/issues/3563

This pull request improves the user experience of the Cell Diagram feature by ensuring the UI handles empty and error states gracefully, both in the frontend and backend. Now, when a project has no components, the UI displays an informative empty state instead of spinning indefinitely. Similarly, API errors surface a retryable empty state instead of causing an infinite spinner. The changes are well-tested, with new and updated tests to cover these scenarios.

**Frontend: Improved empty/error state handling in Cell Diagram**

* The `CellDiagram` component now displays a "No components yet" empty state when the project has no components, and a retryable empty state when the fetch fails, instead of showing an infinite spinner. The diagram view and related controls are hidden in these cases to prevent awkward UI. (`plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx`) [[1]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695R30) [[2]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695R140-R144) [[3]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695L157-R166) [[4]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695R216-R218) [[5]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695R232) [[6]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695R366-R368) [[7]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695L374-R386) [[8]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695L391-R438) [[9]](diffhunk://#diff-3e0bbf696742018cb066af07eb01cdb1d39694049772918ed39589063e33b695L286-R297)

* Added and updated tests to verify the new empty and error states, including checks that the diagram library is not rendered for empty projects and that the retry button works after a fetch failure. (`plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx`) [[1]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R40-R53) [[2]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7L198-R214) [[3]](diffhunk://#diff-6784c5db9bb32018b2c52e2e81d489ed3f0e16669e89df47986aa991a8647bc7R602-R658)

**Backend: Consistent empty project response**

* The backend service (`CellDiagramInfoService`) now returns an empty project (with empty `components` and `connections` arrays) when no components are found, instead of `undefined`. This allows the frontend to distinguish between "no components" and actual errors. (`plugins/openchoreo-backend/src/services/CellDiagramService/CellDiagramInfoService.ts`)

* Updated backend tests to reflect the new behavior, ensuring that an empty project is returned when there are no components. (`plugins/openchoreo-backend/src/services/CellDiagramService/CellDiagramInfoService.test.ts`) [[1]](diffhunk://#diff-55cb7fc3cdad78f91508266453be747f38af0a634cb8f8ef37696518f6f2340fL131-R131) [[2]](diffhunk://#diff-55cb7fc3cdad78f91508266453be747f38af0a634cb8f8ef37696518f6f2340fL145-R148)

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
<img width="1698" height="856" alt="Screenshot 2026-05-25 at 11 49 12" src="https://github.com/user-attachments/assets/858c14e3-0c34-4852-b98a-2973194a597a" />

<img width="1697" height="858" alt="Screenshot 2026-05-25 at 11 49 40" src="https://github.com/user-attachments/assets/0de6ddd9-b595-4bc7-b16e-52b963a0cd59" />

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently treat projects with no components as an empty project and surface a clear "No components yet" UI.
  * Distinct empty/failed/loading states: hide top controls when empty, show spinner while loading, and show a Retry action on failure.

* **Tests**
  * Expanded tests and mocks to cover empty-project, error, retry, and normal diagram rendering scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->