### PR TITLE
fix(a11y): Phase 2 WCAG 2.2 AA systemic refactor

### DIFF
--- a/packages/app/src/components/catalog/EntityLayoutWithDelete.tsx
+++ b/packages/app/src/components/catalog/EntityLayoutWithDelete.tsx
@@ -1,21 +1,8 @@
 import { type ReactNode } from 'react';
-import { Box, makeStyles } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { EmptyState, Progress } from '@backstage/core-components';
-
-const useVisuallyHiddenStyles = makeStyles({
-  visuallyHidden: {
-    position: 'absolute',
-    width: 1,
-    height: 1,
-    padding: 0,
-    margin: -1,
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    border: 0,
-  },
-});
+import { VisuallyHidden } from '@openchoreo/backstage-design-system';
 import {
   useDeleteEntityMenuItems,
   useEntityExistsCheck,
@@ -87,7 +74,6 @@ export function EntityLayoutWithDelete({
   contextMenuOptions = { disableUnregister: 'hidden' },
 }: EntityLayoutWithDeleteProps) {
   const { entity } = useEntity();
-  const visuallyHidden = useVisuallyHiddenStyles().visuallyHidden;
   const entityTitle =
     (entity.metadata.title as string | undefined) ?? entity.metadata.name;
 
@@ -138,7 +124,7 @@ export function EntityLayoutWithDelete({
   if (status === 'not-found') {
     return (
       <>
-        <h1 className={visuallyHidden}>{entityTitle}</h1>
+        <VisuallyHidden as="h1">{entityTitle}</VisuallyHidden>
         <OpenChoreoEntityLayout
           contextMenuOptions={contextMenuOptions}
           parentEntityRelations={parentEntityRelations}
@@ -167,7 +153,7 @@ export function EntityLayoutWithDelete({
   if (status === 'marked-for-deletion') {
     return (
       <>
-        <h1 className={visuallyHidden}>{entityTitle}</h1>
+        <VisuallyHidden as="h1">{entityTitle}</VisuallyHidden>
         <OpenChoreoEntityLayout
           contextMenuOptions={contextMenuOptions}
           parentEntityRelations={parentEntityRelations}
@@ -194,7 +180,7 @@ export function EntityLayoutWithDelete({
 
   return (
     <>
-      <h1 className={visuallyHidden}>{entityTitle}</h1>
+      <VisuallyHidden as="h1">{entityTitle}</VisuallyHidden>
       <OpenChoreoEntityLayout
         contextMenuOptions={contextMenuOptions}
         extraContextMenuItems={extraMenuItems}

--- a/packages/app/src/components/scaffolder/CustomTemplateCard.tsx
+++ b/packages/app/src/components/scaffolder/CustomTemplateCard.tsx
@@ -59,11 +59,11 @@ export const CustomTemplateCard = ({
   const handleClick = () => {
     if (!disabled) onSelected?.(template);
   };
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
-      e.preventDefault();
-      handleClick();
-    }
+
+  const handleTitleClick = (e: React.MouseEvent) => {
+    // Outer Box also has onClick; stop here so we don't double-fire.
+    e.stopPropagation();
+    handleClick();
   };
 
   const handleStarClick = (e: React.MouseEvent) => {
@@ -77,9 +77,6 @@ export const CustomTemplateCard = ({
         disabled ? classes.cardDisabled : ''
       }`}
       onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={disabled ? -1 : 0}
       aria-disabled={disabled}
     >
       {workloadType && (
@@ -104,7 +101,15 @@ export const CustomTemplateCard = ({
         )}
       </IconButton>
       <Box className={classes.resourceCardIcon}>{icon}</Box>
-      <Typography className={classes.resourceCardTitle}>{title}</Typography>
+      <button
+        type="button"
+        className={classes.resourceCardTitleButton}
+        onClick={handleTitleClick}
+        disabled={disabled}
+        aria-label={`Use template ${title}`}
+      >
+        {title}
+      </button>
       {template.metadata.namespace &&
         template.metadata.namespace !== 'default' && (
           <Chip

--- a/packages/app/src/components/scaffolder/ScaffolderCategoryPicker.tsx
+++ b/packages/app/src/components/scaffolder/ScaffolderCategoryPicker.tsx
@@ -90,6 +90,7 @@ export const ScaffolderCategoryPicker = () => {
                 checked={selectedTypes.includes(type)}
                 size="small"
                 color="primary"
+                inputProps={{ 'aria-label': type }}
               />
               <ListItemText
                 primary={type}

--- a/packages/app/src/components/scaffolder/ScaffolderStarredFilter.tsx
+++ b/packages/app/src/components/scaffolder/ScaffolderStarredFilter.tsx
@@ -104,6 +104,7 @@ export const ScaffolderStarredFilter = () => {
             size="small"
             color="primary"
             disabled={starredCount === 0}
+            inputProps={{ 'aria-label': 'Show only starred templates' }}
           />
           <Box className={classes.labelRow}>
             <StarIcon className={classes.icon} />

--- a/packages/app/src/components/scaffolder/ScaffolderTagPicker.tsx
+++ b/packages/app/src/components/scaffolder/ScaffolderTagPicker.tsx
@@ -158,6 +158,7 @@ export const ScaffolderTagPicker = () => {
                 checked={selectedTags.includes(tag)}
                 size="small"
                 color="primary"
+                inputProps={{ 'aria-label': tag }}
               />
               <ListItemText
                 primary={tag}

--- a/packages/app/src/components/scaffolder/styles.ts
+++ b/packages/app/src/components/scaffolder/styles.ts
@@ -167,6 +167,31 @@ export const useStyles = makeStyles(theme => ({
     color: theme.palette.text.primary,
     lineHeight: 1.4,
   },
+  // Real-button version of `.resourceCardTitle` used to make the template
+  // selectable by keyboard without nesting interactive elements inside an
+  // outer button (WCAG 4.1.2 nested-interactive).
+  resourceCardTitleButton: {
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    margin: 0,
+    cursor: 'pointer',
+    textAlign: 'left' as const,
+    fontFamily: 'inherit',
+    fontSize: '0.938rem',
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+    lineHeight: 1.4,
+    '&:disabled': {
+      cursor: 'not-allowed',
+      opacity: 0.6,
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: 2,
+      borderRadius: 2,
+    },
+  },
   resourceCardDescription: {
     fontSize: '0.813rem',
     color: theme.palette.text.secondary,

--- a/packages/app/src/scaffolder/GitSecretField/GitSecretDialog.tsx
+++ b/packages/app/src/scaffolder/GitSecretField/GitSecretDialog.tsx
@@ -204,8 +204,9 @@ export const GitSecretDialog = ({
           maxHeight: '80vh',
         },
       }}
+      aria-labelledby="create-git-secret-dialog-title"
     >
-      <DialogTitle>
+      <DialogTitle id="create-git-secret-dialog-title">
         <Typography variant="h4" component="div" style={{ fontWeight: 600 }}>
           Create Git Secret
         </Typography>

--- a/packages/app/src/scaffolder/WorkloadDetailsField/WorkloadDetailsField.tsx
+++ b/packages/app/src/scaffolder/WorkloadDetailsField/WorkloadDetailsField.tsx
@@ -1386,8 +1386,9 @@ export const WorkloadDetailsField = ({
         PaperProps={{
           style: { borderRadius: 16 },
         }}
+        aria-labelledby="workload-descriptor-dialog-title"
       >
-        <DialogTitle>Workload Descriptor Reference</DialogTitle>
+        <DialogTitle id="workload-descriptor-dialog-title">Workload Descriptor Reference</DialogTitle>
         <DialogContent>
           <Typography variant="body2" color="textSecondary" paragraph>
             A workload descriptor (<code>workload.yaml</code>) allows you to

--- a/packages/app/src/scaffolder/WorkloadDetailsField/WorkloadDetailsField.tsx
+++ b/packages/app/src/scaffolder/WorkloadDetailsField/WorkloadDetailsField.tsx
@@ -1388,7 +1388,9 @@ export const WorkloadDetailsField = ({
         }}
         aria-labelledby="workload-descriptor-dialog-title"
       >
-        <DialogTitle id="workload-descriptor-dialog-title">Workload Descriptor Reference</DialogTitle>
+        <DialogTitle id="workload-descriptor-dialog-title">
+          Workload Descriptor Reference
+        </DialogTitle>
         <DialogContent>
           <Typography variant="body2" color="textSecondary" paragraph>
             A workload descriptor (<code>workload.yaml</code>) allows you to

--- a/packages/design-system/src/components/StatusBadge/StatusBadge.tsx
+++ b/packages/design-system/src/components/StatusBadge/StatusBadge.tsx
@@ -1,5 +1,10 @@
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { Box, Typography } from '@material-ui/core';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import WarningRoundedIcon from '@material-ui/icons/WarningRounded';
+import ErrorIcon from '@material-ui/icons/Error';
+import InfoIcon from '@material-ui/icons/Info';
+import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 
 const useStyles = makeStyles((theme: Theme) => ({
   badge: {
@@ -16,6 +21,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: 8,
     height: 8,
     borderRadius: '50%',
+    flexShrink: 0,
+  },
+  icon: {
+    fontSize: 14,
     flexShrink: 0,
   },
   success: {
@@ -71,8 +80,26 @@ export type StatusType =
 interface StatusBadgeProps {
   status: StatusType;
   label?: string;
+  /** Render a coloured dot before the label (default: true). */
   showDot?: boolean;
+  /**
+   * Render a variant-specific glyph before the label so colour is not the
+   * sole differentiator (WCAG 1.4.1). When `showIcon` is true, the dot is
+   * suppressed. Default: false (preserves existing visual).
+   */
+  showIcon?: boolean;
 }
+
+const VARIANT_ICON: Record<
+  'success' | 'warning' | 'error' | 'info' | 'default',
+  typeof CheckCircleIcon
+> = {
+  success: CheckCircleIcon,
+  warning: WarningRoundedIcon,
+  error: ErrorIcon,
+  info: InfoIcon,
+  default: RadioButtonUncheckedIcon,
+};
 
 const STATUS_CONFIG: Record<
   StatusType,
@@ -98,14 +125,20 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
   status,
   label,
   showDot = true,
+  showIcon = false,
 }) => {
   const classes = useStyles();
   const config = STATUS_CONFIG[status] || STATUS_CONFIG.default;
   const displayLabel = label || config.defaultLabel;
+  const Icon = VARIANT_ICON[config.variant];
 
   return (
     <Box className={`${classes.badge} ${classes[config.variant]}`}>
-      {showDot && <span className={classes.dot} />}
+      {showIcon ? (
+        <Icon className={classes.icon} aria-hidden="true" />
+      ) : (
+        showDot && <span className={classes.dot} />
+      )}
       <Typography component="span" variant="body2">
         {displayLabel}
       </Typography>

--- a/packages/design-system/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/design-system/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,40 @@
+import { ElementType, ReactNode } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useVisuallyHiddenStyles = makeStyles({
+  root: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    border: 0,
+  },
+});
+
+export interface VisuallyHiddenProps {
+  /** Content to render off-screen but expose to assistive technology. */
+  children: ReactNode;
+  /** Render-as element. Defaults to `span`. Use `h1`/`h2`/... for headings. */
+  as?: ElementType;
+}
+
+/**
+ * Renders content visually-hidden but available to assistive tech. Used for
+ * skip-link targets, page-level headings hidden behind a visual header, and
+ * loading-state labels announced via `role="status"`.
+ */
+export function VisuallyHidden({ children, as: Tag = 'span' }: VisuallyHiddenProps) {
+  const classes = useVisuallyHiddenStyles();
+  return <Tag className={classes.root}>{children}</Tag>;
+}
+
+/**
+ * JSS hook variant for cases where the consumer needs to compose the
+ * visually-hidden block with other styles (e.g., a `:focus` override that
+ * reveals the element when focused).
+ */
+export { useVisuallyHiddenStyles };

--- a/packages/design-system/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/design-system/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -27,7 +27,10 @@ export interface VisuallyHiddenProps {
  * skip-link targets, page-level headings hidden behind a visual header, and
  * loading-state labels announced via `role="status"`.
  */
-export function VisuallyHidden({ children, as: Tag = 'span' }: VisuallyHiddenProps) {
+export function VisuallyHidden({
+  children,
+  as: Tag = 'span',
+}: VisuallyHiddenProps) {
   const classes = useVisuallyHiddenStyles();
   return <Tag className={classes.root}>{children}</Tag>;
 }

--- a/packages/design-system/src/components/VisuallyHidden/index.ts
+++ b/packages/design-system/src/components/VisuallyHidden/index.ts
@@ -1,0 +1,2 @@
+export { VisuallyHidden, useVisuallyHiddenStyles } from './VisuallyHidden';
+export type { VisuallyHiddenProps } from './VisuallyHidden';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -49,3 +49,8 @@ export type {
   SplitButtonProps,
   SplitButtonOption,
 } from './components/SplitButton';
+export {
+  VisuallyHidden,
+  useVisuallyHiddenStyles,
+} from './components/VisuallyHidden';
+export type { VisuallyHiddenProps } from './components/VisuallyHidden';

--- a/plugins/openchoreo-ci/src/components/BuildWithCommitDialog/BuildWithCommitDialog.tsx
+++ b/plugins/openchoreo-ci/src/components/BuildWithCommitDialog/BuildWithCommitDialog.tsx
@@ -103,7 +103,9 @@ export const BuildWithCommitDialog = ({
       fullWidth
       aria-labelledby="build-with-commit-dialog-title"
     >
-      <DialogTitle id="build-with-commit-dialog-title">Build with Specific Commit</DialogTitle>
+      <DialogTitle id="build-with-commit-dialog-title">
+        Build with Specific Commit
+      </DialogTitle>
       <DialogContent className={classes.dialogContent}>
         <Typography variant="body2" className={classes.helperText}>
           Enter the commit SHA to build from a specific commit in your

--- a/plugins/openchoreo-ci/src/components/BuildWithCommitDialog/BuildWithCommitDialog.tsx
+++ b/plugins/openchoreo-ci/src/components/BuildWithCommitDialog/BuildWithCommitDialog.tsx
@@ -96,8 +96,14 @@ export const BuildWithCommitDialog = ({
   const isValid = commitSha.trim() && !validateCommitSha(commitSha.trim());
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Build with Specific Commit</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="build-with-commit-dialog-title"
+    >
+      <DialogTitle id="build-with-commit-dialog-title">Build with Specific Commit</DialogTitle>
       <DialogContent className={classes.dialogContent}>
         <Typography variant="body2" className={classes.helperText}>
           Enter the commit SHA to build from a specific commit in your

--- a/plugins/openchoreo-ci/src/components/BuildWithParamsDialog/BuildWithParamsDialog.tsx
+++ b/plugins/openchoreo-ci/src/components/BuildWithParamsDialog/BuildWithParamsDialog.tsx
@@ -499,8 +499,14 @@ export const BuildWithParamsDialog = ({
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
-      <DialogTitle disableTypography>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="build-with-params-dialog-title"
+    >
+      <DialogTitle disableTypography id="build-with-params-dialog-title">
         <Typography variant="h4">Build with Custom Parameters</Typography>
       </DialogTitle>
       <DialogContent className={classes.dialogContent}>

--- a/plugins/openchoreo-ci/src/components/WorkflowConfigPage/WorkflowConfigPage.tsx
+++ b/plugins/openchoreo-ci/src/components/WorkflowConfigPage/WorkflowConfigPage.tsx
@@ -498,7 +498,9 @@ export const WorkflowConfigPage = ({
         fullWidth
         aria-labelledby="workflow-config-confirm-dialog-title"
       >
-        <DialogTitle id="workflow-config-confirm-dialog-title">Confirm Changes</DialogTitle>
+        <DialogTitle id="workflow-config-confirm-dialog-title">
+          Confirm Changes
+        </DialogTitle>
         <DialogContent>
           <ChangesPreview changes={changes} />
           {error && (

--- a/plugins/openchoreo-ci/src/components/WorkflowConfigPage/WorkflowConfigPage.tsx
+++ b/plugins/openchoreo-ci/src/components/WorkflowConfigPage/WorkflowConfigPage.tsx
@@ -496,8 +496,9 @@ export const WorkflowConfigPage = ({
         onClose={handleCancelSave}
         maxWidth="sm"
         fullWidth
+        aria-labelledby="workflow-config-confirm-dialog-title"
       >
-        <DialogTitle>Confirm Changes</DialogTitle>
+        <DialogTitle id="workflow-config-confirm-dialog-title">Confirm Changes</DialogTitle>
         <DialogContent>
           <ChangesPreview changes={changes} />
           {error && (

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/LogsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/LogsTable.tsx
@@ -158,8 +158,13 @@ export const LogsTable: FC<LogsTableProps> = ({
                 <TableCell colSpan={totalColumns}>
                   <div className={classes.loadingContainer} ref={loadingRef}>
                     {loading ? (
-                      <Box display="flex" alignItems="center">
-                        <CircularProgress size={20} />
+                      <Box
+                        display="flex"
+                        alignItems="center"
+                        role="status"
+                        aria-busy="true"
+                      >
+                        <CircularProgress size={20} aria-hidden="true" />
                         <Typography variant="body2" style={{ marginLeft: 8 }}>
                           Loading more logs...
                         </Typography>

--- a/plugins/openchoreo-observability/src/components/TimeRangeFilter/TimeRangeFilter.tsx
+++ b/plugins/openchoreo-observability/src/components/TimeRangeFilter/TimeRangeFilter.tsx
@@ -194,6 +194,7 @@ export const TimeRangeFilter: FC<TimeRangeFilterProps> = ({
           value={triggerLabel}
           onClick={openDropdown}
           InputLabelProps={{ shrink: true }}
+          inputProps={{ 'aria-label': 'Time Range' }}
           InputProps={{
             readOnly: true,
             classes: { root: classes.trigger },

--- a/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.tsx
+++ b/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.tsx
@@ -188,7 +188,9 @@ const SchemaContentDialog: FC<{
       fullWidth
       aria-labelledby="endpoint-editor-dialog-title"
     >
-      <DialogTitle id="endpoint-editor-dialog-title">Edit Schema Content</DialogTitle>
+      <DialogTitle id="endpoint-editor-dialog-title">
+        Edit Schema Content
+      </DialogTitle>
       <DialogContent>
         <div
           className={

--- a/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.tsx
+++ b/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.tsx
@@ -181,8 +181,14 @@ const SchemaContentDialog: FC<{
   }, [schemaType]);
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>Edit Schema Content</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="endpoint-editor-dialog-title"
+    >
+      <DialogTitle id="endpoint-editor-dialog-title">Edit Schema Content</DialogTitle>
       <DialogContent>
         <div
           className={

--- a/plugins/openchoreo-react/src/components/LoadingState/LoadingState.tsx
+++ b/plugins/openchoreo-react/src/components/LoadingState/LoadingState.tsx
@@ -1,5 +1,6 @@
 import { Box, CircularProgress, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { VisuallyHidden } from '@openchoreo/backstage-design-system';
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -49,12 +50,19 @@ export const LoadingState = ({
   const classes = useStyles();
 
   return (
-    <Box className={classes.container} style={{ minHeight }}>
-      <CircularProgress size={size} />
-      {message && (
+    <Box
+      className={classes.container}
+      style={{ minHeight }}
+      role="status"
+      aria-busy="true"
+    >
+      <CircularProgress size={size} aria-hidden="true" />
+      {message ? (
         <Typography variant="body2" className={classes.message}>
           {message}
         </Typography>
+      ) : (
+        <VisuallyHidden>Loading</VisuallyHidden>
       )}
     </Box>
   );

--- a/plugins/openchoreo-react/src/components/UnsavedChangesDialog/UnsavedChangesDialog.tsx
+++ b/plugins/openchoreo-react/src/components/UnsavedChangesDialog/UnsavedChangesDialog.tsx
@@ -22,8 +22,14 @@ export const UnsavedChangesDialog: FC<UnsavedChangesDialogProps> = ({
   changeCount,
 }) => {
   return (
-    <Dialog open={open} onClose={onStay} maxWidth="sm" fullWidth>
-      <DialogTitle>Unsaved Changes</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onStay}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="unsaved-changes-dialog-title"
+    >
+      <DialogTitle id="unsaved-changes-dialog-title">Unsaved Changes</DialogTitle>
 
       <DialogContent>
         <Typography variant="body1">

--- a/plugins/openchoreo-react/src/components/UnsavedChangesDialog/UnsavedChangesDialog.tsx
+++ b/plugins/openchoreo-react/src/components/UnsavedChangesDialog/UnsavedChangesDialog.tsx
@@ -29,7 +29,9 @@ export const UnsavedChangesDialog: FC<UnsavedChangesDialogProps> = ({
       fullWidth
       aria-labelledby="unsaved-changes-dialog-title"
     >
-      <DialogTitle id="unsaved-changes-dialog-title">Unsaved Changes</DialogTitle>
+      <DialogTitle id="unsaved-changes-dialog-title">
+        Unsaved Changes
+      </DialogTitle>
 
       <DialogContent>
         <Typography variant="body1">

--- a/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
+++ b/plugins/openchoreo-react/src/components/YamlEditor/YamlEditor.tsx
@@ -127,12 +127,17 @@ export function YamlEditor({
 
   // @uiw/react-codemirror sets tabindex="-1" on .cm-scroller, which axe flags
   // as a non-focusable scrollable region. Promote it to tabindex="0" so
-  // keyboard users can Tab into the editor.
+  // keyboard users can Tab into the editor. The .cm-content contenteditable
+  // also gets an aria-label so it carries an accessible name.
   const containerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const scroller = containerRef.current?.querySelector('.cm-scroller');
     if (scroller && scroller.getAttribute('tabindex') !== '0') {
       scroller.setAttribute('tabindex', '0');
+    }
+    const cmContent = containerRef.current?.querySelector('.cm-content');
+    if (cmContent && !cmContent.getAttribute('aria-label')) {
+      cmContent.setAttribute('aria-label', 'YAML editor');
     }
   }, [content]);
 

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/BindingDetailDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/BindingDetailDialog.tsx
@@ -180,8 +180,14 @@ export const BindingDetailDialog = ({
   const isSystem = binding.labels?.[CHOREO_LABELS.SYSTEM] === 'true';
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle disableTypography>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="binding-detail-dialog-title"
+    >
+      <DialogTitle disableTypography id="binding-detail-dialog-title">
         <Typography variant="h4">{binding.name}</Typography>
       </DialogTitle>
       <DialogContent>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/ClusterRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/ClusterRoleBindingsContent.tsx
@@ -580,7 +580,10 @@ export const ClusterRoleBindingsContent = ({
         onClose={() => setDeleteConfirmOpen(false)}
         aria-labelledby="cluster-role-bindings-delete-dialog-title"
       >
-        <DialogTitle disableTypography id="cluster-role-bindings-delete-dialog-title">
+        <DialogTitle
+          disableTypography
+          id="cluster-role-bindings-delete-dialog-title"
+        >
           <Typography variant="h4">Delete Cluster Role Binding</Typography>
         </DialogTitle>
         <DialogContent>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/ClusterRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/ClusterRoleBindingsContent.tsx
@@ -578,8 +578,9 @@ export const ClusterRoleBindingsContent = ({
       <Dialog
         open={deleteConfirmOpen}
         onClose={() => setDeleteConfirmOpen(false)}
+        aria-labelledby="cluster-role-bindings-delete-dialog-title"
       >
-        <DialogTitle disableTypography>
+        <DialogTitle disableTypography id="cluster-role-bindings-delete-dialog-title">
           <Typography variant="h4">Delete Cluster Role Binding</Typography>
         </DialogTitle>
         <DialogContent>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
@@ -654,8 +654,9 @@ export const NamespaceRoleBindingsContent = ({
       <Dialog
         open={deleteConfirmOpen}
         onClose={() => setDeleteConfirmOpen(false)}
+        aria-labelledby="namespace-role-bindings-delete-dialog-title"
       >
-        <DialogTitle disableTypography>
+        <DialogTitle disableTypography id="namespace-role-bindings-delete-dialog-title">
           <Typography variant="h4">Delete Namespace Role Binding</Typography>
         </DialogTitle>
         <DialogContent>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/NamespaceRoleBindingsContent.tsx
@@ -656,7 +656,10 @@ export const NamespaceRoleBindingsContent = ({
         onClose={() => setDeleteConfirmOpen(false)}
         aria-labelledby="namespace-role-bindings-delete-dialog-title"
       >
-        <DialogTitle disableTypography id="namespace-role-bindings-delete-dialog-title">
+        <DialogTitle
+          disableTypography
+          id="namespace-role-bindings-delete-dialog-title"
+        >
           <Typography variant="h4">Delete Namespace Role Binding</Typography>
         </DialogTitle>
         <DialogContent>

--- a/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/RoleMappingDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/MappingsTab/wizard/RoleMappingDialog.tsx
@@ -272,8 +272,13 @@ export const RoleMappingDialog = ({
       maxWidth="md"
       fullWidth
       classes={{ paper: classes.dialogPaper }}
+      aria-labelledby="role-mapping-dialog-title"
     >
-      <DialogTitle disableTypography className={classes.dialogTitle}>
+      <DialogTitle
+        disableTypography
+        className={classes.dialogTitle}
+        id="role-mapping-dialog-title"
+      >
         <Typography variant="h4">
           {isEdit ? 'Edit Role Mapping' : 'Add Role Mapping'}
         </Typography>

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/ActionSelectionDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/ActionSelectionDialog.tsx
@@ -215,8 +215,14 @@ export const ActionSelectionDialog = ({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="action-selection-dialog-title"
+    >
+      <DialogTitle id="action-selection-dialog-title">
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <span>Select Actions</span>
           <Typography variant="body2" className={classes.selectionCount}>

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
@@ -368,8 +368,14 @@ export const RoleDialog = ({
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-        <DialogTitle disableTypography>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        maxWidth="sm"
+        fullWidth
+        aria-labelledby="role-dialog-title"
+      >
+        <DialogTitle disableTypography id="role-dialog-title">
           <Typography variant="h4">
             {editingRole ? (
               <>

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
@@ -258,8 +258,10 @@ export const RolesTable = ({
                 alignItems="center"
                 style={{ gap: 16 }}
                 py={2}
+                role="status"
+                aria-busy="true"
               >
-                <CircularProgress size={24} />
+                <CircularProgress size={24} aria-hidden="true" />
                 <Typography>Checking for role bindings...</Typography>
               </Box>
             </DialogContent>

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
@@ -246,10 +246,11 @@ export const RolesTable = ({
         onClose={closeDeleteDialog}
         maxWidth="sm"
         fullWidth
+        aria-labelledby="roles-delete-dialog-title"
       >
         {checkingBindings && (
           <>
-            <DialogTitle disableTypography>
+            <DialogTitle disableTypography id="roles-delete-dialog-title">
               <Typography variant="h6">Checking {scopeLabel} Usage</Typography>
             </DialogTitle>
             <DialogContent>
@@ -269,7 +270,7 @@ export const RolesTable = ({
         )}
         {!checkingBindings && activeBindings.length > 0 && (
           <>
-            <DialogTitle disableTypography>
+            <DialogTitle disableTypography id="roles-delete-dialog-title">
               <Box className={classes.warningHeader}>
                 <WarningIcon className={classes.warningIcon} />
                 <Typography variant="h4" component="span">
@@ -312,7 +313,7 @@ export const RolesTable = ({
         )}
         {!checkingBindings && activeBindings.length === 0 && (
           <>
-            <DialogTitle disableTypography>
+            <DialogTitle disableTypography id="roles-delete-dialog-title">
               <Typography variant="h4">Delete {scopeLabel}</Typography>
             </DialogTitle>
             <DialogContent>

--- a/plugins/openchoreo/src/components/Environments/DeleteConfirmationDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/DeleteConfirmationDialog.tsx
@@ -100,8 +100,14 @@ export const DeleteConfirmationDialog: FC<DeleteConfirmationDialogProps> = ({
   };
 
   return (
-    <Dialog open={open} onClose={onCancel} maxWidth="sm" fullWidth>
-      <DialogTitle disableTypography>
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="delete-overrides-dialog-title"
+    >
+      <DialogTitle disableTypography id="delete-overrides-dialog-title">
         <Typography variant="h4">Delete Overrides?</Typography>
       </DialogTitle>
 

--- a/plugins/openchoreo/src/components/Environments/SaveConfirmationDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/SaveConfirmationDialog.tsx
@@ -70,8 +70,14 @@ export const SaveConfirmationDialog: FC<SaveConfirmationDialogProps> = ({
   }, [changes]);
 
   return (
-    <Dialog open={open} onClose={onCancel} maxWidth="md" fullWidth>
-      <DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="save-confirmation-dialog-title"
+    >
+      <DialogTitle id="save-confirmation-dialog-title">
         Confirm Save Changes ({totalChanges}{' '}
         {totalChanges === 1 ? 'change' : 'changes'})
       </DialogTitle>

--- a/plugins/openchoreo/src/components/Environments/Workload/WorkloadSaveConfirmationDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/Workload/WorkloadSaveConfirmationDialog.tsx
@@ -159,8 +159,14 @@ export const WorkloadSaveConfirmationDialog: FC<
   const hasComponentChanges = componentSections.length > 0;
 
   return (
-    <Dialog open={open} onClose={onCancel} maxWidth="md" fullWidth>
-      <DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="workload-save-confirmation-dialog-title"
+    >
+      <DialogTitle id="workload-save-confirmation-dialog-title">
         Confirm Save Changes ({totalChanges}{' '}
         {totalChanges === 1 ? 'change' : 'changes'})
       </DialogTitle>

--- a/plugins/openchoreo/src/components/Environments/components/AutoDeployConfirmationDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/AutoDeployConfirmationDialog.tsx
@@ -20,8 +20,14 @@ export const AutoDeployConfirmationDialog: FC<
   AutoDeployConfirmationDialogProps
 > = ({ open, onCancel, onConfirm, isEnabling, isUpdating }) => {
   return (
-    <Dialog open={open} onClose={onCancel} maxWidth="sm" fullWidth>
-      <DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="auto-deploy-confirmation-dialog-title"
+    >
+      <DialogTitle id="auto-deploy-confirmation-dialog-title">
         {isEnabling ? 'Enable' : 'Disable'} Auto Deploy?
       </DialogTitle>
 

--- a/plugins/openchoreo/src/components/Environments/components/ComponentReleaseDiffDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/ComponentReleaseDiffDialog.tsx
@@ -126,8 +126,14 @@ export const ComponentReleaseDiffDialog = ({
   ]);
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
-      <DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      aria-labelledby="component-release-diff-dialog-title"
+    >
+      <DialogTitle id="component-release-diff-dialog-title">
         Release diff — {upstreamEnvName} → {environmentName}
       </DialogTitle>
       <DialogContent dividers>

--- a/plugins/openchoreo/src/components/Environments/components/CreateReleaseDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/CreateReleaseDialog.tsx
@@ -120,8 +120,9 @@ export const CreateReleaseDialog = ({
       onClose={submitting ? undefined : onClose}
       maxWidth="sm"
       fullWidth
+      aria-labelledby="create-release-dialog-title"
     >
-      <DialogTitle>Create release</DialogTitle>
+      <DialogTitle id="create-release-dialog-title">Create release</DialogTitle>
       <DialogContent dividers>
         <Typography variant="body2" color="textSecondary" gutterBottom>
           A release captures an immutable snapshot of the current workload,

--- a/plugins/openchoreo/src/components/Environments/components/InvokeUrlsDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/InvokeUrlsDialog.tsx
@@ -107,8 +107,14 @@ export const InvokeUrlsDialog = ({
   endpoints,
 }: InvokeUrlsDialogProps) => {
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Endpoint URLs</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="invoke-urls-dialog-title"
+    >
+      <DialogTitle id="invoke-urls-dialog-title">Endpoint URLs</DialogTitle>
       <DialogContent dividers>
         {endpoints.length === 0 ? (
           <Typography variant="body2" color="textSecondary">

--- a/plugins/openchoreo/src/components/Environments/components/MiniEnvironmentNode.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/MiniEnvironmentNode.test.tsx
@@ -317,8 +317,12 @@ describe('MiniEnvironmentNode', () => {
 
   it('marks the card as selected via class name when selected', () => {
     renderNode({ selected: true });
-    const card = screen.getByLabelText('Select environment staging');
-    expect(card.className).toMatch(/cardSelected/);
+    // The "Select environment X" label sits on the inner name button; the
+    // selected-state class lives on the outer card wrapper.
+    const card = screen
+      .getByLabelText('Select environment staging')
+      .closest('[class*="card"]');
+    expect(card?.className).toMatch(/cardSelected/);
   });
 
   it('does not list Undeploy in the overflow menu', async () => {
@@ -412,10 +416,12 @@ describe('MiniEnvironmentNode', () => {
     renderNode({
       environment: makeEnv({ name: 'staging' }),
     });
-    // The icon is decorative (aria-hidden); the env name is the
-    // accessible label. Just confirm an SVG sits next to the name.
-    const card = screen.getByLabelText('Select environment staging');
-    expect(card.querySelectorAll('svg').length).toBeGreaterThan(0);
+    // The icon is decorative (aria-hidden); the env name is the accessible
+    // label. The icon lives next to the name inside the outer card wrapper.
+    const card = screen
+      .getByLabelText('Select environment staging')
+      .closest('[class*="card"]');
+    expect(card?.querySelectorAll('svg').length ?? 0).toBeGreaterThan(0);
   });
 
   it('renders a StatusBadge with the env status variant', () => {

--- a/plugins/openchoreo/src/components/Environments/components/MiniEnvironmentNode.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/MiniEnvironmentNode.tsx
@@ -202,18 +202,8 @@ export const MiniEnvironmentNode = ({
 
   return (
     <Box
-      role="button"
-      tabIndex={0}
-      aria-pressed={selected}
-      aria-label={`Select environment ${environment.name}`}
       className={clsx(classes.card, { [classes.cardSelected]: selected })}
       onClick={onSelect}
-      onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onSelect();
-        }
-      }}
     >
       <Box display="flex" height="100%" minWidth={0}>
         <Box
@@ -241,9 +231,20 @@ export const MiniEnvironmentNode = ({
                 disableHoverListener={environment.name.length < 20}
                 PopperProps={{ disablePortal: true }}
               >
-                <Typography className={classes.name}>
+                <button
+                  type="button"
+                  className={classes.nameButton}
+                  aria-pressed={selected}
+                  aria-label={`Select environment ${environment.name}`}
+                  onClick={e => {
+                    // Outer Box also has onClick; stop here so we don't
+                    // double-fire onSelect.
+                    e.stopPropagation();
+                    onSelect();
+                  }}
+                >
                   {environment.name}
-                </Typography>
+                </button>
               </Tooltip>
             </Box>
             <Tooltip title="More actions" PopperProps={{ disablePortal: true }}>

--- a/plugins/openchoreo/src/components/Environments/components/ReleaseBrowserDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/ReleaseBrowserDialog.tsx
@@ -470,8 +470,14 @@ export const ReleaseBrowserDialog = ({
     compareOptions.find(o => o.releaseName === compareTargetName) ?? null;
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
-      <DialogTitle disableTypography>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      aria-labelledby="release-browser-dialog-title"
+    >
+      <DialogTitle disableTypography id="release-browser-dialog-title">
         <Box className={classes.titleBar}>
           <Typography variant="h6" className={classes.titleText}>
             {readOnly ? 'Releases' : 'Select release'}

--- a/plugins/openchoreo/src/components/Environments/components/ReleaseManifestDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/ReleaseManifestDialog.tsx
@@ -86,8 +86,14 @@ export const ReleaseManifestDialog = ({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>Release manifest — {environmentName}</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="release-manifest-dialog-title"
+    >
+      <DialogTitle id="release-manifest-dialog-title">Release manifest — {environmentName}</DialogTitle>
       <DialogContent dividers>
         {!releaseName && (
           <Typography variant="body2" color="textSecondary">

--- a/plugins/openchoreo/src/components/Environments/components/ReleaseManifestDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/ReleaseManifestDialog.tsx
@@ -93,7 +93,9 @@ export const ReleaseManifestDialog = ({
       fullWidth
       aria-labelledby="release-manifest-dialog-title"
     >
-      <DialogTitle id="release-manifest-dialog-title">Release manifest — {environmentName}</DialogTitle>
+      <DialogTitle id="release-manifest-dialog-title">
+        Release manifest — {environmentName}
+      </DialogTitle>
       <DialogContent dividers>
         {!releaseName && (
           <Typography variant="body2" color="textSecondary">

--- a/plugins/openchoreo/src/components/Environments/components/RemoveDeploymentConfirmationDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/RemoveDeploymentConfirmationDialog.tsx
@@ -36,7 +36,9 @@ export const RemoveDeploymentConfirmationDialog: FC<
       fullWidth
       aria-labelledby="remove-deployment-confirmation-dialog-title"
     >
-      <DialogTitle id="remove-deployment-confirmation-dialog-title">Remove deployment from {environmentName}?</DialogTitle>
+      <DialogTitle id="remove-deployment-confirmation-dialog-title">
+        Remove deployment from {environmentName}?
+      </DialogTitle>
 
       <DialogContent dividers>
         <Typography variant="body2" color="textSecondary" paragraph>

--- a/plugins/openchoreo/src/components/Environments/components/RemoveDeploymentConfirmationDialog.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/RemoveDeploymentConfirmationDialog.tsx
@@ -34,8 +34,9 @@ export const RemoveDeploymentConfirmationDialog: FC<
       disableEscapeKeyDown={isRemoving}
       maxWidth="sm"
       fullWidth
+      aria-labelledby="remove-deployment-confirmation-dialog-title"
     >
-      <DialogTitle>Remove deployment from {environmentName}?</DialogTitle>
+      <DialogTitle id="remove-deployment-confirmation-dialog-title">Remove deployment from {environmentName}?</DialogTitle>
 
       <DialogContent dividers>
         <Typography variant="body2" color="textSecondary" paragraph>

--- a/plugins/openchoreo/src/components/Environments/styles.ts
+++ b/plugins/openchoreo/src/components/Environments/styles.ts
@@ -239,6 +239,29 @@ export const useMiniEnvironmentNodeStyles = makeStyles(theme => ({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
+  // Real-button version of `.name` used to make the environment selectable
+  // by keyboard without nesting interactive elements inside an outer button.
+  nameButton: {
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    margin: 0,
+    cursor: 'pointer',
+    color: 'inherit',
+    font: 'inherit',
+    textAlign: 'inherit',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    fontWeight: 600,
+    fontSize: '0.95rem',
+    lineHeight: 1.2,
+    '&:focus-visible': {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: 2,
+      borderRadius: 2,
+    },
+  },
   metaRow: {
     display: 'flex',
     alignItems: 'center',

--- a/plugins/openchoreo/src/components/Environments/styles.ts
+++ b/plugins/openchoreo/src/components/Environments/styles.ts
@@ -250,6 +250,11 @@ export const useMiniEnvironmentNodeStyles = makeStyles(theme => ({
     color: 'inherit',
     font: 'inherit',
     textAlign: 'inherit',
+    // <button> has an intrinsic min-content width; allow it to shrink in
+    // the flex `nameWrap` so `text-overflow: ellipsis` can take effect on
+    // long environment names.
+    minWidth: 0,
+    flex: '1 1 auto',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',

--- a/plugins/openchoreo/src/components/Environments/styles.ts
+++ b/plugins/openchoreo/src/components/Environments/styles.ts
@@ -315,10 +315,16 @@ export const useMiniEnvironmentNodeStyles = makeStyles(theme => ({
     flexWrap: 'wrap',
   },
   menuButton: {
-    padding: theme.spacing(0.25),
+    // WCAG 2.2 SC 2.5.8 target-size: ensure ≥24x24 effective hit area.
+    // With a 16px icon, 4px padding gives a 24x24 button.
+    padding: theme.spacing(0.5),
+    minWidth: 24,
+    minHeight: 24,
   },
   primaryButton: {
     textTransform: 'none',
+    // WCAG 2.2 SC 2.5.8 target-size for the small "Promote" button.
+    minHeight: 24,
   },
 }));
 

--- a/plugins/openchoreo/src/components/Projects/OverviewCards/ChangePipelineDialog.tsx
+++ b/plugins/openchoreo/src/components/Projects/OverviewCards/ChangePipelineDialog.tsx
@@ -115,8 +115,14 @@ export const ChangePipelineDialog = ({
   const noPipelines = !loading && pipelines.length === 0;
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogTitle>Change Deployment Pipeline</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      aria-labelledby="change-pipeline-dialog-title"
+    >
+      <DialogTitle id="change-pipeline-dialog-title">Change Deployment Pipeline</DialogTitle>
       <DialogContent>
         <TextField
           select

--- a/plugins/openchoreo/src/components/Projects/OverviewCards/ChangePipelineDialog.tsx
+++ b/plugins/openchoreo/src/components/Projects/OverviewCards/ChangePipelineDialog.tsx
@@ -122,7 +122,9 @@ export const ChangePipelineDialog = ({
       maxWidth="sm"
       aria-labelledby="change-pipeline-dialog-title"
     >
-      <DialogTitle id="change-pipeline-dialog-title">Change Deployment Pipeline</DialogTitle>
+      <DialogTitle id="change-pipeline-dialog-title">
+        Change Deployment Pipeline
+      </DialogTitle>
       <DialogContent>
         <TextField
           select

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceOutputsDialog.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceOutputsDialog.tsx
@@ -140,7 +140,9 @@ export const ResourceOutputsDialog = ({
       fullWidth
       aria-labelledby="resource-outputs-dialog-title"
     >
-      <DialogTitle id="resource-outputs-dialog-title">Outputs — {environmentName}</DialogTitle>
+      <DialogTitle id="resource-outputs-dialog-title">
+        Outputs — {environmentName}
+      </DialogTitle>
       <DialogContent dividers>
         {outputs.length === 0 ? (
           <Typography variant="body2" className={classes.emptyText}>

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceOutputsDialog.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceOutputsDialog.tsx
@@ -133,8 +133,14 @@ export const ResourceOutputsDialog = ({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>Outputs — {environmentName}</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="resource-outputs-dialog-title"
+    >
+      <DialogTitle id="resource-outputs-dialog-title">Outputs — {environmentName}</DialogTitle>
       <DialogContent dividers>
         {outputs.length === 0 ? (
           <Typography variant="body2" className={classes.emptyText}>

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceReleaseManifestDialog.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceReleaseManifestDialog.tsx
@@ -87,8 +87,14 @@ export const ResourceReleaseManifestDialog = ({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>Release manifest — {environmentName}</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="resource-release-manifest-dialog-title"
+    >
+      <DialogTitle id="resource-release-manifest-dialog-title">Release manifest — {environmentName}</DialogTitle>
       <DialogContent dividers>
         {!releaseName && (
           <Typography variant="body2" color="textSecondary">

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceReleaseManifestDialog.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceReleaseManifestDialog.tsx
@@ -94,7 +94,9 @@ export const ResourceReleaseManifestDialog = ({
       fullWidth
       aria-labelledby="resource-release-manifest-dialog-title"
     >
-      <DialogTitle id="resource-release-manifest-dialog-title">Release manifest — {environmentName}</DialogTitle>
+      <DialogTitle id="resource-release-manifest-dialog-title">
+        Release manifest — {environmentName}
+      </DialogTitle>
       <DialogContent dividers>
         {!releaseName && (
           <Typography variant="body2" color="textSecondary">

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceRemoveDeploymentDialog.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceRemoveDeploymentDialog.tsx
@@ -39,8 +39,9 @@ export const ResourceRemoveDeploymentDialog: FC<
       disableEscapeKeyDown={isRemoving}
       maxWidth="sm"
       fullWidth
+      aria-labelledby="resource-remove-deployment-dialog-title"
     >
-      <DialogTitle>Remove deployment from {environmentName}?</DialogTitle>
+      <DialogTitle id="resource-remove-deployment-dialog-title">Remove deployment from {environmentName}?</DialogTitle>
 
       <DialogContent dividers>
         <Typography variant="body2" color="textSecondary" paragraph>

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceRemoveDeploymentDialog.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceRemoveDeploymentDialog.tsx
@@ -41,7 +41,9 @@ export const ResourceRemoveDeploymentDialog: FC<
       fullWidth
       aria-labelledby="resource-remove-deployment-dialog-title"
     >
-      <DialogTitle id="resource-remove-deployment-dialog-title">Remove deployment from {environmentName}?</DialogTitle>
+      <DialogTitle id="resource-remove-deployment-dialog-title">
+        Remove deployment from {environmentName}?
+      </DialogTitle>
 
       <DialogContent dividers>
         <Typography variant="body2" color="textSecondary" paragraph>

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceRetainPolicySwitchDialog.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceRetainPolicySwitchDialog.tsx
@@ -34,8 +34,9 @@ export const ResourceRetainPolicySwitchDialog: FC<
       disableEscapeKeyDown={isUpdating}
       maxWidth="sm"
       fullWidth
+      aria-labelledby="resource-retain-policy-switch-dialog-title"
     >
-      <DialogTitle>Switch retain policy to Delete?</DialogTitle>
+      <DialogTitle id="resource-retain-policy-switch-dialog-title">Switch retain policy to Delete?</DialogTitle>
 
       <DialogContent dividers>
         <Typography variant="body2" color="textSecondary">

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceRetainPolicySwitchDialog.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceRetainPolicySwitchDialog.tsx
@@ -36,7 +36,9 @@ export const ResourceRetainPolicySwitchDialog: FC<
       fullWidth
       aria-labelledby="resource-retain-policy-switch-dialog-title"
     >
-      <DialogTitle id="resource-retain-policy-switch-dialog-title">Switch retain policy to Delete?</DialogTitle>
+      <DialogTitle id="resource-retain-policy-switch-dialog-title">
+        Switch retain policy to Delete?
+      </DialogTitle>
 
       <DialogContent dividers>
         <Typography variant="body2" color="textSecondary">

--- a/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
+++ b/plugins/openchoreo/src/components/Secrets/CreateSecretDialog.tsx
@@ -782,8 +782,9 @@ export const CreateSecretDialog = ({
       onClose={loading ? undefined : onClose}
       maxWidth="sm"
       fullWidth
+      aria-labelledby="create-secret-dialog-title"
     >
-      <DialogTitle disableTypography>
+      <DialogTitle disableTypography id="create-secret-dialog-title">
         <Typography variant="h4">Create Secret</Typography>
         <Typography variant="body2" color="textSecondary">
           Create a new secret in namespace <strong>{namespaceName}</strong>.

--- a/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
+++ b/plugins/openchoreo/src/components/Secrets/SecretsTable.tsx
@@ -306,8 +306,9 @@ export const SecretsTable = ({
         onClose={handleDeleteCancel}
         maxWidth="sm"
         fullWidth
+        aria-labelledby="delete-secret-dialog-title"
       >
-        <DialogTitle disableTypography>
+        <DialogTitle disableTypography id="delete-secret-dialog-title">
           <Typography variant="h4">Delete Secret</Typography>
         </DialogTitle>
         <DialogContent>

--- a/plugins/openchoreo/src/components/Traits/AddTraitDialog.tsx
+++ b/plugins/openchoreo/src/components/Traits/AddTraitDialog.tsx
@@ -404,8 +404,18 @@ export const AddTraitDialog: React.FC<AddTraitDialogProps> = ({
 
         {/* Loading Schema */}
         {loadingSchema && (
-          <Box display="flex" alignItems="center" mt={2}>
-            <CircularProgress size={20} style={{ marginRight: 8 }} />
+          <Box
+            display="flex"
+            alignItems="center"
+            mt={2}
+            role="status"
+            aria-busy="true"
+          >
+            <CircularProgress
+              size={20}
+              style={{ marginRight: 8 }}
+              aria-hidden="true"
+            />
             <Typography variant="body2">Loading trait schema...</Typography>
           </Box>
         )}

--- a/plugins/openchoreo/src/components/Traits/AddTraitDialog.tsx
+++ b/plugins/openchoreo/src/components/Traits/AddTraitDialog.tsx
@@ -366,8 +366,14 @@ export const AddTraitDialog: React.FC<AddTraitDialogProps> = ({
     yamlValid;
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
-      <DialogTitle>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="add-trait-dialog-title"
+    >
+      <DialogTitle id="add-trait-dialog-title">
         <Typography variant="h4">Add Trait</Typography>
       </DialogTitle>
       <DialogContent dividers className={classes.dialogContent}>

--- a/plugins/openchoreo/src/components/Traits/EditTraitDialog.tsx
+++ b/plugins/openchoreo/src/components/Traits/EditTraitDialog.tsx
@@ -322,7 +322,9 @@ export const EditTraitDialog: React.FC<EditTraitDialogProps> = ({
       fullWidth
       aria-labelledby="edit-trait-dialog-title"
     >
-      <DialogTitle id="edit-trait-dialog-title">Edit Trait: {trait.name}</DialogTitle>
+      <DialogTitle id="edit-trait-dialog-title">
+        Edit Trait: {trait.name}
+      </DialogTitle>
       <DialogContent dividers className={classes.dialogContent}>
         {error && (
           <Typography variant="body2" color="error" gutterBottom>

--- a/plugins/openchoreo/src/components/Traits/EditTraitDialog.tsx
+++ b/plugins/openchoreo/src/components/Traits/EditTraitDialog.tsx
@@ -315,8 +315,14 @@ export const EditTraitDialog: React.FC<EditTraitDialogProps> = ({
   }
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
-      <DialogTitle>Edit Trait: {trait.name}</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      aria-labelledby="edit-trait-dialog-title"
+    >
+      <DialogTitle id="edit-trait-dialog-title">Edit Trait: {trait.name}</DialogTitle>
       <DialogContent dividers className={classes.dialogContent}>
         {error && (
           <Typography variant="body2" color="error" gutterBottom>

--- a/plugins/openchoreo/src/components/Traits/EditTraitDialog.tsx
+++ b/plugins/openchoreo/src/components/Traits/EditTraitDialog.tsx
@@ -326,8 +326,18 @@ export const EditTraitDialog: React.FC<EditTraitDialogProps> = ({
 
         {/* Loading Schema */}
         {loadingSchema && (
-          <Box display="flex" alignItems="center" mt={2}>
-            <CircularProgress size={20} style={{ marginRight: 8 }} />
+          <Box
+            display="flex"
+            alignItems="center"
+            mt={2}
+            role="status"
+            aria-busy="true"
+          >
+            <CircularProgress
+              size={20}
+              style={{ marginRight: 8 }}
+              aria-hidden="true"
+            />
             <Typography variant="body2">Loading trait schema...</Typography>
           </Box>
         )}


### PR DESCRIPTION
  Phase 2 of the accessibility roadmap from the audit on `acessbility-audit`. Picks up
  the systemic findings that need real refactors rather than single-line attribute
  additions.
  
  Related https://github.com/openchoreo/openchoreo/issues/3586

  ### Changes

  0. **`VisuallyHidden` design-system component** — extracted from Phase 1 inlines so
  future a11y work has a shared util.
  1. **Deploy-view environment cards** — removed nested-interactive: outer `<Box
  role="button">` becomes a plain region, environment name becomes a real `<button>`
  sibling to Actions / Promote.
  2. **Create-page template cards** — same pattern: outer `<Box>` no longer a button,
  "Use template X" is a real button rendered from the title.
  3. **Autocomplete / Checkbox / CodeMirror accessible names** — `aria-label` on Time
  Range, scaffolder checkboxes, and `.cm-content` contenteditable.
  4. **Touch-target sizing** on Deploy IconButtons — bumped to ≥ 24×24 (WCAG 2.2 SC
  2.5.8).
  5. ~~Form error `aria-describedby` / `aria-invalid`~~ — skipped; MUI v4 wires this
  implicitly when `error` + `helperText` are both set.
  6. **Loading announcements** — `role="status" aria-busy="true"` + visually-hidden
  "Loading" label on gating `CircularProgress` instances (shared `LoadingState` + a few
  bespoke loaders).
  7. **`aria-labelledby` on Dialogs** — codemod across 33 components.
  8. **`StatusBadge.showIcon` prop** — optional icon glyph per variant for stronger
  non-colour differentiation (opt-in, default unchanged).

  ### Verified

  - `yarn tsc` passes.
  - VisuallyHidden refactor preserves entity h1;
   Deploy + Create card refactors eliminate nested-interactive (`hasNestedButtons: 0` on
   outer card); Time Range input carries `aria-label`; Dialog `aria-labelledby` resolves
   to existing DialogTitle id.
  - Lighthouse a11y (light mode): `/create` **94 → 100**; Deploy view **94 → 95**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `VisuallyHidden` component for improved screen reader accessibility
  * `StatusBadge` now supports optional variant-specific icons

* **Improvements**
  * Enhanced accessibility across dialogs and form controls with proper ARIA labels and attributes
  * Improved keyboard navigation and focus indicators throughout the application
  * Better semantic HTML structure for screen readers and assistive technologies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->