### PR TITLE
fix(observability): display memory metrics in IEC binary units instead of SI units

### DIFF
--- a/plugins/openchoreo-observability/src/components/Metrics/MetricGraphByComponent.tsx
+++ b/plugins/openchoreo-observability/src/components/Metrics/MetricGraphByComponent.tsx
@@ -21,6 +21,7 @@ import {
   formatTooltipTime,
   formatMetricValue,
   calculateTimeDomain,
+  calculateMemoryYAxis,
   transformMetricsData,
   getMetricConfigs,
   getLineOpacity,
@@ -67,6 +68,14 @@ export const MetricGraphByComponent = ({
 
   const metrics = useMemo(() => getMetricConfigs(usageType), [usageType]);
 
+  const memoryYAxis = useMemo(
+    () =>
+      usageType === 'memory'
+        ? calculateMemoryYAxis(usageData as MemoryUsageMetrics)
+        : undefined,
+    [usageType, usageData],
+  );
+
   const handleMouseEnter = (payload: LegendPayload) =>
     setHoveringDataKey(payload.dataKey);
 
@@ -94,6 +103,8 @@ export const MetricGraphByComponent = ({
         <YAxis
           width="auto"
           tickFormatter={v => formatMetricValue(v, usageType)}
+          ticks={memoryYAxis?.ticks}
+          domain={memoryYAxis?.domain}
         />
         <Tooltip
           content={

--- a/plugins/openchoreo-observability/src/components/Metrics/utils.test.ts
+++ b/plugins/openchoreo-observability/src/components/Metrics/utils.test.ts
@@ -7,7 +7,22 @@ import {
   getLineOpacity,
   formatMetricName,
   calculateTimeDomain,
+  calculateMemoryYAxis,
 } from './utils';
+import { MemoryUsageMetrics } from '../../types';
+
+const memoryData = (
+  values: (number | null)[],
+  key: keyof MemoryUsageMetrics = 'memoryUsage',
+): MemoryUsageMetrics => ({
+  memoryUsage: [],
+  memoryRequests: [],
+  memoryLimits: [],
+  [key]: values.map((value, i) => ({
+    timestamp: new Date(2024, 0, 1, 0, i).toISOString(),
+    value,
+  })),
+});
 
 // ---- Tests ----
 
@@ -46,12 +61,16 @@ describe('formatMetricValue', () => {
     expect(formatMetricValue(2.5, 'cpu')).toBe('2.5000');
   });
 
-  it('formats memory in MB', () => {
-    expect(formatMetricValue(5000000, 'memory')).toBe('5.00 MB');
+  it('formats memory in GiB', () => {
+    expect(formatMetricValue(5000000000, 'memory')).toBe('4.66 GiB');
   });
 
-  it('formats memory in KB', () => {
-    expect(formatMetricValue(5000, 'memory')).toBe('5.00 KB');
+  it('formats memory in MiB', () => {
+    expect(formatMetricValue(5000000, 'memory')).toBe('4.77 MiB');
+  });
+
+  it('formats memory in KiB', () => {
+    expect(formatMetricValue(5000, 'memory')).toBe('4.88 KiB');
   });
 
   it('formats memory in bytes', () => {
@@ -355,5 +374,103 @@ describe('formatMetricName', () => {
 
   it('formats latencyP99', () => {
     expect(formatMetricName('latencyP99')).toBe('Latency P99');
+  });
+});
+
+describe('calculateMemoryYAxis', () => {
+  const KiB = 1024;
+  const MiB = KiB * 1024;
+  const GiB = MiB * 1024;
+
+  it('returns undefined when all series are empty', () => {
+    expect(calculateMemoryYAxis(memoryData([]))).toBeUndefined();
+  });
+
+  it('returns undefined when all values are null', () => {
+    expect(calculateMemoryYAxis(memoryData([null, null]))).toBeUndefined();
+  });
+
+  it('returns undefined when max is 0', () => {
+    expect(calculateMemoryYAxis(memoryData([0, 0]))).toBeUndefined();
+  });
+
+  it('picks MiB unit with nice round ticks for pod-scale data', () => {
+    // max ≈ 267 MiB → niceStep = 100 MiB, finalMax = 300 MiB, 4 ticks
+    const result = calculateMemoryYAxis(memoryData([267 * MiB]));
+
+    expect(result).toEqual({
+      ticks: [0, 100 * MiB, 200 * MiB, 300 * MiB],
+      domain: [0, 300 * MiB],
+    });
+  });
+
+  it('picks GiB unit for large pods', () => {
+    // max = 3 GiB → niceStep = 1 GiB, finalMax = 3 GiB, 4 ticks
+    const result = calculateMemoryYAxis(memoryData([3 * GiB]));
+
+    expect(result).toEqual({
+      ticks: [0, GiB, 2 * GiB, 3 * GiB],
+      domain: [0, 3 * GiB],
+    });
+  });
+
+  it('picks KiB unit for small data', () => {
+    // max = 5 KiB → niceStep = 2 KiB, finalMax = 6 KiB, 4 ticks
+    const result = calculateMemoryYAxis(memoryData([5 * KiB]));
+
+    expect(result).toEqual({
+      ticks: [0, 2 * KiB, 4 * KiB, 6 * KiB],
+      domain: [0, 6 * KiB],
+    });
+  });
+
+  it('picks bytes unit for sub-KiB data so ticks stay whole bytes', () => {
+    // max = 500 B → niceStep = 200 B, finalMax = 600 B, 4 ticks
+    const result = calculateMemoryYAxis(memoryData([500]));
+
+    expect(result).toEqual({
+      ticks: [0, 200, 400, 600],
+      domain: [0, 600],
+    });
+  });
+
+  it('takes the max across all series', () => {
+    const data: MemoryUsageMetrics = {
+      memoryUsage: [{ timestamp: 't1', value: 50 * MiB }],
+      memoryRequests: [{ timestamp: 't1', value: 100 * MiB }],
+      memoryLimits: [{ timestamp: 't1', value: 200 * MiB }],
+    };
+    const result = calculateMemoryYAxis(data);
+
+    // max is 200 MiB → niceStep = 50, finalMax = 200, 5 ticks
+    expect(result?.ticks[result.ticks.length - 1]).toBe(200 * MiB);
+    expect(result?.domain[1]).toBe(200 * MiB);
+  });
+
+  it('produces ticks evenly spaced starting at 0', () => {
+    const result = calculateMemoryYAxis(memoryData([150 * MiB]));
+
+    expect(result?.ticks[0]).toBe(0);
+    const step = result!.ticks[1] - result!.ticks[0];
+    for (let i = 1; i < result!.ticks.length; i++) {
+      expect(result!.ticks[i] - result!.ticks[i - 1]).toBe(step);
+    }
+  });
+
+  it('domain max equals the last tick and is >= data max', () => {
+    const dataMax = 137 * MiB;
+    const result = calculateMemoryYAxis(memoryData([dataMax]));
+
+    expect(result?.domain[1]).toBe(result?.ticks[result.ticks.length - 1]);
+    expect(result!.domain[1]).toBeGreaterThanOrEqual(dataMax);
+  });
+
+  it('ignores null values when computing the max', () => {
+    const result = calculateMemoryYAxis(
+      memoryData([null, 100 * MiB, null, 50 * MiB]),
+    );
+
+    // Max is 100 MiB → niceStep = 25, finalMax = 100, 5 ticks
+    expect(result?.domain[1]).toBe(100 * MiB);
   });
 });

--- a/plugins/openchoreo-observability/src/components/Metrics/utils.ts
+++ b/plugins/openchoreo-observability/src/components/Metrics/utils.ts
@@ -61,9 +61,10 @@ export const formatMetricValue = (
     return `${(value * 1000000).toFixed(2)} uCPU`;
   }
   if (usageType === 'memory') {
-    // value is in Bytes
-    if (value > 1000000) return `${(value / 1000000).toFixed(2)} MB`;
-    if (value > 1000) return `${(value / 1000).toFixed(2)} KB`;
+    // value is in Bytes; Kubernetes memory uses IEC binary units
+    if (value >= 1024 ** 3) return `${(value / 1024 ** 3).toFixed(2)} GiB`;
+    if (value >= 1024 ** 2) return `${(value / 1024 ** 2).toFixed(2)} MiB`;
+    if (value >= 1024) return `${(value / 1024).toFixed(2)} KiB`;
     return `${value.toFixed(2)} B`;
   }
   if (usageType === 'networkThroughput') {
@@ -76,6 +77,57 @@ export const formatMetricValue = (
     return `${(value * 1000000).toFixed(2)} us`;
   }
   return value.toFixed(2);
+};
+
+/**
+ * Round x up to the next "nice" number (1, 2, 5 × 10^n).
+ */
+const niceCeil = (x: number): number => {
+  if (x <= 0) return 1;
+  const exp = Math.floor(Math.log10(x));
+  const pow = 10 ** exp;
+  const f = x / pow;
+  let nf: number;
+  if (f <= 1) nf = 1;
+  else if (f <= 2) nf = 2;
+  else if (f <= 5) nf = 5;
+  else nf = 10;
+  return nf * pow;
+};
+
+/**
+ * Compute Y-axis ticks (in bytes) that render as round numbers in the
+ * display unit (KiB/MiB/GiB). Returns undefined when the data has no
+ * positive values, so the caller can fall back to Recharts defaults.
+ */
+export const calculateMemoryYAxis = (
+  usageData: MemoryUsageMetrics,
+): { ticks: number[]; domain: [number, number] } | undefined => {
+  let max = 0;
+  Object.values(usageData).forEach(series => {
+    series.forEach(point => {
+      const v = point.value;
+      if (typeof v === 'number' && v > max) max = v;
+    });
+  });
+  if (max <= 0) return undefined;
+
+  const B = 1;
+  const KiB = 1024;
+  const MiB = KiB * 1024;
+  const GiB = MiB * 1024;
+  let unit: number;
+  if (max >= GiB) unit = GiB;
+  else if (max >= MiB) unit = MiB;
+  else if (max >= KiB) unit = KiB;
+  else unit = B;
+
+  const maxInUnit = max / unit;
+  const niceStep = niceCeil(maxInUnit / 4);
+  const finalMaxInUnit = Math.ceil(maxInUnit / niceStep) * niceStep;
+  const numTicks = Math.round(finalMaxInUnit / niceStep) + 1;
+  const ticks = Array.from({ length: numTicks }, (_, i) => i * niceStep * unit);
+  return { ticks, domain: [0, finalMaxInUnit * unit] };
 };
 
 /**


### PR DESCRIPTION
## Purpose
Fixes https://github.com/openchoreo/openchoreo/issues/3621
Display memory values using IEC binary units instead of SI units

## Approach
- Switched memory formatting from decimal SI units (KB/MB) to IEC binary units (KiB/MiB/GiB) using powers of 1024, matching Kubernetes memory conventions
- Added helper function to compute explicit Y-axis ticks for memory in display units (MiB/GiB), then pass them back to Recharts as bytes. This is so that the formatter then renders clean values. If not, recharts divides the byte values into ticks directly resulting in fractional values in Y-axis
- Updated existing test cases
- Added new test cases (for the helper function)

## UI after change
<img width="1484" height="687" alt="Screenshot 2026-05-27 at 13 54 35" src="https://github.com/user-attachments/assets/db70b626-8d82-4969-9c90-df2ff1a17333" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Memory metrics now display with binary units (GiB, MiB, KiB) for more accurate and standardized representation of memory usage
  * Memory metric charts now feature optimized Y-axis scaling with intelligent tick calculations for improved readability and trend visualization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->