### PR TITLE
feat(authz): add resource.workflow ABAC condition for build triggers

### DIFF
--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -10587,6 +10587,15 @@ components:
               type: string
               description: Target deployment environment (e.g. "dev", "staging", "prod")
               example: dev
+            workflow:
+              type: string
+              description: >-
+                Target workflow, dual-scope encoded the same way as
+                environment: "{namespace}/{name}" for namespace-scoped
+                workflows (Workflow, ComponentWorkflow) or the bare "{name}"
+                for cluster-scoped workflows (ClusterWorkflow). Used by ABAC
+                conditions on `resource.workflow`.
+              example: team-shop/build-go
 
     SubjectContext:
       type: object

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -5357,6 +5357,11 @@ export interface components {
          * @example dev
          */
         environment?: string;
+        /**
+         * @description Target workflow, dual-scope encoded the same way as environment: "{namespace}/{name}" for namespace-scoped workflows (Workflow, ComponentWorkflow) or the bare "{name}" for cluster-scoped workflows (ClusterWorkflow). Used by ABAC conditions on `resource.workflow`.
+         * @example team-shop/build-go
+         */
+        workflow?: string;
       };
     };
     /** @description Authenticated subject context */

--- a/plugins/openchoreo-ci/src/components/Workflows/Workflows.tsx
+++ b/plugins/openchoreo-ci/src/components/Workflows/Workflows.tsx
@@ -74,14 +74,6 @@ export const Workflows = () => {
   const { entity } = useEntity();
   const client = useApi(openChoreoCiClientApiRef);
   const { getEntityDetails } = useComponentEntityDetails();
-  const {
-    canBuild,
-    canView,
-    triggerLoading: permissionLoading,
-    viewLoading,
-    triggerBuildDeniedTooltip: deniedTooltip,
-    viewPermissionName,
-  } = useBuildPermission();
 
   // URL-based routing
   const {
@@ -110,6 +102,19 @@ export const Workflows = () => {
   const workflowKind = workflowData.componentDetails?.componentWorkflow?.kind;
   const entityNamespace =
     entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
+
+  // Trigger-build permission, scoped to the component's workflow so ABAC
+  // `resource.workflow` CEL constraints are honored.
+  const {
+    canBuild,
+    canView,
+    triggerLoading: permissionLoading,
+    viewLoading,
+    triggerBuildDeniedTooltip: deniedTooltip,
+    viewPermissionName,
+  } = useBuildPermission(
+    workflowName ? { name: workflowName, kind: workflowKind } : undefined,
+  );
 
   // Fetch workflow retention TTL from catalog entity
   const retentionTtl = useWorkflowRetention(

--- a/plugins/openchoreo-react/src/hooks/useBuildPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useBuildPermission.test.ts
@@ -172,7 +172,10 @@ describe('useBuildPermission', () => {
     await waitFor(() => expect(result.current.triggerLoading).toBe(false));
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.workflow).toEqual({ name: 'build-go', kind: 'ClusterWorkflow' });
+    expect(body.workflow).toEqual({
+      name: 'build-go',
+      kind: 'ClusterWorkflow',
+    });
   });
 
   it('skips the workflow-eval and uses visibility when authz is disabled', async () => {

--- a/plugins/openchoreo-react/src/hooks/useBuildPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useBuildPermission.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useBuildPermission } from './useBuildPermission';
 
 const mockUsePermission = jest.fn();
@@ -20,10 +20,45 @@ jest.mock('@backstage/catalog-model', () => ({
   stringifyEntityRef: () => 'component:default/test',
 }));
 
-describe('useBuildPermission (Variant C: entity-scoped, multiple permissions)', () => {
+// useBuildPermission routes the trigger-build check through
+// useWorkflowScopedPermission, which reads discovery/fetch APIs and the authz
+// feature flag. Mock them the same way useEnvScopedPermission.test.ts does so
+// the hook can render. Stable API singletons keep useApi referentially stable
+// across renders (the workflow-eval useEffect has them in its dep array).
+const mockGetBaseUrl = jest.fn();
+const mockFetch = jest.fn();
+const mockDiscoveryApi = { getBaseUrl: mockGetBaseUrl };
+const mockFetchApi = { fetch: mockFetch };
+jest.mock('@backstage/core-plugin-api', () => {
+  const discoveryRef = Symbol('discoveryApiRef');
+  const fetchRef = Symbol('fetchApiRef');
+  return {
+    discoveryApiRef: discoveryRef,
+    fetchApiRef: fetchRef,
+    useApi: (apiRef: symbol) => {
+      if (apiRef === discoveryRef) return mockDiscoveryApi;
+      if (apiRef === fetchRef) return mockFetchApi;
+      return {};
+    },
+  };
+});
+
+const mockUseAuthzEnabled = jest.fn();
+jest.mock('./useOpenChoreoFeatures', () => ({
+  useAuthzEnabled: () => mockUseAuthzEnabled(),
+}));
+
+describe('useBuildPermission', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetBaseUrl.mockResolvedValue('http://localhost/api/permission');
+    // Default: no workflow passed in the existing cases, so the workflow-eval
+    // path is skipped regardless. Authz enabled is irrelevant when no workflow
+    // is supplied, but default it on for realism.
+    mockUseAuthzEnabled.mockReturnValue(true);
   });
+
+  // --- Behavior without a workflow (backward-compatible visibility check) ---
 
   it('returns both permissions allowed', () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
@@ -55,16 +90,102 @@ describe('useBuildPermission (Variant C: entity-scoped, multiple permissions)', 
     expect(result.current.viewBuildDeniedTooltip).toBeTruthy();
   });
 
-  it('calls usePermission twice with entity resource ref', () => {
+  it('does not call /evaluate-with-context when no workflow is supplied', async () => {
     mockUsePermission.mockReturnValue({ allowed: true, loading: false });
     renderHook(() => useBuildPermission());
 
-    // Called at least 2 times (once per permission, may be more with StrictMode)
-    expect(mockUsePermission.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Give any stray effect a chance to fire.
+    await Promise.resolve();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('calls usePermission with entity resource ref', () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    renderHook(() => useBuildPermission());
+
+    // canView uses usePermission directly; canBuild routes through
+    // useWorkflowScopedPermission, which also calls usePermission internally.
     expect(mockUsePermission).toHaveBeenCalledWith(
       expect.objectContaining({
         resourceRef: 'component:default/test',
       }),
     );
+  });
+
+  // --- Behavior with a workflow (workflow-scoped ABAC check) ---
+
+  it('evaluates the workflow against /evaluate-with-context and ANDs the result', async () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ allowed: true }),
+    });
+
+    const { result } = renderHook(() =>
+      useBuildPermission({ name: 'build-go', kind: 'Workflow' }),
+    );
+
+    await waitFor(() => expect(result.current.triggerLoading).toBe(false));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost/api/permission/evaluate-with-context',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"workflow"'),
+      }),
+    );
+    // Visibility allowed AND workflow-eval allowed → canBuild true.
+    expect(result.current.canBuild).toBe(true);
+    // canView is the plain visibility check, unaffected by the workflow.
+    expect(result.current.canView).toBe(true);
+  });
+
+  it('denies the build when the workflow-scoped evaluation returns false', async () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ allowed: false }),
+    });
+
+    const { result } = renderHook(() =>
+      useBuildPermission({ name: 'build-go', kind: 'Workflow' }),
+    );
+
+    await waitFor(() => expect(result.current.triggerLoading).toBe(false));
+
+    // Visibility passed but the workflow-specific check denied → canBuild false.
+    expect(result.current.canBuild).toBe(false);
+    expect(result.current.triggerBuildDeniedTooltip).toBeTruthy();
+  });
+
+  it('sends the workflow name and kind in the request body', async () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ allowed: true }),
+    });
+
+    const { result } = renderHook(() =>
+      useBuildPermission({ name: 'build-go', kind: 'ClusterWorkflow' }),
+    );
+
+    await waitFor(() => expect(result.current.triggerLoading).toBe(false));
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.workflow).toEqual({ name: 'build-go', kind: 'ClusterWorkflow' });
+  });
+
+  it('skips the workflow-eval and uses visibility when authz is disabled', async () => {
+    mockUseAuthzEnabled.mockReturnValue(false);
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+
+    const { result } = renderHook(() =>
+      useBuildPermission({ name: 'build-go', kind: 'Workflow' }),
+    );
+
+    await Promise.resolve();
+    // No backend call, and canBuild falls back to the visibility decision.
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.canBuild).toBe(true);
   });
 });

--- a/plugins/openchoreo-react/src/hooks/useBuildPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useBuildPermission.ts
@@ -5,6 +5,10 @@ import {
   openchoreoComponentBuildPermission,
   openchoreoComponentViewBuildsPermission,
 } from '@openchoreo/backstage-plugin-common';
+import {
+  useWorkflowScopedPermission,
+  type WorkflowContext,
+} from './useWorkflowScopedPermission';
 
 /**
  * Result of the useBuildPermission hook.
@@ -34,25 +38,38 @@ export interface UseBuildPermissionResult {
  *
  * Must be used within an EntityProvider context.
  *
+ * @param workflow - Optional workflow `{ name, kind }`. When supplied, the
+ *   trigger-build (`canBuild`) check also honors ABAC `resource.workflow` CEL
+ *   constraints via {@link useWorkflowScopedPermission}. When omitted, the
+ *   check is plain visibility-level — identical to the previous behavior, so
+ *   existing call sites need no change. The view-builds (`canView`) check is
+ *   never workflow-scoped.
+ *
  * @example
  * ```tsx
- * const { canBuild, loading, deniedTooltip } = useBuildPermission();
+ * // Workflow-scoped (honors resource.workflow CEL):
+ * const { canBuild, triggerLoading, triggerBuildDeniedTooltip } =
+ *   useBuildPermission({ name: wf.name, kind: wf.kind });
  *
  * return (
- *   <Tooltip title={deniedTooltip}>
+ *   <Tooltip title={triggerBuildDeniedTooltip}>
  *     <span>
- *       <Button disabled={loading || !canBuild}>Build</Button>
+ *       <Button disabled={triggerLoading || !canBuild}>Build</Button>
  *     </span>
  *   </Tooltip>
  * );
  * ```
  */
-export const useBuildPermission = (): UseBuildPermissionResult => {
+export const useBuildPermission = (
+  workflow?: WorkflowContext,
+): UseBuildPermissionResult => {
   const { entity } = useEntity();
-  const { allowed: canBuild, loading: triggerLoading } = usePermission({
-    permission: openchoreoComponentBuildPermission,
-    resourceRef: stringifyEntityRef(entity),
-  });
+  const { allowed: canBuild, loading: triggerLoading } =
+    useWorkflowScopedPermission({
+      permission: openchoreoComponentBuildPermission,
+      resourceRef: stringifyEntityRef(entity),
+      workflow,
+    });
 
   const { allowed: canView, loading: viewLoading } = usePermission({
     permission: openchoreoComponentViewBuildsPermission,

--- a/plugins/openchoreo-react/src/hooks/useWorkflowScopedPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useWorkflowScopedPermission.ts
@@ -36,7 +36,7 @@ interface UseWorkflowScopedPermissionOptions {
   workflow?: WorkflowContext;
 }
 
-interface UseWorkflowScopedPermissionResult {
+export interface UseWorkflowScopedPermissionResult {
   allowed: boolean;
   loading: boolean;
 }
@@ -138,8 +138,11 @@ export function useWorkflowScopedPermission(
   if (!authzEnabled || !workflowName) {
     return { allowed: baseCheck.allowed, loading: baseCheck.loading };
   }
+  const workflowLoading =
+    baseCheck.allowed && (wfLoading || wfAllowed === undefined);
+
   return {
     allowed: baseCheck.allowed && wfAllowed === true,
-    loading: baseCheck.loading || wfLoading || wfAllowed === undefined,
+    loading: baseCheck.loading || workflowLoading,
   };
 }

--- a/plugins/openchoreo-react/src/hooks/useWorkflowScopedPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useWorkflowScopedPermission.ts
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+import {
+  useApi,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+import { usePermission } from '@backstage/plugin-permission-react';
+import type {
+  Permission,
+  ResourcePermission,
+} from '@backstage/plugin-permission-common';
+import { useAuthzEnabled } from './useOpenChoreoFeatures';
+
+/**
+ * Workflow attribute sent to the backend's `/evaluate-with-context` route to
+ * populate the ABAC `resource.workflow` CEL attribute.
+ *
+ * `name` is the workflow resource name; `kind` is its own kind string
+ * (`Workflow` / `ComponentWorkflow` / `ClusterWorkflow`) which the backend
+ * uses to pick cluster- vs namespace-scoped encoding.
+ */
+export interface WorkflowContext {
+  name: string;
+  kind?: string;
+}
+
+interface UseWorkflowScopedPermissionOptions {
+  /** Backstage permission to evaluate (must map to an OpenChoreo action). */
+  permission: Permission | ResourcePermission;
+  /** Entity ref the action targets. */
+  resourceRef: string;
+  /**
+   * Workflow to evaluate against ABAC `resource.workflow` CEL. When omitted,
+   * behaves like a plain `usePermission` call.
+   */
+  workflow?: WorkflowContext;
+}
+
+interface UseWorkflowScopedPermissionResult {
+  allowed: boolean;
+  loading: boolean;
+}
+
+/**
+ * Evaluates a permission for a specific workflow, honoring ABAC CEL
+ * constraints on capability entries.
+ *
+ * This is the workflow-attribute sibling of {@link useEnvScopedPermission} —
+ * same decision flow and disabled-authz degradation.
+ *
+ */
+export function useWorkflowScopedPermission(
+  options: UseWorkflowScopedPermissionOptions,
+): UseWorkflowScopedPermissionResult {
+  const { permission, resourceRef, workflow } = options;
+
+  const baseCheck = usePermission(
+    // `usePermission` overloads — narrow with `resourceRef` when present.
+    'resourceRef' in permission ||
+      (permission as ResourcePermission).resourceType
+      ? { permission: permission as ResourcePermission, resourceRef }
+      : ({ permission, resourceRef } as Parameters<typeof usePermission>[0]),
+  );
+
+  const authzEnabled = useAuthzEnabled();
+
+  const discovery = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+
+  const [wfAllowed, setWfAllowed] = useState<boolean | undefined>(undefined);
+  const [wfLoading, setWfLoading] = useState<boolean>(false);
+
+  // Re-run only when the meaningful workflow fields change, not on every new
+  // object identity from the caller.
+  const workflowName = workflow?.name;
+  const workflowKind = workflow?.kind;
+
+  useEffect(() => {
+    // Don't fire the workflow fetch: authz off, no workflow, or base check still pending.
+    const skip = !authzEnabled || !workflowName || baseCheck.loading;
+    if (skip) {
+      setWfAllowed(undefined);
+      setWfLoading(false);
+      return undefined;
+    }
+
+    if (!baseCheck.allowed) {
+      setWfAllowed(false);
+      setWfLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setWfLoading(true);
+
+    const evaluate = async () => {
+      try {
+        const baseUrl = await discovery.getBaseUrl('permission');
+        const res = await fetchApi.fetch(`${baseUrl}/evaluate-with-context`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            permissionName: permission.name,
+            resourceRef,
+            workflow: { name: workflowName, kind: workflowKind },
+          }),
+        });
+        if (cancelled) return;
+        // Fail closed on network/server errors.
+        const body = res.ok
+          ? ((await res.json()) as { allowed: boolean })
+          : null;
+        setWfAllowed(body?.allowed === true);
+      } catch {
+        if (!cancelled) setWfAllowed(false);
+      } finally {
+        if (!cancelled) setWfLoading(false);
+      }
+    };
+
+    evaluate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    discovery,
+    fetchApi,
+    permission.name,
+    resourceRef,
+    workflowName,
+    workflowKind,
+    authzEnabled,
+    baseCheck.allowed,
+    baseCheck.loading,
+  ]);
+
+  if (!authzEnabled || !workflowName) {
+    return { allowed: baseCheck.allowed, loading: baseCheck.loading };
+  }
+  return {
+    allowed: baseCheck.allowed && wfAllowed === true,
+    loading: baseCheck.loading || wfLoading || wfAllowed === undefined,
+  };
+}

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -241,7 +241,11 @@ export {
   useBuildPermission,
   type UseBuildPermissionResult,
 } from './hooks/useBuildPermission';
-export { type WorkflowContext } from './hooks/useWorkflowScopedPermission';
+export {
+  useWorkflowScopedPermission,
+  type WorkflowContext,
+  type UseWorkflowScopedPermissionResult,
+} from './hooks/useWorkflowScopedPermission';
 export {
   useDeployPermission,
   type UseDeployPermissionResult,

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -241,6 +241,7 @@ export {
   useBuildPermission,
   type UseBuildPermissionResult,
 } from './hooks/useBuildPermission';
+export { type WorkflowContext } from './hooks/useWorkflowScopedPermission';
 export {
   useDeployPermission,
   type UseDeployPermissionResult,

--- a/plugins/openchoreo/src/components/Workflows/OverviewCard/WorkflowsOverviewCard.tsx
+++ b/plugins/openchoreo/src/components/Workflows/OverviewCard/WorkflowsOverviewCard.tsx
@@ -26,12 +26,16 @@ export const WorkflowsOverviewCard = () => {
   const classes = useOverviewCardStyles();
   const {
     latestBuild,
+    componentDetails,
     hasWorkflows,
     loading,
     error,
     triggeringBuild,
     triggerBuild,
   } = useWorkflowsSummary();
+  // Scope the trigger-build check to the component's workflow so ABAC
+  // `resource.workflow` CEL constraints are honored
+  const componentWorkflow = componentDetails?.componentWorkflow;
   const {
     canBuild,
     canView,
@@ -39,7 +43,11 @@ export const WorkflowsOverviewCard = () => {
     triggerLoading: permissionLoading,
     viewLoading: viewPermissionLoading,
     triggerBuildDeniedTooltip: deniedTooltip,
-  } = useBuildPermission();
+  } = useBuildPermission(
+    componentWorkflow?.name
+      ? { name: componentWorkflow.name, kind: componentWorkflow.kind }
+      : undefined,
+  );
 
   // Permission denied state
   if (!viewPermissionLoading && !canView) {

--- a/plugins/permission-backend-module-openchoreo-policy/src/router.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/router.ts
@@ -102,9 +102,10 @@ export async function createRouter(
   /**
    * POST /evaluate-with-context
    *
-   * Env-aware permission check. Used by frontend permission hooks
-   * (useDeployPermission, useLogsPermission, …) to honor ABAC CEL
-   * constraints scoped to `resource.environment`.
+   * Context-aware permission check. Used by frontend permission hooks
+   * (useDeployPermission, useLogsPermission, useBuildPermission, …) to honor
+   * ABAC CEL constraints scoped to `resource.environment` and/or
+   * `resource.workflow`.
    *
    * Decision flow for the resolved capability (with wildcard fallback):
    *   1. If any deny entry matches the entity's scope → DENY.
@@ -119,6 +120,7 @@ export async function createRouter(
    *   - permissionName: string  (e.g. "openchoreo.releasebinding.create")
    *   - resourceRef:   string   (Backstage entity ref)
    *   - environment?: string    (e.g. "dev")
+   *   - workflow?: { name: string; kind?: string }
    *
    * Response:
    *   - 200: { allowed: boolean }
@@ -128,7 +130,8 @@ export async function createRouter(
     const credentials = await httpAuth.credentials(req, { allow: ['user'] });
     const userEntityRef = credentials.principal.userEntityRef;
 
-    const { permissionName, resourceRef, environment } = req.body ?? {};
+    const { permissionName, resourceRef, environment, workflow } =
+      req.body ?? {};
     if (typeof permissionName !== 'string' || !permissionName) {
       return res
         .status(400)
@@ -141,6 +144,22 @@ export async function createRouter(
       typeof environment === 'string' && environment.length > 0
         ? environment
         : undefined;
+
+    // `workflow` is an optional `{ name, kind? }` object feeding the ABAC
+    // `resource.workflow` CEL attribute.
+    let workflowValue: { name: string; kind?: string } | undefined;
+    const hasWorkflowName =
+      workflow &&
+      typeof workflow === 'object' &&
+      typeof workflow.name === 'string' &&
+      workflow.name.length > 0;
+    if (hasWorkflowName) {
+      const workflowKind =
+        typeof workflow.kind === 'string' && workflow.kind.length > 0
+          ? workflow.kind
+          : undefined;
+      workflowValue = { name: workflow.name, kind: workflowKind };
+    }
 
     const action = OPENCHOREO_PERMISSION_TO_ACTION[permissionName];
     if (!action) {
@@ -251,7 +270,12 @@ export async function createRouter(
     }
     try {
       const decisions = await authzService.evaluate(userToken, userEntityRef, [
-        { action, resourcePath: entityPath, environment: envValue },
+        {
+          action,
+          resourcePath: entityPath,
+          environment: envValue,
+          workflow: workflowValue,
+        },
       ]);
       return res.status(200).json({ allowed: decisions[0] === true });
     } catch (err) {

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileCache.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileCache.test.ts
@@ -326,7 +326,14 @@ describe('AuthzProfileCache', () => {
     });
 
     it('treats an absent workflow distinctly from a present one', async () => {
-      await authzCache.getEvaluation(USER, HASH, ACTION, PATH, undefined, undefined);
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        undefined,
+      );
       await authzCache.getEvaluation(
         USER,
         HASH,

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileCache.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileCache.test.ts
@@ -198,4 +198,147 @@ describe('AuthzProfileCache', () => {
       );
     });
   });
+
+  // Single ABAC evaluation results are keyed by
+  // (userEntityRef, tokenHash, action, resourcePath, environment, workflow).
+  // The environment and workflow slots are independent: a check that varies
+  // only by attribute must produce a distinct key, otherwise an env-gated
+  // decision and a workflow-gated decision on the same action+path would
+  // collide and serve one attribute's boolean for the other.
+  describe('getEvaluation / setEvaluation', () => {
+    const USER = 'user:default/alice';
+    const HASH = 'abcdef0123456789';
+    const ACTION = 'workflowrun:create';
+    const PATH = 'ns/team-shop/project/team-shop/component/api';
+
+    it('setEvaluation stores the boolean with a TTL option', async () => {
+      await authzCache.setEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined, // environment
+        'team-shop/build-go', // workflow
+        true,
+        60000,
+      );
+
+      expect(mockCache.set).toHaveBeenCalledTimes(1);
+      const [, value, opts] = mockCache.set.mock.calls[0];
+      expect(value).toBe(true);
+      expect(opts).toEqual({ ttl: 60000 });
+    });
+
+    it('get/set use the same key for the same tuple (round-trip)', async () => {
+      await authzCache.setEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        'team-shop/build-go',
+        true,
+        1000,
+      );
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        'team-shop/build-go',
+      );
+
+      expect(mockCache.set.mock.calls[0][0]).toBe(
+        mockCache.get.mock.calls[0][0],
+      );
+    });
+
+    it('isolates a workflow-gated decision from an env-gated one on the same action+path', async () => {
+      // Same user/hash/action/path. One varies only by environment, the other
+      // only by workflow. Without distinct slots these would collide.
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        'team-shop/production', // env set, workflow absent
+        undefined,
+      );
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        'team-shop/build-go', // workflow set, env absent
+      );
+
+      const envKey = mockCache.get.mock.calls[0][0] as string;
+      const workflowKey = mockCache.get.mock.calls[1][0] as string;
+      expect(envKey).not.toBe(workflowKey);
+    });
+
+    it('produces different keys for different workflows', async () => {
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        'team-shop/build-go',
+      );
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        'team-shop/build-node',
+      );
+
+      expect(mockCache.get.mock.calls[0][0]).not.toBe(
+        mockCache.get.mock.calls[1][0],
+      );
+    });
+
+    it('produces the same key when only the workflow matches (determinism)', async () => {
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        'team-shop/build-go',
+      );
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        'team-shop/build-go',
+      );
+
+      expect(mockCache.get.mock.calls[0][0]).toBe(
+        mockCache.get.mock.calls[1][0],
+      );
+    });
+
+    it('treats an absent workflow distinctly from a present one', async () => {
+      await authzCache.getEvaluation(USER, HASH, ACTION, PATH, undefined, undefined);
+      await authzCache.getEvaluation(
+        USER,
+        HASH,
+        ACTION,
+        PATH,
+        undefined,
+        'team-shop/build-go',
+      );
+
+      expect(mockCache.get.mock.calls[0][0]).not.toBe(
+        mockCache.get.mock.calls[1][0],
+      );
+    });
+  });
 });

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileCache.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileCache.ts
@@ -150,8 +150,12 @@ export class AuthzProfileCache {
    * Builds a cache key for a single ABAC evaluation result.
    *
    * Keys are scoped per-user so we never leak one user's decision to another,
-   * and per-(action, resourcePath, environment) so that the same UI rendering
-   * the same button repeatedly hits the cache instead of /authz/evaluates.
+   * and per-(action, resourcePath, environment, workflow) so that the same UI
+   * rendering the same button repeatedly hits the cache instead of
+   * /authz/evaluates. `environment` and `workflow` occupy distinct slots so an
+   * env-gated decision and a workflow-gated decision on the same action+path
+   * can never collide on one key (which would serve one attribute's `true`/
+   * `false` to the other).
    *
    * The token hash is included so that signing out + back in produces a new
    * key and forces a re-evaluation. Otherwise a stale `false` decision from
@@ -166,6 +170,7 @@ export class AuthzProfileCache {
     action: string,
     resourcePath: string,
     environment: string | undefined,
+    workflow: string | undefined,
   ): string {
     // JSON-encode the tuple so a component containing the separator (or any
     // other character) cannot collide with another distinct tuple.
@@ -175,6 +180,7 @@ export class AuthzProfileCache {
       action,
       resourcePath,
       environment ?? null,
+      workflow ?? null,
     ])}`;
   }
 
@@ -197,6 +203,7 @@ export class AuthzProfileCache {
     action: string,
     resourcePath: string,
     environment: string | undefined,
+    workflow: string | undefined,
   ): Promise<boolean | undefined> {
     const key = this.buildEvaluationKey(
       userEntityRef,
@@ -204,6 +211,7 @@ export class AuthzProfileCache {
       action,
       resourcePath,
       environment,
+      workflow,
     );
     return this.cache.get<boolean>(key);
   }
@@ -214,6 +222,7 @@ export class AuthzProfileCache {
     action: string,
     resourcePath: string,
     environment: string | undefined,
+    workflow: string | undefined,
     allowed: boolean,
     ttlMs: number,
   ): Promise<void> {
@@ -223,6 +232,7 @@ export class AuthzProfileCache {
       action,
       resourcePath,
       environment,
+      workflow,
     );
     await this.cache.set(key, allowed, { ttl: ttlMs });
   }

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.test.ts
@@ -571,7 +571,7 @@ describe('AuthzProfileService', () => {
       });
     });
 
-    it('treats an unknown/absent kind as namespace-scoped', async () => {
+    it('treats an absent kind as cluster-scoped (the backend default)', async () => {
       const { service } = setupService();
       const exp = Math.floor(Date.now() / 1000) + 3600;
 
@@ -585,7 +585,7 @@ describe('AuthzProfileService', () => {
 
       const body = mockPOST.mock.calls[0][1].body;
       expect(body[0].context).toEqual({
-        resource: { workflow: 'team-shop/build-go' },
+        resource: { workflow: 'build-go' },
       });
     });
 

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.test.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.test.ts
@@ -400,6 +400,7 @@ describe('AuthzProfileService', () => {
         'releasebinding:update',
         'ns/team-shop/project/team-shop/component/snip-api-service',
         'team-shop/production',
+        undefined, // no workflow on this input
         false,
         expect.any(Number),
       );
@@ -483,6 +484,163 @@ describe('AuthzProfileService', () => {
           action: 'releasebinding:view',
           resourcePath: 'ns/team-shop',
         },
+      ]);
+
+      const body = mockPOST.mock.calls[0][1].body;
+      expect(body[0].context).toBeUndefined();
+    });
+  });
+
+  describe('evaluate — workflow encoding', () => {
+    const subjectProfile = {
+      user: {
+        type: 'user',
+        entitlement_claim: 'groups',
+        entitlement_values: ['developers'],
+      },
+      capabilities: {},
+    } as unknown as UserCapabilitiesResponse;
+
+    const NS_PATH = 'ns/team-shop/project/team-shop/component/snip-api-service';
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    function setupService() {
+      const cache = createMockCache();
+      cache.getByUser.mockResolvedValue(subjectProfile);
+      cache.getEvaluation.mockResolvedValue(undefined);
+      mockPOST.mockResolvedValue(createOkResponse([{ decision: true }]));
+      return { cache, service: createService(cache) };
+    }
+
+    it('encodes workflow as `{namespace}/{name}` for a namespace-scoped Workflow', async () => {
+      const { service } = setupService();
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+
+      await service.evaluate(buildJwt(exp), 'user:default/alice', [
+        {
+          action: 'workflowrun:create',
+          resourcePath: NS_PATH,
+          workflow: { name: 'build-go', kind: 'Workflow' },
+        },
+      ]);
+
+      const body = mockPOST.mock.calls[0][1].body;
+      expect(body[0].context).toEqual({
+        resource: { workflow: 'team-shop/build-go' },
+      });
+    });
+
+    it('encodes workflow as `{namespace}/{name}` for a ComponentWorkflow', async () => {
+      const { service } = setupService();
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+
+      await service.evaluate(buildJwt(exp), 'user:default/alice', [
+        {
+          action: 'workflowrun:create',
+          resourcePath: NS_PATH,
+          workflow: { name: 'build-go', kind: 'ComponentWorkflow' },
+        },
+      ]);
+
+      const body = mockPOST.mock.calls[0][1].body;
+      expect(body[0].context).toEqual({
+        resource: { workflow: 'team-shop/build-go' },
+      });
+    });
+
+    it('encodes workflow as the bare `{name}` for a cluster-scoped ClusterWorkflow', async () => {
+      const { service } = setupService();
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+
+      await service.evaluate(buildJwt(exp), 'user:default/alice', [
+        {
+          action: 'workflowrun:create',
+          resourcePath: NS_PATH,
+          // Even though the resource path is namespaced, a ClusterWorkflow is
+          // globally unique by name, so no namespace prefix is added.
+          workflow: { name: 'build-go', kind: 'ClusterWorkflow' },
+        },
+      ]);
+
+      const body = mockPOST.mock.calls[0][1].body;
+      expect(body[0].context).toEqual({
+        resource: { workflow: 'build-go' },
+      });
+    });
+
+    it('treats an unknown/absent kind as namespace-scoped', async () => {
+      const { service } = setupService();
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+
+      await service.evaluate(buildJwt(exp), 'user:default/alice', [
+        {
+          action: 'workflowrun:create',
+          resourcePath: NS_PATH,
+          workflow: { name: 'build-go' }, // no kind
+        },
+      ]);
+
+      const body = mockPOST.mock.calls[0][1].body;
+      expect(body[0].context).toEqual({
+        resource: { workflow: 'team-shop/build-go' },
+      });
+    });
+
+    it('sends both environment and workflow when both are supplied', async () => {
+      const { service } = setupService();
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+
+      await service.evaluate(buildJwt(exp), 'user:default/alice', [
+        {
+          action: 'workflowrun:create',
+          resourcePath: NS_PATH,
+          environment: 'production',
+          workflow: { name: 'build-go', kind: 'Workflow' },
+        },
+      ]);
+
+      const body = mockPOST.mock.calls[0][1].body;
+      expect(body[0].context).toEqual({
+        resource: {
+          environment: 'team-shop/production',
+          workflow: 'team-shop/build-go',
+        },
+      });
+    });
+
+    it('caches the decision under the encoded workflow value', async () => {
+      const { cache, service } = setupService();
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+
+      await service.evaluate(buildJwt(exp), 'user:default/alice', [
+        {
+          action: 'workflowrun:create',
+          resourcePath: NS_PATH,
+          workflow: { name: 'build-go', kind: 'Workflow' },
+        },
+      ]);
+
+      expect(cache.setEvaluation).toHaveBeenCalledWith(
+        'user:default/alice',
+        expect.any(String),
+        'workflowrun:create',
+        NS_PATH,
+        undefined, // no environment on this input
+        'team-shop/build-go', // encoded workflow
+        true,
+        expect.any(Number),
+      );
+    });
+
+    it('omits context entirely when neither environment nor workflow is supplied', async () => {
+      const { service } = setupService();
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+
+      await service.evaluate(buildJwt(exp), 'user:default/alice', [
+        { action: 'workflowrun:create', resourcePath: NS_PATH },
       ]);
 
       const body = mockPOST.mock.calls[0][1].body;

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.ts
@@ -369,8 +369,10 @@ export class AuthzProfileService {
         parsed?.namespace && parsed.namespace !== '*'
           ? parsed.namespace
           : undefined;
-      const isClusterScoped =
-        wf.kind?.toLowerCase() === CLUSTER_SCOPED_WORKFLOW_KIND;
+      // Cluster-scoped when the kind explicitly says so, or when it's missing —
+      // cluster-scoped is the backend's default for an absent workflow kind.
+      const kind = wf.kind?.toLowerCase();
+      const isClusterScoped = kind === CLUSTER_SCOPED_WORKFLOW_KIND || !kind;
       const encoded = formatDualScopedName(ns, wf.name, isClusterScoped);
       return encoded || undefined;
     });

--- a/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.ts
+++ b/plugins/permission-backend-module-openchoreo-policy/src/services/AuthzProfileService.ts
@@ -12,15 +12,32 @@ type EvaluateRequest = OpenChoreoComponents['schemas']['EvaluateRequest'];
 type SubjectContext = OpenChoreoComponents['schemas']['SubjectContext'];
 
 /**
+ * Workflow attribute used by ABAC CEL expressions like `resource.workflow`.
+ *
+ * `name` is the workflow resource name (as carried in the build payload).
+ * `kind` is the workflow's own kind string — `Workflow`, `ComponentWorkflow`
+ */
+export interface WorkflowContext {
+  name: string;
+  kind?: string;
+}
+
+/** Workflow kind string the OpenChoreo authz core treats as cluster-scoped. */
+const CLUSTER_SCOPED_WORKFLOW_KIND = 'clusterworkflow';
+
+/**
  * Inputs the policy needs to evaluate one capability entry at runtime.
  * `resourcePath` is the capability path matched by the user's profile
- * (e.g., "ns/acme/project/payments/component/api"). `environment` is the
- * runtime attribute used by ABAC CEL expressions like `resource.environment`.
+ * (e.g., "ns/acme/project/payments/component/api"). `environment` and
+ * `workflow` are the runtime attributes used by ABAC CEL expressions like
+ * `resource.environment` and `resource.workflow`. They are independent — an
+ * input may carry either, both, or neither.
  */
 export interface EvaluateInput {
   action: string;
   resourcePath: string;
   environment?: string;
+  workflow?: WorkflowContext;
 }
 
 /** Default TTL in milliseconds when token expiration cannot be determined */
@@ -344,6 +361,20 @@ export class AuthzProfileService {
       return encoded || undefined;
     });
 
+    const encodedWorkflows: (string | undefined)[] = inputs.map(input => {
+      const wf = input.workflow;
+      if (!wf?.name) return undefined;
+      const parsed = parseCapabilityPath(input.resourcePath);
+      const ns =
+        parsed?.namespace && parsed.namespace !== '*'
+          ? parsed.namespace
+          : undefined;
+      const isClusterScoped =
+        wf.kind?.toLowerCase() === CLUSTER_SCOPED_WORKFLOW_KIND;
+      const encoded = formatDualScopedName(ns, wf.name, isClusterScoped);
+      return encoded || undefined;
+    });
+
     // Include a token-derived component in the cache key so that signing out
     // and back in produces a new key and forces a re-evaluation. Without this,
     // a stale `false` from before an authz binding change would survive
@@ -365,6 +396,7 @@ export class AuthzProfileService {
           action,
           resourcePath,
           encodedEnvs[i],
+          encodedWorkflows[i],
         );
         if (results[i] === undefined) missingIdx.push(i);
       }
@@ -432,9 +464,16 @@ export class AuthzProfileService {
         resource: { type: resourceType, hierarchy },
         action,
       };
+      // Attach whichever ABAC attributes this input carries. Both feed the
+      // same `context.resource` object the authz core reads CEL against; they
+      // are independent, so an input may set one, both, or neither.
       const encodedEnv = encodedEnvs[i];
-      if (encodedEnv) {
-        req.context = { resource: { environment: encodedEnv } };
+      const encodedWorkflow = encodedWorkflows[i];
+      if (encodedEnv || encodedWorkflow) {
+        const resourceContext: { environment?: string; workflow?: string } = {};
+        if (encodedEnv) resourceContext.environment = encodedEnv;
+        if (encodedWorkflow) resourceContext.workflow = encodedWorkflow;
+        req.context = { resource: resourceContext };
       }
       return req;
     });
@@ -456,14 +495,15 @@ export class AuthzProfileService {
         results[i] = allowed;
         if (this.cache) {
           const { action, resourcePath } = inputs[i];
-          // Use the encoded env so cache keys match the form sent to the
-          // backend (and stay isolated per namespace).
+          // Use the encoded env/workflow so cache keys match the form sent to
+          // the backend (and stay isolated per namespace and per attribute).
           await this.cache.setEvaluation(
             userEntityRef,
             tokenHash,
             action,
             resourcePath,
             encodedEnvs[i],
+            encodedWorkflows[i],
             allowed,
             ttlMs,
           );


### PR DESCRIPTION
## Purpose

Adds support for a `resource.workflow` ABAC condition so that the ability to trigger a build can be constrained per workflow

## What changed

- **Backend permission policy**: the context-aware permission endpoint now accepts an optional workflow alongside environment, encodes it the way the OpenChoreo authz engine expects (namespace-scoped vs cluster-scoped), and forwards it to the authz evaluator.

- **Frontend**: a new workflow-scoped permission hook, built as a sibling of the existing environment-scoped one. The shared build permission hook gains an optional workflow argument; passing nothing preserves the previous behavior, so existing callers are unaffected.

- **Build triggers**: both the Workflows-tab "Build" split button and the overview "Build Now" button now pass the component's workflow into the permission check, keeping the gate consistent with the workflow the build actually runs.

### UI


https://github.com/user-attachments/assets/e9254a50-c5a9-4e71-a24d-b199628cad8d


Related issue: https://github.com/openchoreo/openchoreo/issues/3569


## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.


## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permissions can now be scoped to specific workflows so build/view controls respect per-workflow access.
  * UI controls (e.g., Build buttons and overview cards) now reflect workflow-scoped permission checks.

* **Backend**
  * Authorization evaluation accepts workflow context and returns workflow-aware decisions; caching is partitioned by workflow.

* **Tests**
  * Added/updated tests covering workflow-scoped evaluation, encoding, caching, and UI permission behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->