### PR TITLE
fix: update HTTP metrics upon refresh button click

### DIFF
--- a/plugins/openchoreo-observability/src/components/Metrics/HTTPMetricsSection.tsx
+++ b/plugins/openchoreo-observability/src/components/Metrics/HTTPMetricsSection.tsx
@@ -24,6 +24,7 @@ type HTTPMetricsSectionProps = {
   entity: Entity;
   namespaceName: string;
   project: string;
+  refreshNonce: number;
 };
 
 export const HTTPMetricsSection = ({
@@ -31,6 +32,7 @@ export const HTTPMetricsSection = ({
   entity,
   namespaceName,
   project,
+  refreshNonce,
 }: HTTPMetricsSectionProps) => {
   const { networkPolicyProvider, loading: netPolLoading } =
     useDataPlaneNetPolProvider(
@@ -51,6 +53,7 @@ export const HTTPMetricsSection = ({
     environment: undefined as string | undefined,
     timeRange: undefined as string | undefined,
   });
+  const previousRefreshNonceRef = useRef(refreshNonce);
 
   useEffect(() => {
     if (!httpEnabled) {
@@ -65,13 +68,25 @@ export const HTTPMetricsSection = ({
     const filtersChanged =
       JSON.stringify(previousFiltersRef.current) !==
       JSON.stringify(currentFilters);
+    const refreshRequested = previousRefreshNonceRef.current !== refreshNonce;
 
-    if (filters.environment && filters.timeRange && filtersChanged) {
+    if (
+      filters.environment &&
+      filters.timeRange &&
+      (filtersChanged || refreshRequested)
+    ) {
       fetchMetrics(true);
     }
 
     previousFiltersRef.current = currentFilters;
-  }, [httpEnabled, filters.environment, filters.timeRange, fetchMetrics]);
+    previousRefreshNonceRef.current = refreshNonce;
+  }, [
+    httpEnabled,
+    filters.environment,
+    filters.timeRange,
+    fetchMetrics,
+    refreshNonce,
+  ]);
 
   if (netPolLoading || !httpEnabled) {
     return null;

--- a/plugins/openchoreo-observability/src/components/Metrics/ObservabilityMetricsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Metrics/ObservabilityMetricsPage.test.tsx
@@ -1,4 +1,5 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderInTestApp } from '@backstage/test-utils';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { ObservabilityMetricsPage } from './ObservabilityMetricsPage';
@@ -263,6 +264,67 @@ describe('ObservabilityMetricsPage', () => {
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText('Retry')).not.toBeInTheDocument();
+  });
+
+  it('refetches both resource and HTTP metrics when refresh is clicked', async () => {
+    const user = userEvent.setup();
+    const resourceRefresh = jest.fn();
+    const httpFetchMetrics = jest.fn();
+
+    mockUseMetrics.mockImplementation(
+      (
+        _filters: any,
+        _entity: any,
+        _namespace: any,
+        _project: any,
+        type?: string,
+      ) => {
+        if (type === 'http') {
+          return {
+            metrics: {
+              networkThroughput: {
+                requestCount: [],
+                successfulRequestCount: [],
+                unsuccessfulRequestCount: [],
+              },
+              networkLatency: {
+                meanLatency: [],
+                latencyP50: [],
+                latencyP90: [],
+                latencyP99: [],
+              },
+            },
+            loading: false,
+            error: null,
+            fetchMetrics: httpFetchMetrics,
+            refresh: jest.fn(),
+          };
+        }
+        return {
+          metrics: {
+            cpuUsage: { cpuUsage: [], cpuRequests: [], cpuLimits: [] },
+            memoryUsage: {
+              memoryUsage: [],
+              memoryRequests: [],
+              memoryLimits: [],
+            },
+          },
+          loading: false,
+          error: null,
+          fetchMetrics: jest.fn(),
+          refresh: resourceRefresh,
+        };
+      },
+    );
+
+    await renderPage();
+
+    httpFetchMetrics.mockClear();
+
+    await user.click(screen.getByTestId('refresh-btn'));
+
+    expect(resourceRefresh).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(httpFetchMetrics).toHaveBeenCalledTimes(1));
   });
 
   it('renders nothing for namespace error', async () => {

--- a/plugins/openchoreo-observability/src/components/Metrics/ObservabilityMetricsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Metrics/ObservabilityMetricsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Grid,
   Card,
@@ -84,12 +84,15 @@ const ObservabilityMetricsContent = () => {
     canViewMetricsForEnv,
   ]);
 
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
   const handleFiltersChange = (newFilters: Partial<typeof filters>) => {
     updateFilters(newFilters);
   };
 
   const handleRefresh = () => {
     refresh();
+    setRefreshNonce(prev => prev + 1);
   };
 
   if (namespaceError) {
@@ -202,6 +205,7 @@ const ObservabilityMetricsContent = () => {
                 entity={entity}
                 namespaceName={namespace as string}
                 project={project as string}
+                refreshNonce={refreshNonce}
               />
             </Grid>
           )}


### PR DESCRIPTION
## Purpose
This pull request enhances the observability metrics refresh functionality, ensuring that both resource and HTTP metrics are consistently refetched when the user triggers a refresh. The main changes introduce a new mechanism to coordinate refreshes across different metrics components and add a test to verify this behavior.

**Improvements to metrics refresh logic:**

* Added a `refreshNonce` state in `ObservabilityMetricsPage.tsx` that increments on refresh, and passed it to the `HTTPMetricsSection` component to trigger HTTP metrics reloads alongside resource metrics. [[1]](diffhunk://#diff-4884ee7442186284082762654a57d173e27fd0a9337d90098706f08c098672baR87-R95) [[2]](diffhunk://#diff-4884ee7442186284082762654a57d173e27fd0a9337d90098706f08c098672baR208) [[3]](diffhunk://#diff-1aceb7527592f899bf0814023e3c85e63726a36bb85db58a64568237ac975379R27-R35)
* Updated `HTTPMetricsSection.tsx` to use the new `refreshNonce` prop and detect when it changes, triggering a metrics fetch even if filters remain the same. [[1]](diffhunk://#diff-1aceb7527592f899bf0814023e3c85e63726a36bb85db58a64568237ac975379R56) [[2]](diffhunk://#diff-1aceb7527592f899bf0814023e3c85e63726a36bb85db58a64568237ac975379R71-R89)

**Testing enhancements:**

* Added a test to `ObservabilityMetricsPage.test.tsx` to verify that both resource and HTTP metrics are refetched when the refresh button is clicked.
* Included necessary imports for testing user events and asynchronous assertions.

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refresh button now properly triggers HTTP metrics refresh alongside resource metrics.

* **Tests**
  * Added test coverage verifying the refresh functionality correctly refetches both resource and HTTP metrics data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->