### PR TITLE
fix: show raw release binding resource in YAML view

### DIFF
--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -144,6 +144,7 @@ export function transformReleaseBinding(
     status: derived?.status,
     statusReason: derived?.reason,
     statusMessage: derived?.message,
+    resource: binding as unknown as Record<string, unknown>,
     endpoints: (() => {
       const raw = (binding.status as any)?.endpoints;
       if (!Array.isArray(raw)) return undefined;

--- a/plugins/openchoreo-common/src/types/bff-types.ts
+++ b/plugins/openchoreo-common/src/types/bff-types.ts
@@ -554,6 +554,8 @@ export interface ReleaseBindingResponse {
   statusMessage?: string;
   endpoints?: ReleaseBindingEndpoint[];
   conditions?: ReleaseBindingCondition[];
+  /** The raw K8s ReleaseBinding resource, used to display the full definition */
+  resource?: Record<string, unknown>;
 }
 
 export interface ReleaseBindingCondition {

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -102,6 +102,8 @@ export interface ReleaseBinding {
   status?: string;
   statusReason?: string;
   statusMessage?: string;
+  /** Raw K8s resource from the API, if available */
+  resource?: Record<string, unknown>;
 }
 
 /** Release bindings response */

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseBindingDetailTabs.tsx
@@ -240,7 +240,9 @@ export const ReleaseBindingDetailTabs: FC<ReleaseBindingDetailTabsProps> = ({
           <>
             {releaseBindingData ? (
               <YamlViewer
-                value={YAML.stringify(releaseBindingData)}
+                value={YAML.stringify(
+                  (releaseBindingData as any).resource ?? releaseBindingData,
+                )}
                 maxHeight="auto"
               />
             ) : (


### PR DESCRIPTION
## Purpose

Expose the raw Kubernetes ReleaseBinding resource through the BFF response and render it in the release binding detail YAML tab when available.

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release bindings now include an optional raw resource payload in responses, allowing the full underlying resource to be surfaced.
  * The UI shows that raw resource as YAML in the release binding detail view, improving visibility into the complete resource definition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->