### PR TITLE
ci: add workflow to delete release-next-v* branches after merge

### DIFF
--- a/.github/workflows/cleanup-version-branch.yml
+++ b/.github/workflows/cleanup-version-branch.yml
@@ -1,0 +1,36 @@
+name: Cleanup Version Branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - release-v*
+
+jobs:
+  cleanup:
+    name: Delete release-next branch after merge
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release-next-v')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Delete branch
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        with:
+          script: |
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'heads/' + process.env.HEAD_REF
+              })
+            } catch (error) {
+              if (error.status === 404 || (error.message && error.message.includes('Reference does not exist'))) {
+                console.log(`Branch ${process.env.HEAD_REF} already deleted, skipping.`)
+              } else {
+                throw error
+              }
+            }


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated cleanup of merged release branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/backstage-plugins/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->