### PR TITLE
feat: add Wirelogs view and related functionality

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -132,6 +132,7 @@ import {
   ObservabilityRuntimeLogs,
   ObservabilityProjectRuntimeLogs,
   ObservabilityAlerts,
+  ObservabilityWirelogs,
   ObservabilityProjectIncidents,
   ObservabilityCostAnalysis,
   type RenderLogRowAction,
@@ -364,6 +365,12 @@ const serviceEntityPage = (
       </FeatureGatedContent>
     </EntityLayout.Route>
 
+    <EntityLayout.Route path="/wirelogs" title="Wirelogs">
+      <FeatureGatedContent feature="observability">
+        <ObservabilityWirelogs />
+      </FeatureGatedContent>
+    </EntityLayout.Route>
+
     <EntityLayout.Route
       path="/kubernetes"
       title="Kubernetes"
@@ -456,6 +463,12 @@ const genericComponentEntityPage = (
     <EntityLayout.Route path="/alerts" title="Alerts">
       <FeatureGatedContent feature="observability">
         <ObservabilityAlerts />
+      </FeatureGatedContent>
+    </EntityLayout.Route>
+
+    <EntityLayout.Route path="/wirelogs" title="Wirelogs">
+      <FeatureGatedContent feature="observability">
+        <ObservabilityWirelogs />
       </FeatureGatedContent>
     </EntityLayout.Route>
 

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -23,6 +23,7 @@ import { AuthzService } from './services/AuthzService/AuthzService';
 import { DataPlaneInfoService } from './services/DataPlaneService/DataPlaneInfoService';
 import { ClusterDataPlaneInfoService } from './services/ClusterDataPlaneService/ClusterDataPlaneInfoService';
 import { PlatformResourceService } from './services/PlatformResourceService/PlatformResourceService';
+import { WirelogsInfoService } from './services/WirelogsService/WirelogsInfoService';
 import { openChoreoTokenServiceRef } from '@openchoreo/openchoreo-auth';
 import { openchoreoPermissions } from '@openchoreo/backstage-plugin-common';
 import {
@@ -144,6 +145,8 @@ export const choreoPlugin = createBackendPlugin({
           baseUrl,
         );
 
+        const wirelogsInfoService = new WirelogsInfoService(logger, baseUrl);
+
         // Register OpenChoreo component permissions with the permissions registry
         // This enables CONDITIONAL permission checks against catalog entities
         const namespacedResourcePermissions = openchoreoPermissions.filter(
@@ -199,6 +202,7 @@ export const choreoPlugin = createBackendPlugin({
             dataPlaneInfoService,
             clusterDataPlaneInfoService,
             platformResourceService,
+            wirelogsInfoService,
             annotationStore,
             catalogService: catalog,
             auth,

--- a/plugins/openchoreo-backend/src/router.test.ts
+++ b/plugins/openchoreo-backend/src/router.test.ts
@@ -110,6 +110,9 @@ function createMockServices() {
       updateResource: jest.fn(),
       deleteResource: jest.fn(),
     },
+    wirelogsInfoService: {
+      openStream: jest.fn(),
+    },
     annotationStore: {
       getAnnotations: jest.fn(),
       setAnnotations: jest.fn(),
@@ -1034,6 +1037,123 @@ describe('createRouter', () => {
           ),
         }),
       });
+    });
+  });
+
+  describe('GET /wirelogs/stream', () => {
+    /**
+     * Build a Response-like object whose body.getReader() yields the supplied
+     * chunks. Mirrors what `fetch` returns for an upstream SSE stream.
+     */
+    function makeUpstream(chunks: Array<string>, ok = true, status = 200) {
+      const encoder = new TextEncoder();
+      let i = 0;
+      const reader = {
+        read: jest.fn(async () => {
+          if (i >= chunks.length) {
+            return { value: undefined, done: true } as const;
+          }
+          return {
+            value: encoder.encode(chunks[i++]),
+            done: false,
+          } as const;
+        }),
+        cancel: jest.fn().mockResolvedValue(undefined),
+      };
+      return {
+        ok,
+        status,
+        body: { getReader: () => reader },
+        text: jest.fn().mockResolvedValue(''),
+      } as unknown as Response;
+    }
+
+    it('returns 400 when required query params are missing', async () => {
+      const response = await request(app).get('/wirelogs/stream').query({
+        projectName: 'p',
+      });
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'namespaceName, environmentName and projectName are required',
+          ),
+        }),
+      });
+      expect(services.wirelogsInfoService.openStream).not.toHaveBeenCalled();
+    });
+
+    it('streams upstream chunks through as text/event-stream', async () => {
+      services.wirelogsInfoService.openStream.mockResolvedValue(
+        makeUpstream([
+          'data: {"flow":{"uuid":"a"}}\n\n',
+          'data: {"flow":{"uuid":"b"}}\n\n',
+        ]),
+      );
+
+      const response = await request(app).get('/wirelogs/stream').query({
+        namespaceName: 'ns',
+        environmentName: 'dev',
+        projectName: 'proj',
+        componentName: 'svc',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/event-stream/);
+      expect(response.headers['cache-control']).toMatch(/no-cache/);
+      expect(response.text).toContain('"uuid":"a"');
+      expect(response.text).toContain('"uuid":"b"');
+
+      // Service was called with the parsed query string + the mock token.
+      expect(services.wirelogsInfoService.openStream).toHaveBeenCalledWith(
+        {
+          namespaceName: 'ns',
+          environmentName: 'dev',
+          projectName: 'proj',
+          componentName: 'svc',
+        },
+        'mock-user-token',
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('writes an SSE error frame when openStream rejects', async () => {
+      services.wirelogsInfoService.openStream.mockRejectedValue(
+        new Error('connect refused'),
+      );
+
+      const response = await request(app).get('/wirelogs/stream').query({
+        namespaceName: 'ns',
+        environmentName: 'dev',
+        projectName: 'proj',
+      });
+
+      // The SSE headers were already flushed, so the status is 200 even on
+      // an upstream failure — the error rides in the body as an SSE event.
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('event: error');
+      expect(response.text).toContain('Failed to open wirelogs stream');
+      expect(services.logger.error).toHaveBeenCalled();
+    });
+
+    it('emits an SSE error frame when the upstream returns non-ok', async () => {
+      services.wirelogsInfoService.openStream.mockResolvedValue({
+        ok: false,
+        status: 502,
+        body: null,
+        text: jest.fn().mockResolvedValue('bad gateway'),
+      } as unknown as Response);
+
+      const response = await request(app).get('/wirelogs/stream').query({
+        namespaceName: 'ns',
+        environmentName: 'dev',
+        projectName: 'proj',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('event: error');
+      expect(response.text).toContain('"status":502');
+      expect(response.text).toContain('bad gateway');
     });
   });
 });

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -28,6 +28,7 @@ import {
   type ResourceReleaseSchemaSection,
 } from './services/ResourceReleaseService/ResourceReleaseInfoService';
 import { PlatformResourceService } from './services/PlatformResourceService/PlatformResourceService';
+import { WirelogsInfoService } from './services/WirelogsService/WirelogsInfoService';
 import { AuthzService } from './services/AuthzService/AuthzService';
 import { DataPlaneInfoService } from './services/DataPlaneService/DataPlaneInfoService';
 import { ClusterDataPlaneInfoService } from './services/ClusterDataPlaneService/ClusterDataPlaneInfoService';
@@ -96,6 +97,7 @@ export async function createRouter({
   dataPlaneInfoService,
   clusterDataPlaneInfoService,
   platformResourceService,
+  wirelogsInfoService,
   annotationStore,
   catalogService,
   auth,
@@ -122,6 +124,7 @@ export async function createRouter({
   dataPlaneInfoService: DataPlaneInfoService;
   clusterDataPlaneInfoService: ClusterDataPlaneInfoService;
   platformResourceService: PlatformResourceService;
+  wirelogsInfoService: WirelogsInfoService;
   annotationStore: AnnotationStore;
   catalogService: CatalogService;
   auth: AuthService;
@@ -2201,6 +2204,102 @@ export async function createRouter({
       );
     },
   );
+
+  // SSE proxy for Cilium Hubble wirelogs from openchoreo-api (PR #3571).
+  // Frontend opens an EventSource against this route; we open the upstream
+  // stream with the user's bearer token and pipe chunks straight through.
+  router.get('/wirelogs/stream', async (req, res) => {
+    const { namespaceName, environmentName, projectName, componentName } =
+      req.query;
+
+    if (!namespaceName || !environmentName || !projectName) {
+      throw new InputError(
+        'namespaceName, environmentName and projectName are required query parameters',
+      );
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    if (typeof res.flushHeaders === 'function') {
+      res.flushHeaders();
+    }
+
+    const abortController = new AbortController();
+    const onClientClose = () => abortController.abort();
+    req.on('close', onClientClose);
+
+    let upstream: Response;
+    try {
+      upstream = await wirelogsInfoService.openStream(
+        {
+          namespaceName: namespaceName as string,
+          environmentName: environmentName as string,
+          projectName: projectName as string,
+          componentName: componentName as string | undefined,
+        },
+        userToken,
+        abortController.signal,
+      );
+    } catch (err) {
+      logger.error(
+        `Failed to open wirelogs upstream: ${(err as Error).message}`,
+      );
+      res.write(
+        `event: error\ndata: ${JSON.stringify({
+          message: 'Failed to open wirelogs stream',
+        })}\n\n`,
+      );
+      res.end();
+      return;
+    }
+
+    if (!upstream.ok || !upstream.body) {
+      const status = upstream.status;
+      const errorText = await upstream.text().catch(() => '');
+      logger.warn(
+        `Wirelogs upstream returned ${status}: ${errorText.slice(0, 200)}`,
+      );
+      res.write(
+        `event: error\ndata: ${JSON.stringify({
+          status,
+          message: errorText || `Upstream returned ${status}`,
+        })}\n\n`,
+      );
+      res.end();
+      return;
+    }
+
+    const reader = upstream.body.getReader();
+    try {
+      let streaming = true;
+      while (streaming) {
+        const { value, done } = await reader.read();
+        if (done) {
+          streaming = false;
+          break;
+        }
+        if (!res.write(Buffer.from(value))) {
+          await new Promise<void>(resolve => res.once('drain', resolve));
+        }
+      }
+    } catch (err) {
+      if (!abortController.signal.aborted) {
+        logger.warn(`Wirelogs stream interrupted: ${(err as Error).message}`);
+      }
+    } finally {
+      req.off('close', onClientClose);
+      try {
+        await reader.cancel();
+      } catch {
+        // ignore
+      }
+      res.end();
+    }
+  });
 
   return router;
 }

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -2208,7 +2208,7 @@ export async function createRouter({
   // SSE proxy for Cilium Hubble wirelogs from openchoreo-api (PR #3571).
   // Frontend opens an EventSource against this route; we open the upstream
   // stream with the user's bearer token and pipe chunks straight through.
-  router.get('/wirelogs/stream', async (req, res) => {
+  router.get('/wirelogs/stream', requireAuth, async (req, res) => {
     const { namespaceName, environmentName, projectName, componentName } =
       req.query;
 
@@ -2283,7 +2283,22 @@ export async function createRouter({
           break;
         }
         if (!res.write(Buffer.from(value))) {
-          await new Promise<void>(resolve => res.once('drain', resolve));
+          await new Promise<void>(resolve => {
+            const cleanup = (handler: () => void) => {
+              res.off('drain', handler);
+              res.off('close', handler);
+            };
+            const onSettled = () => {
+              cleanup(onSettled);
+              resolve();
+            };
+            res.once('drain', onSettled);
+            res.once('close', onSettled);
+          });
+          if (abortController.signal.aborted) {
+            streaming = false;
+            break;
+          }
         }
       }
     } catch (err) {

--- a/plugins/openchoreo-backend/src/services/WirelogsService/WirelogsInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/WirelogsService/WirelogsInfoService.test.ts
@@ -1,0 +1,149 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { WirelogsInfoService } from './WirelogsInfoService';
+
+const mockFetch = jest.fn();
+const originalFetch = global.fetch;
+beforeAll(() => {
+  (global as any).fetch = mockFetch;
+});
+afterAll(() => {
+  (global as any).fetch = originalFetch;
+});
+
+const logger = mockServices.logger.mock();
+
+describe('WirelogsInfoService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds the upstream URL from baseUrl + namespace/environment, with project as a query param', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const service = new WirelogsInfoService(logger, 'http://api.openchoreo');
+    const controller = new AbortController();
+
+    await service.openStream(
+      {
+        namespaceName: 'team-a',
+        environmentName: 'dev',
+        projectName: 'proj-x',
+      },
+      undefined,
+      controller.signal,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      'http://api.openchoreo/api/v1/namespaces/team-a/environments/dev/wirelogs?project=proj-x',
+    );
+    expect(init.method).toBe('GET');
+    expect(init.headers).toEqual({ Accept: 'text/event-stream' });
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it('strips a trailing /api/v1 from the configured base URL so the path is not doubled', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const service = new WirelogsInfoService(
+      logger,
+      'http://api.openchoreo/api/v1',
+    );
+
+    await service.openStream(
+      {
+        namespaceName: 'team',
+        environmentName: 'dev',
+        projectName: 'proj',
+      },
+      undefined,
+      new AbortController().signal,
+    );
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      'http://api.openchoreo/api/v1/namespaces/team/environments/dev/wirelogs?project=proj',
+    );
+  });
+
+  it('also strips a trailing /api/v1/ (with slash)', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const service = new WirelogsInfoService(
+      logger,
+      'http://api.openchoreo/api/v1/',
+    );
+
+    await service.openStream(
+      {
+        namespaceName: 'team',
+        environmentName: 'dev',
+        projectName: 'proj',
+      },
+      undefined,
+      new AbortController().signal,
+    );
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      'http://api.openchoreo/api/v1/namespaces/team/environments/dev/wirelogs?project=proj',
+    );
+  });
+
+  it('appends the component query parameter when supplied', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const service = new WirelogsInfoService(logger, 'http://api.openchoreo');
+
+    await service.openStream(
+      {
+        namespaceName: 'team',
+        environmentName: 'dev',
+        projectName: 'proj',
+        componentName: 'svc',
+      },
+      'tok',
+      new AbortController().signal,
+    );
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('component=svc');
+  });
+
+  it('attaches a Bearer token when one is supplied', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const service = new WirelogsInfoService(logger, 'http://api.openchoreo');
+
+    await service.openStream(
+      {
+        namespaceName: 'team',
+        environmentName: 'dev',
+        projectName: 'proj',
+      },
+      'my-token',
+      new AbortController().signal,
+    );
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers).toEqual({
+      Accept: 'text/event-stream',
+      Authorization: 'Bearer my-token',
+    });
+  });
+
+  it('URL-encodes namespace and environment path segments', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+    const service = new WirelogsInfoService(logger, 'http://api.openchoreo');
+
+    await service.openStream(
+      {
+        namespaceName: 'team space',
+        environmentName: 'dev/uat',
+        projectName: 'proj',
+      },
+      undefined,
+      new AbortController().signal,
+    );
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/namespaces/team%20space/');
+    expect(url).toContain('/environments/dev%2Fuat/');
+  });
+});

--- a/plugins/openchoreo-backend/src/services/WirelogsService/WirelogsInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/WirelogsService/WirelogsInfoService.ts
@@ -1,0 +1,60 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+
+export interface WirelogsStreamRequest {
+  namespaceName: string;
+  environmentName: string;
+  projectName: string;
+  componentName?: string;
+}
+
+/**
+ * Opens an upstream SSE stream to the OpenChoreo API's wirelogs endpoint
+ * and returns the raw Response. The router pipes the body to the browser.
+ *
+ * When a component is supplied, the upstream Hubble filter scopes flows to
+ * those whose source or destination carries the component label, so the
+ * frontend does not need to re-filter by component.
+ */
+export class WirelogsInfoService {
+  private readonly logger: LoggerService;
+  private readonly baseUrl: string;
+
+  constructor(logger: LoggerService, baseUrl: string) {
+    this.logger = logger;
+    // Mirror createOpenChoreoApiClient: the configured baseUrl may already end
+    // in /api/v1, so strip it here and re-add it in the path below to avoid a
+    // doubled /api/v1/api/v1 prefix.
+    this.baseUrl = baseUrl.replace(/\/api\/v1\/?$/, '');
+  }
+
+  async openStream(
+    request: WirelogsStreamRequest,
+    userToken: string | undefined,
+    signal: AbortSignal,
+  ): Promise<Response> {
+    const url = new URL(
+      `${this.baseUrl}/api/v1/namespaces/${encodeURIComponent(
+        request.namespaceName,
+      )}/environments/${encodeURIComponent(request.environmentName)}/wirelogs`,
+    );
+    url.searchParams.set('project', request.projectName);
+    if (request.componentName) {
+      url.searchParams.set('component', request.componentName);
+    }
+
+    this.logger.debug(`Opening wirelogs SSE stream to ${url.toString()}`);
+
+    const headers: Record<string, string> = {
+      Accept: 'text/event-stream',
+    };
+    if (userToken) {
+      headers.Authorization = `Bearer ${userToken}`;
+    }
+
+    return fetch(url.toString(), {
+      method: 'GET',
+      headers,
+      signal,
+    });
+  }
+}

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -68,6 +68,7 @@ export {
   openchoreoClusterRoleMappingDeletePermission,
   openchoreoLogsViewPermission,
   openchoreoAlertsViewPermission,
+  openchoreoWirelogsViewPermission,
   openchoreoIncidentsViewPermission,
   openchoreoMetricsViewPermission,
   openchoreoTracesViewPermission,

--- a/plugins/openchoreo-common/src/permissions.ts
+++ b/plugins/openchoreo-common/src/permissions.ts
@@ -956,6 +956,17 @@ export const openchoreoAlertsViewPermission = createPermission({
 });
 
 /**
+ * Permission to view Cilium Hubble wirelogs for a project/component.
+ * Resource-based: scoped to the component's namespaced resource so the
+ * tab is gated alongside Logs/Metrics/Alerts on the component page.
+ */
+export const openchoreoWirelogsViewPermission = createPermission({
+  name: 'openchoreo.wirelogs.view',
+  attributes: { action: 'read' },
+  resourceType: OPENCHOREO_RESOURCE_TYPE_NAMESPACED_RESOURCE,
+});
+
+/**
  * Permission to view incidents for a project.
  * Resource-based: requires the specific project context.
  */
@@ -1019,6 +1030,7 @@ export const openchoreoPermissions = [
   openchoreoFinopsUpdatePermission,
   openchoreoTraitsViewPermission,
   openchoreoAlertsViewPermission,
+  openchoreoWirelogsViewPermission,
   openchoreoIncidentsViewPermission,
   openchoreoTraitCreatePermission,
   openchoreoComponentTypeCreatePermission,
@@ -1124,6 +1136,7 @@ export const OPENCHOREO_PERMISSION_TO_ACTION: Record<string, string> = {
   'openchoreo.clusterrolemapping.delete': 'clusterauthzrolebinding:delete',
   'openchoreo.logs.view': 'logs:view',
   'openchoreo.alerts.view': 'alerts:view',
+  'openchoreo.wirelogs.view': 'wirelogs:view',
   'openchoreo.incidents.view': 'incidents:view',
   'openchoreo.metrics.view': 'metrics:view',
   'openchoreo.traces.view': 'traces:view',

--- a/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.test.tsx
@@ -4,13 +4,10 @@ import { ObservabilityWirelogsPage } from './ObservabilityWirelogsPage';
 // ---- Mocks ----------------------------------------------------------------
 
 const mockUseWirelogsPermission = jest.fn();
-const mockUseProjectEnvironments = jest.fn();
 
 jest.mock('@openchoreo/backstage-plugin-react', () => ({
   __esModule: true,
   useWirelogsPermission: (...args: any[]) => mockUseWirelogsPermission(...args),
-  useProjectEnvironments: (...args: any[]) =>
-    mockUseProjectEnvironments(...args),
   ForbiddenState: ({ message, variant }: any) => (
     <div data-testid={`forbidden-${variant}`}>{message}</div>
   ),
@@ -52,9 +49,12 @@ const mockUseGetNamespaceAndProjectByEntity = jest.fn().mockReturnValue({
   namespace: 'ns',
   project: 'proj',
 });
+const mockUseWirelogsEnvironments = jest.fn();
 jest.mock('../../hooks', () => ({
   useGetNamespaceAndProjectByEntity: (...args: any[]) =>
     mockUseGetNamespaceAndProjectByEntity(...args),
+  useWirelogsEnvironments: (...args: any[]) =>
+    mockUseWirelogsEnvironments(...args),
 }));
 
 const mockUseWirelogsStream = jest.fn();
@@ -63,8 +63,20 @@ jest.mock('./useWirelogsStream', () => ({
 }));
 
 jest.mock('./WirelogsFilter', () => ({
-  WirelogsFilter: ({ onDownload, onStart, onStop, onClear, status }: any) => (
-    <div data-testid="filter">
+  WirelogsFilter: ({
+    onDownload,
+    onStart,
+    onStop,
+    onClear,
+    status,
+    disabled,
+    startDisabled,
+  }: any) => (
+    <div
+      data-testid="filter"
+      data-disabled={String(!!disabled)}
+      data-start-disabled={String(!!startDisabled)}
+    >
       <span data-testid="status">{status}</span>
       <button onClick={onStart}>start</button>
       <button onClick={onStop}>stop</button>
@@ -121,16 +133,31 @@ function defaultStream(): StreamState {
 
 const dev = {
   name: 'dev',
+  displayName: 'Dev',
   namespace: 'dev-ns',
   isProduction: false,
   createdAt: '2026-01-01T00:00:00Z',
+  dataPlaneRef: { name: 'dp-dev', kind: 'DataPlane' },
+  hasWirelogs: true,
 };
 const stg = {
   name: 'stg',
+  displayName: 'Staging',
   namespace: 'stg-ns',
   isProduction: false,
   createdAt: '2026-01-01T00:00:00Z',
+  dataPlaneRef: { name: 'dp-stg', kind: 'DataPlane' },
+  hasWirelogs: true,
 };
+
+function setupEnvironments(over: Partial<ReturnType<any>> = {}) {
+  mockUseWirelogsEnvironments.mockReturnValue({
+    environments: [dev, stg],
+    loading: false,
+    error: null,
+    ...over,
+  });
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -141,11 +168,7 @@ beforeEach(() => {
     deniedTooltip: '',
     permissionName: 'view-wirelogs',
   });
-  mockUseProjectEnvironments.mockReturnValue({
-    environments: [dev, stg],
-    loading: false,
-    error: null,
-  });
+  setupEnvironments();
 });
 
 // ---- Tests ----------------------------------------------------------------
@@ -180,7 +203,7 @@ describe('ObservabilityWirelogsPage', () => {
   });
 
   it('renders the env error alert when environments fail to load', () => {
-    mockUseProjectEnvironments.mockReturnValueOnce({
+    mockUseWirelogsEnvironments.mockReturnValueOnce({
       environments: [],
       loading: false,
       error: 'broken',
@@ -190,7 +213,7 @@ describe('ObservabilityWirelogsPage', () => {
   });
 
   it('renders the no-envs alert when env list is empty (not loading)', () => {
-    mockUseProjectEnvironments.mockReturnValueOnce({
+    mockUseWirelogsEnvironments.mockReturnValueOnce({
       environments: [],
       loading: false,
       error: null,
@@ -298,5 +321,53 @@ describe('ObservabilityWirelogsPage', () => {
     createSpy.mockRestore();
     appendSpy.mockRestore();
     removeSpy.mockRestore();
+  });
+
+  it('disables the toolbar and shows a Cilium warning when no environment supports wirelogs', async () => {
+    setupEnvironments({
+      environments: [
+        { ...dev, hasWirelogs: false },
+        { ...stg, hasWirelogs: false },
+      ],
+    });
+    render(<ObservabilityWirelogsPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('filter')).toHaveAttribute(
+        'data-disabled',
+        'true',
+      ),
+    );
+    expect(
+      screen.getByText(/any of this project's environments/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('table')).not.toBeInTheDocument();
+  });
+
+  it('warns and disables Start (but not the env selector) when the selected env cannot stream but another can', async () => {
+    setupEnvironments({
+      environments: [{ ...dev, hasWirelogs: false }, stg],
+    });
+    render(<ObservabilityWirelogsPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('filter')).toHaveAttribute(
+        'data-start-disabled',
+        'true',
+      ),
+    );
+    expect(screen.getByTestId('filter')).toHaveAttribute(
+      'data-disabled',
+      'false',
+    );
+    expect(screen.getByText(/unavailable in the/i).textContent).toMatch(/Dev/);
+    expect(screen.queryByTestId('table')).not.toBeInTheDocument();
+  });
+
+  it('stops an in-flight stream when the selected environment cannot stream wirelogs', async () => {
+    setupStream({ status: 'streaming' });
+    setupEnvironments({
+      environments: [{ ...dev, hasWirelogs: false }, stg],
+    });
+    render(<ObservabilityWirelogsPage />);
+    await waitFor(() => expect(stopMock).toHaveBeenCalled());
   });
 });

--- a/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.test.tsx
@@ -1,0 +1,302 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ObservabilityWirelogsPage } from './ObservabilityWirelogsPage';
+
+// ---- Mocks ----------------------------------------------------------------
+
+const mockUseWirelogsPermission = jest.fn();
+const mockUseProjectEnvironments = jest.fn();
+
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  __esModule: true,
+  useWirelogsPermission: (...args: any[]) => mockUseWirelogsPermission(...args),
+  useProjectEnvironments: (...args: any[]) =>
+    mockUseProjectEnvironments(...args),
+  ForbiddenState: ({ message, variant }: any) => (
+    <div data-testid={`forbidden-${variant}`}>{message}</div>
+  ),
+  EnvironmentFilter: ({ value, onChange, environments }: any) => (
+    <select
+      data-testid="env-filter"
+      value={value?.name ?? ''}
+      onChange={e =>
+        onChange(environments.find((env: any) => env.name === e.target.value))
+      }
+    >
+      {environments.map((env: any) => (
+        <option key={env.name} value={env.name}>
+          {env.name}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'api',
+        annotations: { 'openchoreo.io/component': 'api' },
+      },
+    },
+  }),
+}));
+
+jest.mock('@openchoreo/backstage-plugin-common', () => ({
+  CHOREO_ANNOTATIONS: { COMPONENT: 'openchoreo.io/component' },
+}));
+
+const mockUseGetNamespaceAndProjectByEntity = jest.fn().mockReturnValue({
+  namespace: 'ns',
+  project: 'proj',
+});
+jest.mock('../../hooks', () => ({
+  useGetNamespaceAndProjectByEntity: (...args: any[]) =>
+    mockUseGetNamespaceAndProjectByEntity(...args),
+}));
+
+const mockUseWirelogsStream = jest.fn();
+jest.mock('./useWirelogsStream', () => ({
+  useWirelogsStream: (args: any) => mockUseWirelogsStream(args),
+}));
+
+jest.mock('./WirelogsFilter', () => ({
+  WirelogsFilter: ({ onDownload, onStart, onStop, onClear, status }: any) => (
+    <div data-testid="filter">
+      <span data-testid="status">{status}</span>
+      <button onClick={onStart}>start</button>
+      <button onClick={onStop}>stop</button>
+      <button onClick={onClear}>clear</button>
+      <button onClick={onDownload}>download</button>
+    </div>
+  ),
+}));
+
+jest.mock('./WirelogsTable', () => ({
+  WirelogsTable: ({ flows }: any) => (
+    <div data-testid="table">flows={flows.length}</div>
+  ),
+  matchesSearch: () => true,
+}));
+
+jest.mock('./WirelogsStats', () => ({
+  WirelogsStats: ({ allowed, dropped, visibleCount, totalLoaded }: any) => (
+    <div data-testid="stats">
+      a={allowed} d={dropped} v={visibleCount} t={totalLoaded}
+    </div>
+  ),
+}));
+
+const startMock = jest.fn();
+const stopMock = jest.fn();
+const clearMock = jest.fn();
+
+interface StreamState {
+  flows: any[];
+  status: string;
+  error: string | null;
+  totalReceived: number;
+  start: jest.Mock;
+  stop: jest.Mock;
+  clear: jest.Mock;
+}
+
+function setupStream(over: Partial<StreamState> = {}) {
+  mockUseWirelogsStream.mockReturnValue({ ...defaultStream(), ...over });
+}
+
+function defaultStream(): StreamState {
+  return {
+    flows: [],
+    status: 'idle',
+    error: null,
+    totalReceived: 0,
+    start: startMock,
+    stop: stopMock,
+    clear: clearMock,
+  };
+}
+
+const dev = {
+  name: 'dev',
+  namespace: 'dev-ns',
+  isProduction: false,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+const stg = {
+  name: 'stg',
+  namespace: 'stg-ns',
+  isProduction: false,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupStream();
+  mockUseWirelogsPermission.mockReturnValue({
+    canViewWirelogs: true,
+    loading: false,
+    deniedTooltip: '',
+    permissionName: 'view-wirelogs',
+  });
+  mockUseProjectEnvironments.mockReturnValue({
+    environments: [dev, stg],
+    loading: false,
+    error: null,
+  });
+});
+
+// ---- Tests ----------------------------------------------------------------
+
+describe('ObservabilityWirelogsPage', () => {
+  it('shows a progress indicator while the top-level permission is loading', () => {
+    mockUseWirelogsPermission.mockReturnValueOnce({
+      canViewWirelogs: false,
+      loading: true,
+      deniedTooltip: '',
+      permissionName: 'view-wirelogs',
+    });
+    render(<ObservabilityWirelogsPage />);
+    // While permission is loading, none of the page's content (toolbar /
+    // forbidden state / table) should render yet.
+    expect(screen.queryByTestId('filter')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('forbidden-fullpage')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('table')).not.toBeInTheDocument();
+  });
+
+  it('renders a fullpage forbidden state when the user lacks the wirelogs permission', () => {
+    mockUseWirelogsPermission.mockReturnValueOnce({
+      canViewWirelogs: false,
+      loading: false,
+      deniedTooltip: 'no wirelogs',
+      permissionName: 'view-wirelogs',
+    });
+    render(<ObservabilityWirelogsPage />);
+    expect(screen.getByTestId('forbidden-fullpage')).toHaveTextContent(
+      'no wirelogs',
+    );
+  });
+
+  it('renders the env error alert when environments fail to load', () => {
+    mockUseProjectEnvironments.mockReturnValueOnce({
+      environments: [],
+      loading: false,
+      error: 'broken',
+    });
+    render(<ObservabilityWirelogsPage />);
+    expect(screen.getByText('broken')).toBeInTheDocument();
+  });
+
+  it('renders the no-envs alert when env list is empty (not loading)', () => {
+    mockUseProjectEnvironments.mockReturnValueOnce({
+      environments: [],
+      loading: false,
+      error: null,
+    });
+    render(<ObservabilityWirelogsPage />);
+    expect(screen.getByText(/No environments found/i)).toBeInTheDocument();
+  });
+
+  it('renders the stream error message under the toolbar', () => {
+    setupStream({ status: 'error', error: 'kaboom' });
+    render(<ObservabilityWirelogsPage />);
+    expect(screen.getByText('kaboom')).toBeInTheDocument();
+  });
+
+  it('shows a compact forbidden state for the selected environment when scoped permission is denied', async () => {
+    mockUseWirelogsPermission
+      // top-level (no args) call: allowed
+      .mockReturnValueOnce({
+        canViewWirelogs: true,
+        loading: false,
+        deniedTooltip: '',
+        permissionName: 'view-wirelogs',
+      })
+      // env-scoped call: denied
+      .mockReturnValue({
+        canViewWirelogs: false,
+        loading: false,
+        deniedTooltip: 'no wirelogs in dev',
+        permissionName: 'view-wirelogs',
+      });
+
+    render(<ObservabilityWirelogsPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('forbidden-compact')).toHaveTextContent(
+        'no wirelogs in dev',
+      ),
+    );
+  });
+
+  it('renders the table and stats when env-scoped permission is allowed', async () => {
+    setupStream({
+      flows: [
+        { flow: { uuid: 'a', verdict: 'FORWARDED' } } as any,
+        { flow: { uuid: 'b', verdict: 'DROPPED' } } as any,
+      ],
+      totalReceived: 2,
+    });
+    render(<ObservabilityWirelogsPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('table')).toBeInTheDocument(),
+    );
+    // Stats reflect the verdict tallies.
+    expect(screen.getByTestId('stats')).toHaveTextContent('a=1 d=1 v=2 t=2');
+  });
+
+  it('passes namespace, project, environment and component into the stream hook', async () => {
+    render(<ObservabilityWirelogsPage />);
+    await waitFor(() => {
+      const lastCall =
+        mockUseWirelogsStream.mock.calls[
+          mockUseWirelogsStream.mock.calls.length - 1
+        ][0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({
+          namespaceName: 'ns',
+          projectName: 'proj',
+          environmentName: 'dev',
+          componentName: 'api',
+        }),
+      );
+    });
+  });
+
+  it('downloads a JSON file via createElement + click + revokeObjectURL', () => {
+    const createObjectURL = jest.fn(() => 'blob:url');
+    const revokeObjectURL = jest.fn();
+    (URL as any).createObjectURL = createObjectURL;
+    (URL as any).revokeObjectURL = revokeObjectURL;
+
+    setupStream({
+      flows: [{ flow: { uuid: 'a' } } as any],
+      totalReceived: 1,
+    });
+
+    render(<ObservabilityWirelogsPage />);
+
+    const link = { click: jest.fn(), href: '', download: '' };
+    const createSpy = jest
+      .spyOn(document, 'createElement')
+      .mockImplementationOnce(() => link as any);
+    const appendSpy = jest
+      .spyOn(document.body, 'appendChild')
+      .mockImplementationOnce(node => node);
+    const removeSpy = jest
+      .spyOn(document.body, 'removeChild')
+      .mockImplementationOnce(node => node);
+
+    fireEvent.click(screen.getByText('download'));
+
+    expect(createSpy).toHaveBeenCalledWith('a');
+    expect(link.click).toHaveBeenCalled();
+    expect(link.download).toMatch(/^wirelogs-proj-dev-/);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:url');
+
+    createSpy.mockRestore();
+    appendSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
@@ -23,6 +23,7 @@ const ObservabilityWirelogsContent = () => {
   const { namespace, project } = useGetNamespaceAndProjectByEntity(entity);
   const componentName =
     entity.metadata.annotations?.[CHOREO_ANNOTATIONS.COMPONENT];
+  const componentScopeMissing = entity.kind === 'Component' && !componentName;
 
   const {
     environments,
@@ -52,7 +53,9 @@ const ObservabilityWirelogsContent = () => {
   const stream = useWirelogsStream({
     namespaceName: namespace,
     projectName: project,
-    environmentName: filters.environment?.name,
+    environmentName: componentScopeMissing
+      ? undefined
+      : filters.environment?.name,
     componentName,
   });
 
@@ -103,6 +106,19 @@ const ObservabilityWirelogsContent = () => {
     );
   }
 
+  if (componentScopeMissing) {
+    return (
+      <Box>
+        <Alert severity="error" className={classes.errorContainer}>
+          <Typography variant="body1">
+            This component is missing the {CHOREO_ANNOTATIONS.COMPONENT}{' '}
+            annotation, so wirelogs cannot be scoped to it.
+          </Typography>
+        </Alert>
+      </Box>
+    );
+  }
+
   const isStreaming =
     stream.status === 'streaming' || stream.status === 'connecting';
 
@@ -148,7 +164,7 @@ const ObservabilityWirelogsContent = () => {
         <>
           <WirelogsStats
             visibleCount={visibleFlows.length}
-            totalLoaded={stream.flows.length}
+            totalLoaded={stream.totalReceived}
             allowed={stats.allowed}
             dropped={stats.dropped}
           />

--- a/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Alert } from '@material-ui/lab';
-import { Box, Typography } from '@material-ui/core';
+import { Box, Tooltip, Typography } from '@material-ui/core';
 import { Progress } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import {
   ForbiddenState,
-  useProjectEnvironments,
   useWirelogsPermission,
 } from '@openchoreo/backstage-plugin-react';
-import { useGetNamespaceAndProjectByEntity } from '../../hooks';
+import {
+  useGetNamespaceAndProjectByEntity,
+  useWirelogsEnvironments,
+} from '../../hooks';
 import { WirelogsFilter } from './WirelogsFilter';
 import { WirelogsStats } from './WirelogsStats';
 import { WirelogsTable, matchesSearch } from './WirelogsTable';
@@ -29,7 +31,7 @@ const ObservabilityWirelogsContent = () => {
     environments,
     loading: environmentsLoading,
     error: environmentsError,
-  } = useProjectEnvironments(project, namespace);
+  } = useWirelogsEnvironments(project, namespace);
 
   const [filters, setFilters] = useState<WirelogsFilters>({
     environment: null,
@@ -42,6 +44,14 @@ const ObservabilityWirelogsContent = () => {
       setFilters(prev => ({ ...prev, environment: environments[0] }));
     }
   }, [environments, filters.environment]);
+
+  const anyEnvHasWirelogs = useMemo(
+    () => environments.some(e => e.hasWirelogs),
+    [environments],
+  );
+  const selectedEnvHasWirelogs =
+    environments.find(e => e.name === filters.environment?.name)?.hasWirelogs ??
+    false;
 
   const {
     canViewWirelogs: canViewForEnv,
@@ -58,6 +68,24 @@ const ObservabilityWirelogsContent = () => {
       : filters.environment?.name,
     componentName,
   });
+
+  const { status: streamStatus, stop: stopStream } = stream;
+  useEffect(() => {
+    if (
+      !environmentsLoading &&
+      filters.environment &&
+      !selectedEnvHasWirelogs &&
+      (streamStatus === 'streaming' || streamStatus === 'connecting')
+    ) {
+      stopStream();
+    }
+  }, [
+    environmentsLoading,
+    filters.environment,
+    selectedEnvHasWirelogs,
+    streamStatus,
+    stopStream,
+  ]);
 
   // Component scoping is applied upstream via the Hubble filter; only the
   // free-text search box is applied client-side here.
@@ -122,19 +150,39 @@ const ObservabilityWirelogsContent = () => {
   const isStreaming =
     stream.status === 'streaming' || stream.status === 'connecting';
 
+  const noEnvSupportsWirelogs =
+    !environmentsLoading && environments.length > 0 && !anyEnvHasWirelogs;
+  const selectedEnvUnsupported =
+    !!filters.environment &&
+    !environmentsLoading &&
+    !selectedEnvHasWirelogs &&
+    !noEnvSupportsWirelogs;
+
+  const toolbar = (
+    <WirelogsFilter
+      filters={filters}
+      onFiltersChange={handleFiltersChange}
+      environments={environments}
+      environmentsLoading={environmentsLoading}
+      status={stream.status}
+      onStart={stream.start}
+      onStop={stream.stop}
+      onClear={stream.clear}
+      onDownload={handleDownload}
+      disabled={noEnvSupportsWirelogs}
+      startDisabled={selectedEnvUnsupported}
+    />
+  );
+
   return (
     <Box>
-      <WirelogsFilter
-        filters={filters}
-        onFiltersChange={handleFiltersChange}
-        environments={environments}
-        environmentsLoading={environmentsLoading}
-        status={stream.status}
-        onStart={stream.start}
-        onStop={stream.stop}
-        onClear={stream.clear}
-        onDownload={handleDownload}
-      />
+      {noEnvSupportsWirelogs ? (
+        <Tooltip title="Wirelogs are unavailable in all environments. Configure the Cilium module to enable network observability.">
+          <span>{toolbar}</span>
+        </Tooltip>
+      ) : (
+        toolbar
+      )}
 
       {stream.error && (
         <Alert severity="error" className={classes.errorContainer}>
@@ -160,7 +208,30 @@ const ObservabilityWirelogsContent = () => {
         />
       )}
 
-      {filters.environment && canViewForEnv && (
+      {canViewForEnv && noEnvSupportsWirelogs && (
+        <Alert severity="warning" className={classes.errorContainer}>
+          <Typography variant="body1">
+            Wirelogs require the Cilium network observability module, which
+            isn't configured on any of this project's environments. Configure
+            the Cilium module on a DataPlane to stream wirelogs.
+          </Typography>
+        </Alert>
+      )}
+
+      {canViewForEnv && selectedEnvUnsupported && filters.environment && (
+        <Alert severity="warning" className={classes.errorContainer}>
+          <Typography variant="body1">
+            Wirelogs are unavailable in the{' '}
+            <strong>
+              {filters.environment.displayName || filters.environment.name}
+            </strong>{' '}
+            environment. Configure the Cilium module on its DataPlane to enable
+            network observability.
+          </Typography>
+        </Alert>
+      )}
+
+      {filters.environment && canViewForEnv && selectedEnvHasWirelogs && (
         <>
           <WirelogsStats
             visibleCount={visibleFlows.length}

--- a/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Alert } from '@material-ui/lab';
+import { Box, Typography } from '@material-ui/core';
+import { Progress } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import {
+  ForbiddenState,
+  useProjectEnvironments,
+  useWirelogsPermission,
+} from '@openchoreo/backstage-plugin-react';
+import { useGetNamespaceAndProjectByEntity } from '../../hooks';
+import { WirelogsFilter } from './WirelogsFilter';
+import { WirelogsStats } from './WirelogsStats';
+import { WirelogsTable, matchesSearch } from './WirelogsTable';
+import { useWirelogsStream } from './useWirelogsStream';
+import { useWirelogsStyles } from './styles';
+import type { WirelogsFilters } from './types';
+
+const ObservabilityWirelogsContent = () => {
+  const classes = useWirelogsStyles();
+  const { entity } = useEntity();
+  const { namespace, project } = useGetNamespaceAndProjectByEntity(entity);
+  const componentName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.COMPONENT];
+
+  const {
+    environments,
+    loading: environmentsLoading,
+    error: environmentsError,
+  } = useProjectEnvironments(project, namespace);
+
+  const [filters, setFilters] = useState<WirelogsFilters>({
+    environment: null,
+    searchQuery: '',
+  });
+
+  // Pick the first environment (in deployment-pipeline order) once they load.
+  useEffect(() => {
+    if (!filters.environment && environments.length > 0) {
+      setFilters(prev => ({ ...prev, environment: environments[0] }));
+    }
+  }, [environments, filters.environment]);
+
+  const {
+    canViewWirelogs: canViewForEnv,
+    loading: envPermissionLoading,
+    deniedTooltip: envPermissionDenied,
+    permissionName: envPermissionName,
+  } = useWirelogsPermission(filters.environment?.name);
+
+  const stream = useWirelogsStream({
+    namespaceName: namespace,
+    projectName: project,
+    environmentName: filters.environment?.name,
+    componentName,
+  });
+
+  // Component scoping is applied upstream via the Hubble filter; only the
+  // free-text search box is applied client-side here.
+  const visibleFlows = useMemo(
+    () => stream.flows.filter(e => matchesSearch(e, filters.searchQuery)),
+    [stream.flows, filters.searchQuery],
+  );
+
+  const stats = useMemo(() => {
+    let allowed = 0;
+    let dropped = 0;
+    for (const e of visibleFlows) {
+      if (e.flow.verdict === 'DROPPED') dropped += 1;
+      else if (e.flow.verdict === 'FORWARDED') allowed += 1;
+    }
+    return { allowed, dropped };
+  }, [visibleFlows]);
+
+  const handleFiltersChange = (next: Partial<WirelogsFilters>) => {
+    setFilters(prev => ({ ...prev, ...next }));
+  };
+
+  const handleDownload = () => {
+    const payload = JSON.stringify(visibleFlows, null, 2);
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    link.href = url;
+    link.download = `wirelogs-${project ?? 'project'}-${
+      filters.environment?.name ?? 'env'
+    }-${ts}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  if (environmentsError) {
+    return (
+      <Box>
+        <Alert severity="error" className={classes.errorContainer}>
+          <Typography variant="body1">{environmentsError}</Typography>
+        </Alert>
+      </Box>
+    );
+  }
+
+  const isStreaming =
+    stream.status === 'streaming' || stream.status === 'connecting';
+
+  return (
+    <Box>
+      <WirelogsFilter
+        filters={filters}
+        onFiltersChange={handleFiltersChange}
+        environments={environments}
+        environmentsLoading={environmentsLoading}
+        status={stream.status}
+        onStart={stream.start}
+        onStop={stream.stop}
+        onClear={stream.clear}
+        onDownload={handleDownload}
+      />
+
+      {stream.error && (
+        <Alert severity="error" className={classes.errorContainer}>
+          {stream.error}
+        </Alert>
+      )}
+
+      {!filters.environment &&
+        !environmentsLoading &&
+        environments.length === 0 && (
+          <Alert severity="info" className={classes.errorContainer}>
+            <Typography variant="body1">
+              No environments found. Make sure your component is deployed.
+            </Typography>
+          </Alert>
+        )}
+
+      {filters.environment && !envPermissionLoading && !canViewForEnv && (
+        <ForbiddenState
+          message={envPermissionDenied}
+          permissionName={envPermissionName}
+          variant="compact"
+        />
+      )}
+
+      {filters.environment && canViewForEnv && (
+        <>
+          <WirelogsStats
+            visibleCount={visibleFlows.length}
+            totalLoaded={stream.flows.length}
+            allowed={stats.allowed}
+            dropped={stats.dropped}
+          />
+          <WirelogsTable flows={visibleFlows} isStreaming={isStreaming} />
+        </>
+      )}
+    </Box>
+  );
+};
+
+export const ObservabilityWirelogsPage = () => {
+  const {
+    canViewWirelogs,
+    loading: permissionLoading,
+    deniedTooltip,
+    permissionName,
+  } = useWirelogsPermission();
+
+  if (permissionLoading) {
+    return <Progress />;
+  }
+
+  if (!canViewWirelogs) {
+    return (
+      <ForbiddenState
+        message={deniedTooltip}
+        permissionName={permissionName}
+        variant="fullpage"
+      />
+    );
+  }
+
+  return <ObservabilityWirelogsContent />;
+};

--- a/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
@@ -60,6 +60,9 @@ const ObservabilityWirelogsContent = () => {
     permissionName: envPermissionName,
   } = useWirelogsPermission(filters.environment?.name);
 
+  const envAccessDenied =
+    !!filters.environment && !envPermissionLoading && !canViewForEnv;
+
   const stream = useWirelogsStream({
     namespaceName: namespace,
     projectName: project,
@@ -74,7 +77,7 @@ const ObservabilityWirelogsContent = () => {
     if (
       !environmentsLoading &&
       filters.environment &&
-      !selectedEnvHasWirelogs &&
+      (!selectedEnvHasWirelogs || envAccessDenied) &&
       (streamStatus === 'streaming' || streamStatus === 'connecting')
     ) {
       stopStream();
@@ -83,6 +86,7 @@ const ObservabilityWirelogsContent = () => {
     environmentsLoading,
     filters.environment,
     selectedEnvHasWirelogs,
+    envAccessDenied,
     streamStatus,
     stopStream,
   ]);
@@ -170,7 +174,7 @@ const ObservabilityWirelogsContent = () => {
       onClear={stream.clear}
       onDownload={handleDownload}
       disabled={noEnvSupportsWirelogs}
-      startDisabled={selectedEnvUnsupported}
+      startDisabled={selectedEnvUnsupported || envAccessDenied}
     />
   );
 

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFilter.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFilter.test.tsx
@@ -72,6 +72,19 @@ describe('WirelogsFilter', () => {
     expect(screen.getByText('Start stream').closest('button')).toBeDisabled();
   });
 
+  it('disables Start (but leaves the env selector usable) when startDisabled is set', () => {
+    const props = defaults();
+    render(<WirelogsFilter {...props} startDisabled />);
+    expect(screen.getByText('Start stream').closest('button')).toBeDisabled();
+    expect(screen.getByTestId('env')).not.toBeDisabled();
+  });
+
+  it('disables the env selector when the whole toolbar is disabled', () => {
+    const props = defaults();
+    render(<WirelogsFilter {...props} disabled />);
+    expect(screen.getByTestId('env')).toBeDisabled();
+  });
+
   it('renders Stop while streaming and fires onStop', () => {
     const props = defaults();
     render(<WirelogsFilter {...props} status="streaming" />);

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFilter.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFilter.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { WirelogsFilter } from './WirelogsFilter';
+
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  EnvironmentFilter: ({ value, onChange, environments, disabled }: any) => (
+    <select
+      data-testid="env"
+      value={value?.name ?? ''}
+      disabled={disabled}
+      onChange={e =>
+        onChange(environments.find((env: any) => env.name === e.target.value))
+      }
+    >
+      <option value="">--</option>
+      {environments.map((env: any) => (
+        <option key={env.name} value={env.name}>
+          {env.name}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+// Skip the 1s debounce — call onChange immediately on input.
+jest.mock('../../hooks/useDebouncedSearch', () => ({
+  useDebouncedSearch: (
+    initial: string,
+    onChange: (value: string) => void,
+  ): [string, (e: any) => void] => [
+    initial,
+    (e: any) => onChange(e.target.value),
+  ],
+}));
+
+const env = {
+  name: 'dev',
+  namespace: 'dev-ns',
+  isProduction: false,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+function defaults() {
+  return {
+    filters: { environment: env as any, searchQuery: '' },
+    onFiltersChange: jest.fn(),
+    environments: [env as any],
+    environmentsLoading: false,
+    status: 'idle' as const,
+    onStart: jest.fn(),
+    onStop: jest.fn(),
+    onClear: jest.fn(),
+    onDownload: jest.fn(),
+  };
+}
+
+describe('WirelogsFilter', () => {
+  it('renders Start when idle and fires onStart when clicked', () => {
+    const props = defaults();
+    render(<WirelogsFilter {...props} />);
+    fireEvent.click(screen.getByText('Start stream'));
+    expect(props.onStart).toHaveBeenCalled();
+  });
+
+  it('disables Start when no environment selected', () => {
+    const props = defaults();
+    render(
+      <WirelogsFilter
+        {...props}
+        filters={{ environment: null, searchQuery: '' }}
+      />,
+    );
+    expect(screen.getByText('Start stream').closest('button')).toBeDisabled();
+  });
+
+  it('renders Stop while streaming and fires onStop', () => {
+    const props = defaults();
+    render(<WirelogsFilter {...props} status="streaming" />);
+    fireEvent.click(screen.getByText('Stop stream'));
+    expect(props.onStop).toHaveBeenCalled();
+  });
+
+  it('also renders Stop during the connecting transitional state', () => {
+    const props = defaults();
+    render(<WirelogsFilter {...props} status="connecting" />);
+    expect(screen.getByText('Stop stream')).toBeInTheDocument();
+  });
+
+  it('fires onClear / onDownload from their toolbar buttons', () => {
+    const props = defaults();
+    render(<WirelogsFilter {...props} />);
+    fireEvent.click(screen.getByText('Clear'));
+    fireEvent.click(screen.getByText('Download'));
+    expect(props.onClear).toHaveBeenCalled();
+    expect(props.onDownload).toHaveBeenCalled();
+  });
+
+  it('propagates search input through onFiltersChange', () => {
+    const props = defaults();
+    render(<WirelogsFilter {...props} />);
+    fireEvent.change(screen.getByPlaceholderText(/Filter flows by verdict/i), {
+      target: { value: 'foo' },
+    });
+    expect(props.onFiltersChange).toHaveBeenCalledWith({ searchQuery: 'foo' });
+  });
+
+  it('propagates environment change through onFiltersChange', () => {
+    const props = defaults();
+    const stg = {
+      name: 'stg',
+      namespace: 'stg-ns',
+      isProduction: false,
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    render(
+      <WirelogsFilter {...props} environments={[env as any, stg as any]} />,
+    );
+    fireEvent.change(screen.getByTestId('env'), { target: { value: 'stg' } });
+    expect(props.onFiltersChange).toHaveBeenCalledWith({
+      environment: expect.objectContaining({ name: 'stg' }),
+    });
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFilter.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFilter.tsx
@@ -1,0 +1,122 @@
+import { FC } from 'react';
+import { Box, Button, InputAdornment, TextField } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
+import GetAppIcon from '@material-ui/icons/GetApp';
+import PlayArrowIcon from '@material-ui/icons/PlayArrow';
+import StopIcon from '@material-ui/icons/Stop';
+import ClearAllIcon from '@material-ui/icons/ClearAll';
+import {
+  EnvironmentFilter,
+  type Environment,
+} from '@openchoreo/backstage-plugin-react';
+import { useDebouncedSearch } from '../../hooks/useDebouncedSearch';
+import { useWirelogsStyles } from './styles';
+import type { WirelogsFilters, WirelogStreamStatus } from './types';
+
+interface WirelogsFilterProps {
+  filters: WirelogsFilters;
+  onFiltersChange: (filters: Partial<WirelogsFilters>) => void;
+  environments: Environment[];
+  environmentsLoading: boolean;
+  status: WirelogStreamStatus;
+  onStart: () => void;
+  onStop: () => void;
+  onClear: () => void;
+  onDownload: () => void;
+  disabled?: boolean;
+}
+
+export const WirelogsFilter: FC<WirelogsFilterProps> = ({
+  filters,
+  onFiltersChange,
+  environments,
+  environmentsLoading,
+  status,
+  onStart,
+  onStop,
+  onClear,
+  onDownload,
+  disabled = false,
+}) => {
+  const classes = useWirelogsStyles();
+  const [searchInput, handleSearchChange] = useDebouncedSearch(
+    filters.searchQuery,
+    value => onFiltersChange({ searchQuery: value }),
+  );
+
+  const isStreaming = status === 'streaming' || status === 'connecting';
+
+  return (
+    <Box className={classes.toolbar}>
+      <Box className={classes.envControl}>
+        <EnvironmentFilter
+          environments={environments}
+          loading={environmentsLoading}
+          value={filters.environment}
+          onChange={env => onFiltersChange({ environment: env })}
+          disabled={disabled}
+        />
+      </Box>
+
+      <TextField
+        className={classes.filterField}
+        size="small"
+        placeholder="Filter flows by verdict, workload, IP, path or status…"
+        variant="outlined"
+        value={searchInput}
+        onChange={handleSearchChange}
+        disabled={disabled}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon fontSize="small" />
+            </InputAdornment>
+          ),
+        }}
+      />
+
+      {isStreaming ? (
+        <Button
+          size="small"
+          variant="contained"
+          className={classes.stopButton}
+          onClick={onStop}
+          disableElevation
+          startIcon={<StopIcon />}
+        >
+          Stop stream
+        </Button>
+      ) : (
+        <Button
+          size="small"
+          variant="contained"
+          className={classes.startButton}
+          onClick={onStart}
+          disableElevation
+          disabled={disabled || !filters.environment}
+          startIcon={<PlayArrowIcon />}
+        >
+          Start stream
+        </Button>
+      )}
+      <Button
+        size="small"
+        variant="outlined"
+        className={classes.toolbarButton}
+        onClick={onClear}
+        startIcon={<ClearAllIcon />}
+      >
+        Clear
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        className={classes.toolbarButton}
+        onClick={onDownload}
+        startIcon={<GetAppIcon />}
+      >
+        Download
+      </Button>
+    </Box>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFilter.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFilter.tsx
@@ -24,6 +24,7 @@ interface WirelogsFilterProps {
   onClear: () => void;
   onDownload: () => void;
   disabled?: boolean;
+  startDisabled?: boolean;
 }
 
 export const WirelogsFilter: FC<WirelogsFilterProps> = ({
@@ -37,6 +38,7 @@ export const WirelogsFilter: FC<WirelogsFilterProps> = ({
   onClear,
   onDownload,
   disabled = false,
+  startDisabled = false,
 }) => {
   const classes = useWirelogsStyles();
   const [searchInput, handleSearchChange] = useDebouncedSearch(
@@ -93,7 +95,7 @@ export const WirelogsFilter: FC<WirelogsFilterProps> = ({
           className={classes.startButton}
           onClick={onStart}
           disableElevation
-          disabled={disabled || !filters.environment}
+          disabled={disabled || startDisabled || !filters.environment}
           startIcon={<PlayArrowIcon />}
         >
           Start stream

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFlowDrawer.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFlowDrawer.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { WirelogsFlowDrawer } from './WirelogsFlowDrawer';
+import type { WirelogEvent } from './types';
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  JsonViewer: ({ value }: any) => (
+    <pre data-testid="json-viewer">{JSON.stringify(value)}</pre>
+  ),
+}));
+
+function makeEvent(
+  overrides: Partial<WirelogEvent['flow']> = {},
+): WirelogEvent {
+  return {
+    flow: {
+      uuid: 'flow-1',
+      verdict: 'FORWARDED',
+      Type: 'L3_L4',
+      traffic_direction: 'INGRESS',
+      l4: { TCP: { destination_port: 8080 } },
+      ...overrides,
+    },
+  };
+}
+
+describe('WirelogsFlowDrawer', () => {
+  it('does not render any content when event is null', () => {
+    render(<WirelogsFlowDrawer event={null} onClose={jest.fn()} />);
+    expect(screen.queryByText(/flow-1/)).not.toBeInTheDocument();
+  });
+
+  it('renders title, uuid, verdict and tabs when an event is given', () => {
+    render(<WirelogsFlowDrawer event={makeEvent()} onClose={jest.fn()} />);
+    expect(screen.getByText('flow-1')).toBeInTheDocument();
+    expect(screen.getByText('Forwarded')).toBeInTheDocument();
+    expect(screen.getAllByText('L3/L4').length).toBeGreaterThan(0);
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Raw' })).toBeInTheDocument();
+  });
+
+  it('uses the DROPPED chip variant and "Dropped" label', () => {
+    render(
+      <WirelogsFlowDrawer
+        event={makeEvent({ verdict: 'DROPPED' })}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Dropped')).toBeInTheDocument();
+  });
+
+  it('falls back to "Unknown" for an unrecognised verdict', () => {
+    render(
+      <WirelogsFlowDrawer
+        event={makeEvent({ verdict: undefined })}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('fires onClose when the close button is clicked', () => {
+    const onClose = jest.fn();
+    render(<WirelogsFlowDrawer event={makeEvent()} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFlowDrawer.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFlowDrawer.tsx
@@ -1,0 +1,108 @@
+import { FC } from 'react';
+import {
+  Box,
+  Chip,
+  Divider,
+  Drawer,
+  IconButton,
+  Typography,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import CompareArrowsIcon from '@material-ui/icons/CompareArrows';
+import { useWirelogsDrawerStyles } from './styles';
+import { WirelogsFlowTabs } from './WirelogsFlowTabs';
+import { directionInfo, flowTitle, typeLabel } from './flowFormat';
+import type { WirelogEvent, WirelogFlow } from './types';
+
+const VERDICT_LABELS: Record<string, string> = {
+  DROPPED: 'Dropped',
+  FORWARDED: 'Forwarded',
+};
+
+const WirelogsFlowDrawerContent: FC<{
+  flow: WirelogFlow;
+  onClose: () => void;
+}> = ({ flow, onClose }) => {
+  const classes = useWirelogsDrawerStyles();
+  const dir = directionInfo(flow);
+
+  let verdictClass = classes.verdictUnknownChip;
+  if (flow.verdict === 'DROPPED') {
+    verdictClass = classes.verdictDroppedChip;
+  } else if (flow.verdict === 'FORWARDED') {
+    verdictClass = classes.verdictForwardedChip;
+  }
+  const verdictLabel =
+    (flow.verdict && VERDICT_LABELS[flow.verdict]) || flow.verdict || 'Unknown';
+
+  return (
+    <Box className={classes.drawer}>
+      <Box className={classes.header}>
+        <Box className={classes.headerLeft}>
+          <CompareArrowsIcon className={classes.headerIcon} fontSize="small" />
+          <Box minWidth={0}>
+            <Typography className={classes.title}>{flowTitle(flow)}</Typography>
+            {flow.uuid && (
+              <Typography className={classes.uuid}>{flow.uuid}</Typography>
+            )}
+          </Box>
+        </Box>
+        <Box className={classes.actions}>
+          <IconButton size="small" aria-label="Close" onClick={onClose}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      </Box>
+
+      <Box className={classes.metadataRow}>
+        <Chip
+          size="small"
+          className={`${classes.verdictChip} ${verdictClass}`}
+          label={verdictLabel}
+        />
+        <Chip
+          size="small"
+          variant="outlined"
+          className={classes.metaChip}
+          label={typeLabel(flow)}
+        />
+        {dir.direction !== 'unknown' && (
+          <Chip
+            size="small"
+            variant="outlined"
+            className={classes.metaChip}
+            label={`${dir.direction === 'out' ? '←' : '→'} ${dir.label}`}
+          />
+        )}
+      </Box>
+
+      <Divider />
+
+      <Box className={classes.body}>
+        <WirelogsFlowTabs flow={flow} />
+      </Box>
+    </Box>
+  );
+};
+
+interface WirelogsFlowDrawerProps {
+  event: WirelogEvent | null;
+  onClose: () => void;
+}
+
+export const WirelogsFlowDrawer: FC<WirelogsFlowDrawerProps> = ({
+  event,
+  onClose,
+}) => {
+  return (
+    <Drawer anchor="right" open={event !== null} onClose={onClose}>
+      {event && (
+        <WirelogsFlowDrawerContent
+          key={event.flow.uuid ?? event.flow.time}
+          flow={event.flow}
+          onClose={onClose}
+        />
+      )}
+    </Drawer>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFlowTabs.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFlowTabs.test.tsx
@@ -1,0 +1,180 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { WirelogsFlowTabs, copyText } from './WirelogsFlowTabs';
+import type { WirelogFlow } from './types';
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  JsonViewer: ({ value }: any) => (
+    <pre data-testid="json-viewer">{JSON.stringify(value)}</pre>
+  ),
+}));
+
+const baseFlow = (): WirelogFlow => ({
+  uuid: 'flow-1',
+  verdict: 'FORWARDED',
+  traffic_direction: 'INGRESS',
+  Type: 'L7',
+  source: {
+    pod_name: 'src-pod',
+    namespace: 'src-ns',
+    labels: ['k8s:openchoreo.dev/component=src-comp'],
+  },
+  destination: {
+    pod_name: 'dst-pod',
+    namespace: 'dst-ns',
+  },
+  l4: { TCP: { source_port: 50000, destination_port: 8080 } },
+  IP: { source: '10.0.0.1', destination: '10.0.0.2' },
+});
+
+describe('WirelogsFlowTabs', () => {
+  it('renders the overview panel by default with endpoints + networking', () => {
+    render(<WirelogsFlowTabs flow={baseFlow()} />);
+    expect(screen.getByText('Endpoints')).toBeInTheDocument();
+    expect(screen.getByText('Networking')).toBeInTheDocument();
+    expect(screen.getByText('src-pod')).toBeInTheDocument();
+    expect(screen.getByText('dst-pod')).toBeInTheDocument();
+    // formatAddress puts ip:port in the kv value column.
+    expect(screen.getByText('10.0.0.1:50000')).toBeInTheDocument();
+    expect(screen.getByText('10.0.0.2:8080')).toBeInTheDocument();
+  });
+
+  it('renders the drop banner when the flow is dropped', () => {
+    render(
+      <WirelogsFlowTabs
+        flow={{
+          ...baseFlow(),
+          verdict: 'DROPPED',
+          drop_reason_desc: 'POLICY_DENIED',
+        }}
+      />,
+    );
+    expect(screen.getByText(/Policy denied/)).toBeInTheDocument();
+  });
+
+  it('shows method/url for L7 request flows', () => {
+    render(
+      <WirelogsFlowTabs
+        flow={{
+          ...baseFlow(),
+          l7: {
+            type: 'REQUEST',
+            http: { method: 'POST', url: 'https://api/orders' },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText('POST')).toBeInTheDocument();
+    expect(screen.getByText('https://api/orders')).toBeInTheDocument();
+  });
+
+  it('shows the status code for L7 response flows', () => {
+    render(
+      <WirelogsFlowTabs
+        flow={{
+          ...baseFlow(),
+          l7: { type: 'RESPONSE', http: { code: 502 } },
+        }}
+      />,
+    );
+    // The kv value renders the code as a string.
+    expect(screen.getByText('502')).toBeInTheDocument();
+  });
+
+  it('shows the headers tab only for L7 flows and switches to it', () => {
+    render(
+      <WirelogsFlowTabs
+        flow={{
+          ...baseFlow(),
+          l7: {
+            type: 'REQUEST',
+            http: {
+              method: 'GET',
+              url: '/',
+              headers: [
+                { key: 'x-test', value: 'a' },
+                { key: 'authorization', value: 'b' },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    const headersTab = screen.getByRole('tab', { name: /Headers/i });
+    fireEvent.click(headersTab);
+
+    expect(screen.getByText('x-test')).toBeInTheDocument();
+    expect(screen.getByText('authorization')).toBeInTheDocument();
+  });
+
+  it('hides the headers tab when the flow is not L7', () => {
+    render(<WirelogsFlowTabs flow={{ ...baseFlow(), l7: undefined }} />);
+    expect(
+      screen.queryByRole('tab', { name: /Headers/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows empty-headers message when L7 has no captured headers', () => {
+    render(
+      <WirelogsFlowTabs
+        flow={{
+          ...baseFlow(),
+          l7: { type: 'REQUEST', http: { method: 'GET', url: '/' } },
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: /Headers/i }));
+    expect(
+      screen.getByText(/No request headers captured/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the raw tab with a JSON dump and a copy button', () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const flow = baseFlow();
+    render(<WirelogsFlowTabs flow={flow} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Raw' }));
+
+    expect(screen.getByTestId('json-viewer')).toHaveTextContent('flow-1');
+
+    fireEvent.click(screen.getByText('Copy as JSON'));
+    expect(writeText).toHaveBeenCalledWith(JSON.stringify(flow, null, 2));
+  });
+});
+
+describe('copyText', () => {
+  it('writes through navigator.clipboard.writeText when available', () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    copyText('hello');
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('silently no-ops when navigator.clipboard is missing', () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    // should not throw.
+    expect(() => copyText('hello')).not.toThrow();
+  });
+
+  it('swallows clipboard rejection', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    expect(() => copyText('x')).not.toThrow();
+    // give the rejection a microtask to settle without producing unhandled.
+    await Promise.resolve();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFlowTabs.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsFlowTabs.tsx
@@ -1,0 +1,224 @@
+import { FC, useMemo, useState } from 'react';
+import { Box, Button, Tab, Tabs, Typography } from '@material-ui/core';
+import BlockIcon from '@material-ui/icons/Block';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined';
+import { JsonViewer } from '@openchoreo/backstage-design-system';
+import { useWirelogsDetailStyles } from './styles';
+import {
+  directionInfo,
+  dropReasonText,
+  endpointMeta,
+  formatAddress,
+  getDestinationPort,
+  getSourcePort,
+  isL7,
+  isResponse,
+  l4Protocol,
+} from './flowFormat';
+import type { WirelogEndpoint, WirelogFlow } from './types';
+
+export function copyText(text: string) {
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).catch(() => undefined);
+  }
+}
+
+const KeyValue: FC<{ label: string; value?: string }> = ({ label, value }) => {
+  const classes = useWirelogsDetailStyles();
+  if (!value) return null;
+  return (
+    <Box className={classes.kvRow}>
+      <span className={classes.kvKey}>{label}</span>
+      <span className={classes.kvValue}>{value}</span>
+    </Box>
+  );
+};
+
+const EndpointCard: FC<{
+  label: string;
+  endpoint: WirelogEndpoint | undefined;
+}> = ({ label, endpoint }) => {
+  const classes = useWirelogsDetailStyles();
+  const meta = endpointMeta(endpoint);
+  return (
+    <Box className={classes.endpointCard}>
+      <Typography className={classes.endpointCardLabel}>{label}</Typography>
+      <Typography className={classes.endpointCardTitle}>
+        {meta.name ?? '—'}
+      </Typography>
+      <KeyValue label="namespace" value={meta.namespace} />
+      <KeyValue label="component" value={meta.component} />
+      <KeyValue label="project" value={meta.project} />
+      <KeyValue label="environment" value={meta.environment} />
+    </Box>
+  );
+};
+
+const OverviewPanel: FC<{ flow: WirelogFlow }> = ({ flow }) => {
+  const classes = useWirelogsDetailStyles();
+  const dropped = flow.verdict === 'DROPPED';
+  const dir = directionInfo(flow);
+  const http = flow.l7?.http;
+
+  return (
+    <Box className={classes.tabPanel}>
+      {dropped && (
+        <Box className={classes.droppedBanner}>
+          <BlockIcon fontSize="small" />
+          <span>Dropped: {dropReasonText(flow)}</span>
+        </Box>
+      )}
+
+      <Box className={classes.section}>
+        <Typography className={classes.sectionTitle}>Endpoints</Typography>
+        <Box className={classes.endpointsGrid}>
+          <EndpointCard label="Source" endpoint={flow.source} />
+          <Box className={classes.endpointArrow}>
+            <ArrowForwardIcon fontSize="small" />
+          </Box>
+          <EndpointCard label="Destination" endpoint={flow.destination} />
+        </Box>
+      </Box>
+
+      <Box className={classes.section}>
+        <Typography className={classes.sectionTitle}>Networking</Typography>
+        <KeyValue label="protocol" value={l4Protocol(flow.l4) ?? '—'} />
+        <KeyValue
+          label="direction"
+          value={
+            flow.traffic_direction
+              ? flow.traffic_direction.toLowerCase()
+              : dir.label
+          }
+        />
+        <KeyValue
+          label="source"
+          value={formatAddress(flow.IP?.source, getSourcePort(flow.l4))}
+        />
+        <KeyValue
+          label="destination"
+          value={formatAddress(
+            flow.IP?.destination,
+            getDestinationPort(flow.l4),
+          )}
+        />
+      </Box>
+
+      {http && (
+        <Box className={classes.section}>
+          <Typography className={classes.sectionTitle}>
+            L7 ({flow.l7?.http?.protocol ?? 'HTTP'})
+          </Typography>
+          <KeyValue
+            label="kind"
+            value={isResponse(flow) ? 'response' : 'request'}
+          />
+          {isResponse(flow) && http.code !== undefined && (
+            <KeyValue label="status" value={String(http.code)} />
+          )}
+          {!isResponse(flow) && (
+            <>
+              <KeyValue label="method" value={http.method} />
+              <KeyValue label="url" value={http.url} />
+            </>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const HeadersPanel: FC<{ flow: WirelogFlow }> = ({ flow }) => {
+  const classes = useWirelogsDetailStyles();
+  const headers = flow.l7?.http?.headers ?? [];
+  const kind = isResponse(flow) ? 'Response' : 'Request';
+
+  if (headers.length === 0) {
+    return (
+      <Box className={classes.tabPanel}>
+        <Typography className={classes.emptyTab}>
+          No {kind.toLowerCase()} headers captured for this flow.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box className={classes.tabPanel}>
+      <Typography className={classes.sectionTitle}>
+        {kind} headers ({headers.length})
+      </Typography>
+      <Box className={classes.headersList}>
+        {headers.map((h, i) => (
+          <Box className={classes.headerRow} key={`${h.key}-${i}`}>
+            <span className={classes.headerKey}>{h.key}</span>
+            <span className={classes.headerValue}>{h.value}</span>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+const RawPanel: FC<{ flow: WirelogFlow }> = ({ flow }) => {
+  const classes = useWirelogsDetailStyles();
+  return (
+    <Box className={classes.tabPanel}>
+      <Box className={classes.rawHeader}>
+        <Button
+          className={classes.rawCopyButton}
+          startIcon={<FileCopyOutlinedIcon fontSize="small" />}
+          onClick={() => copyText(JSON.stringify(flow, null, 2))}
+        >
+          Copy as JSON
+        </Button>
+      </Box>
+      <JsonViewer
+        value={flow}
+        showLineNumbers
+        wrapLongLines
+        maxHeight="calc(100vh - 320px)"
+      />
+    </Box>
+  );
+};
+
+export const WirelogsFlowTabs: FC<{ flow: WirelogFlow }> = ({ flow }) => {
+  const classes = useWirelogsDetailStyles();
+  const showHeaders = isL7(flow);
+  const headerCount = flow.l7?.http?.headers?.length ?? 0;
+
+  const tabKeys = useMemo(
+    () => ['overview', ...(showHeaders ? ['headers'] : []), 'raw'],
+    [showHeaders],
+  );
+  const [activeTab, setActiveTab] = useState('overview');
+  const currentTab = tabKeys.includes(activeTab) ? activeTab : 'overview';
+
+  return (
+    <>
+      <Tabs
+        className={classes.tabs}
+        value={currentTab}
+        onChange={(_, value) => setActiveTab(value)}
+        indicatorColor="primary"
+        textColor="primary"
+      >
+        <Tab className={classes.tab} value="overview" label="Overview" />
+        {showHeaders && (
+          <Tab
+            className={classes.tab}
+            value="headers"
+            label={headerCount > 0 ? `Headers ${headerCount}` : 'Headers'}
+          />
+        )}
+        <Tab className={classes.tab} value="raw" label="Raw" />
+      </Tabs>
+
+      {currentTab === 'overview' && <OverviewPanel flow={flow} />}
+      {currentTab === 'headers' && <HeadersPanel flow={flow} />}
+      {currentTab === 'raw' && <RawPanel flow={flow} />}
+    </>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsStats.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsStats.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { WirelogsStats } from './WirelogsStats';
+
+describe('WirelogsStats', () => {
+  it('renders the counts and a 0% ratio when there are no flows', () => {
+    render(
+      <WirelogsStats
+        visibleCount={0}
+        totalLoaded={0}
+        allowed={0}
+        dropped={0}
+      />,
+    );
+    expect(screen.getByText(/Showing/)).toBeInTheDocument();
+    expect(screen.getByText(/0% Degraded/)).toBeInTheDocument();
+  });
+
+  it('labels ratios at or above 90% as Success (high)', () => {
+    render(
+      <WirelogsStats
+        visibleCount={100}
+        totalLoaded={100}
+        allowed={90}
+        dropped={10}
+      />,
+    );
+    expect(screen.getByText(/90% Success/)).toBeInTheDocument();
+  });
+
+  it('labels ratios between 70% and 89% as Success (mid)', () => {
+    render(
+      <WirelogsStats
+        visibleCount={10}
+        totalLoaded={10}
+        allowed={7}
+        dropped={3}
+      />,
+    );
+    expect(screen.getByText(/70% Success/)).toBeInTheDocument();
+  });
+
+  it('labels ratios below 70% as Degraded (low)', () => {
+    render(
+      <WirelogsStats
+        visibleCount={10}
+        totalLoaded={10}
+        allowed={5}
+        dropped={5}
+      />,
+    );
+    expect(screen.getByText(/50% Degraded/)).toBeInTheDocument();
+  });
+
+  it('renders the allowed and dropped counts in their own cells', () => {
+    render(
+      <WirelogsStats
+        visibleCount={20}
+        totalLoaded={30}
+        allowed={15}
+        dropped={5}
+      />,
+    );
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsStats.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsStats.tsx
@@ -1,0 +1,57 @@
+import { FC } from 'react';
+import { Box, Typography } from '@material-ui/core';
+import { useWirelogsStatsStyles } from './styles';
+
+interface WirelogsStatsProps {
+  visibleCount: number;
+  totalLoaded: number;
+  allowed: number;
+  dropped: number;
+}
+
+function getRatioClass(
+  ratio: number,
+  classes: ReturnType<typeof useWirelogsStatsStyles>,
+): string {
+  if (ratio >= 90) return classes.ratioHigh;
+  if (ratio >= 70) return classes.ratioMid;
+  return classes.ratioLow;
+}
+
+export const WirelogsStats: FC<WirelogsStatsProps> = ({
+  visibleCount,
+  totalLoaded,
+  allowed,
+  dropped,
+}) => {
+  const classes = useWirelogsStatsStyles();
+
+  const total = allowed + dropped;
+  const ratio = total > 0 ? Math.round((allowed / total) * 100) : 0;
+  const ratioClass = getRatioClass(ratio, classes);
+  const ratioLabel = ratio >= 70 ? 'Success' : 'Degraded';
+
+  return (
+    <Box className={classes.container}>
+      <Typography variant="body2" className={classes.countLabel}>
+        Showing <span>{visibleCount}</span> flows of last{' '}
+        <span>{totalLoaded}</span> loaded.
+      </Typography>
+
+      <Box className={classes.metrics}>
+        <Typography variant="body2" className={classes.countLabel}>
+          Allowed: <span className={classes.allowed}>{allowed}</span>
+        </Typography>
+        <Typography variant="body2" className={classes.countLabel}>
+          Dropped: <span className={classes.dropped}>{dropped}</span>
+        </Typography>
+        <Typography variant="body2" className={classes.countLabel}>
+          Ratio:{' '}
+          <span className={`${ratioClass}`}>
+            {ratio}% {ratioLabel}
+          </span>
+        </Typography>
+      </Box>
+    </Box>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsTable.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsTable.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WirelogsTable, matchesSearch } from './WirelogsTable';
+import type { WirelogEvent } from './types';
+
+// JsonViewer is loaded via the drawer's tabs; stub it to avoid pulling in the
+// design-system editor (which expects a richer DOM than jsdom provides).
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  JsonViewer: ({ value }: any) => (
+    <pre data-testid="json-viewer">{JSON.stringify(value)}</pre>
+  ),
+}));
+
+function makeEvent(
+  overrides: Partial<WirelogEvent['flow']> = {},
+): WirelogEvent {
+  return {
+    flow: {
+      uuid: 'flow-1',
+      time: '2026-01-01T10:00:00.000Z',
+      verdict: 'FORWARDED',
+      traffic_direction: 'INGRESS',
+      Type: 'L3_L4',
+      source: { pod_name: 'src-pod', namespace: 'src-ns' },
+      destination: { pod_name: 'dst-pod', namespace: 'dst-ns' },
+      l4: { TCP: { source_port: 50000, destination_port: 8080 } },
+      ...overrides,
+    },
+  };
+}
+
+describe('matchesSearch', () => {
+  const event = makeEvent({
+    uuid: 'abc-uuid',
+    IP: { source: '10.0.0.1', destination: '10.0.0.2' },
+    l7: { http: { method: 'GET', url: 'https://api/users', code: 200 } },
+  });
+
+  it.each([
+    ['empty query matches everything', ''],
+    ['uuid', 'abc-uuid'],
+    ['pod name', 'src-pod'],
+    ['namespace', 'dst-ns'],
+    ['source IP', '10.0.0.1'],
+    ['destination IP', '10.0.0.2'],
+    ['HTTP method', 'get'],
+    ['URL substring', 'api/users'],
+    ['HTTP status code', '200'],
+    ['source port', '50000'],
+    ['destination port', '8080'],
+    ['verdict', 'forwarded'],
+  ])('matches by %s', (_label, query) => {
+    expect(matchesSearch(event, query)).toBe(true);
+  });
+
+  it('does not match unrelated text', () => {
+    expect(matchesSearch(event, 'no-such-token')).toBe(false);
+  });
+});
+
+describe('WirelogsTable', () => {
+  it('renders the streaming empty-state message when streaming', () => {
+    render(<WirelogsTable flows={[]} isStreaming />);
+    expect(screen.getByText(/Waiting for traffic/i)).toBeInTheDocument();
+  });
+
+  it('renders the idle empty-state message when not streaming', () => {
+    render(<WirelogsTable flows={[]} isStreaming={false} />);
+    expect(screen.getByText(/Press Start stream/i)).toBeInTheDocument();
+  });
+
+  it('renders flow rows with verdict, type, endpoints and summary', () => {
+    render(
+      <WirelogsTable
+        flows={[
+          makeEvent({
+            uuid: 'a',
+            verdict: 'FORWARDED',
+            l7: {
+              type: 'REQUEST',
+              http: { method: 'GET', url: 'https://api/users' },
+            },
+          }),
+        ]}
+        isStreaming
+      />,
+    );
+    expect(screen.getByText('Forwarded')).toBeInTheDocument();
+    expect(screen.getByText('L7')).toBeInTheDocument();
+    expect(screen.getAllByText('GET').length).toBeGreaterThan(0);
+    expect(screen.getByText('src-pod')).toBeInTheDocument();
+    expect(screen.getByText('dst-pod')).toBeInTheDocument();
+  });
+
+  it('opens the drawer when a row is clicked', () => {
+    render(
+      <WirelogsTable
+        flows={[
+          makeEvent({
+            uuid: 'click-me',
+            l7: {
+              type: 'REQUEST',
+              http: { method: 'POST', url: 'https://api/x' },
+            },
+          }),
+        ]}
+        isStreaming
+      />,
+    );
+    fireEvent.click(screen.getByText('src-pod'));
+    // The drawer header echoes the flow uuid.
+    expect(screen.getByText('click-me')).toBeInTheDocument();
+  });
+
+  it('renders L7 response summary including status code and latency', () => {
+    render(
+      <WirelogsTable
+        flows={[
+          makeEvent({
+            uuid: 'resp',
+            l7: {
+              type: 'RESPONSE',
+              latency_ns: 12_000_000,
+              http: { code: 404 },
+            },
+          }),
+        ]}
+        isStreaming
+      />,
+    );
+    expect(screen.getByText('reply')).toBeInTheDocument();
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('12ms')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['DELETE', 'DELETE'],
+    ['PUT', 'PUT'],
+    ['PATCH', 'PATCH'],
+    ['OPTIONS', 'OPTIONS'],
+  ])('renders %s method badges via the method class branch', (_, method) => {
+    render(
+      <WirelogsTable
+        flows={[
+          makeEvent({
+            uuid: method,
+            l7: {
+              type: 'REQUEST',
+              http: { method, url: 'https://api/x' },
+            },
+          }),
+        ]}
+        isStreaming
+      />,
+    );
+    expect(screen.getAllByText(method).length).toBeGreaterThan(0);
+  });
+
+  it('renders an L4 summary including TCP flags', () => {
+    render(
+      <WirelogsTable
+        flows={[
+          makeEvent({
+            uuid: 'l4',
+            l4: {
+              TCP: {
+                source_port: 50000,
+                destination_port: 443,
+                flags: { SYN: true, ACK: true },
+              },
+            },
+          }),
+        ]}
+        isStreaming
+      />,
+    );
+    // The summary text glues protocol :port [flags] into one span.
+    expect(screen.getByText(/TCP :443 \[SYN,ACK\]/)).toBeInTheDocument();
+  });
+
+  it('shows an em-dash for unknown direction', () => {
+    render(
+      <WirelogsTable
+        flows={[makeEvent({ traffic_direction: undefined })]}
+        isStreaming
+      />,
+    );
+    // First — comes from DirCell.
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsTable.tsx
@@ -35,6 +35,7 @@ interface WirelogsTableProps {
 
 function rowKey(event: WirelogEvent): string {
   if (event.flow.uuid) return event.flow.uuid;
+  if (event.__id) return event.__id;
   return `${event.flow.time ?? ''}:${event.flow.source?.pod_name ?? ''}:${
     event.flow.destination?.pod_name ?? ''
   }`;
@@ -336,8 +337,8 @@ export const WirelogsTable: FC<WirelogsTableProps> = ({
  * re-deriving search logic per consumer.
  */
 export function matchesSearch(event: WirelogEvent, q: string): boolean {
-  if (!q) return true;
-  const needle = q.toLowerCase();
+  const needle = q.trim().toLowerCase();
+  if (!needle) return true;
   const flow: WirelogFlow = event.flow;
   const haystack = [
     flow.uuid,

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsTable.tsx
@@ -1,0 +1,361 @@
+import { FC, UIEvent, useLayoutEffect, useRef, useState } from 'react';
+import {
+  Box,
+  Chip,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@material-ui/core';
+import { useWirelogsTableStyles } from './styles';
+import { WirelogsFlowDrawer } from './WirelogsFlowDrawer';
+import {
+  directionInfo,
+  endpointMeta,
+  flowSummary,
+  formatTime,
+  getDestinationPort,
+  getSourcePort,
+  typeLabel,
+} from './flowFormat';
+import type {
+  WirelogEndpoint,
+  WirelogEvent,
+  WirelogFlow,
+  WirelogVerdict,
+} from './types';
+
+interface WirelogsTableProps {
+  flows: WirelogEvent[];
+  isStreaming: boolean;
+}
+
+function rowKey(event: WirelogEvent): string {
+  if (event.flow.uuid) return event.flow.uuid;
+  return `${event.flow.time ?? ''}:${event.flow.source?.pod_name ?? ''}:${
+    event.flow.destination?.pod_name ?? ''
+  }`;
+}
+
+const VerdictCell: FC<{ verdict: WirelogVerdict | undefined }> = ({
+  verdict,
+}) => {
+  const classes = useWirelogsTableStyles();
+  const labels: Record<string, string> = {
+    DROPPED: 'Dropped',
+    FORWARDED: 'Forwarded',
+  };
+  const label = (verdict && labels[verdict]) || verdict || 'Unknown';
+  let variantClass = classes.verdictUnknownChip;
+  if (verdict === 'DROPPED') {
+    variantClass = classes.verdictDroppedChip;
+  } else if (verdict === 'FORWARDED') {
+    variantClass = classes.verdictForwardedChip;
+  }
+  return (
+    <Chip
+      size="small"
+      className={`${classes.verdictChip} ${variantClass}`}
+      label={
+        <>
+          <span className={classes.verdictDot} />
+          {label}
+        </>
+      }
+    />
+  );
+};
+
+const DirCell: FC<{ flow: WirelogFlow }> = ({ flow }) => {
+  const classes = useWirelogsTableStyles();
+  const { label, direction } = directionInfo(flow);
+  if (direction === 'unknown') {
+    return <span className={classes.dirCell}>—</span>;
+  }
+  return (
+    <span className={classes.dirCell}>
+      <span className={classes.dirArrow}>
+        {direction === 'out' ? '←' : '→'}
+      </span>
+      {label}
+    </span>
+  );
+};
+
+const EndpointCell: FC<{ endpoint: WirelogEndpoint | undefined }> = ({
+  endpoint,
+}) => {
+  const classes = useWirelogsTableStyles();
+  const meta = endpointMeta(endpoint);
+  return (
+    <Box>
+      <Box className={classes.endpointName} title={meta.name}>
+        {meta.name ?? '—'}
+      </Box>
+      {meta.namespace && (
+        <Box className={classes.endpointSub} title={meta.namespace}>
+          {meta.namespace}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+function methodClass(
+  method: string | undefined,
+  classes: ReturnType<typeof useWirelogsTableStyles>,
+): string {
+  switch ((method ?? '').toUpperCase()) {
+    case 'GET':
+      return classes.methodGet;
+    case 'POST':
+      return classes.methodPost;
+    case 'PUT':
+    case 'PATCH':
+      return classes.methodPut;
+    case 'DELETE':
+      return classes.methodDelete;
+    default:
+      return classes.methodOther;
+  }
+}
+
+function statusClass(
+  code: number | undefined,
+  classes: ReturnType<typeof useWirelogsTableStyles>,
+): string {
+  const bucket = code ? Math.floor(code / 100) : 0;
+  switch (bucket) {
+    case 2:
+      return classes.status2xx;
+    case 3:
+      return classes.status3xx;
+    case 4:
+      return classes.status4xx;
+    case 5:
+      return classes.status5xx;
+    default:
+      return classes.statusCode;
+  }
+}
+
+const SummaryCell: FC<{ flow: WirelogFlow }> = ({ flow }) => {
+  const classes = useWirelogsTableStyles();
+  const summary = flowSummary(flow);
+
+  if (summary.kind === 'l7-request') {
+    return (
+      <span className={classes.summaryCell}>
+        <span
+          className={`${classes.methodBadge} ${methodClass(
+            summary.method,
+            classes,
+          )}`}
+        >
+          {summary.method ?? 'HTTP'}
+        </span>
+        <span className={classes.summaryText} title={summary.path}>
+          {summary.path ?? ''}
+        </span>
+      </span>
+    );
+  }
+
+  if (summary.kind === 'l7-response') {
+    return (
+      <span className={classes.summaryCell}>
+        <span className={classes.summaryArrow}>←</span>
+        reply
+        {summary.code !== undefined && (
+          <span
+            className={`${classes.statusCode} ${statusClass(
+              summary.code,
+              classes,
+            )}`}
+          >
+            {summary.code}
+          </span>
+        )}
+        {summary.latency && (
+          <span className={classes.summaryText}>{summary.latency}</span>
+        )}
+      </span>
+    );
+  }
+
+  if (summary.kind === 'l4') {
+    const flagPart = summary.flags.length
+      ? ` [${summary.flags.join(',')}]`
+      : '';
+    return (
+      <span className={classes.summaryCell}>
+        <span className={classes.summaryText}>
+          {summary.protocol}
+          {summary.port ? ` :${summary.port}` : ''}
+          {flagPart}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={classes.summaryCell}>
+      <span className={classes.summaryText}>{summary.text ?? '—'}</span>
+    </span>
+  );
+};
+
+const WirelogsRow: FC<{
+  event: WirelogEvent;
+  selected: boolean;
+  onSelect: () => void;
+}> = ({ event, selected, onSelect }) => {
+  const classes = useWirelogsTableStyles();
+  const flow = event.flow;
+
+  return (
+    <TableRow
+      className={`${classes.row} ${selected ? classes.rowSelected : ''}`}
+      onClick={onSelect}
+      hover
+    >
+      <TableCell className={`${classes.bodyCell} ${classes.timeCell}`}>
+        {formatTime(flow.time)}
+      </TableCell>
+      <TableCell className={classes.bodyCell}>
+        <VerdictCell verdict={flow.verdict} />
+      </TableCell>
+      <TableCell className={classes.bodyCell}>
+        <span className={classes.typeBadge}>{typeLabel(flow)}</span>
+      </TableCell>
+      <TableCell className={classes.bodyCell}>
+        <DirCell flow={flow} />
+      </TableCell>
+      <TableCell className={classes.bodyCell}>
+        <EndpointCell endpoint={flow.source} />
+      </TableCell>
+      <TableCell className={classes.bodyCell}>
+        <EndpointCell endpoint={flow.destination} />
+      </TableCell>
+      <TableCell className={classes.bodyCell}>
+        <SummaryCell flow={flow} />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export const WirelogsTable: FC<WirelogsTableProps> = ({
+  flows,
+  isStreaming,
+}) => {
+  const classes = useWirelogsTableStyles();
+  const [selected, setSelected] = useState<WirelogEvent | null>(null);
+  const selectedKey = selected ? rowKey(selected) : null;
+
+  // tail -f-style auto-scroll: stick to the bottom while the user is at (or
+  // near) the bottom; leave them alone once they scroll up to read older rows.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
+
+  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < 40;
+  };
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    if (stickToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [flows]);
+
+  return (
+    <>
+      <Paper variant="outlined" className={classes.tablePaper}>
+        {flows.length === 0 ? (
+          <Box className={classes.emptyState}>
+            <Typography variant="body2">
+              {isStreaming
+                ? 'Waiting for traffic… flows will appear here as they arrive.'
+                : 'Press Start stream to begin observing Cilium Hubble flows.'}
+            </Typography>
+          </Box>
+        ) : (
+          <div
+            ref={containerRef}
+            className={classes.tableContainer}
+            onScroll={handleScroll}
+          >
+            <Table stickyHeader size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell className={classes.headerCell}>Time</TableCell>
+                  <TableCell className={classes.headerCell}>Verdict</TableCell>
+                  <TableCell className={classes.headerCell}>Type</TableCell>
+                  <TableCell className={classes.headerCell}>
+                    Direction
+                  </TableCell>
+                  <TableCell className={classes.headerCell}>Source</TableCell>
+                  <TableCell className={classes.headerCell}>
+                    Destination
+                  </TableCell>
+                  <TableCell className={classes.headerCell}>Summary</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {flows.map(event => {
+                  const key = rowKey(event);
+                  return (
+                    <WirelogsRow
+                      key={key}
+                      event={event}
+                      selected={key === selectedKey}
+                      onSelect={() => setSelected(event)}
+                    />
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </Paper>
+
+      <WirelogsFlowDrawer event={selected} onClose={() => setSelected(null)} />
+    </>
+  );
+};
+
+/**
+ * Filters a flow list against a free-text search query (pod names, IPs, flow ID).
+ * Exported here so the parent page can drive client-side filtering without
+ * re-deriving search logic per consumer.
+ */
+export function matchesSearch(event: WirelogEvent, q: string): boolean {
+  if (!q) return true;
+  const needle = q.toLowerCase();
+  const flow: WirelogFlow = event.flow;
+  const haystack = [
+    flow.uuid,
+    flow.verdict,
+    flow.source?.pod_name,
+    flow.destination?.pod_name,
+    flow.source?.namespace,
+    flow.destination?.namespace,
+    flow.IP?.source,
+    flow.IP?.destination,
+    flow.l7?.http?.method,
+    flow.l7?.http?.url,
+    flow.l7?.http?.code !== undefined ? String(flow.l7.http.code) : undefined,
+    String(getSourcePort(flow.l4) ?? ''),
+    String(getDestinationPort(flow.l4) ?? ''),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(needle);
+}

--- a/plugins/openchoreo-observability/src/components/Wirelogs/flowFormat.test.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/flowFormat.test.ts
@@ -1,0 +1,383 @@
+import {
+  directionInfo,
+  dropReasonText,
+  endpointMeta,
+  flowSummary,
+  flowTitle,
+  formatAddress,
+  formatLatency,
+  formatTime,
+  getDestinationPort,
+  getSourcePort,
+  isL7,
+  isResponse,
+  l4Protocol,
+  parseLabels,
+  tcpFlags,
+  typeLabel,
+  urlPath,
+} from './flowFormat';
+import type { WirelogFlow } from './types';
+
+describe('getSourcePort / getDestinationPort / l4Protocol', () => {
+  it('reads TCP ports when l4.TCP is set', () => {
+    const l4 = { TCP: { source_port: 1234, destination_port: 80 } };
+    expect(getSourcePort(l4)).toBe(1234);
+    expect(getDestinationPort(l4)).toBe(80);
+    expect(l4Protocol(l4)).toBe('TCP');
+  });
+
+  it('falls back to UDP ports when l4.TCP is absent', () => {
+    const l4 = { UDP: { source_port: 5353, destination_port: 53 } };
+    expect(getSourcePort(l4)).toBe(5353);
+    expect(getDestinationPort(l4)).toBe(53);
+    expect(l4Protocol(l4)).toBe('UDP');
+  });
+
+  it('returns undefined when l4 itself is missing', () => {
+    expect(getSourcePort(undefined)).toBeUndefined();
+    expect(getDestinationPort(undefined)).toBeUndefined();
+    expect(l4Protocol(undefined)).toBeUndefined();
+    expect(l4Protocol({})).toBeUndefined();
+  });
+});
+
+describe('tcpFlags', () => {
+  it('returns the truthy flags in canonical order', () => {
+    expect(
+      tcpFlags({ TCP: { flags: { ACK: true, SYN: true, FIN: false } } }),
+    ).toEqual(['SYN', 'ACK']);
+  });
+
+  it('upper-cases lowercase flag names', () => {
+    expect(tcpFlags({ TCP: { flags: { syn: true, ack: true } } })).toEqual([
+      'SYN',
+      'ACK',
+    ]);
+  });
+
+  it('places unknown flags after the canonical ones', () => {
+    expect(
+      tcpFlags({ TCP: { flags: { CUSTOM: true, ACK: true, SYN: true } } }),
+    ).toEqual(['SYN', 'ACK', 'CUSTOM']);
+  });
+
+  it('returns an empty array when there are no flags', () => {
+    expect(tcpFlags(undefined)).toEqual([]);
+    expect(tcpFlags({ TCP: {} })).toEqual([]);
+    expect(tcpFlags({ TCP: { flags: {} } })).toEqual([]);
+  });
+});
+
+describe('isL7 / typeLabel', () => {
+  it('detects L7 HTTP flows', () => {
+    expect(isL7({ l7: { http: { method: 'GET' } } } as WirelogFlow)).toBe(true);
+    expect(isL7({} as WirelogFlow)).toBe(false);
+    expect(isL7({ l7: {} } as WirelogFlow)).toBe(false);
+  });
+
+  it('returns L7 when l7 present even without http', () => {
+    expect(typeLabel({ l7: { type: 'REQUEST' } } as WirelogFlow)).toBe('L7');
+  });
+
+  it('maps L3_L4 to a slash-separated label', () => {
+    expect(typeLabel({ Type: 'L3_L4' } as WirelogFlow)).toBe('L3/L4');
+  });
+
+  it('passes through unknown types', () => {
+    expect(typeLabel({ Type: 'CUSTOM' } as WirelogFlow)).toBe('CUSTOM');
+  });
+
+  it('defaults to L3/L4 when Type is missing', () => {
+    expect(typeLabel({} as WirelogFlow)).toBe('L3/L4');
+  });
+
+  it('returns L7 when only Type=L7 is set', () => {
+    expect(typeLabel({ Type: 'L7' } as WirelogFlow)).toBe('L7');
+  });
+});
+
+describe('directionInfo', () => {
+  it('maps EGRESS to out', () => {
+    expect(
+      directionInfo({ traffic_direction: 'EGRESS' } as WirelogFlow),
+    ).toEqual({ label: 'out', direction: 'out' });
+  });
+
+  it('maps INGRESS to in', () => {
+    expect(
+      directionInfo({ traffic_direction: 'INGRESS' } as WirelogFlow),
+    ).toEqual({ label: 'in', direction: 'in' });
+  });
+
+  it('returns unknown for missing/unrecognised values', () => {
+    expect(directionInfo({} as WirelogFlow)).toEqual({
+      label: '—',
+      direction: 'unknown',
+    });
+    expect(
+      directionInfo({ traffic_direction: 'WEIRD' } as WirelogFlow),
+    ).toEqual({ label: '—', direction: 'unknown' });
+  });
+});
+
+describe('formatTime', () => {
+  it('returns an em-dash when undefined', () => {
+    expect(formatTime(undefined)).toBe('—');
+  });
+
+  it('returns the input verbatim when not a valid date', () => {
+    expect(formatTime('not-a-date')).toBe('not-a-date');
+  });
+
+  it('zero-pads hours, minutes, seconds and milliseconds', () => {
+    // 04:05:06.078 in local time
+    const iso = new Date(2026, 0, 1, 4, 5, 6, 78).toISOString();
+    expect(formatTime(iso)).toBe('04:05:06.078');
+  });
+});
+
+describe('formatAddress', () => {
+  it('returns dash when ip is missing', () => {
+    expect(formatAddress(undefined, 80)).toBe('—');
+  });
+
+  it('returns just the ip when port missing', () => {
+    expect(formatAddress('10.0.0.1', undefined)).toBe('10.0.0.1');
+  });
+
+  it('joins ip and port with a colon', () => {
+    expect(formatAddress('10.0.0.1', 8080)).toBe('10.0.0.1:8080');
+  });
+});
+
+describe('formatLatency', () => {
+  it('returns undefined when ns is undefined or null', () => {
+    expect(formatLatency(undefined)).toBeUndefined();
+    expect(formatLatency(null as unknown as number)).toBeUndefined();
+  });
+
+  it('formats sub-millisecond latency with 2 decimals', () => {
+    expect(formatLatency(500_000)).toBe('0.50ms');
+  });
+
+  it('rounds millisecond-range latency', () => {
+    expect(formatLatency(12_345_678)).toBe('12ms');
+  });
+
+  it('switches to seconds above 1000ms', () => {
+    expect(formatLatency(2_500_000_000)).toBe('2.50s');
+  });
+});
+
+describe('urlPath', () => {
+  it('returns undefined for empty input', () => {
+    expect(urlPath(undefined)).toBeUndefined();
+  });
+
+  it('returns the path + search for an absolute url', () => {
+    expect(urlPath('https://api.example.com/v1/users?limit=10')).toBe(
+      '/v1/users?limit=10',
+    );
+  });
+
+  it('returns the input when parsing fails', () => {
+    expect(urlPath('not a url')).toBe('not a url');
+  });
+});
+
+describe('parseLabels', () => {
+  it('drops source prefix and parses key=value pairs', () => {
+    expect(
+      parseLabels([
+        'k8s:openchoreo.dev/component=api',
+        'reserved:remote-node',
+        'reserved:foo=bar',
+      ]),
+    ).toEqual({
+      'openchoreo.dev/component': 'api',
+      foo: 'bar',
+    });
+  });
+
+  it('handles bare values without a colon source prefix', () => {
+    expect(parseLabels(['plain=value'])).toEqual({ plain: 'value' });
+  });
+
+  it('returns empty object when labels is undefined', () => {
+    expect(parseLabels(undefined)).toEqual({});
+  });
+});
+
+describe('endpointMeta', () => {
+  it('returns placeholders when endpoint is missing', () => {
+    expect(endpointMeta(undefined)).toEqual({
+      name: undefined,
+      namespace: undefined,
+    });
+  });
+
+  it('prefers workload name, then pod name, then component, then namespace', () => {
+    expect(
+      endpointMeta({
+        namespace: 'ns',
+        pod_name: 'pod-1',
+        workloads: [{ name: 'svc', kind: 'Deployment' }],
+        labels: ['k8s:openchoreo.dev/component=comp'],
+      }),
+    ).toEqual({
+      name: 'svc',
+      namespace: 'ns',
+      component: 'comp',
+      project: undefined,
+      environment: undefined,
+    });
+
+    expect(
+      endpointMeta({
+        namespace: 'ns',
+        pod_name: 'pod-1',
+        labels: ['k8s:openchoreo.dev/component=comp'],
+      }).name,
+    ).toBe('pod-1');
+
+    expect(
+      endpointMeta({
+        namespace: 'ns',
+        labels: ['k8s:openchoreo.dev/component=comp'],
+      }).name,
+    ).toBe('comp');
+
+    expect(endpointMeta({ namespace: 'ns' }).name).toBe('ns');
+  });
+
+  it('exposes project and environment labels when present', () => {
+    expect(
+      endpointMeta({
+        namespace: 'ns',
+        pod_name: 'pod-1',
+        labels: [
+          'k8s:openchoreo.dev/project=proj',
+          'k8s:openchoreo.dev/environment=dev',
+        ],
+      }),
+    ).toMatchObject({ project: 'proj', environment: 'dev' });
+  });
+});
+
+describe('isResponse', () => {
+  it('returns true when l7.type is RESPONSE', () => {
+    expect(isResponse({ l7: { type: 'RESPONSE' } } as WirelogFlow)).toBe(true);
+  });
+
+  it('returns false when l7.type is REQUEST', () => {
+    expect(isResponse({ l7: { type: 'REQUEST' } } as WirelogFlow)).toBe(false);
+  });
+
+  it('uses is_reply as fallback', () => {
+    expect(isResponse({ is_reply: true } as WirelogFlow)).toBe(true);
+  });
+
+  it('returns true when http has a code but no method', () => {
+    expect(isResponse({ l7: { http: { code: 200 } } } as WirelogFlow)).toBe(
+      true,
+    );
+  });
+
+  it('returns false when http has both method and code', () => {
+    expect(
+      isResponse({
+        l7: { http: { method: 'GET', code: 200 } },
+      } as WirelogFlow),
+    ).toBe(false);
+  });
+});
+
+describe('flowSummary / flowTitle', () => {
+  it('summarises an L7 HTTP request', () => {
+    const flow = {
+      l7: {
+        type: 'REQUEST',
+        http: { method: 'GET', url: 'http://x/path?q=1' },
+      },
+    } as WirelogFlow;
+    expect(flowSummary(flow)).toEqual({
+      kind: 'l7-request',
+      method: 'GET',
+      path: '/path?q=1',
+    });
+    expect(flowTitle(flow)).toBe('GET http://x/path?q=1');
+  });
+
+  it('summarises an L7 HTTP response with code + latency', () => {
+    const flow = {
+      l7: { type: 'RESPONSE', latency_ns: 5_000_000, http: { code: 503 } },
+    } as WirelogFlow;
+    expect(flowSummary(flow)).toEqual({
+      kind: 'l7-response',
+      code: 503,
+      latency: '5ms',
+    });
+    expect(flowTitle(flow)).toBe('HTTP 503 response · 5ms');
+  });
+
+  it('falls back to HTTP request title when method/url are absent', () => {
+    expect(
+      flowTitle({ l7: { http: {} }, is_reply: false } as WirelogFlow),
+    ).toBe('HTTP request');
+  });
+
+  it('summarises an L4 TCP flow', () => {
+    const flow = {
+      l4: {
+        TCP: {
+          source_port: 5000,
+          destination_port: 80,
+          flags: { SYN: true },
+        },
+      },
+    } as WirelogFlow;
+    expect(flowSummary(flow)).toEqual({
+      kind: 'l4',
+      protocol: 'TCP',
+      port: 80,
+      flags: ['SYN'],
+    });
+    expect(flowTitle(flow)).toBe('TCP on port 80 [SYN]');
+  });
+
+  it('uses source port in L4 title when destination is unset', () => {
+    expect(
+      flowTitle({
+        l4: { TCP: { source_port: 5000 } },
+      } as WirelogFlow),
+    ).toBe('TCP on port 5000');
+  });
+
+  it('falls back to raw Summary for unknown flows', () => {
+    expect(flowSummary({ Summary: 'rawline' } as WirelogFlow)).toEqual({
+      kind: 'raw',
+      text: 'rawline',
+    });
+    expect(flowTitle({ Summary: 'rawline' } as WirelogFlow)).toBe('rawline');
+    expect(flowTitle({} as WirelogFlow)).toBe('Flow');
+  });
+});
+
+describe('dropReasonText', () => {
+  it('maps known drop reasons to a friendly string', () => {
+    expect(
+      dropReasonText({ drop_reason_desc: 'POLICY_DENIED' } as WirelogFlow),
+    ).toBe('Policy denied by L3 (CiliumNetworkPolicy)');
+  });
+
+  it('humanises unknown SCREAMING_SNAKE drop reasons', () => {
+    expect(
+      dropReasonText({ drop_reason_desc: 'INVALID_PACKET' } as WirelogFlow),
+    ).toBe('Invalid packet');
+  });
+
+  it('falls back to a generic message when no reason is supplied', () => {
+    expect(dropReasonText({} as WirelogFlow)).toBe('Flow dropped');
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Wirelogs/flowFormat.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/flowFormat.ts
@@ -1,0 +1,227 @@
+import type { WirelogEndpoint, WirelogFlow, WirelogL4 } from './types';
+
+const OPENCHOREO_LABEL_PREFIX = 'openchoreo.dev/';
+
+/** Hubble flag-set objects key flags by name; pick the ones set to true. */
+const TCP_FLAG_ORDER = ['SYN', 'ACK', 'PSH', 'FIN', 'RST', 'URG', 'ECE', 'CWR'];
+
+export function getSourcePort(l4: WirelogL4 | undefined): number | undefined {
+  return l4?.TCP?.source_port ?? l4?.UDP?.source_port;
+}
+
+export function getDestinationPort(
+  l4: WirelogL4 | undefined,
+): number | undefined {
+  return l4?.TCP?.destination_port ?? l4?.UDP?.destination_port;
+}
+
+export function l4Protocol(l4: WirelogL4 | undefined): string | undefined {
+  if (l4?.TCP) return 'TCP';
+  if (l4?.UDP) return 'UDP';
+  return undefined;
+}
+
+export function tcpFlags(l4: WirelogL4 | undefined): string[] {
+  const flags = l4?.TCP?.flags;
+  if (!flags) return [];
+  const set = Object.entries(flags)
+    .filter(([, on]) => on)
+    .map(([name]) => name.toUpperCase());
+  return set.sort((a, b) => {
+    const ai = TCP_FLAG_ORDER.indexOf(a);
+    const bi = TCP_FLAG_ORDER.indexOf(b);
+    return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi);
+  });
+}
+
+export function isL7(flow: WirelogFlow): boolean {
+  return Boolean(flow.l7?.http);
+}
+
+export function typeLabel(flow: WirelogFlow): string {
+  if (flow.l7) return 'L7';
+  if (flow.Type === 'L3_L4') return 'L3/L4';
+  if (flow.Type === 'L7') return 'L7';
+  return flow.Type || 'L3/L4';
+}
+
+export type FlowDirection = 'in' | 'out' | 'unknown';
+
+export function directionInfo(flow: WirelogFlow): {
+  label: string;
+  direction: FlowDirection;
+} {
+  switch (flow.traffic_direction) {
+    case 'EGRESS':
+      return { label: 'out', direction: 'out' };
+    case 'INGRESS':
+      return { label: 'in', direction: 'in' };
+    default:
+      return { label: '—', direction: 'unknown' };
+  }
+}
+
+export function formatTime(iso: string | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  const ms = String(d.getMilliseconds()).padStart(3, '0');
+  return `${hh}:${mm}:${ss}.${ms}`;
+}
+
+export function formatAddress(
+  ip: string | undefined,
+  port: number | undefined,
+): string {
+  if (!ip) return '—';
+  return port ? `${ip}:${port}` : ip;
+}
+
+export function formatLatency(ns: number | undefined): string | undefined {
+  if (ns === undefined || ns === null) return undefined;
+  const ms = ns / 1e6;
+  if (ms < 1) return `${ms.toFixed(2)}ms`;
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export function urlPath(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const u = new URL(url);
+    return `${u.pathname}${u.search}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Splits Cilium labels (`<source>:<key>=<value>`) into a key→value map, dropping
+ * the source prefix (`k8s:`, `reserved:`, …) so callers can look up by bare key.
+ */
+export function parseLabels(
+  labels: string[] | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const raw of labels ?? []) {
+    const eq = raw.indexOf('=');
+    if (eq === -1) continue;
+    let key = raw.slice(0, eq);
+    const value = raw.slice(eq + 1);
+    const colon = key.indexOf(':');
+    if (colon !== -1) key = key.slice(colon + 1);
+    out[key] = value;
+  }
+  return out;
+}
+
+export interface EndpointMeta {
+  name: string | undefined;
+  namespace: string | undefined;
+  component?: string;
+  project?: string;
+  environment?: string;
+}
+
+export function endpointMeta(
+  endpoint: WirelogEndpoint | undefined,
+): EndpointMeta {
+  if (!endpoint) {
+    return { name: undefined, namespace: undefined };
+  }
+  const labels = parseLabels(endpoint.labels);
+  const component = labels[`${OPENCHOREO_LABEL_PREFIX}component`];
+  const project = labels[`${OPENCHOREO_LABEL_PREFIX}project`];
+  const environment = labels[`${OPENCHOREO_LABEL_PREFIX}environment`];
+  const name =
+    endpoint.workloads?.[0]?.name ||
+    endpoint.pod_name ||
+    component ||
+    endpoint.namespace;
+  return {
+    name,
+    namespace: endpoint.namespace,
+    component,
+    project,
+    environment,
+  };
+}
+
+export type FlowSummary =
+  | { kind: 'l7-request'; method?: string; path?: string }
+  | { kind: 'l7-response'; code?: number; latency?: string }
+  | { kind: 'l4'; protocol?: string; port?: number; flags: string[] }
+  | { kind: 'raw'; text?: string };
+
+export function isResponse(flow: WirelogFlow): boolean {
+  if (flow.l7?.type === 'RESPONSE') return true;
+  if (flow.l7?.type === 'REQUEST') return false;
+  if (flow.is_reply) return true;
+  const http = flow.l7?.http;
+  return Boolean(http && http.code !== undefined && !http.method);
+}
+
+export function flowSummary(flow: WirelogFlow): FlowSummary {
+  const http = flow.l7?.http;
+  if (http) {
+    if (isResponse(flow)) {
+      return {
+        kind: 'l7-response',
+        code: http.code,
+        latency: formatLatency(flow.l7?.latency_ns),
+      };
+    }
+    return { kind: 'l7-request', method: http.method, path: urlPath(http.url) };
+  }
+  const protocol = l4Protocol(flow.l4);
+  if (protocol) {
+    return {
+      kind: 'l4',
+      protocol,
+      port: getDestinationPort(flow.l4),
+      flags: tcpFlags(flow.l4),
+    };
+  }
+  return { kind: 'raw', text: flow.Summary };
+}
+
+export function flowTitle(flow: WirelogFlow): string {
+  const http = flow.l7?.http;
+  if (http) {
+    if (isResponse(flow)) {
+      const latency = formatLatency(flow.l7?.latency_ns);
+      const code = http.code !== undefined ? ` ${http.code}` : '';
+      return `HTTP${code} response${latency ? ` · ${latency}` : ''}`;
+    }
+    return `${http.method ?? ''} ${http.url ?? ''}`.trim() || 'HTTP request';
+  }
+  const protocol = l4Protocol(flow.l4);
+  if (protocol) {
+    const port = getDestinationPort(flow.l4) ?? getSourcePort(flow.l4);
+    const flags = tcpFlags(flow.l4);
+    const flagPart = flags.length ? ` [${flags.join(',')}]` : '';
+    return `${protocol} on port ${port ?? '?'}${flagPart}`;
+  }
+  return flow.Summary || 'Flow';
+}
+
+const DROP_REASON_TEXT: Record<string, string> = {
+  POLICY_DENIED: 'Policy denied by L3 (CiliumNetworkPolicy)',
+};
+
+export function dropReasonText(flow: WirelogFlow): string {
+  const desc = flow.drop_reason_desc;
+  if (desc && DROP_REASON_TEXT[desc]) return DROP_REASON_TEXT[desc];
+  if (desc) {
+    return desc
+      .toLowerCase()
+      .split('_')
+      .filter(Boolean)
+      .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+      .join(' ');
+  }
+  return 'Flow dropped';
+}

--- a/plugins/openchoreo-observability/src/components/Wirelogs/index.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/index.ts
@@ -1,0 +1,1 @@
+export { ObservabilityWirelogsPage } from './ObservabilityWirelogsPage';

--- a/plugins/openchoreo-observability/src/components/Wirelogs/styles.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/styles.ts
@@ -1,0 +1,486 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useWirelogsStyles = makeStyles(theme => ({
+  errorContainer: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  },
+  toolbar: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    flexWrap: 'wrap',
+    marginBottom: theme.spacing(2),
+  },
+  envControl: {
+    width: 220,
+    flexShrink: 0,
+  },
+  filterField: {
+    flex: 1,
+    minWidth: 260,
+  },
+  startButton: {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    whiteSpace: 'nowrap',
+    '&:hover': {
+      backgroundColor: theme.palette.primary.dark,
+    },
+  },
+  stopButton: {
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.error.contrastText,
+    whiteSpace: 'nowrap',
+    '&:hover': {
+      backgroundColor: theme.palette.error.dark,
+    },
+  },
+  toolbarButton: {
+    whiteSpace: 'nowrap',
+    color: theme.palette.text.secondary,
+    borderColor: theme.palette.divider,
+  },
+}));
+
+export const useWirelogsStatsStyles = makeStyles(theme => ({
+  container: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    margin: theme.spacing(1),
+    flexWrap: 'wrap',
+    gap: theme.spacing(2),
+  },
+  countLabel: {
+    color: theme.palette.text.secondary,
+  },
+  metrics: {
+    display: 'flex',
+    gap: theme.spacing(3),
+    alignItems: 'center',
+  },
+  allowed: {
+    color: theme.palette.success.main,
+  },
+  dropped: {
+    color: theme.palette.error.main,
+  },
+  ratioHigh: {
+    color: theme.palette.success.main,
+  },
+  ratioMid: {
+    color: theme.palette.warning.main,
+  },
+  ratioLow: {
+    color: theme.palette.error.main,
+  },
+}));
+
+export const useWirelogsTableStyles = makeStyles(theme => ({
+  tablePaper: {
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'hidden',
+  },
+  tableContainer: {
+    maxHeight: 'calc(100vh - 320px)',
+    overflowY: 'auto',
+    overflowX: 'auto',
+  },
+  headerCell: {
+    fontWeight: 700,
+    fontSize: '0.65rem',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: theme.palette.text.secondary,
+    backgroundColor: theme.palette.background.default,
+    position: 'sticky',
+    top: 0,
+    zIndex: 1,
+    padding: theme.spacing(0.75, 1.5),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    whiteSpace: 'nowrap',
+  },
+  row: {
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+  rowSelected: {
+    backgroundColor: theme.palette.action.selected,
+  },
+  bodyCell: {
+    padding: theme.spacing(0.75, 1.5),
+    verticalAlign: 'top',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  timeCell: {
+    fontFamily: 'monospace',
+    fontSize: '11px',
+    color: theme.palette.text.primary,
+    whiteSpace: 'nowrap',
+  },
+  verdictChip: {
+    fontSize: '0.6rem',
+    fontWeight: 'bold',
+    height: '18px !important',
+    '& .MuiChip-label': {
+      display: 'flex',
+      alignItems: 'center',
+      padding: '0 6px',
+    },
+  },
+  verdictForwardedChip: {
+    backgroundColor: theme.palette.success.light,
+    color: theme.palette.success.dark,
+    outline: `1px solid ${theme.palette.success.main}`,
+  },
+  verdictDroppedChip: {
+    backgroundColor: theme.palette.error.light,
+    color: theme.palette.error.dark,
+    outline: `1px solid ${theme.palette.error.main}`,
+  },
+  verdictUnknownChip: {
+    backgroundColor: theme.palette.action.disabledBackground,
+    color: theme.palette.text.disabled,
+    outline: `1px solid ${theme.palette.text.secondary}`,
+  },
+  verdictDot: {
+    width: 6,
+    height: 6,
+    borderRadius: '50%',
+    display: 'inline-block',
+    marginRight: theme.spacing(0.5),
+    backgroundColor: 'currentColor',
+  },
+  typeBadge: {
+    display: 'inline-block',
+    fontSize: '0.6rem',
+    fontWeight: 700,
+    letterSpacing: 0.3,
+    padding: theme.spacing(0.1, 0.6),
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: theme.palette.background.default,
+    border: `1px solid ${theme.palette.divider}`,
+    color: theme.palette.text.secondary,
+    whiteSpace: 'nowrap',
+  },
+  dirCell: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    fontSize: '11px',
+    color: theme.palette.text.secondary,
+    whiteSpace: 'nowrap',
+  },
+  dirArrow: {
+    fontSize: '0.9rem',
+    lineHeight: 1,
+  },
+  endpointName: {
+    color: theme.palette.primary.main,
+    fontFamily: 'monospace',
+    fontSize: '11px',
+    fontWeight: 600,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: 200,
+  },
+  endpointSub: {
+    color: theme.palette.text.secondary,
+    fontSize: '0.65rem',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: 200,
+  },
+  summaryCell: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    fontSize: '11px',
+    color: theme.palette.text.primary,
+    whiteSpace: 'nowrap',
+  },
+  summaryArrow: {
+    color: theme.palette.text.secondary,
+    fontSize: '0.85rem',
+  },
+  summaryText: {
+    fontFamily: 'monospace',
+    fontSize: '11px',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: 220,
+  },
+  methodBadge: {
+    fontSize: '0.6rem',
+    fontWeight: 700,
+    fontFamily: 'monospace',
+    padding: theme.spacing(0.1, 0.6),
+    borderRadius: theme.shape.borderRadius,
+  },
+  methodGet: {
+    backgroundColor: theme.palette.success.light,
+    color: theme.palette.success.dark,
+  },
+  methodPost: {
+    backgroundColor: theme.palette.info.light,
+    color: theme.palette.info.dark,
+  },
+  methodPut: {
+    backgroundColor: theme.palette.warning.light,
+    color: theme.palette.warning.dark,
+  },
+  methodDelete: {
+    backgroundColor: theme.palette.error.light,
+    color: theme.palette.error.dark,
+  },
+  methodOther: {
+    backgroundColor: theme.palette.action.selected,
+    color: theme.palette.text.primary,
+  },
+  statusCode: {
+    fontFamily: 'monospace',
+    fontWeight: 700,
+  },
+  status2xx: {
+    color: theme.palette.success.main,
+  },
+  status3xx: {
+    color: theme.palette.info.main,
+  },
+  status4xx: {
+    color: theme.palette.warning.main,
+  },
+  status5xx: {
+    color: theme.palette.error.main,
+  },
+  emptyState: {
+    textAlign: 'center',
+    padding: theme.spacing(6),
+    color: theme.palette.text.secondary,
+  },
+}));
+
+export const useWirelogsDetailStyles = makeStyles(theme => ({
+  tabs: {
+    minHeight: 36,
+    marginTop: theme.spacing(1),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  tab: {
+    minHeight: 36,
+    minWidth: 'auto',
+    textTransform: 'none',
+    fontSize: '0.8rem',
+    padding: theme.spacing(0, 1.5),
+  },
+  tabPanel: {
+    paddingTop: theme.spacing(2),
+  },
+  section: {
+    marginBottom: theme.spacing(2.5),
+  },
+  sectionTitle: {
+    fontSize: '0.68rem',
+    fontWeight: 700,
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(1),
+  },
+  endpointsGrid: {
+    display: 'flex',
+    alignItems: 'stretch',
+    gap: theme.spacing(1),
+  },
+  endpointCard: {
+    flex: 1,
+    minWidth: 0,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(1.5),
+    backgroundColor: theme.palette.background.paper,
+  },
+  endpointCardLabel: {
+    fontSize: '0.62rem',
+    fontWeight: 700,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: theme.palette.text.secondary,
+  },
+  endpointCardTitle: {
+    fontFamily: 'monospace',
+    fontSize: '0.85rem',
+    fontWeight: 700,
+    color: theme.palette.primary.main,
+    marginBottom: theme.spacing(1),
+    wordBreak: 'break-all',
+  },
+  endpointArrow: {
+    display: 'flex',
+    alignItems: 'center',
+    color: theme.palette.text.secondary,
+  },
+  kvRow: {
+    display: 'flex',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.25, 0),
+    fontSize: '0.78rem',
+  },
+  kvKey: {
+    color: theme.palette.text.secondary,
+    minWidth: 84,
+    flexShrink: 0,
+  },
+  kvValue: {
+    color: theme.palette.text.primary,
+    fontFamily: 'monospace',
+    wordBreak: 'break-all',
+  },
+  droppedBanner: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    backgroundColor: theme.palette.error.light,
+    color: theme.palette.error.dark,
+    border: `1px solid ${theme.palette.error.main}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(1, 1.5),
+    marginBottom: theme.spacing(2),
+    fontSize: '0.82rem',
+    fontWeight: 600,
+  },
+  headersList: {
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'hidden',
+  },
+  headerRow: {
+    display: 'flex',
+    gap: theme.spacing(2),
+    padding: theme.spacing(0.75, 1.5),
+    fontSize: '0.78rem',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    '&:last-child': {
+      borderBottom: 'none',
+    },
+  },
+  headerKey: {
+    color: theme.palette.text.primary,
+    fontFamily: 'monospace',
+    fontWeight: 600,
+    minWidth: 160,
+    flexShrink: 0,
+  },
+  headerValue: {
+    color: theme.palette.text.primary,
+    fontFamily: 'monospace',
+    wordBreak: 'break-all',
+  },
+  emptyTab: {
+    fontSize: '0.82rem',
+    color: theme.palette.text.secondary,
+    padding: theme.spacing(2, 0),
+  },
+  rawHeader: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginBottom: theme.spacing(1),
+  },
+  rawCopyButton: {
+    fontSize: '0.72rem',
+    textTransform: 'none',
+    color: theme.palette.text.secondary,
+    padding: theme.spacing(0.25, 0.75),
+    minWidth: 'auto',
+  },
+}));
+
+export const useWirelogsDrawerStyles = makeStyles(theme => ({
+  drawer: {
+    width: 820,
+    maxWidth: '100vw',
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100vh',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1),
+    padding: theme.spacing(2, 2, 1),
+  },
+  headerLeft: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1),
+    minWidth: 0,
+  },
+  headerIcon: {
+    color: theme.palette.text.secondary,
+    marginTop: 2,
+  },
+  title: {
+    fontWeight: 700,
+    fontSize: '0.95rem',
+    fontFamily: 'monospace',
+    color: theme.palette.text.primary,
+    wordBreak: 'break-all',
+  },
+  uuid: {
+    fontSize: '0.72rem',
+    fontFamily: 'monospace',
+    color: theme.palette.text.secondary,
+    marginTop: theme.spacing(0.5),
+    wordBreak: 'break-all',
+  },
+  actions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    flexShrink: 0,
+  },
+  metadataRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    flexWrap: 'wrap',
+    padding: theme.spacing(0, 2, 1.5),
+  },
+  verdictChip: {
+    fontSize: '0.6rem',
+    fontWeight: 'bold',
+    height: '20px !important',
+  },
+  verdictForwardedChip: {
+    backgroundColor: theme.palette.success.light,
+    color: theme.palette.success.dark,
+    outline: `1px solid ${theme.palette.success.main}`,
+  },
+  verdictDroppedChip: {
+    backgroundColor: theme.palette.error.light,
+    color: theme.palette.error.dark,
+    outline: `1px solid ${theme.palette.error.main}`,
+  },
+  verdictUnknownChip: {
+    backgroundColor: theme.palette.action.disabledBackground,
+    color: theme.palette.text.disabled,
+    outline: `1px solid ${theme.palette.text.secondary}`,
+  },
+  metaChip: {
+    fontSize: '0.6rem',
+    fontWeight: 600,
+    height: '20px !important',
+  },
+  body: {
+    flex: 1,
+    overflow: 'auto',
+    padding: theme.spacing(0, 2, 2),
+  },
+}));

--- a/plugins/openchoreo-observability/src/components/Wirelogs/types.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/types.ts
@@ -63,6 +63,7 @@ export interface WirelogFlow {
 export interface WirelogEvent {
   flow: WirelogFlow;
   time?: string;
+  __id?: string;
 }
 
 import type { Environment } from '@openchoreo/backstage-plugin-react';

--- a/plugins/openchoreo-observability/src/components/Wirelogs/types.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/types.ts
@@ -1,0 +1,80 @@
+export type WirelogVerdict = 'FORWARDED' | 'DROPPED' | string;
+
+export type WirelogDirection = 'INGRESS' | 'EGRESS' | string;
+
+export interface WirelogEndpoint {
+  cluster_name?: string;
+  namespace?: string;
+  labels?: string[];
+  pod_name?: string;
+  workloads?: Array<{ name: string; kind: string }>;
+}
+
+export interface WirelogIP {
+  source?: string;
+  destination?: string;
+  source_xlated?: string;
+  ipVersion?: string;
+}
+
+export interface WirelogL4TCPUDP {
+  source_port?: number;
+  destination_port?: number;
+  flags?: Record<string, boolean>;
+}
+
+export interface WirelogL4 {
+  TCP?: WirelogL4TCPUDP;
+  UDP?: WirelogL4TCPUDP;
+}
+
+export interface WirelogL7Http {
+  method?: string;
+  url?: string;
+  protocol?: string;
+  code?: number;
+  headers?: Array<{ key: string; value: string }>;
+}
+
+export interface WirelogL7 {
+  type?: string;
+  latency_ns?: number;
+  http?: WirelogL7Http;
+}
+
+export interface WirelogFlow {
+  time?: string;
+  uuid?: string;
+  verdict?: WirelogVerdict;
+  drop_reason?: number;
+  drop_reason_desc?: string;
+  IP?: WirelogIP;
+  l4?: WirelogL4;
+  l7?: WirelogL7;
+  source?: WirelogEndpoint;
+  destination?: WirelogEndpoint;
+  Type?: string;
+  traffic_direction?: WirelogDirection;
+  is_reply?: boolean;
+  proxy_port?: number;
+  Summary?: string;
+}
+
+export interface WirelogEvent {
+  flow: WirelogFlow;
+  time?: string;
+}
+
+import type { Environment } from '@openchoreo/backstage-plugin-react';
+
+export interface WirelogsFilters {
+  environment: Environment | null;
+  searchQuery: string;
+}
+
+export type WirelogStreamStatus =
+  | 'idle'
+  | 'connecting'
+  | 'streaming'
+  | 'error'
+  | 'closed';

--- a/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.test.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.test.ts
@@ -1,0 +1,266 @@
+// jsdom 16 (which backstage-cli uses for unit tests) does not expose
+// TextEncoder/TextDecoder on globalThis, but the hook under test relies on
+// `new TextDecoder()` to parse SSE bytes. Patch the globals before importing.
+// `util` is normally a restricted import per Backstage's eslint preset, but
+// it's the only way to reach Node's built-in encoders inside this test env.
+// eslint-disable-next-line no-restricted-imports
+const nodeUtil = require('util');
+
+if (typeof (globalThis as any).TextEncoder === 'undefined') {
+  (globalThis as any).TextEncoder = nodeUtil.TextEncoder;
+}
+if (typeof (globalThis as any).TextDecoder === 'undefined') {
+  (globalThis as any).TextDecoder = nodeUtil.TextDecoder;
+}
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import { useWirelogsStream } from './useWirelogsStream';
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return {
+    ...actual,
+    useApi: jest.fn(),
+  };
+});
+
+const encoder = new (globalThis as any).TextEncoder();
+
+function makeReader(chunks: Array<string | Uint8Array>) {
+  let i = 0;
+  return {
+    read: jest.fn(async () => {
+      if (i >= chunks.length) {
+        return { value: undefined, done: true } as const;
+      }
+      const chunk = chunks[i++];
+      const value = typeof chunk === 'string' ? encoder.encode(chunk) : chunk;
+      return { value, done: false } as const;
+    }),
+  };
+}
+
+function streamingResponse(chunks: Array<string | Uint8Array>): Response {
+  const reader = makeReader(chunks);
+  return {
+    ok: true,
+    body: { getReader: () => reader },
+  } as unknown as Response;
+}
+
+function errorResponse(status: number, statusText: string, body = '') {
+  return {
+    ok: false,
+    status,
+    statusText,
+    text: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function makeApis() {
+  const getBaseUrl = jest
+    .fn()
+    .mockResolvedValue('http://backend/api/openchoreo');
+  const fetch = jest.fn();
+  (useApi as jest.Mock).mockImplementation(ref => {
+    if (ref === discoveryApiRef) return { getBaseUrl };
+    if (ref === fetchApiRef) return { fetch };
+    return undefined;
+  });
+  return { getBaseUrl, fetch };
+}
+
+const args = {
+  namespaceName: 'ns',
+  projectName: 'proj',
+  environmentName: 'dev',
+};
+
+describe('useWirelogsStream', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets error state when start is called without required identifiers', () => {
+    makeApis();
+    const { result } = renderHook(() =>
+      useWirelogsStream({
+        namespaceName: undefined,
+        projectName: 'proj',
+        environmentName: 'dev',
+      }),
+    );
+
+    act(() => result.current.start());
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toMatch(/required/);
+  });
+
+  it('streams SSE data frames into flows and surfaces error events', async () => {
+    const { getBaseUrl, fetch } = makeApis();
+    const chunks = [
+      'data: {"flow":{"uuid":"a","verdict":"FORWARDED"}}\n\n',
+      'data: {"flow":{"uuid":"b","verdict":"DROPPED"}}\n\nevent: error\ndata: {"message":"boom"}\n\n',
+    ];
+    fetch.mockResolvedValueOnce(streamingResponse(chunks));
+
+    const { result } = renderHook(() => useWirelogsStream(args));
+
+    act(() => result.current.start());
+
+    await waitFor(() => expect(result.current.flows).toHaveLength(2));
+    expect(result.current.totalReceived).toBe(2);
+    // The error event was emitted between data frames; status flips to error
+    // immediately, then the stream ends and the hook transitions to closed.
+    await waitFor(() => expect(result.current.error).toBe('boom'));
+
+    // URL params include the openchoreo discovery base + all required params.
+    expect(getBaseUrl).toHaveBeenCalledWith('openchoreo');
+    const calledUrl = fetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/wirelogs/stream');
+    expect(calledUrl).toContain('namespaceName=ns');
+    expect(calledUrl).toContain('projectName=proj');
+    expect(calledUrl).toContain('environmentName=dev');
+  });
+
+  it('passes componentName when provided', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(streamingResponse([]));
+
+    const { result } = renderHook(() =>
+      useWirelogsStream({ ...args, componentName: 'svc' }),
+    );
+
+    act(() => result.current.start());
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch.mock.calls[0][0]).toContain('componentName=svc');
+  });
+
+  it('parses frames split across chunk boundaries', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(
+      streamingResponse([
+        'data: {"flow":{"uu',
+        'id":"a"}}\n\ndata: {"flow":{"uuid":"b"}}\n\n',
+      ]),
+    );
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.flows).toHaveLength(2));
+    expect(result.current.flows[0].flow.uuid).toBe('a');
+    expect(result.current.flows[1].flow.uuid).toBe('b');
+  });
+
+  it('evicts older flows once the buffer cap is exceeded', async () => {
+    const { fetch } = makeApis();
+    const frames = Array.from(
+      { length: 4 },
+      (_, i) => `data: {"flow":{"uuid":"u${i}"}}\n\n`,
+    ).join('');
+    fetch.mockResolvedValueOnce(streamingResponse([frames]));
+
+    const { result } = renderHook(() =>
+      useWirelogsStream({ ...args, maxBuffer: 2 }),
+    );
+
+    act(() => result.current.start());
+
+    await waitFor(() => expect(result.current.flows).toHaveLength(2));
+    expect(result.current.flows.map(f => f.flow.uuid)).toEqual(['u2', 'u3']);
+    // totalReceived counts every parsed frame, not just retained ones.
+    expect(result.current.totalReceived).toBe(4);
+  });
+
+  it('drops malformed JSON and frames without flow', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(
+      streamingResponse([
+        'data: not-json\n\n',
+        'data: {"noflow":true}\n\n',
+        'data: {"flow":{"uuid":"ok"}}\n\n',
+      ]),
+    );
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.flows).toHaveLength(1));
+    expect(result.current.flows[0].flow.uuid).toBe('ok');
+    // Only the parseable flow frame counts towards totalReceived.
+    expect(result.current.totalReceived).toBe(1);
+  });
+
+  it('transitions to closed when the stream ends naturally', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(streamingResponse([]));
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.status).toBe('closed'));
+  });
+
+  it('reports an error and leaves status=error when the upstream returns non-ok', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(errorResponse(503, 'Service Unavailable', ''));
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error).toMatch(/503/);
+  });
+
+  it('surfaces the upstream body when one is provided', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(errorResponse(500, 'X', 'bad-thing'));
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error).toBe('bad-thing');
+  });
+
+  it('errors when the response has no body', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      body: null,
+    } as unknown as Response);
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error).toMatch(/no body/);
+  });
+
+  it('clear resets flows, totalReceived and error', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(
+      streamingResponse(['data: {"flow":{"uuid":"a"}}\n\n']),
+    );
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.flows).toHaveLength(1));
+    act(() => result.current.clear());
+    expect(result.current.flows).toEqual([]);
+    expect(result.current.totalReceived).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('stop aborts the in-flight stream and moves status to closed', async () => {
+    const { fetch } = makeApis();
+    fetch.mockImplementation(
+      (_url, opts: any) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener('abort', () =>
+            reject(new DOMException('aborted', 'AbortError')),
+          );
+        }),
+    );
+
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.status).toBe('connecting'));
+    act(() => result.current.stop());
+    expect(result.current.status).toBe('closed');
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.ts
@@ -55,6 +55,7 @@ export function useWirelogsStream({
 
   const abortRef = useRef<AbortController | null>(null);
   const stopRequestedRef = useRef(false);
+  const eventCounterRef = useRef(0);
 
   const stop = useCallback(() => {
     stopRequestedRef.current = true;
@@ -141,8 +142,13 @@ export function useWirelogsStream({
 
             const parsed = parseSseFrame(frame);
             if (parsed?.kind === 'data') {
+              eventCounterRef.current += 1;
+              const event: WirelogEvent = {
+                ...parsed.event,
+                __id: `ev-${eventCounterRef.current}`,
+              };
               setFlows(prev => {
-                const next = [...prev, parsed.event];
+                const next = [...prev, event];
                 return next.length > maxBuffer
                   ? next.slice(next.length - maxBuffer)
                   : next;
@@ -181,12 +187,12 @@ export function useWirelogsStream({
 
   useEffect(() => () => stop(), [stop]);
 
-  // Reset state if the user switches environment/component while streaming.
+  // Reset state when the user switches environment/component.
   useEffect(() => {
     if (abortRef.current) {
       stop();
-      clear();
     }
+    clear();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [namespaceName, projectName, environmentName, componentName]);
 

--- a/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.ts
@@ -1,0 +1,234 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useApi,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+import type { WirelogEvent, WirelogStreamStatus } from './types';
+
+interface UseWirelogsStreamArgs {
+  namespaceName: string | undefined;
+  projectName: string | undefined;
+  environmentName: string | undefined;
+  componentName?: string | undefined;
+  maxBuffer?: number;
+}
+
+interface UseWirelogsStreamResult {
+  flows: WirelogEvent[];
+  status: WirelogStreamStatus;
+  error: string | null;
+  totalReceived: number;
+  start: () => void;
+  stop: () => void;
+  clear: () => void;
+}
+
+const DEFAULT_MAX_BUFFER = 500;
+
+/**
+ * Consumes the openchoreo-backend `/wirelogs/stream` SSE proxy.
+ *
+ * Uses fetchApi.fetch so the Backstage session cookie / token rides along;
+ * EventSource is avoided because it can't carry the auth header the backend
+ * middleware expects. The body is parsed as text/event-stream client-side:
+ * SSE frames are separated by blank lines, and each `data:` line is a JSON
+ * object matching the `WirelogEvent` shape.
+ *
+ * Older flows are evicted past `maxBuffer` to keep the table responsive on
+ * busy clusters — Hubble can emit 100s of flows/sec in a steady state.
+ */
+export function useWirelogsStream({
+  namespaceName,
+  projectName,
+  environmentName,
+  componentName,
+  maxBuffer = DEFAULT_MAX_BUFFER,
+}: UseWirelogsStreamArgs): UseWirelogsStreamResult {
+  const discovery = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+
+  const [flows, setFlows] = useState<WirelogEvent[]>([]);
+  const [status, setStatus] = useState<WirelogStreamStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [totalReceived, setTotalReceived] = useState(0);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const stopRequestedRef = useRef(false);
+
+  const stop = useCallback(() => {
+    stopRequestedRef.current = true;
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    setStatus(prev =>
+      prev === 'streaming' || prev === 'connecting' ? 'closed' : prev,
+    );
+  }, []);
+
+  const clear = useCallback(() => {
+    setFlows([]);
+    setTotalReceived(0);
+    setError(null);
+  }, []);
+
+  const start = useCallback(() => {
+    if (!namespaceName || !projectName || !environmentName) {
+      setError('namespace, project and environment are required');
+      setStatus('error');
+      return;
+    }
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    stopRequestedRef.current = false;
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setStatus('connecting');
+    setError(null);
+
+    (async () => {
+      try {
+        const baseUrl = await discovery.getBaseUrl('openchoreo');
+        const url = new URL(`${baseUrl}/wirelogs/stream`);
+        url.searchParams.set('namespaceName', namespaceName);
+        url.searchParams.set('projectName', projectName);
+        url.searchParams.set('environmentName', environmentName);
+        if (componentName) {
+          url.searchParams.set('componentName', componentName);
+        }
+
+        const response = await fetchApi.fetch(url.toString(), {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream' },
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const text = await response.text().catch(() => '');
+          throw new Error(
+            text ||
+              `Stream request failed: ${response.status} ${response.statusText}`,
+          );
+        }
+        if (!response.body) {
+          throw new Error('Stream response had no body');
+        }
+
+        setStatus('streaming');
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let streaming = true;
+
+        while (streaming) {
+          const { value, done } = await reader.read();
+          if (done) {
+            streaming = false;
+            break;
+          }
+          buffer += decoder.decode(value, { stream: true });
+
+          // SSE frames are delimited by a blank line ("\n\n"). Anything left
+          // after the last \n\n is a partial frame — keep it in the buffer.
+          let separatorIdx = buffer.indexOf('\n\n');
+          while (separatorIdx !== -1) {
+            const frame = buffer.slice(0, separatorIdx);
+            buffer = buffer.slice(separatorIdx + 2);
+
+            const parsed = parseSseFrame(frame);
+            if (parsed?.kind === 'data') {
+              setFlows(prev => {
+                const next = [...prev, parsed.event];
+                return next.length > maxBuffer
+                  ? next.slice(next.length - maxBuffer)
+                  : next;
+              });
+              setTotalReceived(prev => prev + 1);
+            } else if (parsed?.kind === 'error') {
+              setError(parsed.message);
+              setStatus('error');
+            }
+
+            separatorIdx = buffer.indexOf('\n\n');
+          }
+        }
+        if (!stopRequestedRef.current) {
+          setStatus('closed');
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError((err as Error).message || 'Stream failed');
+        setStatus('error');
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+        }
+      }
+    })();
+  }, [
+    discovery,
+    fetchApi,
+    namespaceName,
+    projectName,
+    environmentName,
+    componentName,
+    maxBuffer,
+  ]);
+
+  useEffect(() => () => stop(), [stop]);
+
+  // Reset state if the user switches environment/component while streaming.
+  useEffect(() => {
+    if (abortRef.current) {
+      stop();
+      clear();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [namespaceName, projectName, environmentName, componentName]);
+
+  return {
+    flows,
+    status,
+    error,
+    totalReceived,
+    start,
+    stop,
+    clear,
+  };
+}
+
+type ParsedFrame =
+  | { kind: 'data'; event: WirelogEvent }
+  | { kind: 'error'; message: string }
+  | undefined;
+
+function parseSseFrame(frame: string): ParsedFrame {
+  const lines = frame.split('\n');
+  let eventType: string | undefined;
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trimStart());
+    } else if (line.startsWith('event:')) {
+      eventType = line.slice(6).trim();
+    }
+  }
+  if (dataLines.length === 0) return undefined;
+  const payload = dataLines.join('\n');
+  try {
+    const parsed = JSON.parse(payload);
+    if (eventType === 'error') {
+      return { kind: 'error', message: parsed.message || 'Stream error' };
+    }
+    if (parsed && typeof parsed === 'object' && parsed.flow) {
+      return { kind: 'data', event: parsed as WirelogEvent };
+    }
+  } catch {
+    // ignore malformed frame
+  }
+  return undefined;
+}

--- a/plugins/openchoreo-observability/src/hooks/index.ts
+++ b/plugins/openchoreo-observability/src/hooks/index.ts
@@ -1,5 +1,10 @@
 export { useGetNamespaceAndProjectByEntity } from './useGetNamespaceAndProjectByEntity';
 export { useDataPlaneNetPolProvider } from './useDataPlaneNetPolProvider';
+export { useWirelogsEnvironments } from './useWirelogsEnvironments';
+export type {
+  WirelogsEnvironment,
+  UseWirelogsEnvironmentsResult,
+} from './useWirelogsEnvironments';
 export { useFilters } from './useFilters';
 export { useUrlFilters } from './useUrlFilters';
 export { useMetrics } from './useMetrics';

--- a/plugins/openchoreo-observability/src/hooks/useWirelogsEnvironments.test.tsx
+++ b/plugins/openchoreo-observability/src/hooks/useWirelogsEnvironments.test.tsx
@@ -1,0 +1,254 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { discoveryApiRef, fetchApiRef } from '@backstage/core-plugin-api';
+import { useWirelogsEnvironments } from './useWirelogsEnvironments';
+
+const mockUseProjectEnvironments = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useProjectEnvironments: (...args: any[]) =>
+    mockUseProjectEnvironments(...args),
+}));
+
+const mockDiscoveryApi = { getBaseUrl: jest.fn() };
+const mockFetchApi = { fetch: jest.fn() };
+
+const okResponse = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body } as unknown as Response);
+
+const errResponse = (status: number) =>
+  ({ ok: false, status, json: async () => ({}) } as unknown as Response);
+
+function setup() {
+  return renderHook(() => useWirelogsEnvironments('proj-1', 'ns-1'), {
+    wrapper: ({ children }) => (
+      <TestApiProvider
+        apis={[
+          [discoveryApiRef, mockDiscoveryApi as any],
+          [fetchApiRef, mockFetchApi as any],
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    ),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDiscoveryApi.getBaseUrl.mockResolvedValue(
+    'http://localhost/observability-backend',
+  );
+});
+
+describe('useWirelogsEnvironments', () => {
+  it('returns loading=true while the underlying envs are still loading', () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [],
+      loading: true,
+      error: null,
+    });
+    const { result } = setup();
+    expect(result.current.loading).toBe(true);
+    expect(result.current.environments).toEqual([]);
+    expect(mockFetchApi.fetch).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the underlying environments error', () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [],
+      loading: false,
+      error: 'broken',
+    });
+    const { result } = setup();
+    expect(result.current.error).toBe('broken');
+  });
+
+  it('returns an empty list (no probe calls) when the upstream resolves to zero envs', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [],
+      loading: false,
+      error: null,
+    });
+    const { result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.environments).toEqual([]);
+    expect(mockFetchApi.fetch).not.toHaveBeenCalled();
+  });
+
+  it('flags an env as hasWirelogs=true when its DataPlane reports cilium', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [
+        {
+          name: 'dev',
+          namespace: 'ns-1',
+          dataPlaneRef: { name: 'dp-1', kind: 'DataPlane' },
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mockFetchApi.fetch.mockResolvedValueOnce(
+      okResponse({ networkPolicyProvider: 'cilium' }),
+    );
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.environments).toEqual([
+      {
+        name: 'dev',
+        namespace: 'ns-1',
+        dataPlaneRef: { name: 'dp-1', kind: 'DataPlane' },
+        hasWirelogs: true,
+      },
+    ]);
+  });
+
+  it('flags hasWirelogs=false when DataPlane has a different provider', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [
+        {
+          name: 'dev',
+          namespace: 'ns-1',
+          dataPlaneRef: { name: 'dp-1', kind: 'DataPlane' },
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mockFetchApi.fetch.mockResolvedValueOnce(
+      okResponse({ networkPolicyProvider: 'calico' }),
+    );
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.environments[0].hasWirelogs).toBe(false);
+  });
+
+  it('skips the probe (hasWirelogs=false) when the env has no dataPlaneRef', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [{ name: 'dev', namespace: 'ns-1' /* no dataPlaneRef */ }],
+      loading: false,
+      error: null,
+    });
+    const { result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.environments).toEqual([
+      {
+        name: 'dev',
+        namespace: 'ns-1',
+        hasWirelogs: false,
+      },
+    ]);
+    expect(mockFetchApi.fetch).not.toHaveBeenCalled();
+  });
+
+  it('treats a failed probe as hasWirelogs=false', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [
+        {
+          name: 'dev',
+          namespace: 'ns-1',
+          dataPlaneRef: { name: 'dp-1', kind: 'DataPlane' },
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mockFetchApi.fetch.mockResolvedValueOnce(errResponse(500));
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.environments[0].hasWirelogs).toBe(false);
+  });
+
+  it('treats a thrown probe error (network failure / timeout) as hasWirelogs=false', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [
+        {
+          name: 'dev',
+          namespace: 'ns-1',
+          dataPlaneRef: { name: 'dp-1', kind: 'DataPlane' },
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mockFetchApi.fetch.mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.environments[0].hasWirelogs).toBe(false);
+  });
+
+  it('returns an empty list when discoveryApi.getBaseUrl fails', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [
+        {
+          name: 'dev',
+          namespace: 'ns-1',
+          dataPlaneRef: { name: 'dp-1', kind: 'DataPlane' },
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mockDiscoveryApi.getBaseUrl.mockRejectedValueOnce(
+      new Error('no discovery'),
+    );
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.environments).toEqual([]);
+  });
+
+  it('defaults dataPlaneRef.kind to DataPlane in the probe params', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [
+        {
+          name: 'dev',
+          namespace: 'ns-1',
+          dataPlaneRef: { name: 'dp-1' /* kind omitted */ },
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mockFetchApi.fetch.mockResolvedValueOnce(
+      okResponse({ networkPolicyProvider: 'cilium' }),
+    );
+
+    setup();
+    await waitFor(() => expect(mockFetchApi.fetch).toHaveBeenCalled());
+    const url = mockFetchApi.fetch.mock.calls[0][0] as string;
+    expect(url).toContain('dpKind=DataPlane');
+  });
+
+  it('mixes supported and unsupported envs in one pass', async () => {
+    mockUseProjectEnvironments.mockReturnValue({
+      environments: [
+        {
+          name: 'dev',
+          namespace: 'ns-1',
+          dataPlaneRef: { name: 'dp-1', kind: 'DataPlane' },
+        },
+        {
+          name: 'prod',
+          namespace: 'ns-1',
+          dataPlaneRef: { name: 'dp-2', kind: 'DataPlane' },
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mockFetchApi.fetch
+      .mockResolvedValueOnce(okResponse({ networkPolicyProvider: 'cilium' }))
+      .mockResolvedValueOnce(okResponse({ networkPolicyProvider: 'calico' }));
+
+    const { result } = setup();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const byName = Object.fromEntries(
+      result.current.environments.map(e => [e.name, e.hasWirelogs]),
+    );
+    expect(byName).toEqual({ dev: true, prod: false });
+  });
+});

--- a/plugins/openchoreo-observability/src/hooks/useWirelogsEnvironments.ts
+++ b/plugins/openchoreo-observability/src/hooks/useWirelogsEnvironments.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import {
+  Environment,
+  useProjectEnvironments,
+} from '@openchoreo/backstage-plugin-react';
+
+// Cap each probe so a single hanging DataPlane can't block the page.
+const NETPOL_TIMEOUT_MS = 8000;
+
+export interface WirelogsEnvironment extends Environment {
+  /**
+   * True when the env's DataPlane reports `networkpolicyprovider=cilium`.
+   * Wirelogs are sourced from Hubble (Cilium), so this is the availability
+   * gate for streaming wirelogs in the environment.
+   */
+  hasWirelogs: boolean;
+}
+
+export interface UseWirelogsEnvironmentsResult {
+  environments: WirelogsEnvironment[];
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Layers a Cilium-provider probe on top of `useProjectEnvironments` so the
+ * wirelogs view can disable/warn on envs whose DataPlane can't stream wirelogs.
+ *
+ * Mirrors `useCellEnvironments` in the openchoreo plugin — both hit the same
+ * `dataplane-netpol-provider` endpoint in the observability backend. The
+ * single-env `useDataPlaneNetPolProvider` hook can't be reused here because it
+ * can't be called per-env inside a map.
+ */
+export const useWirelogsEnvironments = (
+  projectName: string | undefined,
+  namespaceName: string | undefined,
+): UseWirelogsEnvironmentsResult => {
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const {
+    environments: baseEnvs,
+    loading: baseLoading,
+    error,
+  } = useProjectEnvironments(projectName, namespaceName);
+  const [environments, setEnvironments] = useState<WirelogsEnvironment[]>([]);
+  const [enriching, setEnriching] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (baseLoading) return undefined;
+    if (baseEnvs.length === 0) {
+      setEnvironments([]);
+      setEnriching(false);
+      return undefined;
+    }
+    setEnriching(true);
+    (async () => {
+      try {
+        const baseUrl = await discoveryApi.getBaseUrl(
+          'openchoreo-observability-backend',
+        );
+        const enriched = await Promise.all(
+          baseEnvs.map(async env => {
+            if (!env.namespace || !env.dataPlaneRef?.name) {
+              return { ...env, hasWirelogs: false };
+            }
+            const controller = new AbortController();
+            const timeout = setTimeout(
+              () => controller.abort(),
+              NETPOL_TIMEOUT_MS,
+            );
+            try {
+              const params = new URLSearchParams({
+                namespaceName: env.namespace,
+                dpName: env.dataPlaneRef.name,
+                dpKind: env.dataPlaneRef.kind ?? 'DataPlane',
+              });
+              const res = await fetchApi.fetch(
+                `${baseUrl}/dataplane-netpol-provider?${params.toString()}`,
+                { signal: controller.signal },
+              );
+              if (!res.ok) return { ...env, hasWirelogs: false };
+              const data = await res.json();
+              return {
+                ...env,
+                hasWirelogs: data?.networkPolicyProvider === 'cilium',
+              };
+            } catch {
+              return { ...env, hasWirelogs: false };
+            } finally {
+              clearTimeout(timeout);
+            }
+          }),
+        );
+        if (!cancelled) setEnvironments(enriched);
+      } catch {
+        if (!cancelled) setEnvironments([]);
+      } finally {
+        if (!cancelled) setEnriching(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [baseEnvs, baseLoading, discoveryApi, fetchApi]);
+
+  return { environments, loading: baseLoading || enriching, error };
+};

--- a/plugins/openchoreo-observability/src/hooks/useWirelogsEnvironments.ts
+++ b/plugins/openchoreo-observability/src/hooks/useWirelogsEnvironments.ts
@@ -49,6 +49,7 @@ export const useWirelogsEnvironments = (
   } = useProjectEnvironments(projectName, namespaceName);
   const [environments, setEnvironments] = useState<WirelogsEnvironment[]>([]);
   const [enriching, setEnriching] = useState(false);
+  const [enrichError, setEnrichError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -56,9 +57,11 @@ export const useWirelogsEnvironments = (
     if (baseEnvs.length === 0) {
       setEnvironments([]);
       setEnriching(false);
+      setEnrichError(null);
       return undefined;
     }
     setEnriching(true);
+    setEnrichError(null);
     (async () => {
       try {
         const baseUrl = await discoveryApi.getBaseUrl(
@@ -98,8 +101,13 @@ export const useWirelogsEnvironments = (
           }),
         );
         if (!cancelled) setEnvironments(enriched);
-      } catch {
-        if (!cancelled) setEnvironments([]);
+      } catch (err) {
+        if (!cancelled) {
+          setEnvironments([]);
+          setEnrichError(
+            err instanceof Error ? err.message : 'Failed to probe environments',
+          );
+        }
       } finally {
         if (!cancelled) setEnriching(false);
       }
@@ -110,5 +118,9 @@ export const useWirelogsEnvironments = (
     };
   }, [baseEnvs, baseLoading, discoveryApi, fetchApi]);
 
-  return { environments, loading: baseLoading || enriching, error };
+  return {
+    environments,
+    loading: baseLoading || enriching,
+    error: error || enrichError,
+  };
 };

--- a/plugins/openchoreo-observability/src/index.ts
+++ b/plugins/openchoreo-observability/src/index.ts
@@ -6,6 +6,7 @@ export {
   ObservabilityRuntimeLogs,
   ObservabilityProjectRuntimeLogs,
   ObservabilityAlerts,
+  ObservabilityWirelogs,
   ObservabilityProjectIncidents,
   ObservabilityCostAnalysis,
 } from './plugin';

--- a/plugins/openchoreo-observability/src/plugin.ts
+++ b/plugins/openchoreo-observability/src/plugin.ts
@@ -114,6 +114,17 @@ export const ObservabilityAlerts = openchoreoObservabilityPlugin.provide(
   }),
 );
 
+export const ObservabilityWirelogs = openchoreoObservabilityPlugin.provide(
+  createRoutableExtension({
+    name: 'ObservabilityWirelogs',
+    component: () =>
+      import('./components/Wirelogs/ObservabilityWirelogsPage').then(
+        m => m.ObservabilityWirelogsPage,
+      ),
+    mountPoint: rootRouteRef,
+  }),
+);
+
 export const ObservabilityProjectIncidents =
   openchoreoObservabilityPlugin.provide(
     createRoutableExtension({

--- a/plugins/openchoreo-react/src/hooks/useWirelogsPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useWirelogsPermission.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react';
+import { useWirelogsPermission } from './useWirelogsPermission';
+
+const mockUseEnvScopedPermission = jest.fn();
+jest.mock('./useEnvScopedPermission', () => ({
+  useEnvScopedPermission: (...args: any[]) =>
+    mockUseEnvScopedPermission(...args),
+}));
+
+const mockEntity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name: 'api', namespace: 'default' },
+};
+const mockUseEntity = jest.fn(() => ({ entity: mockEntity }));
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => mockUseEntity(),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: (e: any) =>
+    `${e.kind}:${e.metadata.namespace}/${e.metadata.name}`.toLowerCase(),
+}));
+
+describe('useWirelogsPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEntity.mockReturnValue({ entity: mockEntity });
+  });
+
+  it('returns canViewWirelogs=true with no tooltip when allowed', () => {
+    mockUseEnvScopedPermission.mockReturnValue({
+      allowed: true,
+      loading: false,
+    });
+    const { result } = renderHook(() => useWirelogsPermission('dev'));
+
+    expect(result.current.canViewWirelogs).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.deniedTooltip).toBe('');
+    expect(result.current.permissionName).toBeTruthy();
+  });
+
+  it('keeps deniedTooltip empty while the permission is loading', () => {
+    mockUseEnvScopedPermission.mockReturnValue({
+      allowed: false,
+      loading: true,
+    });
+    const { result } = renderHook(() => useWirelogsPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('returns an env-specific tooltip when denied with an environment supplied', () => {
+    mockUseEnvScopedPermission.mockReturnValue({
+      allowed: false,
+      loading: false,
+    });
+    const { result } = renderHook(() => useWirelogsPermission('dev'));
+
+    expect(result.current.canViewWirelogs).toBe(false);
+    expect(result.current.deniedTooltip).toBe(
+      'You do not have permission to view wirelogs in dev.',
+    );
+  });
+
+  it('returns a component-scoped tooltip when denied without an environment', () => {
+    mockUseEnvScopedPermission.mockReturnValue({
+      allowed: false,
+      loading: false,
+    });
+    const { result } = renderHook(() => useWirelogsPermission());
+
+    expect(result.current.deniedTooltip).toBe(
+      'You do not have permission to view wirelogs of this component.',
+    );
+  });
+
+  it('uses "project" in the tooltip for System entities', () => {
+    mockUseEntity.mockReturnValueOnce({
+      entity: {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'System',
+        metadata: { name: 'proj', namespace: 'default' },
+      },
+    });
+    mockUseEnvScopedPermission.mockReturnValue({
+      allowed: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useWirelogsPermission());
+
+    expect(result.current.deniedTooltip).toBe(
+      'You do not have permission to view wirelogs of this project.',
+    );
+  });
+
+  it('forwards the entity ref and environment into useEnvScopedPermission', () => {
+    mockUseEnvScopedPermission.mockReturnValue({
+      allowed: true,
+      loading: false,
+    });
+    renderHook(() => useWirelogsPermission('prod'));
+
+    expect(mockUseEnvScopedPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceRef: 'component:default/api',
+        environment: 'prod',
+      }),
+    );
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useWirelogsPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useWirelogsPermission.ts
@@ -1,0 +1,42 @@
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { openchoreoWirelogsViewPermission } from '@openchoreo/backstage-plugin-common';
+import { useEnvScopedPermission } from './useEnvScopedPermission';
+
+export interface UseWirelogsPermissionResult {
+  canViewWirelogs: boolean;
+  loading: boolean;
+  deniedTooltip: string;
+  permissionName: string;
+}
+
+/**
+ * Hook for checking if the current user has permission to view wirelogs
+ * for the current entity. Mirrors useLogsPermission — environment-scoped
+ * when an environment is supplied (ABAC `resource.environment` CEL).
+ */
+export const useWirelogsPermission = (
+  environment?: string,
+): UseWirelogsPermissionResult => {
+  const { entity } = useEntity();
+  const { allowed, loading } = useEnvScopedPermission({
+    permission: openchoreoWirelogsViewPermission,
+    resourceRef: stringifyEntityRef(entity),
+    environment,
+  });
+
+  const scope = entity.kind === 'System' ? 'project' : 'component';
+  let deniedTooltip = '';
+  if (!allowed && !loading) {
+    deniedTooltip = environment
+      ? `You do not have permission to view wirelogs in ${environment}.`
+      : `You do not have permission to view wirelogs of this ${scope}.`;
+  }
+
+  return {
+    canViewWirelogs: allowed,
+    loading,
+    deniedTooltip,
+    permissionName: openchoreoWirelogsViewPermission.name,
+  };
+};

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -295,6 +295,10 @@ export {
   type UseAlertsPermissionResult,
 } from './hooks/useAlertsPermission';
 export {
+  useWirelogsPermission,
+  type UseWirelogsPermissionResult,
+} from './hooks/useWirelogsPermission';
+export {
   useIncidentsPermission,
   type UseIncidentsPermissionResult,
 } from './hooks/useIncidentsPermission';


### PR DESCRIPTION
## Purpose
Related: https://github.com/openchoreo/openchoreo/issues/3294

This pull request introduces support for Cilium Hubble wirelogs in the OpenChoreo platform, adding both backend and frontend components to enable users to view real-time network flow logs. It also introduces a new permission for wirelogs access and updates the routing and service layers accordingly.

Key changes include:

**Wirelogs Feature Integration**

* Added a new `ObservabilityWirelogs` component and corresponding `/wirelogs` tab to the entity page layouts in the frontend (`EntityPage.tsx`). [[1]](diffhunk://#diff-be7251ebe458c47f2b1f8691db3216b5b9e4fa66177033f8dcbaec2eef0939b8R135) [[2]](diffhunk://#diff-be7251ebe458c47f2b1f8691db3216b5b9e4fa66177033f8dcbaec2eef0939b8R368-R373) [[3]](diffhunk://#diff-be7251ebe458c47f2b1f8691db3216b5b9e4fa66177033f8dcbaec2eef0939b8R469-R474)
* Introduced `WirelogsInfoService` in the backend to handle upstream streaming of wirelogs from the OpenChoreo API, with a new `/wirelogs/stream` SSE proxy route for real-time log delivery. [[1]](diffhunk://#diff-d5ebcc398e448cf284d008d1a2d5a79e773d352ba8138c9050c13f034136beadR26) [[2]](diffhunk://#diff-d5ebcc398e448cf284d008d1a2d5a79e773d352ba8138c9050c13f034136beadR148-R149) [[3]](diffhunk://#diff-d5ebcc398e448cf284d008d1a2d5a79e773d352ba8138c9050c13f034136beadR205) [[4]](diffhunk://#diff-529828717f062ed082fc784aced07855df4e26c17da3464de7ae998c2b6b02caR31) [[5]](diffhunk://#diff-529828717f062ed082fc784aced07855df4e26c17da3464de7ae998c2b6b02caR100) [[6]](diffhunk://#diff-529828717f062ed082fc784aced07855df4e26c17da3464de7ae998c2b6b02caR127) [[7]](diffhunk://#diff-529828717f062ed082fc784aced07855df4e26c17da3464de7ae998c2b6b02caR2208-R2303) [[8]](diffhunk://#diff-b259773189d1384746068e15dd2d4555b6275baf606013a1b54815dc812a9d38R1-R60)

**Permissions and Access Control**

* Added a new resource-based permission `openchoreoWirelogsViewPermission` to control access to wirelogs, updated permission exports, and mapped this permission to the corresponding action. [[1]](diffhunk://#diff-4ca069e61d4339c489ba21186788b222a9d0d486d9e97216176cc479b278f5ccR71) [[2]](diffhunk://#diff-dec55e95eb952d9a019bb0377017f145f0d0592f7398fe9db43bffccd5b5ba04R958-R968) [[3]](diffhunk://#diff-dec55e95eb952d9a019bb0377017f145f0d0592f7398fe9db43bffccd5b5ba04R1033) [[4]](diffhunk://#diff-dec55e95eb952d9a019bb0377017f145f0d0592f7398fe9db43bffccd5b5ba04R1139)


## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
UX screen recording

https://github.com/user-attachments/assets/68ed539c-b018-4929-9754-457e24a7bd07

When Cilium module is not configured for any dataplane:
<img width="1512" height="800" alt="image" src="https://github.com/user-attachments/assets/5982bbbe-c9d8-4329-baf7-c4880f9342bf" />


When Cilium module is not configured for some dataplane(s):
<img width="1512" height="796" alt="image" src="https://github.com/user-attachments/assets/fb75b799-4a1f-4538-9603-7a5653e21cc5" />

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Wirelogs observability tab/page with real-time streaming, environment selection, search/filtering, stats, per-flow details (tabs/drawer), and JSON export.

* **Permissions**
  * Added a wirelogs view permission; UI shows loading, forbidden, and contextual denial tooltips.

* **Backend / Streaming**
  * Added an authenticated SSE stream endpoint with validation, streaming headers, error-frame handling, and graceful abort/cleanup.

* **Tests**
  * Extensive unit and integration tests for UI, hooks, streaming, formatting, and backend interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->