### PR TITLE
feat(environments): auto-select a default card in the deploy graph

### DIFF
--- a/.changeset/select-env-card-default.md
+++ b/.changeset/select-env-card-default.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin': patch
+---
+
+Auto-select a default card in the Environments deploy graph instead of
+landing users on an empty detail panel: first env with an active or
+pending deployment, else the first failed env, else the first undeployed
+env, falling back to the Setup card when only never-deployed envs exist.
+Only applies while nothing is selected, so it never overrides a manual
+choice.

--- a/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.test.tsx
@@ -142,6 +142,14 @@ jest.mock('../hooks', () => ({
   isAlreadyPromoted: () => false,
   computeReleaseDrift: () => ({ isBehind: false, aheadUpstreams: [] }),
   NO_DRIFT: { isBehind: false, aheadUpstreams: [] },
+  getEnvironmentStatusVariant: (status?: string, statusReason?: string) => {
+    if (statusReason === 'ResourcesUndeployed')
+      return { variant: 'undeployed', label: 'Undeployed' };
+    if (status === 'Ready') return { variant: 'active', label: 'Active' };
+    if (status === 'NotReady') return { variant: 'pending', label: 'Pending' };
+    if (status === 'Failed') return { variant: 'failed', label: 'Failed' };
+    return { variant: 'not-deployed', label: 'Not Deployed' };
+  },
 }));
 
 jest.mock('../hooks/useIncidentsSummary', () => ({
@@ -245,7 +253,7 @@ describe('PipelineCanvas (deploy split view)', () => {
     expect(screen.getByTestId('deploy-flow-canvas')).toBeInTheDocument();
   });
 
-  it('renders the split view with the canvas and detail panel when envs exist', () => {
+  it('renders the split view and auto-selects the first active env when envs exist', () => {
     const envs = [
       makeEnv({ name: 'development' }),
       makeEnv({ name: 'staging' }),
@@ -258,9 +266,14 @@ describe('PipelineCanvas (deploy split view)', () => {
     expect(screen.getByTestId('deploy-flow-canvas')).toBeInTheDocument();
     expect(screen.getByTestId('env-detail-panel')).toBeInTheDocument();
     expect(capturedFlowCanvasProps?.environments).toHaveLength(2);
-    expect(capturedFlowCanvasProps?.selectedEnvName).toBeNull();
+    // Both envs default to a Ready deployment, so the first one is selected.
+    expect(capturedFlowCanvasProps?.selectedEnvName).toBe('development');
     expect(capturedFlowCanvasProps?.selectedSetup).toBe(false);
-    expect(capturedDetailPanelProps?.selection).toBeNull();
+    const panelSelection = capturedDetailPanelProps?.selection;
+    expect(panelSelection?.kind).toBe('env');
+    expect(
+      panelSelection?.kind === 'env' ? panelSelection.environment.name : null,
+    ).toBe('development');
   });
 
   it('passes selection.kind=setup to the panel when Setup is selected on the canvas', () => {

--- a/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.tsx
+++ b/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.tsx
@@ -9,12 +9,13 @@ import {
   isAlreadyPromoted as isAlreadyPromotedUtil,
   useEnvironmentRouting,
   computeReleaseDrift,
+  getEnvironmentStatusVariant,
   NO_DRIFT,
 } from '../hooks';
 import type { Environment, ReleaseDriftInfo } from '../hooks';
 import type { PendingAction } from '../types';
 import { EnvironmentDetailPanel, NotificationBanner } from '../components';
-import { useEnvironmentsContext } from '../EnvironmentsContext';
+import { useEnvironmentsContext, type Selection } from '../EnvironmentsContext';
 import { useIncidentsSummary } from '../hooks/useIncidentsSummary';
 import { isForbiddenError, getErrorMessage } from '../../../utils/errorUtils';
 import { EmptyState, ForbiddenState } from '@openchoreo/backstage-plugin-react';
@@ -85,6 +86,36 @@ const DetailPanelSkeleton: FC = () => {
 };
 
 /**
+ * Picks the card to select by default when the user hasn't chosen one.
+ * Priority: first env with an active (or pending) deployment → first failed
+ * → first undeployed (was deployed, torn down). If only never-deployed envs
+ * remain, fall back to the Setup card. Uses the same classifier as the cards
+ * so selection can't drift from what's displayed.
+ */
+function resolveDefaultSelection(envs: Environment[]): Selection {
+  if (envs.length === 0) return null;
+
+  const variantOf = (e: Environment) =>
+    getEnvironmentStatusVariant(e.deployment.status, e.deployment.statusReason)
+      .variant;
+
+  const active = envs.find(e => {
+    const v = variantOf(e);
+    return v === 'active' || v === 'pending';
+  });
+  if (active) return { kind: 'env', name: active.name };
+
+  const failed = envs.find(e => variantOf(e) === 'failed');
+  if (failed) return { kind: 'env', name: failed.name };
+
+  const undeployed = envs.find(e => variantOf(e) === 'undeployed');
+  if (undeployed) return { kind: 'env', name: undeployed.name };
+
+  // Only never-deployed envs remain — point the user at Setup.
+  return { kind: 'setup' };
+}
+
+/**
  * Deploy tab orchestrator. Owns selection state and wires action
  * callbacks; renders the minimap canvas (left) + detail panel (right)
  * once at least one environment is loaded.
@@ -134,6 +165,18 @@ export const PipelineCanvas: FC = () => {
       setSelection(null);
     }
   }, [selection, envMap, setSelection]);
+
+  // Auto-select a sensible default card once data has loaded, so users don't
+  // land on an empty detail panel. Only acts while nothing is selected, so it
+  // never overrides a manual choice and cooperates with the clear-effect above
+  // (which re-nulls selection when the selected env disappears).
+  useEffect(() => {
+    if (selection !== null) return;
+    if (loading) return;
+    if (displayEnvironments.length === 0) return;
+
+    setSelection(resolveDefaultSelection(displayEnvironments));
+  }, [selection, loading, displayEnvironments, setSelection]);
 
   const selectedEnvName = selection?.kind === 'env' ? selection.name : null;
   const selectedSetup = selection?.kind === 'setup';

--- a/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.tsx
+++ b/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import { Box } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { useEntity } from '@backstage/plugin-catalog-react';
@@ -160,21 +160,29 @@ export const PipelineCanvas: FC = () => {
     return map;
   }, [displayEnvironments]);
 
+  // One-shot guard so the default-selection effect below doesn't override a
+  // user's explicit Close/Clear (both of which set selection back to null).
+  const didAutoSelectRef = useRef(false);
+
   useEffect(() => {
     if (selection?.kind === 'env' && !envMap.has(selection.name)) {
       setSelection(null);
+      // The selected env vanished — allow a fresh default to be picked.
+      didAutoSelectRef.current = false;
     }
   }, [selection, envMap, setSelection]);
 
   // Auto-select a sensible default card once data has loaded, so users don't
-  // land on an empty detail panel. Only acts while nothing is selected, so it
-  // never overrides a manual choice and cooperates with the clear-effect above
-  // (which re-nulls selection when the selected env disappears).
+  // land on an empty detail panel. Runs only once after the initial load (or
+  // again after the selected env disappears, via the ref reset above), so it
+  // never overrides a manual Close/Clear back to an empty panel.
   useEffect(() => {
+    if (didAutoSelectRef.current) return;
     if (selection !== null) return;
     if (loading) return;
     if (displayEnvironments.length === 0) return;
 
+    didAutoSelectRef.current = true;
     setSelection(resolveDefaultSelection(displayEnvironments));
   }, [selection, loading, displayEnvironments, setSelection]);
 

--- a/plugins/openchoreo/src/components/Environments/hooks/index.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/index.ts
@@ -16,6 +16,7 @@ export {
 } from './computeReleaseDrift';
 export {
   useEnvironmentStatusVariant,
+  getEnvironmentStatusVariant,
   type EnvironmentStatusVariant,
 } from './useEnvironmentStatusVariant';
 export {

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentStatusVariant.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentStatusVariant.ts
@@ -5,7 +5,10 @@ export interface EnvironmentStatusVariant {
   label: string;
 }
 
-export function useEnvironmentStatusVariant(
+// Pure classifier shared by the hook and by non-render callers (e.g. default
+// selection resolution). Keep this as the single source of truth so card
+// display and selection logic can never drift apart.
+export function getEnvironmentStatusVariant(
   status?: 'Ready' | 'NotReady' | 'Failed',
   statusReason?: string,
 ): EnvironmentStatusVariant {
@@ -22,4 +25,11 @@ export function useEnvironmentStatusVariant(
     return { variant: 'failed', label: 'Failed' };
   }
   return { variant: 'not-deployed', label: 'Not Deployed' };
+}
+
+export function useEnvironmentStatusVariant(
+  status?: 'Ready' | 'NotReady' | 'Failed',
+  statusReason?: string,
+): EnvironmentStatusVariant {
+  return getEnvironmentStatusVariant(status, statusReason);
 }


### PR DESCRIPTION
  Land users on the most relevant card instead of an empty detail panel:
  first active/pending env, else failed, else undeployed, else the Setup
  card when only never-deployed envs exist. Only applies while nothing is
  selected, so it never overrides a manual choice.

  Closes #3677


https://github.com/user-attachments/assets/26dbdc7d-1ed7-4459-a81b-02ccaa1bf2d6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pipeline environments now automatically select the most relevant card on initial load, prioritizing active and pending deployments.

* **Refactor**
  * Improved internal code organization for environment status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->