### PR TITLE
feat(authz): add resource.resourceType ABAC condition  for resource update UIs

### DIFF
--- a/.changeset/resourcetype_condition_for_resource_update.md
+++ b/.changeset/resourcetype_condition_for_resource_update.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-react': minor
+---
+
+Add `resource.resourceType` ABAC condition to resource update, gating the resource definition editor per resource type.

--- a/plugins/openchoreo-react/src/hooks/useResourceDefinitionPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useResourceDefinitionPermission.test.ts
@@ -28,6 +28,15 @@ jest.mock('./useComponentUpdateContextPermission', () => ({
     mockUseComponentUpdateContextPermission(),
 }));
 
+// resourceType-aware update hook. By default it passes through the base
+// `usePermission` result for resources. Individual tests override it to
+// simulate an ABAC resourceType deny.
+const mockUseResourceUpdateContextPermission = jest.fn();
+jest.mock('./useResourceUpdateContextPermission', () => ({
+  useResourceUpdateContextPermission: () =>
+    mockUseResourceUpdateContextPermission(),
+}));
+
 const makeEntity = (kind: string) => ({
   entity: {
     apiVersion: 'backstage.io/v1alpha1',
@@ -47,6 +56,14 @@ describe('useResourceDefinitionPermission', () => {
       const base = results[results.length - 1]?.value;
       return {
         canUpdateComponent: base?.allowed ?? false,
+        loading: base?.loading ?? false,
+      };
+    });
+    mockUseResourceUpdateContextPermission.mockImplementation(() => {
+      const { results } = mockUsePermission.mock;
+      const base = results[results.length - 1]?.value;
+      return {
+        canUpdateResource: base?.allowed ?? false,
         loading: base?.loading ?? false,
       };
     });
@@ -151,6 +168,38 @@ describe('useResourceDefinitionPermission', () => {
     // Even if the context hook would deny, a non-component kind ignores it.
     mockUseComponentUpdateContextPermission.mockReturnValue({
       canUpdateComponent: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useResourceDefinitionPermission());
+
+    expect(result.current.canUpdate).toBe(true);
+    expect(result.current.canDelete).toBe(true);
+  });
+
+  it('flips canUpdate to false for a resource when resourceType ABAC denies', () => {
+    mockUseEntity.mockReturnValue(makeEntity('Resource'));
+    // Base RBAC allows, but the resourceType-aware hook denies (ABAC condition).
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockUseResourceUpdateContextPermission.mockReturnValue({
+      canUpdateResource: false,
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useResourceDefinitionPermission());
+
+    expect(result.current.canUpdate).toBe(false);
+    expect(result.current.updateDeniedTooltip).toBeTruthy();
+    // Delete is unaffected by the resourceType condition.
+    expect(result.current.canDelete).toBe(true);
+  });
+
+  it('does not apply the resourceType condition to non-resource kinds', () => {
+    mockUseEntity.mockReturnValue(makeEntity('TraitType'));
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    // Even if the context hook would deny, a non-resource kind ignores it.
+    mockUseResourceUpdateContextPermission.mockReturnValue({
+      canUpdateResource: false,
       loading: false,
     });
 

--- a/plugins/openchoreo-react/src/hooks/useResourceDefinitionPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useResourceDefinitionPermission.ts
@@ -48,6 +48,7 @@ import {
   openchoreoNamespaceDeletePermission,
 } from '@openchoreo/backstage-plugin-common';
 import { useComponentUpdateContextPermission } from './useComponentUpdateContextPermission';
+import { useResourceUpdateContextPermission } from './useResourceUpdateContextPermission';
 
 /**
  * Result of the useResourceDefinitionPermission hook.
@@ -235,14 +236,19 @@ export const useResourceDefinitionPermission =
       usePermission(deleteInput);
 
     const componentCtx = useComponentUpdateContextPermission();
-    const isComponent = entity.kind.toLowerCase() === 'component';
+    const resourceCtx = useResourceUpdateContextPermission();
+    const kindLower = entity.kind.toLowerCase();
+    const isComponent = kindLower === 'component';
+    const isResource = kindLower === 'resource';
 
-    // For components, fold the `resource.componentType` ABAC condition into the
-    // update decision. For every other kind, keep today's behavior exactly
-    // (and deny by default when the kind is not in the map).
+    // For components/resources, fold the matching `resource.*Type` ABAC
+    // condition into the update decision. For every other kind, keep today's
+    // behavior exactly (and deny by default when the kind is not in the map).
     let effectiveCanUpdate: boolean;
     if (isComponent) {
       effectiveCanUpdate = componentCtx.canUpdateComponent;
+    } else if (isResource) {
+      effectiveCanUpdate = resourceCtx.canUpdateResource;
     } else {
       effectiveCanUpdate = permissions ? canUpdate : false;
     }
@@ -251,7 +257,8 @@ export const useResourceDefinitionPermission =
     const loading =
       updateLoading ||
       deleteLoading ||
-      (isComponent ? componentCtx.loading : false);
+      (isComponent ? componentCtx.loading : false) ||
+      (isResource ? resourceCtx.loading : false);
 
     return {
       canUpdate: effectiveCanUpdate,

--- a/plugins/openchoreo-react/src/hooks/useResourceUpdateContextPermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useResourceUpdateContextPermission.test.ts
@@ -1,0 +1,253 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useResourceUpdateContextPermission } from './useResourceUpdateContextPermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+const mockUseEntity = jest.fn();
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => mockUseEntity(),
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'resource:default/test',
+}));
+
+const mockGetBaseUrl = jest.fn();
+const mockFetch = jest.fn();
+// Stable API singletons — see useEnvScopedPermission.test.ts for why.
+const mockDiscoveryApi = { getBaseUrl: mockGetBaseUrl };
+const mockFetchApi = { fetch: mockFetch };
+jest.mock('@backstage/core-plugin-api', () => {
+  const discoveryRef = Symbol('discoveryApiRef');
+  const fetchRef = Symbol('fetchApiRef');
+  return {
+    discoveryApiRef: discoveryRef,
+    fetchApiRef: fetchRef,
+    useApi: (apiRef: symbol) => {
+      if (apiRef === discoveryRef) return mockDiscoveryApi;
+      if (apiRef === fetchRef) return mockFetchApi;
+      return {};
+    },
+  };
+});
+
+const mockUseAuthzEnabled = jest.fn();
+jest.mock('./useOpenChoreoFeatures', () => ({
+  useAuthzEnabled: () => mockUseAuthzEnabled(),
+}));
+
+// Stand-in for the imported permission + annotation constants. The hook only
+// reads `permission.name`, so we don't need the full Permission type here.
+jest.mock('@openchoreo/backstage-plugin-common', () => ({
+  openchoreoResourceUpdatePermission: {
+    type: 'resource',
+    name: 'openchoreo.resource.update',
+    attributes: { action: 'update' },
+  },
+  CHOREO_ANNOTATIONS: {
+    RESOURCE_TYPE: 'openchoreo.io/resource-type',
+    RESOURCE_TYPE_KIND: 'openchoreo.io/resource-type-kind',
+  },
+}));
+
+interface MakeEntityArgs {
+  resourceType?: string;
+  resourceTypeKind?: string;
+}
+
+const makeEntity = (args: MakeEntityArgs = {}) => {
+  const annotations: Record<string, string> = {};
+  if (args.resourceType !== undefined) {
+    annotations['openchoreo.io/resource-type'] = args.resourceType;
+  }
+  if (args.resourceTypeKind !== undefined) {
+    annotations['openchoreo.io/resource-type-kind'] = args.resourceTypeKind;
+  }
+  return {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Resource',
+      metadata: { name: 'test', namespace: 'default', annotations },
+    },
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetBaseUrl.mockResolvedValue('http://localhost/api/permission');
+  mockUseAuthzEnabled.mockReturnValue(true);
+  // The annotation carries the bare ResourceType name, used verbatim.
+  mockUseEntity.mockReturnValue(makeEntity({ resourceType: 'redis' }));
+});
+
+describe('useResourceUpdateContextPermission', () => {
+  it('returns ALLOW when authz on, base allowed, backend allows', async () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ allowed: true }),
+    });
+
+    const { result } = renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [, init] = mockFetch.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({
+      permissionName: 'openchoreo.resource.update',
+      resourceRef: 'resource:default/test',
+      resourceType: { name: 'redis', kind: undefined },
+    });
+  });
+
+  it('returns DENY when authz on, base allowed, backend denies', async () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ allowed: false }),
+    });
+
+    const { result } = renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(false);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fetch and propagates base allowed when authz disabled', async () => {
+    mockUseAuthzEnabled.mockReturnValue(false);
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+
+    const { result } = renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('degrades to base (no fetch) when entity has no resourceType annotation', async () => {
+    mockUseEntity.mockReturnValue(makeEntity());
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+
+    const { result } = renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('propagates base denied without firing the contextual call', async () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+
+    const { result } = renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on network error', async () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(false);
+  });
+
+  it('fails closed on non-ok HTTP response', async () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({}) });
+
+    const { result } = renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(false);
+  });
+
+  it('forwards resourceType.kind from the annotation to the backend', async () => {
+    mockUseEntity.mockReturnValue(
+      makeEntity({
+        resourceType: 'redis',
+        resourceTypeKind: 'ClusterResourceType',
+      }),
+    );
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ allowed: true }),
+    });
+
+    renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.resourceType).toEqual({
+      name: 'redis',
+      kind: 'ClusterResourceType',
+    });
+  });
+
+  it('passes a slashed resourceType annotation through unchanged', async () => {
+    mockUseEntity.mockReturnValue(makeEntity({ resourceType: 'group/redis' }));
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ allowed: true }),
+    });
+
+    renderHook(() => useResourceUpdateContextPermission());
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.resourceType.name).toBe('group/redis');
+  });
+
+  it('reports loading while the base check is loading', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+
+    const { result } = renderHook(() => useResourceUpdateContextPermission());
+
+    expect(result.current.loading).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse the previous entity allow result when the resourceType changes', async () => {
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+    // First entity's resourceType is allowed by the backend; a subsequent
+    // entity is denied.
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ allowed: true }),
+      })
+      .mockResolvedValue({ ok: true, json: async () => ({ allowed: false }) });
+
+    const { result, rerender } = renderHook(() =>
+      useResourceUpdateContextPermission(),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(true);
+
+    // Switch to a different resource before the new evaluation resolves. The
+    // stale allow from the first entity must not leak through: the hook reports
+    // loading (not a settled allow) until the backend re-evaluates.
+    mockUseEntity.mockReturnValue(makeEntity({ resourceType: 'postgres' }));
+    rerender();
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.canUpdateResource).toBe(false);
+
+    // Once the backend denies the new resourceType, the result settles to deny.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canUpdateResource).toBe(false);
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useResourceUpdateContextPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useResourceUpdateContextPermission.ts
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+import {
+  useApi,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { usePermission } from '@backstage/plugin-permission-react';
+import {
+  CHOREO_ANNOTATIONS,
+  openchoreoResourceUpdatePermission,
+} from '@openchoreo/backstage-plugin-common';
+import { useAuthzEnabled } from './useOpenChoreoFeatures';
+
+/**
+ * Result of the useResourceUpdateContextPermission hook.
+ */
+export interface UseResourceUpdateContextPermissionResult {
+  /** Whether the user has permission to update this resource */
+  canUpdateResource: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+}
+
+/**
+ * Evaluates `openchoreo.resource.update` for the current entity, layering the
+ * `resource.resourceType` ABAC condition on top of the plain RBAC check.
+ *
+ * Degrades to a plain {@link usePermission} when authz is off or the entity has
+ * no resourceType annotation, so it is safe to call unconditionally.
+ *
+ * Must be used within an EntityProvider context.
+ */
+export const useResourceUpdateContextPermission =
+  (): UseResourceUpdateContextPermissionResult => {
+    const { entity } = useEntity();
+    const resourceRef = stringifyEntityRef(entity);
+
+    const baseCheck = usePermission({
+      permission: openchoreoResourceUpdatePermission,
+      resourceRef,
+    });
+
+    const authzEnabled = useAuthzEnabled();
+    const discovery = useApi(discoveryApiRef);
+    const fetchApi = useApi(fetchApiRef);
+
+    // Tagged with the input tuple it was evaluated for, so a stale result is
+    // never reused across entities.
+    const [ctxResult, setCtxResult] = useState<{
+      key: string;
+      allowed: boolean | undefined;
+    }>({ key: '', allowed: undefined });
+    const [ctxLoading, setCtxLoading] = useState<boolean>(false);
+
+    // The `resource-type` annotation is the bare ResourceType name, used as-is.
+    const resourceTypeName =
+      entity.metadata.annotations?.[CHOREO_ANNOTATIONS.RESOURCE_TYPE];
+    const resourceTypeKind =
+      entity.metadata.annotations?.[CHOREO_ANNOTATIONS.RESOURCE_TYPE_KIND];
+
+    const ctxKey = `${resourceRef}|${resourceTypeName ?? ''}|${
+      resourceTypeKind ?? ''
+    }`;
+
+    useEffect(() => {
+      const skip = !authzEnabled || !resourceTypeName || baseCheck.loading;
+      if (skip) {
+        setCtxResult({ key: ctxKey, allowed: undefined });
+        setCtxLoading(false);
+        return undefined;
+      }
+
+      if (!baseCheck.allowed) {
+        setCtxResult({ key: ctxKey, allowed: false });
+        setCtxLoading(false);
+        return undefined;
+      }
+
+      let cancelled = false;
+      setCtxLoading(true);
+
+      const evaluate = async () => {
+        try {
+          const baseUrl = await discovery.getBaseUrl('permission');
+          const res = await fetchApi.fetch(`${baseUrl}/evaluate-with-context`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              permissionName: openchoreoResourceUpdatePermission.name,
+              resourceRef,
+              resourceType: {
+                name: resourceTypeName,
+                kind: resourceTypeKind,
+              },
+            }),
+          });
+          if (cancelled) return;
+          // Fail closed on network/server errors.
+          const body = res.ok
+            ? ((await res.json()) as { allowed: boolean })
+            : null;
+          setCtxResult({ key: ctxKey, allowed: body?.allowed === true });
+        } catch {
+          if (!cancelled) setCtxResult({ key: ctxKey, allowed: false });
+        } finally {
+          if (!cancelled) setCtxLoading(false);
+        }
+      };
+
+      evaluate();
+
+      return () => {
+        cancelled = true;
+      };
+    }, [
+      discovery,
+      fetchApi,
+      ctxKey,
+      resourceRef,
+      resourceTypeName,
+      resourceTypeKind,
+      authzEnabled,
+      baseCheck.allowed,
+      baseCheck.loading,
+    ]);
+
+    if (!authzEnabled || !resourceTypeName) {
+      return {
+        canUpdateResource: baseCheck.allowed,
+        loading: baseCheck.loading,
+      };
+    }
+
+    // A result for a different tuple reads as "not yet known", never an allow.
+    const ctxAllowed = ctxResult.key === ctxKey ? ctxResult.allowed : undefined;
+
+    const ctxStillLoading =
+      baseCheck.allowed && (ctxLoading || ctxAllowed === undefined);
+
+    return {
+      canUpdateResource: baseCheck.allowed && ctxAllowed === true,
+      loading: baseCheck.loading || ctxStillLoading,
+    };
+  };

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -285,6 +285,10 @@ export {
   type UseComponentUpdateContextPermissionResult,
 } from './hooks/useComponentUpdateContextPermission';
 export {
+  useResourceUpdateContextPermission,
+  type UseResourceUpdateContextPermissionResult,
+} from './hooks/useResourceUpdateContextPermission';
+export {
   useWorkloadUpdatePermission,
   type UseWorkloadUpdatePermissionResult,
 } from './hooks/useWorkloadUpdatePermission';


### PR DESCRIPTION

## Purpose

Resource update is now gated by the resource's type, not just the plain openchoreo.resource.update RBAC check. On top of the base permission, the UI asks the backend whether the user may update a resource of that specific resourceType (the resource.resourceType ABAC attribute) and folds the answer into the edit decision.

### UI

https://github.com/user-attachments/assets/1c460de6-8ba8-4c45-b1ac-5b79eca8f69d



Related: https://github.com/openchoreo/openchoreo/issues/3569
## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attribute-based access control (ABAC) condition for resource update permissions, restricting resource definition editor access based on resource type attributes.
  * Enhanced permission evaluation with contextual authorization checks that combine role-based and attribute-based controls.

* **Tests**
  * Added comprehensive test coverage for new resource update permission evaluation and resource-type-aware authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->