### PR TITLE
fix(scaffolder): clear stale Build & Deploy data on source switch during component creation

### DIFF
--- a/.changeset/build-and-deploy-clears-stale-source-data.md
+++ b/.changeset/build-and-deploy-clears-stale-source-data.md
@@ -1,0 +1,12 @@
+---
+'@openchoreo/backstage-plugin-catalog-backend-module': patch
+---
+
+Fix stale form data in the component-creation Build & Deploy section.
+Generated templates now nest deploymentSource and its branch-specific
+fields (workflow_name, git_source, workflow_parameters, containerImage,
+autoDeploy, ciPlatform, ciIdentifier) under a single buildAndDeploy
+object rendered by a composite field, so switching deployment source
+clears the previous branch's data atomically — fixes
+"instance.workflow requires property \"name\"" when a user picks Build
+from Source and then switches to Container Image or External CI.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -23,6 +23,7 @@ import { TraitsFieldExtension } from './scaffolder/TraitsField';
 import { SwitchFieldExtension } from './scaffolder/SwitchField';
 import { AdvancedConfigurationFieldExtension } from './scaffolder/AdvancedConfigurationField';
 import { DeploymentSourcePickerFieldExtension } from './scaffolder/DeploymentSourcePicker';
+import { BuildAndDeployFieldExtension } from './scaffolder/BuildAndDeployField';
 import { ContainerImageFieldExtension } from './scaffolder/ContainerImageField';
 import { ComponentTypeYamlEditorFieldExtension } from './scaffolder/ComponentTypeYamlEditor';
 import { TraitYamlEditorFieldExtension } from './scaffolder/TraitYamlEditor';
@@ -254,6 +255,7 @@ const routes = (
         <SwitchFieldExtension />
         <AdvancedConfigurationFieldExtension />
         <DeploymentSourcePickerFieldExtension />
+        <BuildAndDeployFieldExtension />
         <ContainerImageFieldExtension />
         <ComponentTypeYamlEditorFieldExtension />
         <TraitYamlEditorFieldExtension />

--- a/packages/app/src/scaffolder/BuildAndDeployField/BuildAndDeployField.tsx
+++ b/packages/app/src/scaffolder/BuildAndDeployField/BuildAndDeployField.tsx
@@ -1,0 +1,142 @@
+import { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
+import { Box } from '@material-ui/core';
+import toIdSchema from '@rjsf/utils/lib/schema/toIdSchema';
+
+const BRANCH_FIELDS: Record<string, string[]> = {
+  'build-from-source': ['workflow_name', 'git_source', 'workflow_parameters'],
+  'deploy-from-image': ['containerImage', 'autoDeploy'],
+  'external-ci': ['ciPlatform', 'ciIdentifier'],
+};
+
+const CI_PLATFORMS_WITH_IDENTIFIER = new Set([
+  'jenkins',
+  'github-actions',
+  'gitlab-ci',
+]);
+
+/**
+ * Composite field that owns the entire "Build & Deploy" object.
+ *
+ * Why this exists: RJSF's `dependencies + oneOf` doesn't clear stale data
+ * from the inactive branch when the discriminator changes, and Backstage's
+ * scaffolder Stepper deliberately strips RJSF's `omitExtraData`/`liveOmit`
+ * props that would otherwise enable that. By making the entire object live
+ * under one custom field, we can replace the object atomically on source
+ * change — the previous branch's keys vanish in a single onChange call.
+ */
+export const BuildAndDeployField = (
+  props: FieldExtensionComponentProps<any>,
+) => {
+  const {
+    formData = {},
+    onChange,
+    schema,
+    uiSchema = {},
+    idSchema,
+    errorSchema,
+    registry,
+    formContext,
+    required,
+    disabled,
+    readonly,
+    onBlur,
+    onFocus,
+  } = props;
+
+  const { SchemaField } = registry.fields;
+  const properties = (schema.properties ?? {}) as Record<string, any>;
+  const currentSource = formData.deploymentSource as string | undefined;
+  const currentCiPlatform = formData.ciPlatform as string | undefined;
+
+  const visibleFields = ['deploymentSource', ...(BRANCH_FIELDS[currentSource ?? ''] ?? [])]
+    .filter(field => {
+      if (field === 'ciIdentifier') {
+        return (
+          currentSource === 'external-ci' &&
+          currentCiPlatform !== undefined &&
+          CI_PLATFORMS_WITH_IDENTIFIER.has(currentCiPlatform)
+        );
+      }
+      return true;
+    })
+    .filter(field => properties[field]);
+
+  const renderChild = (field: string) => {
+    const childSchema = properties[field];
+    const childUiSchema = (uiSchema as any)[field] ?? {};
+    const childFormData = formData[field];
+    const baseId = idSchema?.$id ?? 'root';
+    const childIdSchema =
+      (idSchema as any)?.[field] ??
+      toIdSchema(
+        registry.schemaUtils.getValidator(),
+        childSchema,
+        `${baseId}_${field}`,
+        registry.rootSchema,
+        childFormData,
+      );
+    const childErrorSchema = (errorSchema as any)?.[field];
+    const isRequired = (schema.required ?? []).includes(field);
+
+    const handleChildChange = (value: any) => {
+      if (field === 'deploymentSource' && value !== currentSource) {
+        // Replace the whole object so siblings from the previous branch
+        // disappear atomically. Keep no other keys.
+        onChange({ deploymentSource: value });
+        return;
+      }
+
+      let next: Record<string, any> = { ...formData, [field]: value };
+
+      // Within external-ci, dropping ciIdentifier when ciPlatform changes
+      // to one that doesn't use it (e.g. 'none') avoids the same stale-data
+      // class of bug at the nested level.
+      if (field === 'ciPlatform') {
+        if (!CI_PLATFORMS_WITH_IDENTIFIER.has(value)) {
+          const { ciIdentifier: _ciIdentifier, ...rest } = next;
+          next = rest;
+        }
+      }
+
+      onChange(next);
+    };
+
+    return (
+      <SchemaField
+        key={field}
+        name={field}
+        schema={childSchema}
+        uiSchema={childUiSchema}
+        formData={childFormData}
+        onChange={handleChildChange}
+        idSchema={childIdSchema}
+        errorSchema={childErrorSchema}
+        registry={registry}
+        formContext={formContext}
+        required={isRequired}
+        disabled={disabled}
+        readonly={readonly}
+        onBlur={onBlur}
+        onFocus={onFocus}
+      />
+    );
+  };
+
+  return (
+    <Box>
+      {schema.title && (
+        <Box mb={1} mt={2}>
+          <strong>{schema.title}</strong>
+        </Box>
+      )}
+      {visibleFields.map(renderChild)}
+      {!required && null}
+    </Box>
+  );
+};
+
+export const BuildAndDeployFieldSchema = {
+  returnValue: {
+    type: 'object' as const,
+  },
+};

--- a/packages/app/src/scaffolder/BuildAndDeployField/BuildAndDeployField.tsx
+++ b/packages/app/src/scaffolder/BuildAndDeployField/BuildAndDeployField.tsx
@@ -48,7 +48,10 @@ export const BuildAndDeployField = (
   const currentSource = formData.deploymentSource as string | undefined;
   const currentCiPlatform = formData.ciPlatform as string | undefined;
 
-  const visibleFields = ['deploymentSource', ...(BRANCH_FIELDS[currentSource ?? ''] ?? [])]
+  const visibleFields = [
+    'deploymentSource',
+    ...(BRANCH_FIELDS[currentSource ?? ''] ?? []),
+  ]
     .filter(field => {
       if (field === 'ciIdentifier') {
         return (

--- a/packages/app/src/scaffolder/BuildAndDeployField/extensions.ts
+++ b/packages/app/src/scaffolder/BuildAndDeployField/extensions.ts
@@ -1,0 +1,14 @@
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+import {
+  BuildAndDeployField,
+  BuildAndDeployFieldSchema,
+} from './BuildAndDeployField';
+
+export const BuildAndDeployFieldExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: 'BuildAndDeployField',
+    component: BuildAndDeployField,
+    schema: BuildAndDeployFieldSchema,
+  }),
+);

--- a/packages/app/src/scaffolder/BuildAndDeployField/index.ts
+++ b/packages/app/src/scaffolder/BuildAndDeployField/index.ts
@@ -1,0 +1,1 @@
+export { BuildAndDeployFieldExtension } from './extensions';

--- a/packages/app/src/scaffolder/CustomReviewState/CustomReviewStep.tsx
+++ b/packages/app/src/scaffolder/CustomReviewState/CustomReviewStep.tsx
@@ -222,17 +222,19 @@ function ComponentReview({ data }: { data: Record<string, unknown> }) {
     setMeta(componentMeta, 'Description', String(data.description));
   }
 
-  // Section: Build & Deploy
+  // Section: Build & Deploy — values live under data.buildAndDeploy after the
+  // BuildAndDeployField composite restructure.
+  const buildAndDeploy = (data.buildAndDeploy ?? {}) as Record<string, unknown>;
   const buildMeta: Record<string, string> = {};
-  if (data.deploymentSource) {
+  if (buildAndDeploy.deploymentSource) {
     setMeta(
       buildMeta,
       'Deployment Source',
-      sanitizeLabel(String(data.deploymentSource)),
+      sanitizeLabel(String(buildAndDeploy.deploymentSource)),
     );
   }
 
-  const workflow = data.workflow_name as
+  const workflow = buildAndDeploy.workflow_name as
     | { kind?: string; name?: string }
     | undefined;
   if (workflow?.name) {
@@ -242,7 +244,9 @@ function ComponentReview({ data }: { data: Record<string, unknown> }) {
     }
   }
 
-  const gitSource = data.git_source as Record<string, unknown> | undefined;
+  const gitSource = buildAndDeploy.git_source as
+    | Record<string, unknown>
+    | undefined;
   if (gitSource) {
     if (gitSource.repo_url)
       setMeta(buildMeta, 'Repository URL', String(gitSource.repo_url));
@@ -254,21 +258,21 @@ function ComponentReview({ data }: { data: Record<string, unknown> }) {
       setMeta(buildMeta, 'Git Secret', String(gitSource.git_secret_ref));
   }
 
-  if (data.containerImage) {
-    setMeta(buildMeta, 'Container Image', String(data.containerImage));
+  if (buildAndDeploy.containerImage) {
+    setMeta(buildMeta, 'Container Image', String(buildAndDeploy.containerImage));
   }
-  if (data.autoDeploy !== undefined) {
-    setMeta(buildMeta, 'Auto Deploy', data.autoDeploy ? 'Yes' : 'No');
+  if (buildAndDeploy.autoDeploy !== undefined) {
+    setMeta(buildMeta, 'Auto Deploy', buildAndDeploy.autoDeploy ? 'Yes' : 'No');
   }
-  if (data.ciPlatform) {
-    setMeta(buildMeta, 'CI Platform', String(data.ciPlatform));
+  if (buildAndDeploy.ciPlatform) {
+    setMeta(buildMeta, 'CI Platform', String(buildAndDeploy.ciPlatform));
   }
-  if (data.ciIdentifier) {
-    setMeta(buildMeta, 'CI Identifier', String(data.ciIdentifier));
+  if (buildAndDeploy.ciIdentifier) {
+    setMeta(buildMeta, 'CI Identifier', String(buildAndDeploy.ciIdentifier));
   }
 
   // Section: Workflow Parameters — split key-value arrays into own sub-sections
-  const workflowParams = data.workflow_parameters as
+  const workflowParams = buildAndDeploy.workflow_parameters as
     | { parameters?: Record<string, unknown>; schema?: unknown }
     | undefined;
   let workflowScalarMeta: Record<string, string> | undefined;

--- a/packages/app/src/scaffolder/CustomReviewState/CustomReviewStep.tsx
+++ b/packages/app/src/scaffolder/CustomReviewState/CustomReviewStep.tsx
@@ -259,7 +259,11 @@ function ComponentReview({ data }: { data: Record<string, unknown> }) {
   }
 
   if (buildAndDeploy.containerImage) {
-    setMeta(buildMeta, 'Container Image', String(buildAndDeploy.containerImage));
+    setMeta(
+      buildMeta,
+      'Container Image',
+      String(buildAndDeploy.containerImage),
+    );
   }
   if (buildAndDeploy.autoDeploy !== undefined) {
     setMeta(buildMeta, 'Auto Deploy', buildAndDeploy.autoDeploy ? 'Yes' : 'No');

--- a/packages/app/src/scaffolder/WorkloadDetailsField/WorkloadDetailsField.tsx
+++ b/packages/app/src/scaffolder/WorkloadDetailsField/WorkloadDetailsField.tsx
@@ -345,7 +345,8 @@ export const WorkloadDetailsField = ({
   // Env vars and file mounts require a container with an image.
   // For build-from-source and external-ci the image isn't known yet,
   // so we hide these sections.
-  const deploymentSource = (formContext as any)?.formData?.deploymentSource;
+  const deploymentSource = (formContext as any)?.formData?.buildAndDeploy
+    ?.deploymentSource;
   const isFromImage = deploymentSource === 'deploy-from-image';
   const isBuildFromSource = deploymentSource === 'build-from-source';
   const isExternalCi = deploymentSource === 'external-ci';

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.cluster.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.cluster.test.ts
@@ -142,11 +142,10 @@ describe('CtdToTemplateConverter – convertClusterCtdToTemplateEntity', () => {
     };
     const result = converter.convertClusterCtdToTemplateEntity(ctd);
     const parameters = result.spec?.parameters as any[];
-    const buildSection = parameters[1];
-    const buildBranch = buildSection.dependencies.deploymentSource.oneOf[0];
+    const buildAndDeploy = parameters[1].properties.buildAndDeploy;
 
     expect(
-      buildBranch.properties.workflow_name['ui:options'].allowedWorkflows,
+      buildAndDeploy.properties.workflow_name['ui:options'].allowedWorkflows,
     ).toEqual([
       { kind: 'ClusterWorkflow', name: 'docker-build' },
       { kind: 'ClusterWorkflow', name: 'buildpacks' },
@@ -166,10 +165,10 @@ describe('CtdToTemplateConverter – convertClusterCtdToTemplateEntity', () => {
     };
     const result = converter.convertClusterCtdToTemplateEntity(ctd);
     const parameters = result.spec?.parameters as any[];
-    const buildBranch = parameters[1].dependencies.deploymentSource.oneOf[0];
+    const buildAndDeploy = parameters[1].properties.buildAndDeploy;
 
     expect(
-      buildBranch.properties.workflow_name['ui:options'].allowedWorkflows,
+      buildAndDeploy.properties.workflow_name['ui:options'].allowedWorkflows,
     ).toEqual([
       { kind: 'ClusterWorkflow', name: 'default-build' },
       { kind: 'Workflow', name: 'ns-build' },

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
@@ -316,109 +316,79 @@ describe('CtdToTemplateConverter', () => {
       // Should have 3 sections
       expect(parameters).toHaveLength(3);
 
-      // Check Build & Deploy section (second section)
+      // Check Build & Deploy section (second section). All branch-specific
+      // fields now live as siblings of `deploymentSource` under a single
+      // `buildAndDeploy` object owned by BuildAndDeployField — the composite
+      // field is the only way to atomically clear the inactive branch's data
+      // on source change.
       const buildDeploySection = parameters[1];
       expect(buildDeploySection.title).toBe('Build & Deploy');
-      expect(buildDeploySection.required).toEqual(['deploymentSource']);
+      expect(buildDeploySection.required).toEqual(['buildAndDeploy']);
 
-      // Check deploymentSource property
-      expect(buildDeploySection.properties.deploymentSource).toBeDefined();
-      expect(buildDeploySection.properties.deploymentSource.type).toBe(
-        'string',
-      );
-      expect(buildDeploySection.properties.deploymentSource.enum).toEqual([
+      const buildAndDeploy =
+        buildDeploySection.properties.buildAndDeploy;
+      expect(buildAndDeploy).toBeDefined();
+      expect(buildAndDeploy.type).toBe('object');
+      expect(buildAndDeploy['ui:field']).toBe('BuildAndDeployField');
+      expect(buildAndDeploy.required).toEqual(['deploymentSource']);
+
+      // deploymentSource still rendered by DeploymentSourcePicker
+      expect(buildAndDeploy.properties.deploymentSource).toBeDefined();
+      expect(buildAndDeploy.properties.deploymentSource.type).toBe('string');
+      expect(buildAndDeploy.properties.deploymentSource.enum).toEqual([
         'build-from-source',
         'deploy-from-image',
         'external-ci',
       ]);
-      expect(buildDeploySection.properties.deploymentSource['ui:field']).toBe(
+      expect(buildAndDeploy.properties.deploymentSource['ui:field']).toBe(
         'DeploymentSourcePicker',
       );
 
-      // autoDeploy is NOT a top-level property — it's only in the deploy-from-image branch
-      expect(buildDeploySection.properties.autoDeploy).toBeUndefined();
-
-      // Check dependencies structure uses oneOf
-      expect(buildDeploySection.dependencies.deploymentSource).toBeDefined();
-      expect(
-        buildDeploySection.dependencies.deploymentSource.oneOf,
-      ).toBeDefined();
-      expect(
-        buildDeploySection.dependencies.deploymentSource.oneOf,
-      ).toHaveLength(3);
-
-      // Check build-from-source branch
-      const buildFromSourceBranch =
-        buildDeploySection.dependencies.deploymentSource.oneOf[0];
-      expect(buildFromSourceBranch.properties.deploymentSource.const).toBe(
-        'build-from-source',
-      );
-
-      // Check git_source composite field
-      expect(buildFromSourceBranch.properties.git_source).toBeDefined();
-      expect(buildFromSourceBranch.properties.git_source.type).toBe('object');
-      expect(buildFromSourceBranch.properties.git_source['ui:field']).toBe(
+      // Build-from-source siblings
+      expect(buildAndDeploy.properties.git_source).toBeDefined();
+      expect(buildAndDeploy.properties.git_source.type).toBe('object');
+      expect(buildAndDeploy.properties.git_source['ui:field']).toBe(
         'GitSourceField',
       );
       expect(
-        buildFromSourceBranch.properties.git_source.properties.repo_url,
+        buildAndDeploy.properties.git_source.properties.repo_url,
       ).toBeDefined();
       expect(
-        buildFromSourceBranch.properties.git_source.properties.branch,
+        buildAndDeploy.properties.git_source.properties.branch,
       ).toBeDefined();
       expect(
-        buildFromSourceBranch.properties.git_source.properties.component_path,
+        buildAndDeploy.properties.git_source.properties.component_path,
       ).toBeDefined();
       expect(
-        buildFromSourceBranch.properties.git_source.properties.git_secret_ref,
-      ).toBeDefined();
-
-      expect(buildFromSourceBranch.properties.workflow_name).toBeDefined();
-      expect(
-        buildFromSourceBranch.properties.workflow_parameters,
+        buildAndDeploy.properties.git_source.properties.git_secret_ref,
       ).toBeDefined();
 
-      // Check workflow_name passes allowedWorkflows via ui:options
+      expect(buildAndDeploy.properties.workflow_name).toBeDefined();
+      expect(buildAndDeploy.properties.workflow_parameters).toBeDefined();
+
+      // workflow_name still passes allowedWorkflows via ui:options
       expect(
-        buildFromSourceBranch.properties.workflow_name['ui:options']
+        buildAndDeploy.properties.workflow_name['ui:options']
           .allowedWorkflows,
       ).toEqual([
         { kind: 'Workflow', name: 'nodejs-build' },
         { kind: 'Workflow', name: 'docker-build' },
       ]);
-      expect(buildFromSourceBranch.properties.workflow_name['ui:field']).toBe(
+      expect(buildAndDeploy.properties.workflow_name['ui:field']).toBe(
         'BuildWorkflowPicker',
       );
 
-      // Check workflow_parameters uses custom UI field
-      expect(
-        buildFromSourceBranch.properties.workflow_parameters['ui:field'],
-      ).toBe('BuildWorkflowParameters');
-
-      // autoDeploy should NOT appear in build-from-source branch (only in deploy-from-image)
-      expect(buildFromSourceBranch.properties.autoDeploy).toBeUndefined();
-
-      // Check required fields for build-from-source
-      expect(buildFromSourceBranch.required).toEqual([
-        'workflow_name',
-        'workflow_parameters',
-      ]);
-
-      // Check deploy-from-image branch
-      const deployFromImageBranch =
-        buildDeploySection.dependencies.deploymentSource.oneOf[1];
-      expect(deployFromImageBranch.properties.deploymentSource.const).toBe(
-        'deploy-from-image',
+      // workflow_parameters still uses custom UI field
+      expect(buildAndDeploy.properties.workflow_parameters['ui:field']).toBe(
+        'BuildWorkflowParameters',
       );
-      expect(deployFromImageBranch.properties.containerImage).toBeDefined();
-      expect(deployFromImageBranch.properties.containerImage['ui:field']).toBe(
+
+      // Deploy-from-image siblings
+      expect(buildAndDeploy.properties.containerImage).toBeDefined();
+      expect(buildAndDeploy.properties.containerImage['ui:field']).toBe(
         'ContainerImageField',
       );
-      // Check autoDeploy appears in deploy-from-image branch
-      expect(deployFromImageBranch.properties.autoDeploy).toBeDefined();
-
-      // Check required fields for deploy-from-image
-      expect(deployFromImageBranch.required).toEqual(['containerImage']);
+      expect(buildAndDeploy.properties.autoDeploy).toBeDefined();
     });
 
     it('should encode mixed Workflow and ClusterWorkflow allowedWorkflows with correct kind', () => {
@@ -443,13 +413,10 @@ describe('CtdToTemplateConverter', () => {
 
       const result = converter.convertCtdToTemplateEntity(ctd, 'test-org');
       const parameters = result.spec?.parameters as any[];
-      const buildDeploySection = parameters[1];
-      const buildFromSourceBranch =
-        buildDeploySection.dependencies.deploymentSource.oneOf[0];
+      const buildAndDeploy = parameters[1].properties.buildAndDeploy;
 
       expect(
-        buildFromSourceBranch.properties.workflow_name['ui:options']
-          .allowedWorkflows,
+        buildAndDeploy.properties.workflow_name['ui:options'].allowedWorkflows,
       ).toEqual([
         { kind: 'Workflow', name: 'nodejs-build' },
         { kind: 'ClusterWorkflow', name: 'dockerfile-builder' },
@@ -581,13 +548,18 @@ describe('CtdToTemplateConverter', () => {
       expect(input.workloadDetails).toBe('${{ parameters.workloadDetails }}');
 
       // CI/CD parameters including git secret ref (from git_source composite field)
+      // All CI/CD fields are nested under buildAndDeploy after the BuildAndDeployField restructure.
       expect(input.gitSecretRef).toBe(
-        '${{ parameters.git_source.git_secret_ref }}',
+        '${{ parameters.buildAndDeploy.git_source.git_secret_ref }}',
       );
-      expect(input.repo_url).toBe('${{ parameters.git_source.repo_url }}');
-      expect(input.branch).toBe('${{ parameters.git_source.branch }}');
+      expect(input.repo_url).toBe(
+        '${{ parameters.buildAndDeploy.git_source.repo_url }}',
+      );
+      expect(input.branch).toBe(
+        '${{ parameters.buildAndDeploy.git_source.branch }}',
+      );
       expect(input.component_path).toBe(
-        '${{ parameters.git_source.component_path }}',
+        '${{ parameters.buildAndDeploy.git_source.component_path }}',
       );
     });
   });
@@ -668,59 +640,25 @@ describe('CtdToTemplateConverter', () => {
       },
     };
 
-    it('should include external-ci branch in oneOf', () => {
+    it('should expose external-ci as an option with a ciPlatform sibling', () => {
       const result = converter.convertCtdToTemplateEntity(baseCtd, 'test-org');
       const parameters = result.spec?.parameters as any[];
-      const buildSection = parameters[1];
-      const externalCIBranch =
-        buildSection.dependencies.deploymentSource.oneOf[2];
+      const buildAndDeploy = parameters[1].properties.buildAndDeploy;
 
-      expect(externalCIBranch.properties.deploymentSource.const).toBe(
+      expect(buildAndDeploy.properties.deploymentSource.enum).toContain(
         'external-ci',
       );
-      expect(externalCIBranch.properties.ciPlatform).toBeDefined();
-      expect(externalCIBranch.properties.ciPlatform.enum).toEqual([
+      expect(buildAndDeploy.properties.ciPlatform).toBeDefined();
+      expect(buildAndDeploy.properties.ciPlatform.enum).toEqual([
         'none',
         'jenkins',
         'github-actions',
         'gitlab-ci',
       ]);
-    });
-
-    it('should include ciPlatform conditional dependencies for each platform', () => {
-      const result = converter.convertCtdToTemplateEntity(baseCtd, 'test-org');
-      const parameters = result.spec?.parameters as any[];
-      const buildSection = parameters[1];
-
-      const ciPlatformDeps = buildSection.dependencies.ciPlatform;
-      expect(ciPlatformDeps).toBeDefined();
-      expect(ciPlatformDeps.oneOf).toHaveLength(4);
-
-      // none, jenkins, github-actions, gitlab-ci
-      const platforms = ciPlatformDeps.oneOf.map(
-        (o: any) => o.properties.ciPlatform.const,
-      );
-      expect(platforms).toEqual([
-        'none',
-        'jenkins',
-        'github-actions',
-        'gitlab-ci',
-      ]);
-    });
-
-    it('should require ciIdentifier for jenkins but not for none', () => {
-      const result = converter.convertCtdToTemplateEntity(baseCtd, 'test-org');
-      const parameters = result.spec?.parameters as any[];
-      const ciPlatformDeps = parameters[1].dependencies.ciPlatform;
-
-      const noneBranch = ciPlatformDeps.oneOf[0];
-      const jenkinsBranch = ciPlatformDeps.oneOf[1];
-
-      expect(noneBranch.properties.ciIdentifier).toBeUndefined();
-      expect(jenkinsBranch.properties.ciIdentifier).toBeDefined();
-      expect(jenkinsBranch.properties.ciIdentifier.title).toBe(
-        'Jenkins Job Path',
-      );
+      // The composite renders ciIdentifier only when ciPlatform requires it;
+      // the schema carries a generic shape and the picker labels it per platform.
+      expect(buildAndDeploy.properties.ciIdentifier).toBeDefined();
+      expect(buildAndDeploy.properties.ciIdentifier.type).toBe('string');
     });
   });
 

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.test.ts
@@ -325,8 +325,7 @@ describe('CtdToTemplateConverter', () => {
       expect(buildDeploySection.title).toBe('Build & Deploy');
       expect(buildDeploySection.required).toEqual(['buildAndDeploy']);
 
-      const buildAndDeploy =
-        buildDeploySection.properties.buildAndDeploy;
+      const buildAndDeploy = buildDeploySection.properties.buildAndDeploy;
       expect(buildAndDeploy).toBeDefined();
       expect(buildAndDeploy.type).toBe('object');
       expect(buildAndDeploy['ui:field']).toBe('BuildAndDeployField');
@@ -368,8 +367,7 @@ describe('CtdToTemplateConverter', () => {
 
       // workflow_name still passes allowedWorkflows via ui:options
       expect(
-        buildAndDeploy.properties.workflow_name['ui:options']
-          .allowedWorkflows,
+        buildAndDeploy.properties.workflow_name['ui:options'].allowedWorkflows,
       ).toEqual([
         { kind: 'Workflow', name: 'nodejs-build' },
         { kind: 'Workflow', name: 'docker-build' },

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
@@ -293,8 +293,16 @@ export class CtdToTemplateConverter {
       'ui:field': 'SwitchField',
     };
 
-    return {
-      title: 'Build & Deploy',
+    // All branch-specific fields live as siblings of `deploymentSource` under a
+    // single `buildAndDeploy` object owned by `BuildAndDeployField`. The
+    // composite renders only the fields belonging to the current
+    // deploymentSource, and replaces its entire object atomically on source
+    // change — siblings from the previous branch disappear in one onChange.
+    // This avoids RJSF's stale-data-on-oneOf-switch behaviour, which Backstage's
+    // Stepper blocks from being fixed via omitExtraData/liveOmit.
+    const buildAndDeployObject: any = {
+      type: 'object',
+      'ui:field': 'BuildAndDeployField',
       required: ['deploymentSource'],
       properties: {
         deploymentSource: {
@@ -304,124 +312,72 @@ export class CtdToTemplateConverter {
           enum: ['build-from-source', 'deploy-from-image', 'external-ci'],
           'ui:field': 'DeploymentSourcePicker',
         },
-      },
-      dependencies: {
-        deploymentSource: {
-          oneOf: [
-            // Build from source branch
-            {
-              properties: {
-                deploymentSource: {
-                  const: 'build-from-source',
-                },
-                workflow_name: workflowField,
-                git_source: {
-                  title: 'Source Repository',
-                  type: 'object',
-                  'ui:field': 'GitSourceField',
-                  'ui:options': {
-                    namespaceName: namespaceName,
-                  },
-                  properties: {
-                    repo_url: { type: 'string' },
-                    branch: { type: 'string' },
-                    component_path: { type: 'string' },
-                    git_secret_ref: { type: 'string' },
-                  },
-                },
-                workflow_parameters: {
-                  title: 'Workflow Parameters',
-                  type: 'object',
-                  'ui:field': 'BuildWorkflowParameters',
-                  'ui:options': {
-                    namespaceName: namespaceName,
-                    ctdKind: ctdKind,
-                  },
-                },
-              },
-              required: ['workflow_name', 'workflow_parameters'],
-            },
-            // Deploy from image branch
-            {
-              properties: {
-                deploymentSource: {
-                  const: 'deploy-from-image',
-                },
-                containerImage: {
-                  title: 'Container Image',
-                  type: 'string',
-                  description:
-                    'Full image reference (e.g., ghcr.io/org/app:v1.0.0 or nginx:latest)',
-                  'ui:field': 'ContainerImageField',
-                },
-                autoDeploy: autoDeployField,
-              },
-              required: ['containerImage'],
-            },
-            // External CI branch
-            {
-              properties: {
-                deploymentSource: {
-                  const: 'external-ci',
-                },
-                ciPlatform: {
-                  title: 'CI Platform (Optional)',
-                  type: 'string',
-                  description:
-                    'Select your CI platform to enable build visibility in Backstage. You can configure this later via the annotation editor.',
-                  enum: ['none', 'jenkins', 'github-actions', 'gitlab-ci'],
-                  enumNames: [
-                    "Skip - I'll configure this later",
-                    'Jenkins',
-                    'GitHub Actions',
-                    'GitLab CI',
-                  ],
-                  default: 'none',
-                },
-              },
-            },
-          ],
+        // build-from-source branch
+        workflow_name: workflowField,
+        git_source: {
+          title: 'Source Repository',
+          type: 'object',
+          'ui:field': 'GitSourceField',
+          'ui:options': {
+            namespaceName: namespaceName,
+          },
+          properties: {
+            repo_url: { type: 'string' },
+            branch: { type: 'string' },
+            component_path: { type: 'string' },
+            git_secret_ref: { type: 'string' },
+          },
         },
+        workflow_parameters: {
+          title: 'Workflow Parameters',
+          type: 'object',
+          'ui:field': 'BuildWorkflowParameters',
+          'ui:options': {
+            namespaceName: namespaceName,
+            ctdKind: ctdKind,
+          },
+        },
+        // deploy-from-image branch
+        containerImage: {
+          title: 'Container Image',
+          type: 'string',
+          description:
+            'Full image reference (e.g., ghcr.io/org/app:v1.0.0 or nginx:latest)',
+          'ui:field': 'ContainerImageField',
+        },
+        autoDeploy: autoDeployField,
+        // external-ci branch
         ciPlatform: {
-          oneOf: [
-            {
-              properties: {
-                ciPlatform: { const: 'none' },
-              },
-            },
-            {
-              properties: {
-                ciPlatform: { const: 'jenkins' },
-                ciIdentifier: {
-                  title: 'Jenkins Job Path',
-                  type: 'string',
-                  description:
-                    'Full job path (e.g., /job/my-org/job/my-service or folder/job-name)',
-                },
-              },
-            },
-            {
-              properties: {
-                ciPlatform: { const: 'github-actions' },
-                ciIdentifier: {
-                  title: 'GitHub Repository Slug',
-                  type: 'string',
-                  description: 'Repository slug (e.g., my-org/my-repo)',
-                },
-              },
-            },
-            {
-              properties: {
-                ciPlatform: { const: 'gitlab-ci' },
-                ciIdentifier: {
-                  title: 'GitLab Project ID',
-                  type: 'string',
-                  description: 'Numeric project ID from GitLab',
-                },
-              },
-            },
+          title: 'CI Platform (Optional)',
+          type: 'string',
+          description:
+            'Select your CI platform to enable build visibility in Backstage. You can configure this later via the annotation editor.',
+          enum: ['none', 'jenkins', 'github-actions', 'gitlab-ci'],
+          enumNames: [
+            "Skip - I'll configure this later",
+            'Jenkins',
+            'GitHub Actions',
+            'GitLab CI',
           ],
+          default: 'none',
         },
+        // Rendered by BuildAndDeployField only when ciPlatform requires it.
+        // Title/description are platform-specific, so this field carries a
+        // generic shape and the picker UI provides the specific labelling.
+        ciIdentifier: {
+          title: 'CI Job / Project Identifier',
+          type: 'string',
+          description:
+            'Identifier for the external CI job (e.g., Jenkins job path, GitHub repo slug, or GitLab project ID).',
+        },
+      },
+    };
+
+    return {
+      title: 'Build & Deploy',
+      required: ['buildAndDeploy'],
+      properties: {
+        buildAndDeploy: buildAndDeployObject,
       },
     };
   }
@@ -521,19 +477,22 @@ export class CtdToTemplateConverter {
           // Workload Details (from section 2 — nested under workloadDetails)
           workloadDetails: '${{ parameters.workloadDetails }}',
 
-          // CI/CD Setup (from section 1)
-          deploymentSource: '${{ parameters.deploymentSource }}',
-          autoDeploy: '${{ parameters.autoDeploy }}',
-          containerImage: '${{ parameters.containerImage }}',
-          repo_url: '${{ parameters.git_source.repo_url }}',
-          branch: '${{ parameters.git_source.branch }}',
-          component_path: '${{ parameters.git_source.component_path }}',
-          gitSecretRef: '${{ parameters.git_source.git_secret_ref }}',
-          workflow: '${{ parameters.workflow_name }}',
-          workflow_parameters: '${{ parameters.workflow_parameters }}',
+          // CI/CD Setup (from section 1 — nested under buildAndDeploy)
+          deploymentSource: '${{ parameters.buildAndDeploy.deploymentSource }}',
+          autoDeploy: '${{ parameters.buildAndDeploy.autoDeploy }}',
+          containerImage: '${{ parameters.buildAndDeploy.containerImage }}',
+          repo_url: '${{ parameters.buildAndDeploy.git_source.repo_url }}',
+          branch: '${{ parameters.buildAndDeploy.git_source.branch }}',
+          component_path:
+            '${{ parameters.buildAndDeploy.git_source.component_path }}',
+          gitSecretRef:
+            '${{ parameters.buildAndDeploy.git_source.git_secret_ref }}',
+          workflow: '${{ parameters.buildAndDeploy.workflow_name }}',
+          workflow_parameters:
+            '${{ parameters.buildAndDeploy.workflow_parameters }}',
           // External CI parameters
-          ciPlatform: '${{ parameters.ciPlatform }}',
-          ciIdentifier: '${{ parameters.ciIdentifier }}',
+          ciPlatform: '${{ parameters.buildAndDeploy.ciPlatform }}',
+          ciIdentifier: '${{ parameters.buildAndDeploy.ciIdentifier }}',
         },
       },
     ];


### PR DESCRIPTION
## Purpose

Fixes `Invalid input passed to action openchoreo:component:create, instance.workflow requires property "name"` when a user picks **Build from Source**, then switches to **Container Image** (or **External CI**) before submitting the component-creation template.

## Goals

Clear stale Build & Deploy data on source switch during component creation

## Approach

- New composite field `BuildAndDeployField` (`packages/app/src/scaffolder/BuildAndDeployField/`). It receives the entire buildAndDeploy object as its value, renders the `DeploymentSourcePicker` plus only the sub-fields belonging to the current source (via registry.fields.SchemaField, so each existing custom field — `BuildWorkflowPicker`, `GitSourceField`, `ContainerImageField`, etc. — is reused unchanged).
- When the user picks a different source, the composite calls `onChange({ deploymentSource: newValue })`. Because the parent slot buildAndDeploy is replaced wholesale, every sibling key from the previous branch disappears in that single change - atomically, no decorator, no submit-time cleanup. The same trick handles the inner ciPlatform → ciIdentifier case.
- `CtdToTemplateConverter.ts` was updated to emit the flat-with-composite shape (no more dependencies/oneOf), and generateSteps now reads parameters.buildAndDeploy.workflow_name, parameters.buildAndDeploy.git_source.*, etc.
- `WorkloadDetailsField` was updated to read the discriminator from its new nested path: formContext.formData.buildAndDeploy?.deploymentSource.

## Automation tests

- Unit tests
  Updated unit tests
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Build & Deploy field to the scaffolder for managing deployment source configuration with branch-based subfields.
  * CI platform identifier field is now conditionally displayed based on platform requirements.

* **Refactor**
  * Reorganized deployment configuration structure within the scaffolder form to use a nested composite object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->