### PR TITLE
fix: fetch all pages when listing workflow runs

### DIFF
--- a/.changeset/workflow-runs-fetch-all-pages.md
+++ b/.changeset/workflow-runs-fetch-all-pages.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-workflows-backend': patch
+---
+
+fetch all pages when listing workflow runs

--- a/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
+++ b/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
@@ -285,14 +285,9 @@ export class GenericWorkflowService {
           }),
       );
 
-      // Filter by workflowName before transforming (check both flat and K8s fields)
       // TODO: If upstream API supports filtering, pass workflowName as query param instead
       let filtered = workflowName
-        ? rawItems.filter(
-            run =>
-              run.spec?.workflow?.name === workflowName ||
-              run.workflowName === workflowName,
-          )
+        ? rawItems.filter(run => run.spec?.workflow?.name === workflowName)
         : rawItems;
 
       // Filter by project and component labels if provided

--- a/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
+++ b/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
@@ -3,6 +3,7 @@ import {
   createOpenChoreoApiClient,
   createObservabilityClientWithUrl,
   assertApiResponse,
+  fetchAllPages,
   ObservabilityUrlResolver,
 } from '@openchoreo/openchoreo-client-node';
 import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
@@ -270,18 +271,19 @@ export class GenericWorkflowService {
         logger: this.logger,
       });
 
-      const { data, error, response } = await client.GET(
-        '/api/v1/namespaces/{namespaceName}/workflowruns',
-        {
-          params: {
-            path: { namespaceName },
-          },
-        },
+      const rawItems = await fetchAllPages(cursor =>
+        client
+          .GET('/api/v1/namespaces/{namespaceName}/workflowruns', {
+            params: {
+              path: { namespaceName },
+              query: { limit: 100, cursor },
+            },
+          })
+          .then(res => {
+            assertApiResponse(res, 'fetch workflow runs');
+            return res.data;
+          }),
       );
-
-      assertApiResponse({ data, error, response }, 'fetch workflow runs');
-
-      const rawItems = ((data as any)?.items || []) as any[];
 
       // Filter by workflowName before transforming (check both flat and K8s fields)
       // TODO: If upstream API supports filtering, pass workflowName as query param instead
@@ -319,12 +321,7 @@ export class GenericWorkflowService {
         }`,
       );
 
-      return {
-        items,
-        pagination: (data as any)?.pagination as
-          | { nextCursor?: string }
-          | undefined,
-      };
+      return { items };
     } catch (error) {
       this.logger.error(
         `Failed to fetch workflow runs for namespace ${namespaceName}: ${error}`,


### PR DESCRIPTION
## Summary

- `GenericWorkflowService.listWorkflowRuns` was fetching only the first page of results from the OpenChoreo API, capping at the server default of 20 items
- Switched to `fetchAllPages` with `limit: 100` per page, the same pattern already used by the CI backend's `WorkflowService`

Closes [#2961](https://github.com/openchoreo/openchoreo/issues/2961)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pagination handling for workflow run queries using cursor-based fetching for better performance with large datasets
  * Simplified response format for workflow run lists

<!-- end of auto-generated comment: release notes by coderabbit.ai -->