### PR TITLE
fix: fetch all pages when listing workflows

### DIFF
--- a/.changeset/workflow-list-fetch-all-pages.md
+++ b/.changeset/workflow-list-fetch-all-pages.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-workflows-backend': patch
+---
+
+fetch all pages when listing workflows

--- a/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
+++ b/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
@@ -116,19 +116,22 @@ export class GenericWorkflowService {
         logger: this.logger,
       });
 
-      const { data, error, response } = await client.GET(
-        '/api/v1/namespaces/{namespaceName}/workflows',
-        {
-          params: {
-            path: { namespaceName },
-          },
-        },
+      const rawItems = await fetchAllPages(cursor =>
+        client
+          .GET('/api/v1/namespaces/{namespaceName}/workflows', {
+            params: {
+              path: { namespaceName },
+              query: { limit: 100, cursor },
+            },
+          })
+          .then(res => {
+            assertApiResponse(res, 'fetch workflows');
+            return res.data;
+          }),
       );
 
-      assertApiResponse({ data, error, response }, 'fetch workflows');
-
       // Map K8s-style Workflow to the local flat Workflow interface
-      const items: Workflow[] = ((data as any)?.items || []).map((wf: any) => {
+      const items: Workflow[] = rawItems.map((wf: any) => {
         const name: string = wf.metadata?.name ?? '';
         const isCI =
           wf.metadata?.labels?.[CHOREO_LABELS.WORKFLOW_TYPE] === 'component';
@@ -148,9 +151,6 @@ export class GenericWorkflowService {
 
       return {
         items,
-        pagination: (data as any)?.pagination as
-          | { nextCursor?: string }
-          | undefined,
       };
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
## Summary

- `GenericWorkflowService.listWorkflows` was fetching only the first page of results, capping at the server default of 20 items
- Same issue as #623 (`listWorkflowRuns`) — switched to `fetchAllPages` with `limit: 100` per page

Related: #623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow and workflow-run listings to retrieve all pages of data, ensuring complete information is displayed instead of only the first page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->