### PR TITLE
fix: surface token acquisition failures in direct mode

### DIFF
--- a/.changeset/surface-token-acquisition-failures.md
+++ b/.changeset/surface-token-acquisition-failures.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Surface IDP token acquisition failures instead of silently sending unauthenticated requests. Direct-mode fetches and permission checks now throw with the original error as cause when auth is enabled and the token cannot be acquired.

--- a/packages/app/src/apis/OpenChoreoFetchApi.test.ts
+++ b/packages/app/src/apis/OpenChoreoFetchApi.test.ts
@@ -142,5 +142,46 @@ describe('OpenChoreoFetchApi', () => {
       const headers = mockFetch.mock.calls[0][1].headers as Headers;
       expect(headers.get('Authorization')).toBeNull();
     });
+
+    it('throws without sending the request when token acquisition fails', async () => {
+      const tokenError = new Error('consent_required');
+      mockOauthApi.getAccessToken.mockRejectedValue(tokenError);
+      const api = createApi();
+
+      await expect(
+        api.fetch('http://example.com', {
+          headers: { 'x-openchoreo-direct': 'true' },
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('Failed to acquire an identity token'),
+        cause: tokenError,
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws when token resolution returns an empty token', async () => {
+      mockOauthApi.getAccessToken.mockResolvedValue('');
+      const api = createApi();
+
+      await expect(
+        api.fetch('http://example.com', {
+          headers: { 'x-openchoreo-direct': 'true' },
+        }),
+      ).rejects.toThrow(/empty token/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('sends the request without a token when auth is disabled, even if acquisition would fail', async () => {
+      mockOauthApi.getAccessToken.mockRejectedValue(new Error('no token'));
+      const api = createApi(false);
+
+      await api.fetch('http://example.com', {
+        headers: { 'x-openchoreo-direct': 'true' },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const headers = mockFetch.mock.calls[0][1].headers as Headers;
+      expect(headers.get('Authorization')).toBeNull();
+    });
   });
 });

--- a/packages/app/src/apis/OpenChoreoFetchApi.ts
+++ b/packages/app/src/apis/OpenChoreoFetchApi.ts
@@ -61,14 +61,21 @@ export class OpenChoreoFetchApi implements FetchApi {
     if (isDirect) {
       // Direct mode: IDP token in Authorization header, no Backstage token
       if (this.authEnabled) {
+        let idpToken: string | undefined;
         try {
-          const idpToken = await this.oauthApi.getAccessToken();
-          if (idpToken) {
-            headers.set('Authorization', `Bearer ${idpToken}`);
-          }
-        } catch {
-          // Continue without IDP token if not available
+          idpToken = await this.oauthApi.getAccessToken();
+        } catch (error) {
+          throw new Error(
+            `Failed to acquire an identity token for a direct API call: ${error}`,
+            { cause: error },
+          );
         }
+        if (!idpToken) {
+          throw new Error(
+            'Failed to acquire an identity token for a direct API call: token resolution returned an empty token',
+          );
+        }
+        headers.set('Authorization', `Bearer ${idpToken}`);
       }
     } else {
       // Normal mode: Backstage token + IDP token in custom header

--- a/packages/app/src/apis/OpenChoreoPermissionApi.test.ts
+++ b/packages/app/src/apis/OpenChoreoPermissionApi.test.ts
@@ -133,6 +133,43 @@ describe('OpenChoreoPermissionApi', () => {
     expect(headers['x-openchoreo-token']).toBeUndefined();
   });
 
+  it('throws without calling the backend when token acquisition fails', async () => {
+    const tokenError = new Error('consent_required');
+    mockOauthApi.getAccessToken.mockRejectedValue(tokenError);
+    const api = createApi();
+
+    await expect(
+      api.authorize({ permission: { name: 'test.read' } }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Failed to acquire an identity token'),
+      cause: tokenError,
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when token resolution returns an empty token', async () => {
+    mockOauthApi.getAccessToken.mockResolvedValue('');
+    const api = createApi();
+
+    await expect(
+      api.authorize({ permission: { name: 'test.read' } }),
+    ).rejects.toThrow(/empty token/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not throw on token acquisition failure when auth is disabled', async () => {
+    mockOauthApi.getAccessToken.mockRejectedValue(new Error('no token'));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [{ result: AuthorizeResult.ALLOW }] }),
+    });
+    const api = createApi({ authEnabled: false });
+
+    await expect(
+      api.authorize({ permission: { name: 'test.read' } }),
+    ).resolves.toEqual({ result: AuthorizeResult.ALLOW });
+  });
+
   it('throws on non-OK response', async () => {
     mockFetch.mockResolvedValue({
       ok: false,

--- a/packages/app/src/apis/OpenChoreoPermissionApi.ts
+++ b/packages/app/src/apis/OpenChoreoPermissionApi.ts
@@ -63,8 +63,16 @@ export class OpenChoreoPermissionApi {
     if (this.authEnabled) {
       try {
         idpToken = await this.oauthApi.getAccessToken();
-      } catch {
-        // Continue without IDP token if not available
+      } catch (error) {
+        throw new Error(
+          `Failed to acquire an identity token for permission evaluation: ${error}`,
+          { cause: error },
+        );
+      }
+      if (!idpToken) {
+        throw new Error(
+          'Failed to acquire an identity token for permission evaluation: token resolution returned an empty token',
+        );
       }
     }
 


### PR DESCRIPTION
When auth is enabled in the portal (`openchoreo.features.auth.enabled`), the IDP token is required by configuration. A swallowed `getAccessToken()` failure in direct mode produced a silently unauthenticated request and a bare 401 with no diagnostics. Now the acquisition error is thrown with the original failure as `cause` (surfacing e.g. `AADSTS...` codes) and the request is not sent.

When auth is disabled in the portal, no token is fetched and requests are sent as-is; whether the target service enforces JWT is its own configuration concern.

Second commit applies the same fix to `OpenChoreoPermissionApi`, where a swallowed token failure made every permission check silently resolve to deny, indistinguishable from a missing role binding.

Fixes openchoreo/openchoreo#3742