### PR TITLE
fix(scaffolder): read workflow_name from buildAndDeploy in source fields

### DIFF
--- a/packages/app/src/scaffolder/BuildWorkflowParameters/BuildWorkflowParametersExtension.tsx
+++ b/packages/app/src/scaffolder/BuildWorkflowParameters/BuildWorkflowParametersExtension.tsx
@@ -83,10 +83,11 @@ export const BuildWorkflowParameters = ({
   const fetchApi = useApi(fetchApiRef);
   const catalogApi = useApi(catalogApiRef);
 
-  // Get the selected workflow from sibling field in the same section
-  const selectedWorkflowValue = formContext?.formData?.workflow_name as
-    | { kind?: WorkflowKind; name?: string }
-    | undefined;
+  // Get the selected workflow from sibling field in the same section.
+  // Build & Deploy fields are nested under `buildAndDeploy` (owned by
+  // BuildAndDeployField), so the sibling workflow lives there, not at the root.
+  const selectedWorkflowValue = (formContext?.formData as any)?.buildAndDeploy
+    ?.workflow_name as { kind?: WorkflowKind; name?: string } | undefined;
 
   // Determine CTD kind from ui:options so we can treat all workflows for
   // ClusterComponentType as ClusterWorkflows.

--- a/packages/app/src/scaffolder/GitSourceField/GitSourceField.tsx
+++ b/packages/app/src/scaffolder/GitSourceField/GitSourceField.tsx
@@ -93,10 +93,11 @@ export const GitSourceField = ({
   const catalogApi = useApi(catalogApiRef);
   const secretManagementEnabled = useSecretManagementEnabled();
 
-  // Read the selected workflow from formContext (object with kind and name)
-  const selectedWorkflow = formContext?.formData?.workflow_name as
-    | { kind?: string; name?: string }
-    | undefined;
+  // Read the selected workflow from formContext (object with kind and name).
+  // Build & Deploy fields are nested under `buildAndDeploy` (owned by
+  // BuildAndDeployField), so the sibling workflow lives there, not at the root.
+  const selectedWorkflow = (formContext?.formData as any)?.buildAndDeploy
+    ?.workflow_name as { kind?: string; name?: string } | undefined;
   const selectedWorkflowName =
     selectedWorkflow &&
     typeof selectedWorkflow === 'object' &&


### PR DESCRIPTION
  The #619 refactor nested Build & Deploy fields under buildAndDeploy, but
  GitSourceField and BuildWorkflowParameters still read workflow_name from the
  form root. Source repo details and workflow parameters never rendered as a
  result. Read from formData.buildAndDeploy.workflow_name instead.

https://github.com/user-attachments/assets/72b03e65-a209-46f8-98a4-7bfd3198034b



