### PR TITLE
ci: bump all package.json versions in prepare-next-version

### DIFF
--- a/.github/workflows/prepare-next-version.yml
+++ b/.github/workflows/prepare-next-version.yml
@@ -84,17 +84,75 @@ jobs:
           fi
           echo "VERSION=${VER}" >> $GITHUB_ENV
 
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: 'yarn'
+
       - name: Create version bump branch and PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PRE_RELEASE_ID: ${{ github.event.inputs.pre_release_id }}
         run: |
           BRANCH="release-next-v${{ env.VERSION }}"
 
           git fetch origin "${{ env.TARGET }}"
           git checkout -b "${BRANCH}" "origin/${{ env.TARGET }}"
 
+          # 1. Write VERSION (source of truth validated by release-orchestrator)
           echo "${{ env.VERSION }}" > VERSION
-          git add VERSION
+
+          # 2. Install so changeset + scripts can run
+          yarn install --immutable
+
+          # 3. Pre-release mode lifecycle. A single `pre enter` (constant tag
+          #    'next') spans every milestone of a release line; the milestone
+          #    identifier (m1, m2, ...) comes from the clean VERSION override
+          #    below, not from the changesets tag. pre.json keeps the queued
+          #    .changeset/*.md files on disk until the stable cut.
+          PRE_JSON=".changeset/pre.json"
+          IN_PRE_MODE="false"
+          if [ -f "$PRE_JSON" ] && [ "$(jq -r '.mode' "$PRE_JSON" 2>/dev/null)" = "pre" ]; then
+            IN_PRE_MODE="true"
+          fi
+          if [ -n "${PRE_RELEASE_ID}" ]; then
+            if [ "$IN_PRE_MODE" = "false" ]; then
+              echo "Entering pre-release mode (tag: next)"
+              yarn changeset pre enter next
+            else
+              echo "Already in pre-release mode; skipping 'pre enter'"
+            fi
+          else
+            if [ "$IN_PRE_MODE" = "true" ]; then
+              echo "Exiting pre-release mode before stable consume"
+              yarn changeset pre exit
+            fi
+          fi
+
+          # 4. Consume changesets: writes CHANGELOG entries and maintains
+          #    pre.json bookkeeping (so the same changeset isn't re-applied next
+          #    milestone). The version string it emits (e.g. 1.2.0-next.N) is
+          #    intentionally discarded by the override in step 5.
+          yarn changeset version
+
+          # 5. Override every package.json (+ private root) to the exact clean
+          #    VERSION so the tag, VERSION file, and published versions all match.
+          node scripts/set-version.js "${{ env.VERSION }}"
+
+          # 6. On the stable cut, drop pre.json so the next line starts fresh.
+          if [ -z "${PRE_RELEASE_ID}" ] && [ -f "$PRE_JSON" ]; then
+            rm -f "$PRE_JSON"
+          fi
+
+          # 7. Normalize formatting (matches release:version) + refresh lockfile.
+          yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' 'package.json' || true
+          yarn install --mode=update-lockfile
+
+          # 8. Stage everything: VERSION, all package.json, CHANGELOGs, .changeset
+          #    changes (pre.json create/update/remove, .md removals at the stable
+          #    cut), and the lockfile.
+          git add -A VERSION package.json yarn.lock .changeset packages plugins
           git diff --staged --quiet || git commit -s -m "chore: bump version to ${{ env.VERSION }}"
 
           git push --force-with-lease origin "${BRANCH}"
@@ -109,6 +167,6 @@ jobs:
               --base "${{ env.TARGET }}" \
               --head "${BRANCH}" \
               --title "${PR_TITLE}" \
-              --body "Bump to next development version ${{ env.VERSION }}. Before merging, add a \`${{ env.VERSION }}\` section header to \`CHANGELOG.md\` if this is a new release." \
+              --body "Bump to ${{ env.VERSION }}. The \`VERSION\` file, every \`package.json\` (including the root), and the \`CHANGELOG.md\` files were updated automatically. For pre-releases the queued \`.changeset/*.md\` files stay in place (tracked in \`.changeset/pre.json\`) and are consumed only at the stable cut, which writes the consolidated changelog." \
               --label "type/release"
           fi

--- a/scripts/set-version.js
+++ b/scripts/set-version.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/**
+ * Set Version Script
+ *
+ * Forces the top-level `version` field of the root package.json and every
+ * workspace package.json (packages/* and plugins/*) to an exact value.
+ *
+ * Used by prepare-next-version.yml AFTER `changeset version` has written
+ * CHANGELOG entries and maintained .changeset/pre.json bookkeeping. In
+ * pre-release mode Changesets computes a version like 1.2.0-next.0; we discard
+ * that string and stamp the exact, clean version from the VERSION file (e.g.
+ * 1.2.0-m1) so the downstream release-orchestrator "Validate VERSION file"
+ * check passes and the git tag / npm publish use the milestone identifier the
+ * operator chose.
+ *
+ * Only the top-level `version` field is rewritten. Internal @openchoreo/* deps
+ * use `workspace:^`, which `changeset version` never rewrites and which Yarn
+ * resolves to concrete versions at publish time, so dependency specifiers are
+ * left untouched — with a defensive rewrite for any non-workspace internal pin
+ * (a no-op today, future-proofing against someone pinning an internal dep).
+ *
+ * Usage: node scripts/set-version.js <version>
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.join(__dirname, '..');
+const DEP_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+const VERSION = process.argv[2];
+if (!VERSION || !/^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/.test(VERSION)) {
+  console.error(`ERROR: invalid or missing version argument: "${VERSION}"`);
+  console.error('Usage: node scripts/set-version.js <version>');
+  process.exit(1);
+}
+
+/**
+ * Find all package.json files in the monorepo (root + packages/* + plugins/*)
+ */
+function findPackageJsonFiles() {
+  const files = [path.join(ROOT_DIR, 'package.json')];
+
+  const dirs = ['packages', 'plugins'];
+  for (const dir of dirs) {
+    const dirPath = path.join(ROOT_DIR, dir);
+    if (fs.existsSync(dirPath)) {
+      const subdirs = fs.readdirSync(dirPath, { withFileTypes: true });
+      for (const subdir of subdirs) {
+        if (subdir.isDirectory()) {
+          const pkgPath = path.join(dirPath, subdir.name, 'package.json');
+          if (fs.existsSync(pkgPath)) {
+            files.push(pkgPath);
+          }
+        }
+      }
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Main function
+ */
+function main() {
+  console.log(`Set Version to ${VERSION}\n`);
+
+  const packageFiles = findPackageJsonFiles();
+  console.log(`Found ${packageFiles.length} package.json files\n`);
+
+  let changed = 0;
+
+  for (const pkgPath of packageFiles) {
+    const relativePath = path.relative(ROOT_DIR, pkgPath);
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    let dirty = false;
+
+    if (pkg.version !== VERSION) {
+      pkg.version = VERSION;
+      dirty = true;
+    }
+
+    // Defensive: rewrite any internal @openchoreo/* dep that pins a concrete
+    // version (NOT workspace:/link:) to ^VERSION. No-op today (all workspace:^).
+    for (const field of DEP_FIELDS) {
+      const deps = pkg[field];
+      if (!deps) continue;
+      for (const [name, range] of Object.entries(deps)) {
+        if (!name.startsWith('@openchoreo/')) continue;
+        if (range.startsWith('workspace:') || range.startsWith('link:')) continue;
+        const next = `^${VERSION}`;
+        if (deps[name] !== next) {
+          deps[name] = next;
+          dirty = true;
+        }
+      }
+    }
+
+    if (dirty) {
+      // Preserve 2-space indent + trailing newline (matches repo convention;
+      // prettier runs afterward to normalize anyway).
+      fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+      changed++;
+      console.log(`   set ${relativePath} -> ${VERSION}`);
+    }
+  }
+
+  console.log(`\nset-version: updated ${changed} package.json file(s) to ${VERSION}`);
+}
+
+main();


### PR DESCRIPTION
  Stamp the resolved VERSION into the root and every workspace
  package.json, and accumulate CHANGELOGs, via changesets pre-release
  mode so queued changesets stay on disk until the stable cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to improve versioning consistency across packages during version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->