### PR TITLE
fix(auth): include configured scope in token exchange and refresh flows

### DIFF
--- a/.changeset/fix-auth-scope-frontend-exposure.md
+++ b/.changeset/fix-auth-scope-frontend-exposure.md
@@ -1,0 +1,6 @@
+---
+'@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth': patch
+'@openchoreo/backstage-plugin-common': patch
+---
+
+Fix OAuth scopes in the auth code flow: inject configured scope into the passport-oauth2 token exchange and refresh, and expose the scope to the frontend client via `openchoreo.features.auth.scope` so sign-in and session refresh requests use the operator-configured scope instead of hardcoded defaults.

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -216,6 +216,8 @@ openchoreo:
     # When disabled (false), users are automatically logged in as guests (no OAuth required)
     auth:
       enabled: ${OPENCHOREO_FEATURES_AUTH_ENABLED}
+      # Must match auth.providers.openchoreo-auth.development.scope
+      scope: ${OPENCHOREO_AUTH_OIDC_SCOPE}
     # Authorization configuration (Access Control)
     # When disabled, hides Access Control sidebar item and pages
     authz:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -203,6 +203,8 @@ openchoreo:
     # When disabled (false), users are automatically logged in as guests (no OAuth required)
     auth:
       enabled: ${OPENCHOREO_FEATURES_AUTH_ENABLED}
+      # Must match auth.providers.openchoreo-auth.development.scope
+      scope: 'openid profile email'
     # Authorization configuration (Access Control)
     # When disabled, hides Access Control sidebar item and pages
     authz:

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -144,8 +144,17 @@ export const apis: AnyApiFactory[] = [
       oauthRequestApi: oauthRequestApiRef,
       configApi: configApiRef,
     },
-    factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
-      OAuth2.create({
+    factory: ({ discoveryApi, oauthRequestApi, configApi }) => {
+      const env =
+        configApi.getOptionalString('auth.environment') ?? 'development';
+      const scopeStr = configApi.getOptionalString(
+        'openchoreo.features.auth.scope',
+      );
+      const scopes = scopeStr?.split(/\s+/).filter(Boolean) ?? [];
+      const defaultScopes = scopes.length
+        ? scopes
+        : ['openid', 'profile', 'email'];
+      return OAuth2.create({
         discoveryApi,
         oauthRequestApi,
         configApi,
@@ -154,9 +163,10 @@ export const apis: AnyApiFactory[] = [
           title: 'OpenChoreo',
           icon: () => null,
         },
-        environment: configApi.getOptionalString('auth.environment'),
-        defaultScopes: ['openid', 'profile', 'email'],
-      }),
+        environment: env,
+        defaultScopes,
+      });
+    },
   }),
   createApiFactory({
     api: visitsApiRef,

--- a/plugins/auth-backend-module-openchoreo-auth/config.d.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/config.d.ts
@@ -1,0 +1,15 @@
+export interface Config {
+  auth?: {
+    providers?: {
+      'openchoreo-auth'?: {
+        [environment: string]: {
+          /**
+           * OAuth2 scopes to request from the identity provider.
+           * Space-separated list, e.g. 'openid profile email groups offline_access'.
+           */
+          scope?: string;
+        };
+      };
+    };
+  };
+}

--- a/plugins/auth-backend-module-openchoreo-auth/package.json
+++ b/plugins/auth-backend-module-openchoreo-auth/package.json
@@ -21,6 +21,7 @@
     "pluginId": "auth",
     "pluginPackage": "@backstage/plugin-auth-backend"
   },
+  "configSchema": "config.d.ts",
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",
@@ -47,6 +48,7 @@
     "@types/passport-oauth2": "1.8.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ]
 }

--- a/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.ts
@@ -236,6 +236,22 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
       },
     );
 
+    // passport-oauth2 omits scope from the authorization-code token exchange by default.
+    // Some IdPs require it; without it they return a token scoped to the client defaults
+    // rather than what was requested in /authorize.
+    const oauth2 = (strategy as any)._oauth2;
+    const origGetOAuthAccessToken = oauth2.getOAuthAccessToken.bind(oauth2);
+    oauth2.getOAuthAccessToken = function getOAuthAccessToken(
+      code: string,
+      params: any,
+      callback: any,
+    ) {
+      if (params?.grant_type === 'authorization_code') {
+        params.scope = scope;
+      }
+      return origGetOAuthAccessToken(code, params, callback);
+    };
+
     return { helper: PassportOAuthAuthenticatorHelper.from(strategy), scope };
   },
 
@@ -255,7 +271,7 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
     return { fullProfile, session };
   },
 
-  async refresh(input, { helper }) {
+  async refresh(input, { helper, scope }) {
     const { refreshToken } = input;
 
     // Check if this is our pseudo-refresh token
@@ -313,7 +329,9 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
       return result;
     }
 
-    // Fallback to default refresh behavior
-    return helper.refresh(input);
+    // Use config scope directly, same as start() does.
+    // The frontend always sends hardcoded 'openid profile email' which doesn't
+    // reflect the full scope configured for this provider.
+    return helper.refresh({ ...input, scope });
   },
 });

--- a/plugins/openchoreo-common/config.d.ts
+++ b/plugins/openchoreo-common/config.d.ts
@@ -77,6 +77,15 @@ export interface Config {
          * @visibility frontend
          */
         enabled?: boolean;
+
+        /**
+         * OAuth scopes to request during sign-in and session refresh.
+         * Must match the scopes configured in auth.providers.openchoreo-auth.<env>.scope.
+         * Exposed here so the frontend OAuth2 client uses the same scope set as the backend.
+         * Example: 'openid profile email groups offline_access'
+         * @visibility frontend
+         */
+        scope?: string;
       };
 
       /**


### PR DESCRIPTION
### Purpose

Root cause: passport-oauth2 omits scope from the authorization-code token exchange
by default, causing the IdP to return a token scoped to client defaults rather than
the configured scope. Additionally, the frontend OAuth2 client hardcoded
'openid profile email' as its default scopes instead of using the operator-configured
scope set.

Backend fixes:
- Monkey-patch _oauth2.getOAuthAccessToken to inject the configured scope into the
  authorization-code token exchange (passport-oauth2 omits it by default).
- Thread config scope through the refresh() handler so it overrides the
  frontend-supplied scope on every session refresh.
- Initialize strategy with the configured scope so start() passes it to the
  authorization URL.

Frontend fix:
- Add openchoreo.features.auth.scope (@visibility frontend) to the openchoreo-common
  config schema so the value is included in the frontend config bundle.
- Set openchoreo.features.auth.scope: ${OPENCHOREO_AUTH_OIDC_SCOPE} in
  app-config.production.yaml (mirrors auth.providers.openchoreo-auth.development.scope).
- The frontend OAuth2.create() factory now reads openchoreo.features.auth.scope for
  defaultScopes, falling back to 'openid profile email' if unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OAuth/OIDC scope support for the OpenChoreo authentication flow, allowing administrators to set environment-specific scopes (including a new `openchoreo.features.auth.scope` setting) to match backend configuration.

* **Bug Fixes**
  * Fixed the OAuth authentication flow so the configured scope is consistently applied during both authorization-code sign-in and session refresh, rather than relying on hardcoded/default scope values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->