### PR TITLE
fix: fix `Add Trait` button not getting enabled in yaml view

### DIFF
--- a/.changeset/enable-add-trait-button-in-yaml-view.md
+++ b/.changeset/enable-add-trait-button-in-yaml-view.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin-react': patch
+---
+
+Fix the "Add Trait" / "Update Trait" button staying disabled in the YAML
+view of the trait dialogs even after the user has filled in every
+required field. `TraitConfigToggle` now propagates each YAML edit to
+the parent (debounced 150 ms; flushed synchronously on blur and when
+switching to form view), so schema-validity recomputes as the user
+types instead of only on focus loss.

--- a/.changeset/json-schema-yaml-utils.md
+++ b/.changeset/json-schema-yaml-utils.md
@@ -1,0 +1,14 @@
+---
+'@openchoreo/backstage-plugin-react': patch
+---
+
+Add JSON Schema → annotated YAML utilities (`buildYamlString`,
+`buildYamlData`, `generateDefaults`) for editors that toggle between a
+structured form and a raw YAML view. `buildYamlString` walks the schema
+recursively so nested required scalars get a `# required` hint and
+enum-constrained scalars get `# allowed: <values>`; `allOf` composition,
+nullable type arrays (`["object", "null"]`), and non-string enum values
+are handled. `TraitConfigToggle` now delegates to these helpers in
+place of its previous single-level annotation, so deeply-required and
+enum fields in trait schemas surface their constraints in the YAML
+view.

--- a/plugins/openchoreo-observability/src/components/Wirelogs/styles.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/styles.ts
@@ -123,7 +123,7 @@ export const useWirelogsTableStyles = makeStyles(theme => ({
     letterSpacing: 0.5,
     textTransform: 'uppercase',
     color: theme.palette.text.secondary,
-    padding: theme.spacing(0.75, 1.5),
+    padding: theme.spacing(1.5),
     whiteSpace: 'nowrap',
     minWidth: 0,
     boxSizing: 'border-box',

--- a/plugins/openchoreo-react/src/components/TraitConfigToggle/TraitConfigToggle.tsx
+++ b/plugins/openchoreo-react/src/components/TraitConfigToggle/TraitConfigToggle.tsx
@@ -3,97 +3,8 @@ import { FormYamlToggle } from '@openchoreo/backstage-design-system';
 import { JSONSchema7 } from 'json-schema';
 import YAML from 'yaml';
 import { YamlEditor } from '../YamlEditor';
+import { buildYamlString } from '../../utils/jsonSchemaYaml';
 import { useStyles } from './styles';
-
-/**
- * Generate a default object from a JSON Schema by walking its properties
- * and using `default` values where specified, or type-appropriate placeholders.
- */
-function generateDefaults(schema: JSONSchema7): Record<string, any> {
-  if (schema.type !== 'object' || !schema.properties) {
-    return {};
-  }
-
-  const result: Record<string, any> = {};
-
-  for (const [key, propDef] of Object.entries(schema.properties)) {
-    if (typeof propDef === 'boolean') continue;
-
-    if (propDef.default !== undefined) {
-      result[key] = propDef.default;
-    } else {
-      switch (propDef.type) {
-        case 'string':
-          result[key] = '';
-          break;
-        case 'number':
-        case 'integer':
-          result[key] = 0;
-          break;
-        case 'boolean':
-          result[key] = false;
-          break;
-        case 'array':
-          result[key] = [];
-          break;
-        case 'object':
-          result[key] = generateDefaults(propDef);
-          break;
-        default:
-          result[key] = null;
-          break;
-      }
-    }
-  }
-
-  return result;
-}
-
-/**
- * Merge schema defaults with actual form data so that every schema property
- * appears in the YAML, but user-provided values take precedence.
- * Strips undefined values from formData so that cleared fields fall back
- * to schema defaults rather than overwriting them with undefined.
- */
-function buildYamlData(
-  schema: JSONSchema7 | undefined,
-  formData: Record<string, any>,
-): Record<string, any> {
-  if (!schema) return formData || {};
-  const defaults = generateDefaults(schema);
-  const cleanData = Object.fromEntries(
-    Object.entries(formData || {}).filter(([_, v]) => v !== undefined),
-  );
-  return { ...defaults, ...cleanData };
-}
-
-/**
- * Build a YAML string from merged data, annotating required fields with
- * an inline `# required` comment so the user knows what must be filled in.
- */
-function buildYamlString(
-  schema: JSONSchema7 | undefined,
-  formData: Record<string, any>,
-): string {
-  const data = buildYamlData(schema, formData);
-  const doc = new YAML.Document(data);
-
-  if (schema?.required && doc.contents && 'items' in doc.contents) {
-    const requiredSet = new Set(schema.required);
-    for (const item of (doc.contents as YAML.YAMLMap).items) {
-      if (
-        YAML.isScalar(item.key) &&
-        typeof item.key.value === 'string' &&
-        requiredSet.has(item.key.value) &&
-        YAML.isScalar(item.value)
-      ) {
-        item.value.comment = ' required';
-      }
-    }
-  }
-
-  return doc.toString({ indent: 2 });
-}
 
 export interface TraitConfigToggleProps {
   schema?: JSONSchema7;
@@ -174,14 +85,16 @@ export const TraitConfigToggle = ({
       if (parsed) {
         setYamlError(undefined);
         onValidityChange?.(true);
-        // Don't call onChange here — propagate only on blur to avoid
-        // re-rendering the entire parent form on every keystroke.
+        // Propagate per keystroke so the parent can recompute schema validity
+        // (e.g. enabling Save/Add when required fields become non-empty).
+        // The RjsfForm child is unmounted in YAML mode, so this is cheap.
+        onChange(parsed);
       } else {
         setYamlError('Invalid YAML: must be a valid YAML object');
         onValidityChange?.(false);
       }
     },
-    [onValidityChange, parseYaml],
+    [onChange, onValidityChange, parseYaml],
   );
 
   /** Flush valid YAML to the parent when focus leaves the editor container. */

--- a/plugins/openchoreo-react/src/components/TraitConfigToggle/TraitConfigToggle.tsx
+++ b/plugins/openchoreo-react/src/components/TraitConfigToggle/TraitConfigToggle.tsx
@@ -60,6 +60,20 @@ export const TraitConfigToggle = ({
   );
 
   /**
+   * Drop any scheduled debounced flush and forget the buffered parse
+   * result.  Called when we no longer want the pending value to reach
+   * the parent — e.g. when the YAML has just become invalid, so the
+   * last-known-good parse no longer represents the editor's content.
+   */
+  const cancelPendingFlush = useCallback(() => {
+    if (flushTimer.current !== null) {
+      clearTimeout(flushTimer.current);
+      flushTimer.current = null;
+    }
+    pendingParsed.current = null;
+  }, []);
+
+  /**
    * Send the latest parsed YAML to the parent right now, skipping the
    * debounce wait.
    *
@@ -72,16 +86,12 @@ export const TraitConfigToggle = ({
    * a no-op.
    */
   const sendPendingChangeNow = useCallback(() => {
-    if (flushTimer.current !== null) {
-      clearTimeout(flushTimer.current);
-      flushTimer.current = null;
-    }
     const buffered = pendingParsed.current;
+    cancelPendingFlush();
     if (buffered !== null) {
-      pendingParsed.current = null;
       onChange(buffered);
     }
-  }, [onChange]);
+  }, [onChange, cancelPendingFlush]);
 
   // Clear the debounce timer on unmount so we don't onChange into a
   // gone-away parent.
@@ -148,9 +158,12 @@ export const TraitConfigToggle = ({
       } else {
         setYamlError('Invalid YAML: must be a valid YAML object');
         onValidityChange?.(false);
+        // The last valid parse no longer matches the editor text — drop
+        // it so a pending debounce can't push stale data to the parent.
+        cancelPendingFlush();
       }
     },
-    [onChange, onValidityChange, parseYaml],
+    [onChange, onValidityChange, parseYaml, cancelPendingFlush],
   );
 
   /** Flush valid YAML to the parent when focus leaves the editor container. */

--- a/plugins/openchoreo-react/src/components/TraitConfigToggle/TraitConfigToggle.tsx
+++ b/plugins/openchoreo-react/src/components/TraitConfigToggle/TraitConfigToggle.tsx
@@ -1,10 +1,20 @@
-import { useState, useCallback, useRef, ReactNode } from 'react';
+import { useState, useCallback, useEffect, useRef, ReactNode } from 'react';
 import { FormYamlToggle } from '@openchoreo/backstage-design-system';
 import { JSONSchema7 } from 'json-schema';
 import YAML from 'yaml';
 import { YamlEditor } from '../YamlEditor';
 import { buildYamlString } from '../../utils/jsonSchemaYaml';
 import { useStyles } from './styles';
+
+/**
+ * How long to coalesce keystrokes before pushing the parsed YAML to the
+ * parent.  The parent typically re-runs ajv schema validation in a
+ * useEffect keyed on `parameters`, which is non-trivial for big schemas —
+ * debouncing keeps typing responsive while still flushing well before the
+ * user can act on a disabled Save/Add button (focus loss flushes
+ * immediately, see `handleYamlBlur`).
+ */
+const FLUSH_DEBOUNCE_MS = 150;
 
 export interface TraitConfigToggleProps {
   schema?: JSONSchema7;
@@ -29,6 +39,10 @@ export const TraitConfigToggle = ({
   );
   const [yamlError, setYamlError] = useState<string | undefined>();
 
+  /** Pending debounced flush — timer id and the parsed value waiting to ship. */
+  const flushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingParsed = useRef<Record<string, any> | null>(null);
+
   /** Try to parse YAML content; returns the parsed object or undefined on failure. */
   const parseYaml = useCallback(
     (content: string): Record<string, any> | undefined => {
@@ -45,6 +59,38 @@ export const TraitConfigToggle = ({
     [],
   );
 
+  /**
+   * Send the latest parsed YAML to the parent right now, skipping the
+   * debounce wait.
+   *
+   * Normally `handleYamlChange` waits FLUSH_DEBOUNCE_MS after the last
+   * keystroke before calling `onChange`.  At certain moments — focus
+   * leaving the editor (the user is about to click Save/Add), switching
+   * to form view (the form reads from parent state) — that wait is too
+   * long, so we cancel the timer and call `onChange` immediately with
+   * whatever the latest parse produced.  If no edit is pending, this is
+   * a no-op.
+   */
+  const sendPendingChangeNow = useCallback(() => {
+    if (flushTimer.current !== null) {
+      clearTimeout(flushTimer.current);
+      flushTimer.current = null;
+    }
+    const buffered = pendingParsed.current;
+    if (buffered !== null) {
+      pendingParsed.current = null;
+      onChange(buffered);
+    }
+  }, [onChange]);
+
+  // Clear the debounce timer on unmount so we don't onChange into a
+  // gone-away parent.
+  useEffect(() => {
+    return () => {
+      if (flushTimer.current !== null) clearTimeout(flushTimer.current);
+    };
+  }, []);
+
   const handleModeChange = useCallback(
     (newMode: 'form' | 'yaml') => {
       if (newMode === mode) return;
@@ -57,7 +103,8 @@ export const TraitConfigToggle = ({
         // Switching to form — block if YAML is invalid
         const parsed = parseYaml(yamlContent);
         if (parsed) {
-          onChange(parsed);
+          pendingParsed.current = parsed;
+          sendPendingChangeNow();
           setYamlError(undefined);
           onValidityChange?.(true);
         } else {
@@ -72,9 +119,9 @@ export const TraitConfigToggle = ({
       schema,
       formData,
       yamlContent,
-      onChange,
       onValidityChange,
       parseYaml,
+      sendPendingChangeNow,
     ],
   );
 
@@ -85,10 +132,19 @@ export const TraitConfigToggle = ({
       if (parsed) {
         setYamlError(undefined);
         onValidityChange?.(true);
-        // Propagate per keystroke so the parent can recompute schema validity
-        // (e.g. enabling Save/Add when required fields become non-empty).
-        // The RjsfForm child is unmounted in YAML mode, so this is cheap.
-        onChange(parsed);
+        // Coalesce keystrokes — see FLUSH_DEBOUNCE_MS doc.  Blur and mode
+        // switch flush synchronously so disabled-button state can't lag
+        // behind the user.
+        pendingParsed.current = parsed;
+        if (flushTimer.current !== null) clearTimeout(flushTimer.current);
+        flushTimer.current = setTimeout(() => {
+          flushTimer.current = null;
+          if (pendingParsed.current !== null) {
+            const next = pendingParsed.current;
+            pendingParsed.current = null;
+            onChange(next);
+          }
+        }, FLUSH_DEBOUNCE_MS);
       } else {
         setYamlError('Invalid YAML: must be a valid YAML object');
         onValidityChange?.(false);
@@ -110,12 +166,9 @@ export const TraitConfigToggle = ({
       ) {
         return;
       }
-      const parsed = parseYaml(yamlContent);
-      if (parsed) {
-        onChange(parsed);
-      }
+      sendPendingChangeNow();
     },
-    [yamlContent, parseYaml, onChange],
+    [sendPendingChangeNow],
   );
 
   return (

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -509,6 +509,11 @@ export {
   pickRangeForAge,
 } from './utils/timeUtils';
 export {
+  buildYamlString,
+  buildYamlData,
+  generateDefaults,
+} from './utils/jsonSchemaYaml';
+export {
   deepCompareObjects,
   formatChangeValue,
   getChangeStats,

--- a/plugins/openchoreo-react/src/utils/jsonSchemaYaml.ts
+++ b/plugins/openchoreo-react/src/utils/jsonSchemaYaml.ts
@@ -1,0 +1,175 @@
+/**
+ * JSON Schema → annotated YAML helpers.
+ *
+ * Used by editors that let a user toggle between a structured form and a raw
+ * YAML view of the same data.  `buildYamlString` serializes form data into
+ * YAML with inline hints (`# required`, `# allowed: ...`) so the YAML view
+ * carries the same affordances as the form.  The helpers are framework- and
+ * domain-agnostic — they know nothing about traits, workloads, or Backstage.
+ */
+import { JSONSchema7 } from 'json-schema';
+import YAML from 'yaml';
+
+/**
+ * Generate a default object from a JSON Schema by walking its properties and
+ * using `default` values where specified, or type-appropriate placeholders.
+ */
+export function generateDefaults(schema: JSONSchema7): Record<string, any> {
+  if (schema.type !== 'object' || !schema.properties) {
+    return {};
+  }
+
+  const result: Record<string, any> = {};
+
+  for (const [key, propDef] of Object.entries(schema.properties)) {
+    if (typeof propDef === 'boolean') continue;
+
+    if (propDef.default !== undefined) {
+      result[key] = propDef.default;
+      continue;
+    }
+
+    switch (propDef.type) {
+      case 'string':
+        result[key] = '';
+        break;
+      case 'number':
+      case 'integer':
+        result[key] = 0;
+        break;
+      case 'boolean':
+        result[key] = false;
+        break;
+      case 'array':
+        result[key] = [];
+        break;
+      case 'object':
+        result[key] = generateDefaults(propDef);
+        break;
+      default:
+        result[key] = null;
+        break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Merge schema defaults with form data so every schema property appears in
+ * the YAML, but user-provided values take precedence.  Strips `undefined`
+ * from form data so cleared fields fall back to defaults instead of
+ * overwriting them with `undefined`.
+ */
+export function buildYamlData(
+  schema: JSONSchema7 | undefined,
+  formData: Record<string, any>,
+): Record<string, any> {
+  if (!schema) return formData ?? {};
+  const defaults = generateDefaults(schema);
+  const cleanData = Object.fromEntries(
+    Object.entries(formData ?? {}).filter(([, v]) => v !== undefined),
+  );
+  return { ...defaults, ...cleanData };
+}
+
+/** Format a single enum value for the `# allowed: ...` comment. */
+function formatEnumValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return value;
+  return String(value);
+}
+
+/**
+ * Build the inline comment for a property: `required`, `allowed: a, b, c`,
+ * or both joined by `; `.  Returns `undefined` when there is nothing to
+ * annotate.
+ */
+function buildPropertyComment(
+  propSchema: JSONSchema7,
+  isRequired: boolean,
+): string | undefined {
+  const parts: string[] = [];
+  if (isRequired) parts.push('required');
+  if (Array.isArray(propSchema.enum) && propSchema.enum.length > 0) {
+    parts.push(`allowed: ${propSchema.enum.map(formatEnumValue).join(', ')}`);
+  }
+  return parts.length > 0 ? ` ${parts.join('; ')}` : undefined;
+}
+
+/** True when `items` is a single sub-schema we can recurse into. */
+function isObjectSchema(value: unknown): value is JSONSchema7 {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively annotate a YAML map with `# required` / `# allowed: ...`
+ * comments based on the matching object schema.  Only scalar leaves are
+ * annotated — non-leaf keys are skipped because the user doesn't type a
+ * value there, so labelling them as "required" would just be noise.
+ * Nested maps and array items are walked so deeply-required leaves are
+ * still reached.
+ */
+function annotateMap(map: YAML.YAMLMap, schema: JSONSchema7): void {
+  if (!schema.properties) return;
+  const requiredSet = new Set(schema.required ?? []);
+
+  for (const pair of map.items) {
+    if (!YAML.isScalar(pair.key) || typeof pair.key.value !== 'string') {
+      continue;
+    }
+    const propSchema = schema.properties[pair.key.value];
+    if (!propSchema || typeof propSchema === 'boolean') continue;
+
+    if (YAML.isScalar(pair.value)) {
+      const comment = buildPropertyComment(
+        propSchema,
+        requiredSet.has(pair.key.value),
+      );
+      if (comment) pair.value.comment = comment;
+    } else if (YAML.isMap(pair.value) && propSchema.type === 'object') {
+      annotateMap(pair.value, propSchema);
+    } else if (
+      YAML.isSeq(pair.value) &&
+      propSchema.type === 'array' &&
+      isObjectSchema(propSchema.items)
+    ) {
+      annotateSeq(pair.value, propSchema.items);
+    }
+  }
+}
+
+/** Recursively annotate items in a YAML sequence against the array item schema. */
+function annotateSeq(seq: YAML.YAMLSeq, itemsSchema: JSONSchema7): void {
+  for (const item of seq.items) {
+    if (YAML.isMap(item) && itemsSchema.type === 'object') {
+      annotateMap(item, itemsSchema);
+    } else if (
+      YAML.isSeq(item) &&
+      itemsSchema.type === 'array' &&
+      isObjectSchema(itemsSchema.items)
+    ) {
+      annotateSeq(item, itemsSchema.items);
+    }
+  }
+}
+
+/**
+ * Build a YAML string from form data, annotating required scalar fields with
+ * `# required` and enum-constrained scalars with `# allowed: <values>` so the
+ * user knows what must be filled in and which values are accepted.  The walk
+ * is recursive, so nested objects and array items are covered.
+ */
+export function buildYamlString(
+  schema: JSONSchema7 | undefined,
+  formData: Record<string, any>,
+): string {
+  const data = buildYamlData(schema, formData);
+  const doc = new YAML.Document(data);
+
+  if (schema && YAML.isMap(doc.contents)) {
+    annotateMap(doc.contents, schema);
+  }
+
+  return doc.toString({ indent: 2 });
+}

--- a/plugins/openchoreo-react/src/utils/jsonSchemaYaml.ts
+++ b/plugins/openchoreo-react/src/utils/jsonSchemaYaml.ts
@@ -11,17 +11,68 @@ import { JSONSchema7 } from 'json-schema';
 import YAML from 'yaml';
 
 /**
+ * True when `value` is a plain object (not null, not an array).  Used to
+ * decide whether a value can be deep-merged or recursed into.
+ */
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * True when `schema.type` permits `type` — either as a bare string or as a
+ * member of a `["object", "null"]`-style array (nullable schemas, common in
+ * generated CRD / OpenAPI schemas).
+ */
+function schemaAllowsType(schema: JSONSchema7, type: string): boolean {
+  if (schema.type === type) return true;
+  return Array.isArray(schema.type) && (schema.type as string[]).includes(type);
+}
+
+/**
+ * Best-effort flattening of `allOf` composition: merges sub-schema properties
+ * and required keys into the parent so the rest of the walk can treat the
+ * result as a flat object schema.  `$ref`, `oneOf`, and `anyOf` are out of
+ * scope — schemas reaching this module are expected to be $ref-resolved.
+ */
+function flattenAllOf(schema: JSONSchema7): JSONSchema7 {
+  if (!schema.allOf || schema.allOf.length === 0) return schema;
+  let merged: JSONSchema7 = { ...schema };
+  for (const sub of schema.allOf) {
+    if (typeof sub !== 'object') continue;
+    const subFlat = flattenAllOf(sub);
+    merged = {
+      ...merged,
+      type: merged.type ?? subFlat.type,
+      properties: { ...subFlat.properties, ...merged.properties },
+      required: [...(merged.required ?? []), ...(subFlat.required ?? [])],
+    };
+  }
+  return merged;
+}
+
+/** Pick the first non-`null` type when the schema declares a type array. */
+function primaryType(schema: JSONSchema7): string | undefined {
+  if (typeof schema.type === 'string') return schema.type;
+  if (Array.isArray(schema.type)) {
+    return (schema.type as string[]).find(t => t !== 'null');
+  }
+  return undefined;
+}
+
+/**
  * Generate a default object from a JSON Schema by walking its properties and
  * using `default` values where specified, or type-appropriate placeholders.
+ * `allOf` branches are folded in so inherited properties get defaults too.
  */
 export function generateDefaults(schema: JSONSchema7): Record<string, any> {
-  if (schema.type !== 'object' || !schema.properties) {
+  const flat = flattenAllOf(schema);
+  if (!schemaAllowsType(flat, 'object') || !flat.properties) {
     return {};
   }
 
   const result: Record<string, any> = {};
 
-  for (const [key, propDef] of Object.entries(schema.properties)) {
+  for (const [key, propDef] of Object.entries(flat.properties)) {
     if (typeof propDef === 'boolean') continue;
 
     if (propDef.default !== undefined) {
@@ -29,7 +80,7 @@ export function generateDefaults(schema: JSONSchema7): Record<string, any> {
       continue;
     }
 
-    switch (propDef.type) {
+    switch (primaryType(propDef)) {
       case 'string':
         result[key] = '';
         break;
@@ -56,28 +107,53 @@ export function generateDefaults(schema: JSONSchema7): Record<string, any> {
 }
 
 /**
- * Merge schema defaults with form data so every schema property appears in
- * the YAML, but user-provided values take precedence.  Strips `undefined`
- * from form data so cleared fields fall back to defaults instead of
- * overwriting them with `undefined`.
+ * Recursively merge form data on top of schema defaults so every required
+ * schema property appears in the YAML, even when the user has provided only
+ * a partial nested object.  Plain objects deep-merge; arrays are atomic
+ * (user data replaces the default empty array).  `undefined` at any depth
+ * falls back to the corresponding default.
+ */
+function deepMergeDefaults(
+  defaults: Record<string, any>,
+  data: Record<string, any>,
+): Record<string, any> {
+  const result: Record<string, any> = { ...defaults };
+  for (const [key, value] of Object.entries(data)) {
+    if (value === undefined) continue;
+    const defaultValue = result[key];
+    if (isPlainObject(defaultValue) && isPlainObject(value)) {
+      result[key] = deepMergeDefaults(defaultValue, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Build the data tree that will be serialized to YAML: schema defaults
+ * deep-merged with `formData` so every schema property is represented,
+ * but user-provided values take precedence at every depth.
  */
 export function buildYamlData(
   schema: JSONSchema7 | undefined,
   formData: Record<string, any>,
 ): Record<string, any> {
   if (!schema) return formData ?? {};
-  const defaults = generateDefaults(schema);
-  const cleanData = Object.fromEntries(
-    Object.entries(formData ?? {}).filter(([, v]) => v !== undefined),
-  );
-  return { ...defaults, ...cleanData };
+  return deepMergeDefaults(generateDefaults(schema), formData ?? {});
 }
 
-/** Format a single enum value for the `# allowed: ...` comment. */
+/**
+ * Format a single enum value for the `# allowed: ...` comment.  Non-string
+ * values go through `JSON.stringify` so objects/arrays render legibly;
+ * strings containing list separators (`,`, `#`) get quoted so the comment
+ * stays unambiguous.
+ */
 function formatEnumValue(value: unknown): string {
-  if (value === null) return 'null';
-  if (typeof value === 'string') return value;
-  return String(value);
+  if (typeof value === 'string') {
+    return /[,#"]/.test(value) ? JSON.stringify(value) : value;
+  }
+  return JSON.stringify(value);
 }
 
 /**
@@ -99,7 +175,7 @@ function buildPropertyComment(
 
 /** True when `items` is a single sub-schema we can recurse into. */
 function isObjectSchema(value: unknown): value is JSONSchema7 {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  return isPlainObject(value);
 }
 
 /**
@@ -111,14 +187,15 @@ function isObjectSchema(value: unknown): value is JSONSchema7 {
  * still reached.
  */
 function annotateMap(map: YAML.YAMLMap, schema: JSONSchema7): void {
-  if (!schema.properties) return;
-  const requiredSet = new Set(schema.required ?? []);
+  const flat = flattenAllOf(schema);
+  if (!flat.properties) return;
+  const requiredSet = new Set(flat.required ?? []);
 
   for (const pair of map.items) {
     if (!YAML.isScalar(pair.key) || typeof pair.key.value !== 'string') {
       continue;
     }
-    const propSchema = schema.properties[pair.key.value];
+    const propSchema = flat.properties[pair.key.value];
     if (!propSchema || typeof propSchema === 'boolean') continue;
 
     if (YAML.isScalar(pair.value)) {
@@ -127,11 +204,14 @@ function annotateMap(map: YAML.YAMLMap, schema: JSONSchema7): void {
         requiredSet.has(pair.key.value),
       );
       if (comment) pair.value.comment = comment;
-    } else if (YAML.isMap(pair.value) && propSchema.type === 'object') {
+    } else if (
+      YAML.isMap(pair.value) &&
+      schemaAllowsType(propSchema, 'object')
+    ) {
       annotateMap(pair.value, propSchema);
     } else if (
       YAML.isSeq(pair.value) &&
-      propSchema.type === 'array' &&
+      schemaAllowsType(propSchema, 'array') &&
       isObjectSchema(propSchema.items)
     ) {
       annotateSeq(pair.value, propSchema.items);
@@ -142,11 +222,11 @@ function annotateMap(map: YAML.YAMLMap, schema: JSONSchema7): void {
 /** Recursively annotate items in a YAML sequence against the array item schema. */
 function annotateSeq(seq: YAML.YAMLSeq, itemsSchema: JSONSchema7): void {
   for (const item of seq.items) {
-    if (YAML.isMap(item) && itemsSchema.type === 'object') {
+    if (YAML.isMap(item) && schemaAllowsType(itemsSchema, 'object')) {
       annotateMap(item, itemsSchema);
     } else if (
       YAML.isSeq(item) &&
-      itemsSchema.type === 'array' &&
+      schemaAllowsType(itemsSchema, 'array') &&
       isObjectSchema(itemsSchema.items)
     ) {
       annotateSeq(item, itemsSchema.items);


### PR DESCRIPTION
## Purpose

This PR add following changes:

1. Indicate required and enum related fields in trait schema in YAML view using comments
<img width="1910" height="1588" alt="image" src="https://github.com/user-attachments/assets/7e313e89-44c0-4d03-81e3-6f7aecf9c8e7" />

2. Fixed 'Add Trait' button not getting enabled in YAML view



https://github.com/user-attachments/assets/591f2ced-7f0b-4a65-8cb8-2bf87aa602c9

3. Fix wirelogs table header size to consistent with other tables

<img width="3000" height="694" alt="image" src="https://github.com/user-attachments/assets/201b2898-a873-425b-894a-1a9aaa519dfc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced YAML editor updates with debounced change propagation and automatic flush when leaving the editor or switching views.
  * Added public JSON Schema → YAML utilities to generate defaults, build YAML data, and produce YAML strings (including inline comment hints for required/enumerated fields).
* **Bug Fixes**
  * Resolved an issue where the “Add/Update Trait” button could remain disabled after completing required inputs in YAML view.
* **Style**
  * Updated wirelogs table cell padding to improve spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->