### PR TITLE
feat:add deployment status investigation support for portal assistant

### DIFF
--- a/.changeset/lazy-olives-repeat.md
+++ b/.changeset/lazy-olives-repeat.md
@@ -1,0 +1,6 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-portal-assistant-backend': patch
+'@openchoreo/backstage-plugin-openchoreo-portal-assistant': patch
+---
+
+Provide investigation support for deployment issues.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -75,6 +75,7 @@ import {
 
 import {
   Environments,
+  type RenderInvestigateAction,
   CellDiagram,
   DeploymentStatusCard,
   RuntimeHealthCard,
@@ -117,6 +118,7 @@ import { Workflows } from '@openchoreo/backstage-plugin-openchoreo-ci';
 import {
   FailedBuildSnackbar,
   InvestigateLogButton,
+  InvestigateDependencyButton,
 } from '@openchoreo/backstage-plugin-openchoreo-portal-assistant';
 import {
   WorkflowRunsContent,
@@ -158,6 +160,14 @@ const renderInvestigateLogAction: RenderLogRowAction = (
   log,
   getLogsSnapshot,
 ) => <InvestigateLogButton log={log} getLogsSnapshot={getLogsSnapshot} />;
+
+// Same pattern for the deploy panel: the openchoreo plugin exposes a
+// render-prop slot for a status-aware "Investigate with AI" button and the
+// shell injects perch's button here, so the openchoreo plugin owns no
+// dependency on perch.
+const renderInvestigateDependencyAction: RenderInvestigateAction = scope => (
+  <InvestigateDependencyButton {...scope} />
+);
 
 const PLATFORM_KIND_DISPLAY_NAMES: Record<string, string> = {
   domain: 'Namespace',
@@ -337,7 +347,9 @@ const serviceEntityPage = (
     </EntityLayout.Route>
 
     <EntityLayout.Route path="/environments" title="Deploy">
-      <Environments />
+      <Environments
+        renderInvestigateAction={renderInvestigateDependencyAction}
+      />
     </EntityLayout.Route>
 
     <EntityLayout.Route path="/runtime-logs" title="Logs">
@@ -444,7 +456,9 @@ const genericComponentEntityPage = (
     </EntityLayout.Route>
 
     <EntityLayout.Route path="/environments" title="Deploy">
-      <Environments />
+      <Environments
+        renderInvestigateAction={renderInvestigateDependencyAction}
+      />
     </EntityLayout.Route>
 
     <EntityLayout.Route path="/runtime-logs" title="Logs">

--- a/plugins/openchoreo-portal-assistant/src/api/PerchAgentApi.ts
+++ b/plugins/openchoreo-portal-assistant/src/api/PerchAgentApi.ts
@@ -28,7 +28,6 @@ export type PrefetchedLogEntry = {
 };
 
 /**
-/**
  * Discriminator the frontend launchers send to the agent so it can
  * layer in case-specific guidance.
  *
@@ -38,8 +37,16 @@ export type PrefetchedLogEntry = {
  *   up in returned log rows (or when ``pinnedLogTraceId`` is set
  *   from the row-level Investigate button) — there is no
  *   trace-page launcher; users start from the Logs tab.
+ * - ``dependency_pending``: Deploy tab / K8s-artifacts investigation
+ *   of a component stuck NotReady because an outbound endpoint
+ *   connection can't resolve (the depended-on component is undeployed
+ *   or not ready). The agent reads the binding's pending connections
+ *   and explains why each named dependency is down plus how to recover.
  */
-export type ChatCaseType = 'build_failure' | 'runtime_debug';
+export type ChatCaseType =
+  | 'build_failure'
+  | 'runtime_debug'
+  | 'dependency_pending';
 
 export type ChatScope = {
   namespace?: string;

--- a/plugins/openchoreo-portal-assistant/src/components/InvestigateDependencyButton/InvestigateDependencyButton.test.tsx
+++ b/plugins/openchoreo-portal-assistant/src/components/InvestigateDependencyButton/InvestigateDependencyButton.test.tsx
@@ -1,0 +1,230 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InvestigateDependencyButton } from './InvestigateDependencyButton';
+import type { ChatScope } from '../../api/PerchAgentApi';
+
+// Hoisted shared spies — Jest hoists jest.mock above imports, so the
+// factories below cannot close over outer variables. We dereference the
+// holder at call time instead. (Same pattern as InvestigateLogButton.test.)
+const holder: {
+  enabled: boolean;
+  openDrawer: jest.Mock;
+  warmup: jest.Mock;
+} = {
+  enabled: true,
+  openDrawer: jest.fn(),
+  warmup: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  // PerchAgentApi.ts calls createApiRef at module load — keep a real-ish
+  // stub so the import doesn't blow up during test setup.
+  createApiRef: (config: { id: string }) => ({ id: config.id }),
+  useApi: () => ({ warmup: (...args: unknown[]) => holder.warmup(...args) }),
+}));
+
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useAssistantEnabled: () => holder.enabled,
+}));
+
+jest.mock('../AssistantContext/AssistantDrawerContext', () => ({
+  useAssistantDrawer: () => ({
+    openDrawer: (...args: unknown[]) => holder.openDrawer(...args),
+  }),
+}));
+
+type DrawerCall = {
+  scopeOverrides: Partial<ChatScope>;
+  conversationKey: string;
+  suggestions?: string[];
+  initialMessage?: string;
+};
+
+const firstCall = () => holder.openDrawer.mock.calls[0][0] as DrawerCall;
+
+beforeEach(() => {
+  holder.enabled = true;
+  holder.openDrawer = jest.fn();
+  holder.warmup = jest.fn().mockResolvedValue(undefined);
+});
+
+describe('InvestigateDependencyButton', () => {
+  it('renders nothing when the assistant feature is disabled', () => {
+    holder.enabled = false;
+    const { container } = render(
+      <InvestigateDependencyButton
+        component="snip-frontend"
+        environment="development"
+        status="Pending"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the labelled button when enabled', () => {
+    render(
+      <InvestigateDependencyButton
+        component="snip-frontend"
+        status="Pending"
+      />,
+    );
+    const button = screen.getByRole('button', {
+      name: /investigate this with portal assistant/i,
+    });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Investigate with AI');
+  });
+
+  it('opens the drawer with a status-aware dependency_pending suggestion chip', () => {
+    render(
+      <InvestigateDependencyButton
+        namespace="default"
+        project="url-shortener"
+        component="snip-frontend"
+        environment="development"
+        caseType="dependency_pending"
+        status="Pending"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(holder.openDrawer).toHaveBeenCalledTimes(1);
+    const call = firstCall();
+    expect(call.scopeOverrides).toEqual({
+      caseType: 'dependency_pending',
+      namespace: 'default',
+      project: 'url-shortener',
+      component: 'snip-frontend',
+      environment: 'development',
+    });
+    expect(call.suggestions).toEqual([
+      "Why is snip-frontend's development deployment Pending?",
+      'Which dependency is it waiting on?',
+    ]);
+    // Suggestion path does not also pre-draft a composer message.
+    expect(call.initialMessage).toBeUndefined();
+    expect(call.conversationKey).toBe(
+      'dependency_pending:default:url-shortener:snip-frontend:development',
+    );
+  });
+
+  it('uses a root-cause follow-up suggestion for the runtime_debug case', () => {
+    render(
+      <InvestigateDependencyButton
+        namespace="default"
+        component="snip-frontend"
+        environment="development"
+        caseType="runtime_debug"
+        status="Failed"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    const call = firstCall();
+    expect(call.scopeOverrides.caseType).toBe('runtime_debug');
+    expect(call.suggestions).toEqual([
+      "Why is snip-frontend's development deployment Failed?",
+      'What is the root cause?',
+    ]);
+    expect(call.conversationKey.startsWith('runtime_debug:')).toBe(true);
+  });
+
+  it('defaults caseType to dependency_pending when not provided', () => {
+    render(
+      <InvestigateDependencyButton
+        component="snip-frontend"
+        status="Pending"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    const call = firstCall();
+    expect(call.scopeOverrides.caseType).toBe('dependency_pending');
+    // No environment → status suggestion omits the env segment.
+    expect(call.suggestions?.[0]).toBe(
+      "Why is snip-frontend's deployment Pending?",
+    );
+  });
+
+  it('omits scope fields that were not supplied', () => {
+    render(
+      <InvestigateDependencyButton
+        component="snip-frontend"
+        status="Pending"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    const { scopeOverrides } = firstCall();
+    expect(scopeOverrides).toEqual({
+      caseType: 'dependency_pending',
+      component: 'snip-frontend',
+    });
+    expect(scopeOverrides.namespace).toBeUndefined();
+    expect(scopeOverrides.project).toBeUndefined();
+    expect(scopeOverrides.environment).toBeUndefined();
+  });
+
+  it('falls back to a pre-drafted message when no status is provided', () => {
+    render(
+      <InvestigateDependencyButton
+        namespace="default"
+        component="snip-frontend"
+        environment="development"
+        caseType="dependency_pending"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    const call = firstCall();
+    expect(call.suggestions).toBeUndefined();
+    expect(call.initialMessage).toBe(
+      'Why is `snip-frontend` in `development` stuck pending?',
+    );
+    expect(call.conversationKey).toBe(
+      'dependency_pending:default:-:snip-frontend:development',
+    );
+  });
+
+  it('uses a generic fallback message for the runtime_debug case without status', () => {
+    render(
+      <InvestigateDependencyButton
+        component="snip-frontend"
+        environment="development"
+        caseType="runtime_debug"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(firstCall().initialMessage).toBe(
+      "What's wrong with `snip-frontend` in `development`?",
+    );
+  });
+
+  it('warms the assistant tool cache on hover', () => {
+    render(
+      <InvestigateDependencyButton
+        component="snip-frontend"
+        status="Pending"
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByRole('button'));
+    expect(holder.warmup).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows warm-up rejections without throwing', async () => {
+    holder.warmup = jest.fn().mockRejectedValue(new Error('boom'));
+    render(
+      <InvestigateDependencyButton
+        component="snip-frontend"
+        status="Pending"
+      />,
+    );
+    expect(() =>
+      fireEvent.mouseEnter(screen.getByRole('button')),
+    ).not.toThrow();
+    // Flush the rejected warm-up promise; the .catch() handles it so no
+    // unhandled rejection escapes.
+    await Promise.resolve();
+    expect(holder.warmup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/openchoreo-portal-assistant/src/components/InvestigateDependencyButton/InvestigateDependencyButton.tsx
+++ b/plugins/openchoreo-portal-assistant/src/components/InvestigateDependencyButton/InvestigateDependencyButton.tsx
@@ -1,0 +1,156 @@
+import { useRef } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { useAssistantEnabled } from '@openchoreo/backstage-plugin-react';
+import { Button, Tooltip, makeStyles } from '@material-ui/core';
+import ChatOutlinedIcon from '@material-ui/icons/ChatOutlined';
+import {
+  perchAgentApiRef,
+  type ChatScope,
+  type ChatCaseType,
+} from '../../api/PerchAgentApi';
+import { useAssistantDrawer } from '../AssistantContext/AssistantDrawerContext';
+
+interface InvestigateDependencyButtonProps {
+  /** Control-plane namespace of the *dependent* (pending) component. */
+  namespace?: string;
+  /** Project of the dependent component. */
+  project?: string;
+  /** The dependent component that is stuck NotReady. */
+  component?: string;
+  /** Environment the binding is in (e.g. ``development``). */
+  environment?: string;
+  /**
+   * Which assistant flow to launch. Defaults to ``dependency_pending``
+   * (the connections-pending case). Pass ``runtime_debug`` for a generic
+   * failed/unhealthy component so the seed message and prompt aren't
+   * framed as "stuck pending".
+   */
+  caseType?: ChatCaseType;
+  /**
+   * Human-readable deployment status (e.g. ``Pending`` / ``Failed``).
+   * When provided (with a component), the drawer opens showing a
+   * status-aware suggestion chip — "Why is <comp>'s <env> deployment
+   * <status>?" — instead of pre-drafting a generic prompt.
+   */
+  status?: string;
+}
+
+const useStyles = makeStyles(theme => ({
+  button: {
+    textTransform: 'none',
+    color: theme.palette.warning.main,
+    borderColor: theme.palette.warning.main,
+  },
+  icon: {
+    fontSize: 16,
+  },
+}));
+
+/**
+ * "Investigate" button shown in the K8s-artifacts header when a component
+ * is stuck NotReady because an outbound endpoint connection can't resolve.
+ *
+ * Clicking opens the Perch drawer with ``caseType: 'dependency_pending'``
+ * and the pending dependencies pinned, so the agent explains why the
+ * depended-on component is down (undeployed / not ready) and how to
+ * recover — the detail the static artifacts view can't infer.
+ *
+ * Renders ``null`` when the assistant feature flag is off, so the caller
+ * can mount it unconditionally.
+ */
+export const InvestigateDependencyButton = ({
+  namespace,
+  project,
+  component,
+  environment,
+  caseType,
+  status,
+}: InvestigateDependencyButtonProps) => {
+  const classes = useStyles();
+  const enabled = useAssistantEnabled();
+  const { openDrawer } = useAssistantDrawer();
+  const assistantApi = useApi(perchAgentApiRef);
+
+  // Re-warm the per-user MCP tools cache on hover/focus — same throttle as
+  // InvestigateLogButton. The provider-level warmup at sign-in goes stale,
+  // and this is a real chat entry point on the Deploy tab.
+  const lastWarmedAtRef = useRef<number>(0);
+  const WARMUP_MIN_INTERVAL_MS = 30_000;
+  const warmIfStale = () => {
+    if (!enabled) return;
+    const now = Date.now();
+    if (now - lastWarmedAtRef.current < WARMUP_MIN_INTERVAL_MS) return;
+    lastWarmedAtRef.current = now;
+    // Best-effort: swallow rejections so a failed warm-up never surfaces as
+    // an unhandled promise rejection. A cache miss on first chat is fine.
+    void assistantApi.warmup().catch(() => {});
+  };
+
+  if (!enabled) return null;
+
+  const handleClick = () => {
+    const resolvedCaseType: ChatCaseType = caseType ?? 'dependency_pending';
+
+    const overrides: Partial<ChatScope> = {
+      caseType: resolvedCaseType,
+      ...(namespace ? { namespace } : {}),
+      ...(project ? { project } : {}),
+      ...(component ? { component } : {}),
+      ...(environment ? { environment } : {}),
+    };
+
+    // Stable per-binding key so re-opening on the same env preserves the
+    // thread, but switching env/component/case re-seeds.
+    const conversationKey = `${resolvedCaseType}:${namespace ?? '-'}:${
+      project ?? '-'
+    }:${component ?? '-'}:${environment ?? '-'}`;
+
+    // When we know the component + a human-readable status, open the drawer
+    // showing a status-aware suggestion chip the user clicks to start (chips
+    // send verbatim on click). Plain text — chips don't render markdown.
+    const statusText = status?.trim();
+    if (component && statusText) {
+      const envPart = environment ? `${environment} ` : '';
+      const primary = `Why is ${component}'s ${envPart}deployment ${statusText}?`;
+      const followUp =
+        resolvedCaseType === 'dependency_pending'
+          ? 'Which dependency is it waiting on?'
+          : 'What is the root cause?';
+      openDrawer({
+        scopeOverrides: overrides,
+        conversationKey,
+        suggestions: [primary, followUp],
+      });
+      return;
+    }
+
+    // Fallback (e.g. K8s-artifacts header, no status passed): pre-draft a
+    // prompt into the composer. "stuck pending" reads wrong for a failure,
+    // so frame by case.
+    const where = environment ? ` in \`${environment}\`` : '';
+    const subject = component ? `\`${component}\`` : 'this component';
+    const initialMessage =
+      resolvedCaseType === 'dependency_pending'
+        ? `Why is ${subject}${where} stuck pending?`
+        : `What's wrong with ${subject}${where}?`;
+
+    openDrawer({ initialMessage, scopeOverrides: overrides, conversationKey });
+  };
+
+  return (
+    <Tooltip title="Investigate this with Portal Assistant">
+      <Button
+        variant="outlined"
+        size="small"
+        className={classes.button}
+        startIcon={<ChatOutlinedIcon className={classes.icon} />}
+        onClick={handleClick}
+        onMouseEnter={warmIfStale}
+        onFocus={warmIfStale}
+        aria-label="Investigate this with Portal Assistant"
+      >
+        Investigate with AI
+      </Button>
+    </Tooltip>
+  );
+};

--- a/plugins/openchoreo-portal-assistant/src/index.ts
+++ b/plugins/openchoreo-portal-assistant/src/index.ts
@@ -41,3 +41,4 @@ export {
   InvestigateLogButton,
   type LogRowForInvestigation,
 } from './components/InvestigateLogButton/InvestigateLogButton';
+export { InvestigateDependencyButton } from './components/InvestigateDependencyButton/InvestigateDependencyButton';

--- a/plugins/openchoreo/src/components/Environments/Environments.tsx
+++ b/plugins/openchoreo/src/components/Environments/Environments.tsx
@@ -13,7 +13,11 @@ import {
 import type { PendingAction } from './types';
 import { useEnvironmentsStyles } from './styles';
 import { EnvironmentsRouter } from './EnvironmentsRouter';
-import { EnvironmentsProvider, type Selection } from './EnvironmentsContext';
+import {
+  EnvironmentsProvider,
+  type Selection,
+  type RenderInvestigateAction,
+} from './EnvironmentsContext';
 import { NotificationBanner } from './components';
 import {
   ForbiddenState,
@@ -21,7 +25,19 @@ import {
   useEnvironmentReadPermission,
 } from '@openchoreo/backstage-plugin-react';
 
-export const Environments = () => {
+export interface EnvironmentsProps {
+  /**
+   * Host-app slot for the deploy-panel "investigate" button. Injected by
+   * ``packages/app`` (which owns the portal-assistant dependency) and
+   * forwarded to the detail panel via context. See
+   * ``EnvironmentsContextValue.renderInvestigateAction``.
+   */
+  renderInvestigateAction?: RenderInvestigateAction;
+}
+
+export const Environments = ({
+  renderInvestigateAction,
+}: EnvironmentsProps = {}) => {
   // Initialize global styles (includes keyframe animation)
   useEnvironmentsStyles();
 
@@ -130,6 +146,7 @@ export const Environments = () => {
       beginAwaitingNewRelease,
       selection,
       setSelection,
+      renderInvestigateAction,
     }),
     [
       environments,
@@ -150,6 +167,7 @@ export const Environments = () => {
       awaitingNewRelease,
       beginAwaitingNewRelease,
       selection,
+      renderInvestigateAction,
     ],
   );
 

--- a/plugins/openchoreo/src/components/Environments/EnvironmentsContext.tsx
+++ b/plugins/openchoreo/src/components/Environments/EnvironmentsContext.tsx
@@ -13,6 +13,35 @@ export type Selection =
   | { kind: 'setup' }
   | null;
 
+/**
+ * Scope handed to the host-app-supplied "investigate" slot when a
+ * deployment is in a problem state. Mirrors the render-prop pattern used
+ * for runtime-log debugging (``RenderLogRowAction`` in the observability
+ * plugin): this plugin owns the shape and decides *where* the affordance
+ * renders, while ``packages/app`` injects the actual assistant button —
+ * so the openchoreo plugin keeps no dependency on portal-assistant.
+ */
+export interface InvestigateScope {
+  /** Control-plane namespace of the component. */
+  namespace?: string;
+  /** Project the component belongs to. */
+  project?: string;
+  /** The component whose deployment is in trouble. */
+  component: string;
+  /** Environment resource name the binding is in. */
+  environment?: string;
+  /**
+   * Which assistant flow to launch: ``dependency_pending`` when the cause
+   * is an unresolved connection, otherwise ``runtime_debug``.
+   */
+  caseType: 'dependency_pending' | 'runtime_debug';
+  /** Human-readable deployment status, e.g. ``Pending`` / ``Failed``. */
+  status: string;
+}
+
+/** Render-prop slot for the deploy-panel investigate affordance. */
+export type RenderInvestigateAction = (scope: InvestigateScope) => ReactNode;
+
 interface EnvironmentsContextValue {
   /** All environments loaded from the API */
   environments: Environment[];
@@ -71,6 +100,13 @@ interface EnvironmentsContextValue {
   selection: Selection;
   /** Setter for the canvas selection. */
   setSelection: (next: Selection) => void;
+  /**
+   * Optional host-app slot rendered next to the status badge when a
+   * deployment is pending/failed. Supplied by ``packages/app`` so the
+   * plugin stays free of any portal-assistant coupling. Undefined → no
+   * button is shown.
+   */
+  renderInvestigateAction?: RenderInvestigateAction;
 }
 
 const EnvironmentsContext = createContext<EnvironmentsContextValue | null>(

--- a/plugins/openchoreo/src/components/Environments/components/EnvironmentDetailPanel.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/EnvironmentDetailPanel.test.tsx
@@ -97,8 +97,28 @@ jest.mock('../hooks/useReleases', () => ({
   }),
 }));
 
+// Stub the context. The host app injects the Investigate button through
+// `renderInvestigateAction` (so the openchoreo plugin owns no
+// portal-assistant dependency); mirror that here with a probe element that
+// exposes the scope the panel passes, so the wiring assertions below hold.
 jest.mock('../EnvironmentsContext', () => ({
-  useEnvironmentsContext: () => ({ environments: [] }),
+  useEnvironmentsContext: () => ({
+    environments: [],
+    renderInvestigateAction: (scope: {
+      caseType?: string;
+      status?: string;
+      component?: string;
+      environment?: string;
+    }) => (
+      <div
+        data-testid="investigate-dependency-button"
+        data-casetype={scope.caseType}
+        data-status={scope.status}
+        data-component={scope.component}
+        data-environment={scope.environment}
+      />
+    ),
+  }),
 }));
 
 jest.mock('./ComponentReleaseDiffDialog', () => ({
@@ -658,6 +678,58 @@ describe('EnvironmentDetailPanel', () => {
     ) as HTMLElement | null;
     expect(sectionAncestor).not.toBeNull();
     expect(sectionAncestor!.contains(actionsHeading)).toBe(true);
+  });
+
+  describe('Investigate with AI', () => {
+    it('shows the button for a pending connection (dependency_pending case)', () => {
+      renderPanel({
+        selection: {
+          kind: 'env',
+          environment: makeEnv({
+            name: 'development',
+            deployment: {
+              status: 'NotReady',
+              statusReason: 'ConnectionsPending',
+            },
+          }),
+        },
+      });
+      const btn = screen.getByTestId('investigate-dependency-button');
+      expect(btn).toHaveAttribute('data-casetype', 'dependency_pending');
+      expect(btn).toHaveAttribute('data-status', 'Pending');
+      expect(btn).toHaveAttribute('data-component', 'my-component');
+      expect(btn).toHaveAttribute('data-environment', 'development');
+    });
+
+    it('shows the button for a failed deployment (runtime_debug case)', () => {
+      renderPanel({
+        selection: {
+          kind: 'env',
+          environment: makeEnv({
+            name: 'production',
+            deployment: { status: 'Failed' },
+          }),
+        },
+      });
+      const btn = screen.getByTestId('investigate-dependency-button');
+      expect(btn).toHaveAttribute('data-casetype', 'runtime_debug');
+      expect(btn).toHaveAttribute('data-status', 'Failed');
+    });
+
+    it('hides the button for a healthy (active) deployment', () => {
+      renderPanel({
+        selection: {
+          kind: 'env',
+          environment: makeEnv({
+            name: 'development',
+            deployment: { status: 'Ready' },
+          }),
+        },
+      });
+      expect(
+        screen.queryByTestId('investigate-dependency-button'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('routes the manifest dialog pivot to the release browser', async () => {

--- a/plugins/openchoreo/src/components/Environments/components/EnvironmentDetailPanel.tsx
+++ b/plugins/openchoreo/src/components/Environments/components/EnvironmentDetailPanel.tsx
@@ -24,6 +24,7 @@ import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import ReportProblemOutlinedIcon from '@material-ui/icons/ReportProblemOutlined';
 import SettingsOutlinedIcon from '@material-ui/icons/SettingsOutlined';
 import { StatusBadge } from '@openchoreo/backstage-design-system';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import {
   formatRelativeTime,
@@ -136,7 +137,7 @@ export const EnvironmentDetailPanel = ({
   const [browserOpen, setBrowserOpen] = useState(false);
   const [diffOpen, setDiffOpen] = useState(false);
   const { entity } = useEntity();
-  const { environments } = useEnvironmentsContext();
+  const { environments, renderInvestigateAction } = useEnvironmentsContext();
   const { releases, loading: releasesLoading } = useReleases(entity);
   const deployments: ReleaseDeployments = useMemo(() => {
     const map: ReleaseDeployments = {};
@@ -294,6 +295,33 @@ export const EnvironmentDetailPanel = ({
         </Box>
         <Box className={classes.headerStatusRow}>
           <StatusBadge status={statusVariant.variant} />
+          {/* Offer an AI investigation when the environment is in a problem
+              state (pending or failed), pushed to the right of the status
+              row. The actual button is injected by the host app via
+              `renderInvestigateAction` (so this plugin keeps no
+              portal-assistant dependency). Route to the dependency_pending
+              flow when the cause is an unresolved connection; otherwise the
+              generic runtime_debug flow so a failed deploy isn't framed as
+              "stuck pending". */}
+          {renderInvestigateAction &&
+            (statusVariant.variant === 'pending' ||
+              statusVariant.variant === 'failed') && (
+              <Box ml="auto">
+                {renderInvestigateAction({
+                  namespace:
+                    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE],
+                  project:
+                    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT],
+                  component: entity.metadata.name,
+                  environment: environment.resourceName ?? environment.name,
+                  caseType:
+                    environment.deployment.statusReason === 'ConnectionsPending'
+                      ? 'dependency_pending'
+                      : 'runtime_debug',
+                  status: statusVariant.label,
+                })}
+              </Box>
+            )}
         </Box>
       </Box>
 

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -6,6 +6,13 @@ export { openChoreoClientApiRef } from './api/OpenChoreoClientApi';
 // at runtime when entity tabs (Environments, CellDiagram) try to useApi.
 export { OpenChoreoClient } from './api/OpenChoreoClient';
 export { Environments } from './components/Environments/Environments';
+// Render-prop slot for injecting the assistant "Investigate" button into
+// the deploy panel from the host app (keeps this plugin free of any
+// portal-assistant dependency).
+export type {
+  RenderInvestigateAction,
+  InvestigateScope,
+} from './components/Environments/EnvironmentsContext';
 export { ResourceEnvironments } from './components/ResourceEnvironments';
 export { CellDiagram } from './components/CellDiagram/CellDiagram';
 export {


### PR DESCRIPTION
## Purpose

We have added investigation support for deployment status of OpenChoreo.

## Goals

Add investigation button and provide the solution and the prompt whenever needed. 

https://github.com/user-attachments/assets/a65c521f-60b9-410c-8475-3a41a10c8d4c

## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Investigate with AI” button to environment detail panels for pending and failed deployments.
  * Drawer prompts are now deployment-aware, including support for investigations blocked by pending outbound endpoint dependencies.
  * Exposed a typed render-slot so hosts can inject the investigate action into the Environments panel; assistant tools are warmed on hover/focus.

* **Tests**
  * Expanded Jest coverage for conditional rendering, correct drawer payloads (case type/status/scope), and warmup error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->