### PR TITLE
fix: add back button to catalog import page header

### DIFF
--- a/.changeset/import-page-back-button.md
+++ b/.changeset/import-page-back-button.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a back button to the purple header of the catalog import (Register / Import to catalog) page so users can return to the APIs and catalog lists. Host-app only (`packages/app`); no published package is affected.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,9 +1,6 @@
 import { Route } from 'react-router-dom';
 import { catalogPlugin } from '@backstage/plugin-catalog';
-import {
-  CatalogImportPage,
-  catalogImportPlugin,
-} from '@backstage/plugin-catalog-import';
+import { catalogImportPlugin } from '@backstage/plugin-catalog-import';
 import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
 import { SearchPage } from '@backstage/plugin-search';
 import {
@@ -15,6 +12,7 @@ import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
 import { apis } from './apis';
 import { CustomApiExplorerPage } from './components/catalog/CustomApiExplorerPage';
+import { CustomCatalogImportPage } from './components/catalog/CustomCatalogImportPage';
 import { searchPage } from './components/search/SearchPage';
 import { Root } from './components/Root';
 import { HomePage } from './components/Home';
@@ -53,7 +51,7 @@ import {
 } from './apis/customOverrides';
 
 // catalog-import NFS plugin — registered so the `/catalog-import` route ref
-// resolves under NFS. Our legacy `<RequirePermission><CatalogImportPage /></...>`
+// resolves under NFS. Our legacy `<RequirePermission><CustomCatalogImportPage /></...>`
 // mount in `<FlatRoutes>` provides the actual page rendering.
 import catalogImportPluginAlpha from '@backstage/plugin-catalog-import/alpha';
 // api-docs and kubernetes NFS plugins — registered so that `apiDocsConfigRef`,
@@ -120,7 +118,7 @@ const routes = (
       path="/catalog-import"
       element={
         <RequirePermission permission={catalogEntityCreatePermission}>
-          <CatalogImportPage />
+          <CustomCatalogImportPage />
         </RequirePermission>
       }
     />

--- a/packages/app/src/components/catalog/CustomCatalogImportPage.tsx
+++ b/packages/app/src/components/catalog/CustomCatalogImportPage.tsx
@@ -1,0 +1,105 @@
+import { useNavigate } from 'react-router-dom';
+import {
+  Content,
+  ContentHeader,
+  Header,
+  Page,
+  SupportButton,
+} from '@backstage/core-components';
+import {
+  useApi,
+  configApiRef,
+  createRoutableExtension,
+} from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
+import {
+  ImportInfoCard,
+  ImportStepper,
+  catalogImportPlugin,
+} from '@backstage/plugin-catalog-import';
+import { catalogImportTranslationRef } from '@backstage/plugin-catalog-import/alpha';
+import Box from '@material-ui/core/Box';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+
+const useStyles = makeStyles({
+  title: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  backButton: {
+    color: 'inherit',
+    marginRight: 8,
+    marginLeft: -12,
+    '&:hover': {
+      backgroundColor: 'rgba(255, 255, 255, 0.15)',
+    },
+  },
+});
+
+const CustomCatalogImportPageContent = () => {
+  const classes = useStyles();
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const configApi = useApi(configApiRef);
+  const { t } = useTranslationRef(catalogImportTranslationRef);
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
+  const headerTitle = t('defaultImportPage.headerTitle');
+
+  const contentItems = [
+    <Grid item xs={12} md={4} lg={6} xl={8} key={0}>
+      <ImportInfoCard />
+    </Grid>,
+    <Grid item xs={12} md={8} lg={6} xl={4} key={1}>
+      <ImportStepper />
+    </Grid>,
+  ];
+
+  return (
+    <Page themeId="home">
+      <Header
+        title={
+          <Box className={classes.title}>
+            <IconButton
+              className={classes.backButton}
+              size="small"
+              onClick={() => navigate(-1)}
+              aria-label="Back"
+              title="Back"
+            >
+              <ArrowBackIcon />
+            </IconButton>
+            {headerTitle}
+          </Box>
+        }
+        pageTitleOverride={headerTitle}
+      />
+      <Content>
+        <ContentHeader
+          title={t('defaultImportPage.contentHeaderTitle', { appTitle })}
+        >
+          <SupportButton>
+            {t('defaultImportPage.supportTitle', { appTitle })}
+          </SupportButton>
+        </ContentHeader>
+        <Grid container spacing={2}>
+          {isMobile ? contentItems : contentItems.reverse()}
+        </Grid>
+      </Content>
+    </Page>
+  );
+};
+
+// Routable extension on the catalog-import plugin so the `importPage` routeRef
+// keeps its path for useRouteRef consumers and bound external routes.
+export const CustomCatalogImportPage = catalogImportPlugin.provide(
+  createRoutableExtension({
+    name: 'CustomCatalogImportPage',
+    component: () => Promise.resolve(CustomCatalogImportPageContent),
+    mountPoint: catalogImportPlugin.routes.importPage,
+  }),
+);


### PR DESCRIPTION
## Purpose

Adds a back button to the Register / Import to catalog page so users can return to the APIs (and catalog) list. Fixes openchoreo/openchoreo#2909.

## Approach

The page rendered the upstream `CatalogImportPage`, whose header has no back button. Replaced it with a thin custom routable extension (`CustomCatalogImportPage`) that:
- reuses the upstream `ImportInfoCard` + `ImportStepper`, so the import flow is unchanged;
- adds an `ArrowBack` button at the top-left of the purple header;
- mounts the same `importPage` routeRef, so `useRouteRef` consumers (APIs "Register" button) and the `registerComponent`/`registerApi` route bindings keep working.

Both sidebar entry points (APIs → Register and Create → Import to catalog) route here, so this covers both.

## Related Issues

openchoreo/openchoreo#2909