### PR TITLE
fix: collapse full-access role categories into "All <category> actions" in Access Control

### DIFF
--- a/.changeset/normalize-role-actions-display.md
+++ b/.changeset/normalize-role-actions-display.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin': patch
+---
+
+Display role actions consistently in collapsed form in Access Control. When a
+role grants every action in a category, the Roles table and Role dialog now
+show a single "All <category> actions" entry (e.g. "All alerts actions", "All
+metrics actions") instead of listing each operation individually, matching how
+the action selection dialog already renders them. Roles are still stored as-is;
+the collapsing is display-only and re-applies once the action catalog loads.

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.test.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.test.tsx
@@ -87,9 +87,10 @@ describe('RoleDialog', () => {
       },
     });
 
-    // The four component actions collapse to a single wildcard chip.
+    // The four component actions collapse to a single wildcard chip, but the
+    // count reflects the actual number of granular actions granted.
     expect(screen.getByText('All component actions')).toBeInTheDocument();
-    expect(screen.getByText('Select Actions (1 selected)')).toBeInTheDocument();
+    expect(screen.getByText('Select Actions (4 selected)')).toBeInTheDocument();
   });
 
   it('applies a quick-start template and normalizes its actions', async () => {
@@ -98,9 +99,14 @@ describe('RoleDialog', () => {
 
     await user.click(screen.getByRole('button', { name: 'Admin' }));
 
-    // The admin template grants every action -> collapses to the global wildcard.
+    // The admin template grants every action -> collapses to the global
+    // wildcard chip, but the count reflects all granular actions it expands to.
     expect(screen.getByText('All Actions')).toBeInTheDocument();
-    expect(screen.getByText('Select Actions (1 selected)')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `Select Actions (${AVAILABLE_ACTIONS.length} selected)`,
+      ),
+    ).toBeInTheDocument();
   });
 
   it('validates that a role name is required', async () => {

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.test.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RoleDialog } from './RoleDialog';
+import { SCOPE_CLUSTER } from '../constants';
+
+// ---- Mocks ----
+
+const mockUseActions = jest.fn();
+jest.mock('../hooks', () => ({
+  useActions: () => mockUseActions(),
+}));
+
+jest.mock('../../../utils/errorUtils', () => ({
+  isForbiddenError: (err: any) => err?.message?.includes('403'),
+  getErrorMessage: (err: any) => err?.message ?? 'Unknown error',
+}));
+
+jest.mock('./ActionSelectionDialog', () => ({
+  ActionSelectionDialog: ({ open, onConfirm }: any) =>
+    open ? (
+      <div data-testid="action-selection-dialog">
+        <button
+          data-testid="confirm-actions"
+          onClick={() => onConfirm(['project:view'])}
+        >
+          Confirm
+        </button>
+      </div>
+    ) : null,
+}));
+
+// ---- Helpers ----
+
+const AVAILABLE_ACTIONS = [
+  'component:view',
+  'component:create',
+  'component:update',
+  'component:delete',
+  'project:view',
+  'project:create',
+  'logs:view',
+];
+
+function actionInfos(names: string[]) {
+  return names.map(name => ({ name }));
+}
+
+type Props = React.ComponentProps<typeof RoleDialog>;
+
+function renderDialog(overrides: Partial<Props> = {}) {
+  const onClose = jest.fn();
+  const onSave = jest.fn().mockResolvedValue(undefined);
+
+  const props: Props = {
+    open: true,
+    onClose,
+    onSave,
+    scope: SCOPE_CLUSTER,
+    ...overrides,
+  };
+
+  const utils = render(<RoleDialog {...props} />);
+  return { ...utils, onClose, onSave };
+}
+
+// ---- Tests ----
+
+describe('RoleDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseActions.mockReturnValue({
+      actions: actionInfos(AVAILABLE_ACTIONS),
+      loading: false,
+    });
+  });
+
+  it('normalizes an editing role\'s actions into wildcard chips on open', () => {
+    renderDialog({
+      editingRole: {
+        name: 'editor',
+        actions: [
+          'component:view',
+          'component:create',
+          'component:update',
+          'component:delete',
+        ],
+      },
+    });
+
+    // The four component actions collapse to a single wildcard chip.
+    expect(screen.getByText('All component actions')).toBeInTheDocument();
+    expect(screen.getByText('Select Actions (1 selected)')).toBeInTheDocument();
+  });
+
+  it('applies a quick-start template and normalizes its actions', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole('button', { name: 'Admin' }));
+
+    // The admin template grants every action -> collapses to the global wildcard.
+    expect(screen.getByText('All Actions')).toBeInTheDocument();
+    expect(screen.getByText('Select Actions (1 selected)')).toBeInTheDocument();
+  });
+
+  it('validates that a role name is required', async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderDialog();
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(screen.getByText('Role name is required')).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('saves a valid role', async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderDialog();
+
+    await user.type(screen.getByRole('textbox'), 'reader');
+    await user.click(screen.getByRole('button', { name: /select actions/i }));
+    await user.click(await screen.findByTestId('confirm-actions'));
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        name: 'reader',
+        actions: ['project:view'],
+      }),
+    );
+  });
+
+  it('shows a permission message when saving is forbidden', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn().mockRejectedValue(new Error('403 Forbidden'));
+    renderDialog({
+      onSave,
+      editingRole: { name: 'editor', actions: ['project:view'] },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Update' }));
+
+    expect(
+      await screen.findByText(/do not have permission to save this role/i),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces a generic error message when saving fails', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn().mockRejectedValue(new Error('Server exploded'));
+    renderDialog({
+      onSave,
+      editingRole: { name: 'editor', actions: ['project:view'] },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Update' }));
+
+    expect(await screen.findByText('Server exploded')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.test.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.test.tsx
@@ -74,7 +74,7 @@ describe('RoleDialog', () => {
     });
   });
 
-  it('normalizes an editing role\'s actions into wildcard chips on open', () => {
+  it("normalizes an editing role's actions into wildcard chips on open", () => {
     renderDialog({
       editingRole: {
         name: 'editor',
@@ -103,9 +103,7 @@ describe('RoleDialog', () => {
     // wildcard chip, but the count reflects all granular actions it expands to.
     expect(screen.getByText('All Actions')).toBeInTheDocument();
     expect(
-      screen.getByText(
-        `Select Actions (${AVAILABLE_ACTIONS.length} selected)`,
-      ),
+      screen.getByText(`Select Actions (${AVAILABLE_ACTIONS.length} selected)`),
     ).toBeInTheDocument();
   });
 

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
@@ -316,17 +316,21 @@ export const RoleDialog = ({
   );
 
   useEffect(() => {
+    if (!open) return;
     if (editingRole) {
       setName(editingRole.name);
-      setSelectedActions(
-        normalizeActions(editingRole.actions, availableActions),
-      );
+      setSelectedActions(editingRole.actions);
     } else {
       setName('');
       setSelectedActions([]);
     }
     setError(null);
-  }, [editingRole, open, availableActions]);
+  }, [editingRole, open]);
+
+  useEffect(() => {
+    if (!open || availableActions.length === 0) return;
+    setSelectedActions(prev => normalizeActions(prev, availableActions));
+  }, [open, availableActions]);
 
   const handleApplyTemplate = (templateKey: keyof typeof ROLE_TEMPLATES) => {
     const template = ROLE_TEMPLATES[templateKey];

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
@@ -21,7 +21,7 @@ import {
 import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
 import { isForbiddenError, getErrorMessage } from '../../../utils/errorUtils';
 import { ActionSelectionDialog } from './ActionSelectionDialog';
-import { getActionDisplayLabel } from './actionUtils';
+import { getActionDisplayLabel, normalizeActions } from './actionUtils';
 
 const useStyles = makeStyles(theme => ({
   formField: {
@@ -309,20 +309,22 @@ export const RoleDialog = ({
   useEffect(() => {
     if (editingRole) {
       setName(editingRole.name);
-      setSelectedActions(editingRole.actions);
+      setSelectedActions(
+        normalizeActions(editingRole.actions, availableActions),
+      );
     } else {
       setName('');
       setSelectedActions([]);
     }
     setError(null);
-  }, [editingRole, open]);
+  }, [editingRole, open, availableActions]);
 
   const handleApplyTemplate = (templateKey: keyof typeof ROLE_TEMPLATES) => {
     const template = ROLE_TEMPLATES[templateKey];
     if (!editingRole) {
       setName(template.name);
     }
-    setSelectedActions(template.actions);
+    setSelectedActions(normalizeActions(template.actions, availableActions));
   };
 
   const handleSave = async () => {

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RoleDialog.tsx
@@ -21,7 +21,11 @@ import {
 import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
 import { isForbiddenError, getErrorMessage } from '../../../utils/errorUtils';
 import { ActionSelectionDialog } from './ActionSelectionDialog';
-import { getActionDisplayLabel, normalizeActions } from './actionUtils';
+import {
+  getActionDisplayLabel,
+  normalizeActions,
+  expandWildcards,
+} from './actionUtils';
 
 const useStyles = makeStyles(theme => ({
   formField: {
@@ -306,6 +310,11 @@ export const RoleDialog = ({
   const [error, setError] = useState<string | null>(null);
   const [actionDialogOpen, setActionDialogOpen] = useState(false);
 
+  const granularActionCount = useMemo(
+    () => expandWildcards(selectedActions, availableActions).size,
+    [selectedActions, availableActions],
+  );
+
   useEffect(() => {
     if (editingRole) {
       setName(editingRole.name);
@@ -457,7 +466,7 @@ export const RoleDialog = ({
             >
               {actionsLoading
                 ? 'Loading actions...'
-                : `Select Actions (${selectedActions.length} selected)`}
+                : `Select Actions (${granularActionCount} selected)`}
             </Button>
 
             {selectedActions.length > 0 ? (

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.test.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.test.tsx
@@ -1,0 +1,292 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RolesTable, type BindingSummary } from './RolesTable';
+import { SCOPE_CLUSTER, SCOPE_NAMESPACE } from '../constants';
+
+// ---- Mocks ----
+
+const mockUseActions = jest.fn();
+jest.mock('../hooks', () => ({
+  useActions: () => mockUseActions(),
+}));
+
+// ---- Helpers ----
+
+const AVAILABLE_ACTIONS = [
+  'component:view',
+  'component:create',
+  'component:update',
+  'component:delete',
+  'project:view',
+  'project:create',
+  'environment:view',
+  'environment:create',
+  'dataplane:view',
+  'dataplane:create',
+  'workflow:view',
+  'workflow:create',
+  'logs:view',
+];
+
+function actionInfos(names: string[]) {
+  return names.map(name => ({ name }));
+}
+
+type Props = React.ComponentProps<typeof RolesTable>;
+
+function renderTable(overrides: Partial<Props> = {}) {
+  const onEdit = jest.fn();
+  const onDelete = jest.fn().mockResolvedValue(undefined);
+  const onCheckBindings = jest.fn().mockResolvedValue([] as BindingSummary[]);
+
+  const props: Props = {
+    roles: [{ name: 'admin', actions: ['logs:view'] }],
+    scope: SCOPE_CLUSTER,
+    scopeLabel: 'Cluster Role',
+    canUpdate: true,
+    canDelete: true,
+    updateDeniedTooltip: '',
+    deleteDeniedTooltip: '',
+    onEdit,
+    onDelete,
+    onCheckBindings,
+    ...overrides,
+  };
+
+  const utils = render(<RolesTable {...props} />);
+  return { ...utils, props, onEdit, onDelete, onCheckBindings };
+}
+
+// ---- Tests ----
+
+describe('RolesTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseActions.mockReturnValue({
+      actions: actionInfos(AVAILABLE_ACTIONS),
+      loading: false,
+    });
+  });
+
+  it('renders roles with their names and descriptions', () => {
+    renderTable({
+      roles: [
+        { name: 'admin', actions: ['logs:view'], description: 'Full access' },
+      ],
+    });
+
+    expect(screen.getByText('admin')).toBeInTheDocument();
+    expect(screen.getByText('Full access')).toBeInTheDocument();
+  });
+
+  it('shows a System chip for system roles', () => {
+    renderTable({
+      roles: [
+        {
+          name: 'admin',
+          actions: ['logs:view'],
+          labels: { 'openchoreo.io/system': 'true' },
+        },
+      ],
+    });
+
+    expect(screen.getByText('System')).toBeInTheDocument();
+  });
+
+  it('renders "No actions" when a role has no actions', () => {
+    renderTable({ roles: [{ name: 'empty', actions: [] }] });
+
+    expect(screen.getByText('No actions')).toBeInTheDocument();
+  });
+
+  it('collapses a fully-selected category into a wildcard label', () => {
+    renderTable({
+      roles: [
+        {
+          name: 'editor',
+          actions: [
+            'component:view',
+            'component:create',
+            'component:update',
+            'component:delete',
+          ],
+        },
+      ],
+    });
+
+    expect(screen.getByText('All component actions')).toBeInTheDocument();
+  });
+
+  it('shows a "+N more" chip when a role has more than five actions', () => {
+    renderTable({
+      roles: [
+        {
+          name: 'busy',
+          actions: [
+            'component:view',
+            'project:view',
+            'environment:view',
+            'dataplane:view',
+            'workflow:view',
+            'logs:view',
+          ],
+        },
+      ],
+    });
+
+    // 6 chips after normalization (logs collapses to logs:*) -> first 5 + "+1 more".
+    expect(screen.getByText('+1 more')).toBeInTheDocument();
+  });
+
+  it('filters roles by search query on name', async () => {
+    const user = userEvent.setup();
+    renderTable({
+      roles: [
+        { name: 'admin', actions: ['logs:view'] },
+        { name: 'viewer', actions: ['logs:view'] },
+      ],
+    });
+
+    await user.type(
+      screen.getByPlaceholderText(/search cluster roles/i),
+      'viewer',
+    );
+
+    expect(screen.getByText('viewer')).toBeInTheDocument();
+    expect(screen.queryByText('admin')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty-search message when nothing matches', async () => {
+    const user = userEvent.setup();
+    renderTable({ roles: [{ name: 'admin', actions: ['logs:view'] }] });
+
+    await user.type(
+      screen.getByPlaceholderText(/search cluster roles/i),
+      'zzz',
+    );
+
+    expect(
+      screen.getByText('No cluster roles match your search'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an empty-state message when there are no roles', () => {
+    renderTable({ roles: [] });
+
+    expect(
+      screen.getByText(/no cluster roles defined yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onEdit when the edit button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onEdit, props } = renderTable();
+
+    await user.click(screen.getByRole('button', { name: /edit role admin/i }));
+
+    expect(onEdit).toHaveBeenCalledWith(props.roles[0]);
+  });
+
+  it('disables edit and delete buttons when permissions are denied', () => {
+    renderTable({ canUpdate: false, canDelete: false });
+
+    expect(screen.getByRole('button', { name: /edit role admin/i })).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /delete role admin/i }),
+    ).toBeDisabled();
+  });
+
+  it('shows a checking spinner while bindings are being looked up', async () => {
+    const user = userEvent.setup();
+    let resolveCheck: (value: BindingSummary[]) => void = () => {};
+    const onCheckBindings = jest.fn().mockImplementation(
+      () =>
+        new Promise<BindingSummary[]>(resolve => {
+          resolveCheck = resolve;
+        }),
+    );
+    renderTable({ onCheckBindings });
+
+    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+
+    expect(screen.getByText('Checking for role bindings...')).toBeInTheDocument();
+
+    resolveCheck([]);
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Checking for role bindings...'),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('confirms and calls onDelete when there are no active bindings', async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderTable();
+
+    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByText(/are you sure you want to delete/i),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith('admin'));
+  });
+
+  it('cancels deletion without calling onDelete', async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderTable();
+
+    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+    );
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('blocks deletion and lists active bindings (cluster scope)', async () => {
+    const user = userEvent.setup();
+    const onCheckBindings = jest.fn().mockResolvedValue([
+      {
+        name: 'binding-a',
+        entitlement: { claim: 'group', value: 'devs' },
+        effect: 'allow',
+        type: SCOPE_CLUSTER,
+      },
+      {
+        name: 'binding-b',
+        entitlement: { claim: 'group', value: 'ops' },
+        effect: 'allow',
+        type: SCOPE_NAMESPACE,
+        namespace: 'team-a',
+      },
+    ] as BindingSummary[]);
+    const { onDelete } = renderTable({ onCheckBindings });
+
+    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+
+    expect(await screen.findByText('Cannot Delete Cluster Role')).toBeInTheDocument();
+    expect(screen.getByText('Binding: binding-a')).toBeInTheDocument();
+    expect(screen.getByText('Type: Cluster')).toBeInTheDocument();
+    expect(screen.getByText('Type: Namespace (team-a)')).toBeInTheDocument();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('treats a binding-check failure as no active bindings', async () => {
+    const user = userEvent.setup();
+    const onCheckBindings = jest.fn().mockRejectedValue(new Error('boom'));
+    renderTable({ onCheckBindings });
+
+    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+
+    expect(
+      await screen.findByText(/are you sure you want to delete/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.test.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.test.tsx
@@ -190,7 +190,9 @@ describe('RolesTable', () => {
   it('disables edit and delete buttons when permissions are denied', () => {
     renderTable({ canUpdate: false, canDelete: false });
 
-    expect(screen.getByRole('button', { name: /edit role admin/i })).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /edit role admin/i }),
+    ).toBeDisabled();
     expect(
       screen.getByRole('button', { name: /delete role admin/i }),
     ).toBeDisabled();
@@ -207,9 +209,13 @@ describe('RolesTable', () => {
     );
     renderTable({ onCheckBindings });
 
-    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+    await user.click(
+      screen.getByRole('button', { name: /delete role admin/i }),
+    );
 
-    expect(screen.getByText('Checking for role bindings...')).toBeInTheDocument();
+    expect(
+      screen.getByText('Checking for role bindings...'),
+    ).toBeInTheDocument();
 
     resolveCheck([]);
     await waitFor(() =>
@@ -223,7 +229,9 @@ describe('RolesTable', () => {
     const user = userEvent.setup();
     const { onDelete } = renderTable();
 
-    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+    await user.click(
+      screen.getByRole('button', { name: /delete role admin/i }),
+    );
 
     const dialog = await screen.findByRole('dialog');
     expect(
@@ -239,7 +247,9 @@ describe('RolesTable', () => {
     const user = userEvent.setup();
     const { onDelete } = renderTable();
 
-    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+    await user.click(
+      screen.getByRole('button', { name: /delete role admin/i }),
+    );
 
     const dialog = await screen.findByRole('dialog');
     await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
@@ -269,9 +279,13 @@ describe('RolesTable', () => {
     ] as BindingSummary[]);
     const { onDelete } = renderTable({ onCheckBindings });
 
-    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+    await user.click(
+      screen.getByRole('button', { name: /delete role admin/i }),
+    );
 
-    expect(await screen.findByText('Cannot Delete Cluster Role')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Cannot Delete Cluster Role'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Binding: binding-a')).toBeInTheDocument();
     expect(screen.getByText('Type: Cluster')).toBeInTheDocument();
     expect(screen.getByText('Type: Namespace (team-a)')).toBeInTheDocument();
@@ -283,7 +297,9 @@ describe('RolesTable', () => {
     const onCheckBindings = jest.fn().mockRejectedValue(new Error('boom'));
     renderTable({ onCheckBindings });
 
-    await user.click(screen.getByRole('button', { name: /delete role admin/i }));
+    await user.click(
+      screen.getByRole('button', { name: /delete role admin/i }),
+    );
 
     expect(
       await screen.findByText(/are you sure you want to delete/i),

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
@@ -32,6 +32,8 @@ import WarningIcon from '@material-ui/icons/Warning';
 import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
 import { useStyles } from './styles';
 import { SCOPE_CLUSTER, type BindingScope } from '../constants';
+import { useActions } from '../hooks';
+import { normalizeActions, getActionDisplayLabel } from './actionUtils';
 
 interface RoleRow {
   name: string;
@@ -74,6 +76,11 @@ export const RolesTable = ({
   onCheckBindings,
 }: RolesTableProps) => {
   const classes = useStyles();
+  const { actions: availableActionInfos } = useActions();
+  const availableActions = useMemo(
+    () => availableActionInfos.map(a => a.name),
+    [availableActionInfos],
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [roleToDelete, setRoleToDelete] = useState<string | null>(null);
@@ -158,86 +165,92 @@ export const RolesTable = ({
               </TableRow>
             </TableHead>
             <TableBody>
-              {filteredRoles.map(role => (
-                <TableRow key={role.name}>
-                  <TableCell>
-                    <Typography variant="body1">
-                      {role.name}
-                      {role.labels?.[CHOREO_LABELS.SYSTEM] === 'true' && (
+              {filteredRoles.map(role => {
+                const displayActions = normalizeActions(
+                  role.actions,
+                  availableActions,
+                );
+                return (
+                  <TableRow key={role.name}>
+                    <TableCell>
+                      <Typography variant="body1">
+                        {role.name}
+                        {role.labels?.[CHOREO_LABELS.SYSTEM] === 'true' && (
+                          <Chip
+                            label="System"
+                            size="small"
+                            variant="outlined"
+                            style={{
+                              marginLeft: 8,
+                              fontSize: '0.7rem',
+                              height: 20,
+                            }}
+                          />
+                        )}
+                      </Typography>
+                      {role.description && (
+                        <Typography variant="body2" color="textSecondary">
+                          {role.description}
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell className={classes.actionsCell}>
+                      {displayActions.length === 0 ? (
+                        <Typography variant="body2" color="textSecondary">
+                          No actions
+                        </Typography>
+                      ) : (
+                        displayActions
+                          .slice(0, 5)
+                          .map(action => (
+                            <Chip
+                              key={action}
+                              label={getActionDisplayLabel(action)}
+                              size="small"
+                              className={classes.actionsChip}
+                            />
+                          ))
+                      )}
+                      {displayActions.length > 5 && (
                         <Chip
-                          label="System"
+                          label={`+${displayActions.length - 5} more`}
                           size="small"
                           variant="outlined"
-                          style={{
-                            marginLeft: 8,
-                            fontSize: '0.7rem',
-                            height: 20,
-                          }}
+                          className={classes.actionsChip}
                         />
                       )}
-                    </Typography>
-                    {role.description && (
-                      <Typography variant="body2" color="textSecondary">
-                        {role.description}
-                      </Typography>
-                    )}
-                  </TableCell>
-                  <TableCell className={classes.actionsCell}>
-                    {role.actions.length === 0 ? (
-                      <Typography variant="body2" color="textSecondary">
-                        No actions
-                      </Typography>
-                    ) : (
-                      role.actions
-                        .slice(0, 5)
-                        .map(action => (
-                          <Chip
-                            key={action}
-                            label={action}
+                    </TableCell>
+                    <TableCell align="right">
+                      <Tooltip title={updateDeniedTooltip || 'Edit'}>
+                        <span>
+                          <IconButton
                             size="small"
-                            className={classes.actionsChip}
-                          />
-                        ))
-                    )}
-                    {role.actions.length > 5 && (
-                      <Chip
-                        label={`+${role.actions.length - 5} more`}
-                        size="small"
-                        variant="outlined"
-                        className={classes.actionsChip}
-                      />
-                    )}
-                  </TableCell>
-                  <TableCell align="right">
-                    <Tooltip title={updateDeniedTooltip || 'Edit'}>
-                      <span>
-                        <IconButton
-                          size="small"
-                          onClick={() => onEdit(role)}
-                          disabled={!canUpdate}
-                          color="primary"
-                          aria-label={`Edit role ${role.name}`}
-                        >
-                          <EditIcon />
-                        </IconButton>
-                      </span>
-                    </Tooltip>
-                    <Tooltip title={deleteDeniedTooltip || 'Delete'}>
-                      <span>
-                        <IconButton
-                          size="small"
-                          onClick={() => handleDeleteRole(role.name)}
-                          disabled={!canDelete}
-                          className={classes.deleteIconButton}
-                          aria-label={`Delete role ${role.name}`}
-                        >
-                          <DeleteIcon />
-                        </IconButton>
-                      </span>
-                    </Tooltip>
-                  </TableCell>
-                </TableRow>
-              ))}
+                            onClick={() => onEdit(role)}
+                            disabled={!canUpdate}
+                            color="primary"
+                            aria-label={`Edit role ${role.name}`}
+                          >
+                            <EditIcon />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                      <Tooltip title={deleteDeniedTooltip || 'Delete'}>
+                        <span>
+                          <IconButton
+                            size="small"
+                            onClick={() => handleDeleteRole(role.name)}
+                            disabled={!canDelete}
+                            className={classes.deleteIconButton}
+                            aria-label={`Delete role ${role.name}`}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </TableContainer>

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/RolesTable.tsx
@@ -33,7 +33,11 @@ import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
 import { useStyles } from './styles';
 import { SCOPE_CLUSTER, type BindingScope } from '../constants';
 import { useActions } from '../hooks';
-import { normalizeActions, getActionDisplayLabel } from './actionUtils';
+import {
+  normalizeActions,
+  getActionDisplayLabel,
+  expandWildcards,
+} from './actionUtils';
 
 interface RoleRow {
   name: string;
@@ -170,6 +174,12 @@ export const RolesTable = ({
                   role.actions,
                   availableActions,
                 );
+                const visibleActions = displayActions.slice(0, 5);
+                const hiddenActionCount =
+                  availableActions.length === 0
+                    ? 0
+                    : expandWildcards(displayActions, availableActions).size -
+                      expandWildcards(visibleActions, availableActions).size;
                 return (
                   <TableRow key={role.name}>
                     <TableCell>
@@ -200,20 +210,18 @@ export const RolesTable = ({
                           No actions
                         </Typography>
                       ) : (
-                        displayActions
-                          .slice(0, 5)
-                          .map(action => (
-                            <Chip
-                              key={action}
-                              label={getActionDisplayLabel(action)}
-                              size="small"
-                              className={classes.actionsChip}
-                            />
-                          ))
+                        visibleActions.map(action => (
+                          <Chip
+                            key={action}
+                            label={getActionDisplayLabel(action)}
+                            size="small"
+                            className={classes.actionsChip}
+                          />
+                        ))
                       )}
-                      {displayActions.length > 5 && (
+                      {hiddenActionCount > 0 && (
                         <Chip
-                          label={`+${displayActions.length - 5} more`}
+                          label={`+${hiddenActionCount} more`}
                           size="small"
                           variant="outlined"
                           className={classes.actionsChip}

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.test.ts
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.test.ts
@@ -49,6 +49,32 @@ describe('normalizeActions', () => {
     expect(normalizeActions(['*'], AVAILABLE_ACTIONS)).toEqual(['*']);
   });
 
+  it('preserves stale actions absent from the catalog instead of dropping them', () => {
+    // Unknown category and unknown action within a known category must survive
+    // the normalization round-trip so saving an edited role keeps them.
+    expect(
+      normalizeActions(
+        ['component:view', 'component:frobnicate', 'foo:bar', 'foo:*'],
+        AVAILABLE_ACTIONS,
+      ),
+    ).toEqual(['component:view', 'component:frobnicate', 'foo:bar', 'foo:*']);
+  });
+
+  it('does not duplicate a known category wildcard when preserving', () => {
+    expect(
+      normalizeActions(
+        [
+          'component:view',
+          'component:create',
+          'component:update',
+          'component:delete',
+          'foo:bar',
+        ],
+        AVAILABLE_ACTIONS,
+      ),
+    ).toEqual(['component:*', 'foo:bar']);
+  });
+
   it('collapses some categories while leaving partial ones expanded', () => {
     const actions = [
       'component:view',

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.test.ts
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.test.ts
@@ -75,6 +75,15 @@ describe('normalizeActions', () => {
     ).toEqual(['component:*', 'foo:bar']);
   });
 
+  it('keeps the global wildcard collapsed when a stale action is also present', () => {
+    // The stale token must not inflate the size gate and force per-category
+    // wildcards when the role already grants everything via `*`.
+    expect(normalizeActions(['*', 'foo:bar'], AVAILABLE_ACTIONS)).toEqual([
+      '*',
+      'foo:bar',
+    ]);
+  });
+
   it('collapses some categories while leaving partial ones expanded', () => {
     const actions = [
       'component:view',

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.test.ts
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.test.ts
@@ -1,0 +1,65 @@
+import { normalizeActions } from './actionUtils';
+
+const AVAILABLE_ACTIONS = [
+  'component:view',
+  'component:create',
+  'component:update',
+  'component:delete',
+  'project:view',
+  'project:create',
+  'logs:view',
+];
+
+describe('normalizeActions', () => {
+  it('returns the input unchanged when the action catalog has not loaded yet', () => {
+    const actions = ['component:view', 'component:create'];
+    expect(normalizeActions(actions, [])).toEqual(actions);
+  });
+
+  it('collapses a fully-selected category into a category wildcard', () => {
+    const actions = [
+      'component:view',
+      'component:create',
+      'component:update',
+      'component:delete',
+    ];
+    expect(normalizeActions(actions, AVAILABLE_ACTIONS)).toEqual([
+      'component:*',
+    ]);
+  });
+
+  it('collapses access to every action into the global wildcard', () => {
+    expect(normalizeActions([...AVAILABLE_ACTIONS], AVAILABLE_ACTIONS)).toEqual(
+      ['*'],
+    );
+  });
+
+  it('keeps a partially-selected category as individual actions', () => {
+    const actions = ['component:view', 'component:create'];
+    expect(normalizeActions(actions, AVAILABLE_ACTIONS)).toEqual([
+      'component:view',
+      'component:create',
+    ]);
+  });
+
+  it('is idempotent for already-collapsed wildcards', () => {
+    expect(normalizeActions(['component:*'], AVAILABLE_ACTIONS)).toEqual([
+      'component:*',
+    ]);
+    expect(normalizeActions(['*'], AVAILABLE_ACTIONS)).toEqual(['*']);
+  });
+
+  it('collapses some categories while leaving partial ones expanded', () => {
+    const actions = [
+      'component:view',
+      'component:create',
+      'component:update',
+      'component:delete',
+      'project:view',
+    ];
+    expect(normalizeActions(actions, AVAILABLE_ACTIONS)).toEqual([
+      'component:*',
+      'project:view',
+    ]);
+  });
+});

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.ts
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.ts
@@ -101,6 +101,32 @@ export function convertToWildcards(
 }
 
 /**
+ * Collapse a role's stored actions into their wildcard form for display.
+ *
+ * Roles may be persisted with the fully expanded action list (e.g. every
+ * `component:*` operation listed individually). This re-applies the same
+ * wildcard collapsing the selection dialog performs on confirm, so a role
+ * with full access to a category shows as `category:*` (and full access to
+ * everything as `*`) consistently on load.
+ *
+ * When the action catalog has not loaded yet (`availableActions` is empty),
+ * the input is returned unchanged so nothing is dropped before we can tell
+ * which categories are complete.
+ */
+export function normalizeActions(
+  actions: string[],
+  availableActions: string[],
+): string[] {
+  if (availableActions.length === 0) {
+    return actions;
+  }
+  return convertToWildcards(
+    expandWildcards(actions, availableActions),
+    availableActions,
+  );
+}
+
+/**
  * Get a human-readable display label for an action.
  * - `*` -> "All Actions"
  * - `category:*` -> "All category actions"

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.ts
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.ts
@@ -120,10 +120,25 @@ export function normalizeActions(
   if (availableActions.length === 0) {
     return actions;
   }
-  return convertToWildcards(
+  const normalizedKnown = convertToWildcards(
     expandWildcards(actions, availableActions),
     availableActions,
   );
+
+  // convertToWildcards only re-emits actions whose category exists in the
+  // catalog, so any unknown/stale action (e.g. a renamed or removed catalog
+  // entry) would be silently dropped here, losing that permission on save.
+  // Preserve such actions alongside the normalized, catalog-backed ones.
+  const unknownOrStale = actions.filter(action => {
+    if (action === '*') return false;
+    if (action.endsWith(':*')) {
+      const category = action.slice(0, -2);
+      return !availableActions.some(a => a.startsWith(`${category}:`));
+    }
+    return !availableActions.includes(action);
+  });
+
+  return Array.from(new Set([...normalizedKnown, ...unknownOrStale]));
 }
 
 /**

--- a/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.ts
+++ b/plugins/openchoreo/src/components/AccessControl/RolesTab/actionUtils.ts
@@ -120,10 +120,18 @@ export function normalizeActions(
   if (availableActions.length === 0) {
     return actions;
   }
-  const normalizedKnown = convertToWildcards(
-    expandWildcards(actions, availableActions),
-    availableActions,
+  const availableSet = new Set(availableActions);
+
+  // Drop stale tokens before collapsing: a stale individual action left in the
+  // expanded set inflates its size past availableActions.length, which defeats
+  // convertToWildcards' global-`*` gate and forces per-category wildcards even
+  // when the role grants everything (e.g. `['*', 'foo:bar']`).
+  const knownExpanded = new Set(
+    [...expandWildcards(actions, availableActions)].filter(action =>
+      availableSet.has(action),
+    ),
   );
+  const normalizedKnown = convertToWildcards(knownExpanded, availableActions);
 
   // convertToWildcards only re-emits actions whose category exists in the
   // catalog, so any unknown/stale action (e.g. a renamed or removed catalog
@@ -135,7 +143,7 @@ export function normalizeActions(
       const category = action.slice(0, -2);
       return !availableActions.some(a => a.startsWith(`${category}:`));
     }
-    return !availableActions.includes(action);
+    return !availableSet.has(action);
   });
 
   return Array.from(new Set([...normalizedKnown, ...unknownOrStale]));


### PR DESCRIPTION
## Purpose

  Resolves openchoreo/openchoreo#2907
  (https://github.com/openchoreo/openchoreo/issues/2907).

  In Access Control, a role's actions were rendered individually. A role granted
  every action in a category (e.g. all alerts or all metrics operations,
  persisted one-by-one) listed each operation as its own chip, producing long,
  noisy lists. The action **selection dialog** already collapses these on
  confirm, so the *same* role looked different depending on where you viewed it
  (Roles table vs. edit dialog vs. selection dialog).

  ## Goals

  Display role actions consistently in their collapsed form everywhere: when a
  role grants every action in a category, show a single chip — e.g. "All alerts
  actions", "All metrics actions" — instead of listing each operation, matching
  what the selection dialog produces.

  ## Approach

  - Add `normalizeActions()` in a new `RolesTab/actionUtils.ts`. It round-trips a
    role's stored actions through `expandWildcards` → `convertToWildcards`,
    reusing the same per-category collapsing logic the selection dialog applies
    on confirm, so display and edit stay in sync. If the action catalog hasn't
    loaded yet (`availableActions` empty) it returns the input unchanged, so
    nothing is dropped before we can tell which categories are complete.
  - **RolesTable**: fetch the action catalog via `useActions()`, render the
    normalized actions as chips, and label fully-granted categories through
    `getActionDisplayLabel` as "All <category> actions" (e.g. "All alerts
    actions"). The "+N more" overflow now counts the collapsed chips.
  - **RoleDialog**: collapse actions on load (when editing a role) and when
    applying a role template; the effect re-runs once `availableActions`
    resolves.
  - Unit tests in `actionUtils.test.ts` cover the expand/collapse/normalize paths
    and the empty-catalog passthrough.


### Before the change
[Before](https://github.com/user-attachments/assets/26b651d0-02ed-49ea-b0a4-12637e4654a3)

### After the change
[After](https://github.com/user-attachments/assets/261954dc-3a9e-4a36-8aad-d09a4f190ac0)


  ## User stories

  As a platform engineer managing roles, I want a role's permissions shown
  compactly and consistently across the Roles table and edit dialog, so I can see
  at a glance which categories a role fully grants.

  ## Release note

  Access Control: when a role grants every action in a category, the Roles table
  and Role dialog now show a single collapsed chip (e.g. "All alerts actions",
  "All metrics actions") instead of listing each individual action, matching the
  action selection dialog.

  ## Documentation

  N/A

  ## Training

  N/A

  ## Certification

  N/A

  ## Marketing

  N/A

  ## Automation tests

  - Unit tests
    > Added `actionUtils.test.ts` covering `expandWildcards`,
    > `convertToWildcards`, and `normalizeActions` (full-category collapse,
    > partial selection kept individual, and empty-catalog passthrough).
  - Integration tests
    > N/A — no backend/integration surface changed.

  ## Security checks

  - Followed secure coding standards? **yes**
  - Ran FindSecurityBugs plugin and verified report? **N/A** — TypeScript/React frontend; no Java.
  - Confirmed no keys, passwords, tokens, usernames, or other secrets committed? **yes**

  ## Samples

  N/A

  ## Related PRs

  N/A

  ## Migrations (if applicable)

  N/A

  ## Test environment

  - Node.js 22, Yarn 4.4.1
  - Local Backstage dev server against k3d OpenChoreo `1.2.0-m.1`
  - Browser: Chrome (latest)

  ## Learning

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role action lists now display compactly: if a role grants all actions in a category, the UI shows a single collapsed entry (e.g., “All component actions”) instead of every operation.
  * The Roles table and Role dialog normalize action display after the action catalog loads, and the “Select Actions” count reflects the expanded granular selection.
* **Tests**
  * Added/expanded test coverage for action normalization, role validation and save behavior (including forbidden/403 messaging), and delete flows with binding checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->