### PR TITLE
fix(backend): pin Node to 22.22 to avoid node-fetch premature-close regression

### DIFF
--- a/.changeset/pin-node-22-22.md
+++ b/.changeset/pin-node-22-22.md
@@ -1,0 +1,12 @@
+---
+'backend': patch
+---
+
+Pin the backend Docker image to Node 22.22 to avoid a node-fetch
+premature-close regression introduced by the Node 22.23 / 24.17
+CVE-2026-48931 keep-alive fix. The internal call from the catalog to the
+permission backend (node-fetch@2 → /api/permission/authorize) fails with
+ERR_STREAM_PREMATURE_CLOSE on Node 22.23+, surfacing as a 500 on catalog
+entities/by-refs ("Failed to load platform details") whenever authz is
+enabled. Revert the pin once a Node 22.x release containing
+nodejs/node#64004 ships.

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1 - Create yarn install skeleton layer
-FROM --platform=linux/amd64 node:22-bookworm-slim AS packages
+# Pinned to 22.22: see the runtime stage below for why.
+FROM --platform=linux/amd64 node:22.22-bookworm-slim AS packages
 
 WORKDIR /app
 COPY backstage.json package.json yarn.lock ./
@@ -14,7 +15,7 @@ COPY plugins plugins
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
 
 # Stage 2 - Install dependencies and build packages
-FROM --platform=linux/amd64 node:22-bookworm-slim AS build
+FROM --platform=linux/amd64 node:22.22-bookworm-slim AS build
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3
@@ -51,7 +52,22 @@ RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
     && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
 
 # Stage 3 - Build the actual backend image and install production dependencies
-FROM node:22-bookworm-slim
+#
+# Pinned to 22.22 (not floating 22) to avoid a regression introduced in Node
+# 22.23.0 / 24.17.0 by the CVE-2026-48931 fix ("response queue poisoning in
+# http.Agent"). That security fix changed keep-alive socket-reuse behaviour and
+# exposes a latent node-fetch@2 bug whose "malformed chunked response detector"
+# throws false-positive ERR_STREAM_PREMATURE_CLOSE on reused pooled sockets.
+# Backstage's internal service-to-service calls (e.g. catalog -> permission
+# /api/permission/authorize) use node-fetch@2 via cross-fetch, so they fail with
+# "Premature close", breaking catalog entities/by-refs ("Failed to load platform
+# details") whenever authz is enabled.
+#   - Backstage:  https://github.com/backstage/backstage/issues/34651
+#   - Node.js:    https://github.com/nodejs/node/issues/63989
+#   - Upstream fix: https://github.com/nodejs/node/pull/64004 (merged, awaiting a
+#     22.x patch release). Revert this pin to `node:22-bookworm-slim` once the
+#     Node 22 release containing PR #64004 (expected 22.23.1+) is available.
+FROM node:22.22-bookworm-slim
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -23,17 +23,16 @@ const backend = createBackend();
 // system to access the user's IDP token when making authorization decisions.
 backend.add(
   rootHttpRouterServiceFactory({
-    configure: ({ app, applyDefaults, middleware }) => {
-      // Apply standard middleware first
-      app.use(middleware.helmet());
-      app.use(middleware.cors());
-      app.use(middleware.compression());
-
-      // IDP token middleware - reads token from header and establishes
-      // AsyncLocalStorage context so getUserTokenFromContext() works everywhere
+    configure: ({ app, applyDefaults }) => {
+      // IDP token middleware — reads the IDP token from the x-openchoreo-token
+      // header and establishes the AsyncLocalStorage context so
+      // getUserTokenFromContext() works in the permission policy and elsewhere.
+      // Registered before applyDefaults() so it wraps all route handlers.
       app.use(createIdpTokenHeaderMiddleware());
 
-      // Apply remaining defaults (routes, error handling, etc.)
+      // applyDefaults() applies the standard middleware stack ONCE:
+      // helmet, cors, compression, logging, rateLimit, then routes + error
+      // handling. Do NOT re-apply any of these manually here.
       applyDefaults();
     },
   }),


### PR DESCRIPTION
With authz enabled the portal showed "Failed to load platform details" and broken catalog views: the catalog's internal call to the permission backend (node-fetch@2 via cross-fetch -> /api/permission/authorize) failed with ERR_STREAM_PREMATURE_CLOSE, surfacing as a 500 on /api/catalog/entities/by-refs.

Root cause is the Node 22.23.0 / 24.17.0 security fix for CVE-2026-48931 ("response queue poisoning in http.Agent"), which changed keep-alive socket-reuse behaviour and exposes a latent node-fetch@2 bug (its malformed-chunked-response detector throws false-positive premature-close on reused pooled sockets). The base image node:22-bookworm-slim floated to 22.23.0, which is why this appeared in newly built images. Pin to 22.22 (last release before the regression) until the Node 22.x patch with nodejs/node#64004 ships.

  - https://github.com/backstage/backstage/issues/34651
  - https://github.com/nodejs/node/issues/63989
  - https://github.com/nodejs/node/pull/64004

Also drop the duplicated helmet/cors/compression from the root router configure block — applyDefaults() already applies them, so they ran twice; keep only the IDP token middleware before applyDefaults().


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js base image version in deployment configuration to improve stability and security.
  * Streamlined HTTP request middleware initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->