### PR TITLE
feat(observability): hide Wirelogs tab unless an environment runs Cilium

### DIFF
--- a/.changeset/hide-wirelogs-tab-without-cilium.md
+++ b/.changeset/hide-wirelogs-tab-without-cilium.md
@@ -1,0 +1,7 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': minor
+---
+
+Add the `useComponentHasAnyCiliumEnabledEnvironment` hook, which resolves on the client whether any of a component's project environments runs Cilium — it fetches the project's environments and probes each backing DataPlane's `networkpolicyprovider` (the same source the Wirelogs page uses to enable/disable individual environments). It returns `false` until the probe confirms at least one Cilium environment.
+
+The portal uses this to hide the component-level **Wirelogs** tab unless at least one environment runs Cilium (wirelogs are sourced from Cilium Hubble). Previously the tab was always shown and, on a core OpenChoreo setup with no Cilium DataPlanes, rendered an empty "configure Cilium" state — a dead tab with no usable content. Resolving availability at render time means no catalog-sync annotation or DataPlane event cascade is required.

--- a/packages/app/src/components/catalog/EntityPage.test.tsx
+++ b/packages/app/src/components/catalog/EntityPage.test.tsx
@@ -1,0 +1,110 @@
+import { render } from '@testing-library/react';
+import { Entity } from '@backstage/catalog-model';
+import { TestApiProvider } from '@backstage/test-utils';
+import { featureFlagsApiRef } from '@backstage/core-plugin-api';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { useComponentHasAnyCiliumEnabledEnvironment } from '@openchoreo/backstage-plugin-openchoreo-observability';
+
+// Control the Cilium gate without hitting the observability backend; keep every
+// other observability export real so module-load wiring is untouched.
+jest.mock('@openchoreo/backstage-plugin-openchoreo-observability', () => ({
+  ...jest.requireActual(
+    '@openchoreo/backstage-plugin-openchoreo-observability',
+  ),
+  useComponentHasAnyCiliumEnabledEnvironment: jest.fn(),
+}));
+
+// The real delete-aware layout pulls catalog/permission APIs we don't need
+// here; render its children straight through.
+jest.mock('./EntityLayoutWithDelete', () => ({
+  EntityLayoutWithDelete: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+// Replace EntityLayout with a shell that evaluates each route's `if` predicate
+// (so the Cilium-gated Wirelogs route runs) without mounting tab content. The
+// real EntitySwitch is kept so component-type routing still drives which page
+// component renders.
+jest.mock('@backstage/plugin-catalog', () => {
+  const actual = jest.requireActual('@backstage/plugin-catalog');
+  const EntityLayout = ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  );
+  EntityLayout.Route = ({
+    if: predicate,
+  }: {
+    if?: (...args: any[]) => any;
+  }) => {
+    if (typeof predicate === 'function') {
+      try {
+        predicate();
+      } catch {
+        // Sibling route predicates may expect a fully-populated entity; we only
+        // care that the gated routes' own predicates execute here.
+      }
+    }
+    return null;
+  };
+  return { ...actual, EntityLayout };
+});
+
+// eslint-disable-next-line import/first
+import { entityPage } from './EntityPage';
+
+const mockHasCilium =
+  useComponentHasAnyCiliumEnabledEnvironment as jest.MockedFunction<
+    typeof useComponentHasAnyCiliumEnabledEnvironment
+  >;
+
+const componentEntity = (type: string): Entity => ({
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name: 'test-component', namespace: 'default' },
+  spec: { type, lifecycle: 'production', owner: 'team-a' },
+});
+
+const featureFlagsApi = {
+  registerFlag: () => {},
+  getRegisteredFlags: () => [],
+  isActive: () => false,
+  save: () => {},
+};
+
+// Plain render (no renderInTestApp) so we exercise the EntitySwitch routing and
+// the page components directly, without the app route collector mounting every
+// routable extension (techdocs etc.) in the tree.
+const renderPage = (entity: Entity) =>
+  render(
+    <TestApiProvider apis={[[featureFlagsApiRef, featureFlagsApi]]}>
+      <EntityProvider entity={entity}>{entityPage}</EntityProvider>
+    </TestApiProvider>,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('entityPage component routing', () => {
+  it('renders the service entity page and gates the Wirelogs route on Cilium availability', () => {
+    mockHasCilium.mockReturnValue(true);
+
+    // deployment/service maps to the "service" page variant.
+    renderPage(componentEntity('deployment/service'));
+
+    expect(mockHasCilium).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'Component' }),
+    );
+  });
+
+  it('renders the generic component entity page and gates the Wirelogs route', () => {
+    mockHasCilium.mockReturnValue(false);
+
+    // deployment/web-app maps to the "website" (non-service) variant.
+    renderPage(componentEntity('deployment/web-app'));
+
+    expect(mockHasCilium).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'Component' }),
+    );
+  });
+});

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -49,7 +49,7 @@ import {
   RELATION_PROVIDES_API,
 } from '@backstage/catalog-model';
 import { TableColumn } from '@backstage/core-components';
-import { EntityTable } from '@backstage/plugin-catalog-react';
+import { EntityTable, useEntity } from '@backstage/plugin-catalog-react';
 import {
   RELATION_DEPLOYS_TO,
   RELATION_DEPLOYED_BY,
@@ -137,6 +137,7 @@ import {
   ObservabilityWirelogs,
   ObservabilityProjectIncidents,
   ObservabilityCostAnalysis,
+  useComponentHasAnyCiliumEnabledEnvironment,
   type RenderLogRowAction,
 } from '@openchoreo/backstage-plugin-openchoreo-observability';
 
@@ -328,219 +329,247 @@ function OverviewContent() {
  * Service entity page with delete menu support.
  * Routes are defined as static JSX children so routable extensions are discoverable.
  */
-const serviceEntityPage = (
-  <EntityLayoutWithDelete>
-    <EntityLayout.Route path="/" title="Overview">
-      <OverviewContent />
-    </EntityLayout.Route>
+const ServiceEntityPage = () => {
+  const { entity } = useEntity();
+  const hasAnyCiliumEnabledEnvironment =
+    useComponentHasAnyCiliumEnabledEnvironment(entity);
 
-    <EntityLayout.Route path="/definition" title="Definition">
-      <ResourceDefinitionTab />
-    </EntityLayout.Route>
+  return (
+    <EntityLayoutWithDelete>
+      <EntityLayout.Route path="/" title="Overview">
+        <OverviewContent />
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/workflows" title="Build">
-      <FeatureGatedContent feature="workflows">
-        {/* Auto-popping launcher — renders nothing unless the latest
+      <EntityLayout.Route path="/definition" title="Definition">
+        <ResourceDefinitionTab />
+      </EntityLayout.Route>
+
+      <EntityLayout.Route path="/workflows" title="Build">
+        <FeatureGatedContent feature="workflows">
+          {/* Auto-popping launcher — renders nothing unless the latest
             run is in a failed state. The fixed pill on this tab was
             intentionally removed; the snackbar still fires so a user
             opening a failed build gets an "Investigate" prompt. */}
-        <FailedBuildSnackbar />
-        <Workflows />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+          <FailedBuildSnackbar />
+          <Workflows />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/environments" title="Deploy">
-      <Environments
-        renderInvestigateAction={renderInvestigateDependencyAction}
-      />
-    </EntityLayout.Route>
-
-    <EntityLayout.Route path="/runtime-logs" title="Logs">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityRuntimeLogs
-          renderRowAction={renderInvestigateLogAction}
+      <EntityLayout.Route path="/environments" title="Deploy">
+        <Environments
+          renderInvestigateAction={renderInvestigateDependencyAction}
         />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/runtime-events" title="Events">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityRuntimeEvents />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/runtime-logs" title="Logs">
+        <FeatureGatedContent feature="observability">
+          <ObservabilityRuntimeLogs
+            renderRowAction={renderInvestigateLogAction}
+          />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/metrics" title="Metrics">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityMetrics />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/runtime-events" title="Events">
+        <FeatureGatedContent feature="observability">
+          <ObservabilityRuntimeEvents />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/alerts" title="Alerts">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityAlerts />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/metrics" title="Metrics">
+        <FeatureGatedContent feature="observability">
+          <ObservabilityMetrics />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/wirelogs" title="Wirelogs">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityWirelogs />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/alerts" title="Alerts">
+        <FeatureGatedContent feature="observability">
+          <ObservabilityAlerts />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route
-      path="/kubernetes"
-      title="Kubernetes"
-      if={isKubernetesAvailable}
-    >
-      <EntityKubernetesContent />
-    </EntityLayout.Route>
+      <EntityLayout.Route
+        path="/wirelogs"
+        title="Wirelogs"
+        if={() => hasAnyCiliumEnabledEnvironment}
+      >
+        <FeatureGatedContent feature="observability">
+          <ObservabilityWirelogs />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/api" title="API" if={hasApis}>
-      <Grid container spacing={3} alignItems="stretch">
-        <Grid item md={6}>
-          <EntityProvidedApisCard columns={apiCardColumns} />
+      <EntityLayout.Route
+        path="/kubernetes"
+        title="Kubernetes"
+        if={isKubernetesAvailable}
+      >
+        <EntityKubernetesContent />
+      </EntityLayout.Route>
+
+      <EntityLayout.Route path="/api" title="API" if={hasApis}>
+        <Grid container spacing={3} alignItems="stretch">
+          <Grid item md={6}>
+            <EntityProvidedApisCard columns={apiCardColumns} />
+          </Grid>
+          <Grid item md={6}>
+            <EntityConsumedApisCard columns={apiCardColumns} />
+          </Grid>
         </Grid>
-        <Grid item md={6}>
-          <EntityConsumedApisCard columns={apiCardColumns} />
-        </Grid>
-      </Grid>
-    </EntityLayout.Route>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs" if={hasTechdocsAnnotation}>
-      {techdocsContent}
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/docs" title="Docs" if={hasTechdocsAnnotation}>
+        {techdocsContent}
+      </EntityLayout.Route>
 
-    {/* External CI Platform Tabs - only shown when annotation is present */}
-    <EntityLayout.Route
-      path="/jenkins"
-      title="Jenkins"
-      if={hasJenkinsAnnotation}
-    >
-      <EntityJenkinsContent />
-    </EntityLayout.Route>
+      {/* External CI Platform Tabs - only shown when annotation is present */}
+      <EntityLayout.Route
+        path="/jenkins"
+        title="Jenkins"
+        if={hasJenkinsAnnotation}
+      >
+        <EntityJenkinsContent />
+      </EntityLayout.Route>
 
-    <EntityLayout.Route
-      path="/github-actions"
-      title="GitHub Actions"
-      if={hasGithubActionsAnnotation}
-    >
-      <EntityGithubActionsContent />
-    </EntityLayout.Route>
+      <EntityLayout.Route
+        path="/github-actions"
+        title="GitHub Actions"
+        if={hasGithubActionsAnnotation}
+      >
+        <EntityGithubActionsContent />
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/gitlab" title="GitLab" if={hasGitlabAnnotation}>
-      <EntityGitlabContent />
-    </EntityLayout.Route>
-  </EntityLayoutWithDelete>
-);
+      <EntityLayout.Route
+        path="/gitlab"
+        title="GitLab"
+        if={hasGitlabAnnotation}
+      >
+        <EntityGitlabContent />
+      </EntityLayout.Route>
+    </EntityLayoutWithDelete>
+  );
+};
 
 /**
  * Website entity page with delete menu support.
  * Routes are defined as static JSX children so routable extensions are discoverable.
  */
-const genericComponentEntityPage = (
-  <EntityLayoutWithDelete>
-    <EntityLayout.Route path="/" title="Overview">
-      <OverviewContent />
-    </EntityLayout.Route>
+const GenericComponentEntityPage = () => {
+  const { entity } = useEntity();
+  const hasAnyCiliumEnabledEnvironment =
+    useComponentHasAnyCiliumEnabledEnvironment(entity);
 
-    <EntityLayout.Route path="/definition" title="Definition">
-      <ResourceDefinitionTab />
-    </EntityLayout.Route>
+  return (
+    <EntityLayoutWithDelete>
+      <EntityLayout.Route path="/" title="Overview">
+        <OverviewContent />
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/workflows" title="Build">
-      <FeatureGatedContent feature="workflows">
-        {/* Auto-popping launcher — renders nothing unless the latest
+      <EntityLayout.Route path="/definition" title="Definition">
+        <ResourceDefinitionTab />
+      </EntityLayout.Route>
+
+      <EntityLayout.Route path="/workflows" title="Build">
+        <FeatureGatedContent feature="workflows">
+          {/* Auto-popping launcher — renders nothing unless the latest
             run is in a failed state. The fixed pill on this tab was
             intentionally removed; the snackbar still fires so a user
             opening a failed build gets an "Investigate" prompt. */}
-        <FailedBuildSnackbar />
-        <Workflows />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+          <FailedBuildSnackbar />
+          <Workflows />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/environments" title="Deploy">
-      <Environments
-        renderInvestigateAction={renderInvestigateDependencyAction}
-      />
-    </EntityLayout.Route>
-
-    <EntityLayout.Route path="/runtime-logs" title="Logs">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityRuntimeLogs
-          renderRowAction={renderInvestigateLogAction}
+      <EntityLayout.Route path="/environments" title="Deploy">
+        <Environments
+          renderInvestigateAction={renderInvestigateDependencyAction}
         />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/runtime-events" title="Events">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityRuntimeEvents />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/runtime-logs" title="Logs">
+        <FeatureGatedContent feature="observability">
+          <ObservabilityRuntimeLogs
+            renderRowAction={renderInvestigateLogAction}
+          />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/metrics" title="Metrics">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityMetrics />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/runtime-events" title="Events">
+        <FeatureGatedContent feature="observability">
+          <ObservabilityRuntimeEvents />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/alerts" title="Alerts">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityAlerts />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/metrics" title="Metrics">
+        <FeatureGatedContent feature="observability">
+          <ObservabilityMetrics />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/wirelogs" title="Wirelogs">
-      <FeatureGatedContent feature="observability">
-        <ObservabilityWirelogs />
-      </FeatureGatedContent>
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/alerts" title="Alerts">
+        <FeatureGatedContent feature="observability">
+          <ObservabilityAlerts />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route
-      path="/kubernetes"
-      title="Kubernetes"
-      if={isKubernetesAvailable}
-    >
-      <EntityKubernetesContent />
-    </EntityLayout.Route>
+      <EntityLayout.Route
+        path="/wirelogs"
+        title="Wirelogs"
+        if={() => hasAnyCiliumEnabledEnvironment}
+      >
+        <FeatureGatedContent feature="observability">
+          <ObservabilityWirelogs />
+        </FeatureGatedContent>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/api" title="API" if={hasApis}>
-      <Grid container spacing={3} alignItems="stretch">
-        <Grid item md={6}>
-          <EntityProvidedApisCard columns={apiCardColumns} />
+      <EntityLayout.Route
+        path="/kubernetes"
+        title="Kubernetes"
+        if={isKubernetesAvailable}
+      >
+        <EntityKubernetesContent />
+      </EntityLayout.Route>
+
+      <EntityLayout.Route path="/api" title="API" if={hasApis}>
+        <Grid container spacing={3} alignItems="stretch">
+          <Grid item md={6}>
+            <EntityProvidedApisCard columns={apiCardColumns} />
+          </Grid>
+          <Grid item md={6}>
+            <EntityConsumedApisCard columns={apiCardColumns} />
+          </Grid>
         </Grid>
-        <Grid item md={6}>
-          <EntityConsumedApisCard columns={apiCardColumns} />
-        </Grid>
-      </Grid>
-    </EntityLayout.Route>
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs" if={hasTechdocsAnnotation}>
-      {techdocsContent}
-    </EntityLayout.Route>
+      <EntityLayout.Route path="/docs" title="Docs" if={hasTechdocsAnnotation}>
+        {techdocsContent}
+      </EntityLayout.Route>
 
-    {/* External CI Platform Tabs - only shown when annotation is present */}
-    <EntityLayout.Route
-      path="/jenkins"
-      title="Jenkins"
-      if={hasJenkinsAnnotation}
-    >
-      <EntityJenkinsContent />
-    </EntityLayout.Route>
+      {/* External CI Platform Tabs - only shown when annotation is present */}
+      <EntityLayout.Route
+        path="/jenkins"
+        title="Jenkins"
+        if={hasJenkinsAnnotation}
+      >
+        <EntityJenkinsContent />
+      </EntityLayout.Route>
 
-    <EntityLayout.Route
-      path="/github-actions"
-      title="GitHub Actions"
-      if={hasGithubActionsAnnotation}
-    >
-      <EntityGithubActionsContent />
-    </EntityLayout.Route>
+      <EntityLayout.Route
+        path="/github-actions"
+        title="GitHub Actions"
+        if={hasGithubActionsAnnotation}
+      >
+        <EntityGithubActionsContent />
+      </EntityLayout.Route>
 
-    <EntityLayout.Route path="/gitlab" title="GitLab" if={hasGitlabAnnotation}>
-      <EntityGitlabContent />
-    </EntityLayout.Route>
-  </EntityLayoutWithDelete>
-);
+      <EntityLayout.Route
+        path="/gitlab"
+        title="GitLab"
+        if={hasGitlabAnnotation}
+      >
+        <EntityGitlabContent />
+      </EntityLayout.Route>
+    </EntityLayoutWithDelete>
+  );
+};
 
 /**
  * NOTE: This page is designed to work on small screens such as mobile devices.
@@ -589,11 +618,11 @@ const isGenericComponent = (entity: Entity) =>
 const componentPage = (
   <EntitySwitch>
     <EntitySwitch.Case if={isServiceComponent}>
-      {serviceEntityPage}
+      <ServiceEntityPage />
     </EntitySwitch.Case>
 
     <EntitySwitch.Case if={isGenericComponent}>
-      {genericComponentEntityPage}
+      <GenericComponentEntityPage />
     </EntitySwitch.Case>
 
     {/* Fallback for unknown component types or 'default' variant */}

--- a/plugins/openchoreo-observability/src/hooks/index.ts
+++ b/plugins/openchoreo-observability/src/hooks/index.ts
@@ -5,6 +5,7 @@ export type {
   WirelogsEnvironment,
   UseWirelogsEnvironmentsResult,
 } from './useWirelogsEnvironments';
+export { useComponentHasAnyCiliumEnabledEnvironment } from './useComponentHasAnyCiliumEnabledEnvironment';
 export { useFilters } from './useFilters';
 export { useUrlFilters } from './useUrlFilters';
 export { useMetrics } from './useMetrics';

--- a/plugins/openchoreo-observability/src/hooks/useComponentHasAnyCiliumEnabledEnvironment.test.tsx
+++ b/plugins/openchoreo-observability/src/hooks/useComponentHasAnyCiliumEnabledEnvironment.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+import { Entity } from '@backstage/catalog-model';
+import { useComponentHasAnyCiliumEnabledEnvironment } from './useComponentHasAnyCiliumEnabledEnvironment';
+
+const mockUseGetNamespaceAndProjectByEntity = jest.fn();
+const mockUseWirelogsEnvironments = jest.fn();
+
+jest.mock('./useGetNamespaceAndProjectByEntity', () => ({
+  useGetNamespaceAndProjectByEntity: (...args: any[]) =>
+    mockUseGetNamespaceAndProjectByEntity(...args),
+}));
+jest.mock('./useWirelogsEnvironments', () => ({
+  useWirelogsEnvironments: (...args: any[]) =>
+    mockUseWirelogsEnvironments(...args),
+}));
+
+const entity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name: 'svc' },
+};
+
+const setup = () =>
+  renderHook(() => useComponentHasAnyCiliumEnabledEnvironment(entity));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseGetNamespaceAndProjectByEntity.mockReturnValue({
+    namespace: 'ns-1',
+    project: 'proj-1',
+    error: null,
+  });
+});
+
+describe('useComponentHasAnyCiliumEnabledEnvironment', () => {
+  it('returns true when at least one environment runs Cilium', () => {
+    mockUseWirelogsEnvironments.mockReturnValue({
+      environments: [
+        { name: 'dev', hasWirelogs: false },
+        { name: 'prod', hasWirelogs: true },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    const { result } = setup();
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when no environment runs Cilium', () => {
+    mockUseWirelogsEnvironments.mockReturnValue({
+      environments: [
+        { name: 'dev', hasWirelogs: false },
+        { name: 'prod', hasWirelogs: false },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    const { result } = setup();
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false while the probe is in flight (no environments yet)', () => {
+    mockUseWirelogsEnvironments.mockReturnValue({
+      environments: [],
+      loading: true,
+      error: null,
+    });
+
+    const { result } = setup();
+    expect(result.current).toBe(false);
+  });
+
+  it('derives project + namespace from the entity and forwards them to the probe', () => {
+    mockUseWirelogsEnvironments.mockReturnValue({
+      environments: [],
+      loading: false,
+      error: null,
+    });
+
+    setup();
+
+    expect(mockUseGetNamespaceAndProjectByEntity).toHaveBeenCalledWith(entity);
+    expect(mockUseWirelogsEnvironments).toHaveBeenCalledWith('proj-1', 'ns-1');
+  });
+});

--- a/plugins/openchoreo-observability/src/hooks/useComponentHasAnyCiliumEnabledEnvironment.ts
+++ b/plugins/openchoreo-observability/src/hooks/useComponentHasAnyCiliumEnabledEnvironment.ts
@@ -1,0 +1,20 @@
+import { Entity } from '@backstage/catalog-model';
+import { useGetNamespaceAndProjectByEntity } from './useGetNamespaceAndProjectByEntity';
+import { useWirelogsEnvironments } from './useWirelogsEnvironments';
+
+/**
+ * Resolves Cilium CNI availability for a component entity on the client:
+ * derives the project + namespace from the entity's annotations,
+ * fetches the project's environments and probes each backing
+ * DataPlane's `networkpolicyprovider` via the observability backend.
+ *
+ * Returns `true` once at least one environment runs Cilium. While the probe is
+ * in flight `environments` is empty, so the result is `false` until it resolves.
+ */
+export const useComponentHasAnyCiliumEnabledEnvironment = (
+  entity: Entity,
+): boolean => {
+  const { namespace, project } = useGetNamespaceAndProjectByEntity(entity);
+  const { environments } = useWirelogsEnvironments(project, namespace);
+  return environments.some(env => env.hasWirelogs);
+};

--- a/plugins/openchoreo-observability/src/index.ts
+++ b/plugins/openchoreo-observability/src/index.ts
@@ -12,6 +12,7 @@ export {
   ObservabilityCostAnalysis,
 } from './plugin';
 export type { RenderLogRowAction } from './components/RuntimeLogs/LogEntry';
+export { useComponentHasAnyCiliumEnabledEnvironment } from './hooks';
 export {
   logRowActionRendererApiRef,
   type LogRowActionRendererApi,


### PR DESCRIPTION
## Purpose
Wirelogs stream from Cilium Hubble, so the component-level **Wirelogs** tab is only useful when one of the project's environments runs on a Cilium DataPlane. Today the tab is always rendered — on a core OpenChoreo setup with no Cilium DataPlanes it's a dead tab that just shows a "configure Cilium" empty state. This PR hides the tab unless at least one of the component's project environments is backed by a Cilium DataPlane.

Related: https://github.com/openchoreo/openchoreo/issues/3978

## Goals
- Stop rendering the Wirelogs tab when none of the project's environments can stream wirelogs.
- Resolve tab visibility from data the observability backend already exposes — no new annotations, no backend/catalog-sync
  changes, no DataPlane event plumbing.

## Approach
- New client hook. useComponentHasAnyCiliumEnabledEnvironment(entity) derives the project + namespace from the component's annotations (useGetNamespaceAndProjectByEntity), fetches the project's environments, and probes each backing DataPlane's networkpolicyprovider (useWirelogsEnvironments — the same source the Wirelogs page uses to enable/disable individual environments). It returns true once any environment reports networkPolicyProvider === 'cilium', and false while the probe is in flight, so the tab never flashes in before availability is confirmed.

- Gate the tab. The two component entity pages (serviceEntityPage, genericComponentEntityPage) are converted from static JSX constants into function components (ServiceEntityPage, GenericComponentEntityPage) so they can call the hook, and the /wirelogs route is guarded with if={() => hasAnyCiliumEnabledEnvironment}. (This conversion is what accounts for most of the diff size in EntityPage.tsx.)

- Exported for reuse. The hook is re-exported from the observability plugin's public entrypoint.

Resolving availability at render time means no catalog-sync annotation and no DataPlane event cascade are required — visibility is always derived from live backend state on page load.

- Screen Recording

https://github.com/user-attachments/assets/0ed54b83-5917-4e17-800d-d560415dca46



Verified end-to-end locally: event-forwarder → Backstage events HTTP ingress → cascade → the Wirelogs tab flips on a live Cilium annotation change.

## User stories

- As a **core OpenChoreo user** (no Cilium), I no longer see a Wirelogs tab I can't use — one fewer tab on every component.
- As an **operator enabling Cilium** on a DataPlane, the Wirelogs tab appears on the affected projects' components within seconds, without a catalog re-sync.

## Release note

Hide the component-level Wirelogs tab unless one of the project's environments runs on a Cilium DataPlane, and update tab visibility live when a DataPlane's Cilium configuration changes.

## Documentation

No documentation changes required.

## Training

N/A

## Certification

N/A

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * The **Wirelogs** tab now appears only when a component has at least one eligible environment.
  * Component pages update the visibility of the **Wirelogs** tab dynamically based on available environment support.

* **Bug Fixes**
  * Prevents showing an empty or unusable **Wirelogs** experience when no matching environment is available.

* **Tests**
  * Added coverage for the new environment-availability hook and the component page routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->