### PR TITLE
feat(observability): limit wirelogs stream duration

### DIFF
--- a/.changeset/wirelogs-stream-timeout.md
+++ b/.changeset/wirelogs-stream-timeout.md
@@ -1,0 +1,8 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+'@openchoreo/backstage-plugin-backend': patch
+---
+
+Limit how long a wirelogs stream can run. Wirelogs (Cilium Hubble flows) previously streamed indefinitely — there's no upstream timeout, so a forgotten tab could hold an open SSE connection for hours and degrade the browser.
+
+The backend `/wirelogs/stream` proxy now enforces a hard cap (default 15 minutes, configurable via `openchoreo.observability.wirelogs.streamTimeoutSeconds`): it advertises the cap to the client in a `meta` SSE frame and, on hitting it, sends a `timeout` frame before closing so the UI can label the stop precisely. The wirelogs view layers graduated soft warnings over this — confirmation dialogs at roughly one-third and two-thirds of the cap let the user stop early or knowingly continue, and a toast explains when the server ends the stream (the Start button resumes a fresh session).

--- a/README.md
+++ b/README.md
@@ -317,6 +317,25 @@ eventForwarder:
   enabled: true
 ```
 
+## Observability
+
+### Configuration
+
+| Setting                                                  | Environment Variable                                       | Default | Description                                                                                                                                                                                            |
+| -------------------------------------------------------- | ---------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `openchoreo.observability.wirelogs.streamTimeoutSeconds` | `OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS` | `900`   | Hard cap (seconds) on a single wirelogs SSE stream before the backend ends it. The UI shows soft warnings at ~1/3 and ~2/3 of this value and a toast when the server stops it. Defaults to 15 minutes. |
+
+**Production (Helm):**
+
+The Helm chart injects this environment variable. You can configure it via Helm values:
+
+```yaml
+backstage:
+  observability:
+    wirelogs:
+      streamTimeoutSeconds: 900
+```
+
 ## External CI Platform Integration
 
 OpenChoreo includes built-in support for viewing CI build status from external platforms directly in Backstage.

--- a/app-config.local.yaml.example
+++ b/app-config.local.yaml.example
@@ -53,6 +53,15 @@ openchoreo:
     tokenUrl: http://thunder.openchoreo.localhost:8080/oauth2/token
     # scope: 'openid'  # Optional: space-separated scopes for client credentials token (depends on your IDP)
 
+  # Observability tuning (optional).
+  # Hard cap (seconds) on a single wirelogs SSE stream before the backend ends
+  # it; the UI shows soft warnings at ~1/3 and ~2/3 of this value and a toast
+  # when the server stops it. Default is 900 (15 minutes). Lower it to watch
+  # the timeout flow quickly during local testing.
+  # observability:
+  #   wirelogs:
+  #     streamTimeoutSeconds: 900
+
   # Feature flags (optional overrides)
   # All features are enabled by default. Uncomment to disable specific features:
   features:

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -208,6 +208,15 @@ openchoreo:
   events:
     enabled: ${OPENCHOREO_EVENTS_ENABLED}
 
+  # Observability tuning.
+  # Hard cap (seconds) on a single wirelogs SSE stream before the backend ends
+  # it; the UI shows soft warnings at ~1/3 and ~2/3 of this value and a toast
+  # when the server stops it. Defaults to 900 (15 minutes) when unset.
+  # Environment variable: OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS
+  observability:
+    wirelogs:
+      streamTimeoutSeconds: ${OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS}
+
   # Feature flags for enabling/disabling OpenChoreo functionality
   # Environment variables: OPENCHOREO_FEATURES_WORKFLOWS_ENABLED, OPENCHOREO_FEATURES_OBSERVABILITY_ENABLED, OPENCHOREO_FEATURES_AUTH_ENABLED, OPENCHOREO_FEATURES_AUTHZ_ENABLED, OPENCHOREO_FEATURES_ASSISTANT_ENABLED
   features:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -190,11 +190,10 @@ openchoreo:
   # Observability tuning (optional).
   # Hard cap (seconds) on a single wirelogs SSE stream before the backend ends
   # it; the UI shows soft warnings at ~1/3 and ~2/3 of this value and a toast
-  # when the server stops it. Default is 900 (15 minutes). Lower it to watch
-  # the timeout flow quickly during local testing.
-  # observability:
-  #   wirelogs:
-  #     streamTimeoutSeconds: 900
+  # when the server stops it. Defaults to 900 (15 minutes) when unset.
+  observability:
+    wirelogs:
+      streamTimeoutSeconds: ${OPENCHOREO_OBSERVABILITY_WIRELOGS_STREAM_TIMEOUT_SECONDS}
 
   # Feature flags for enabling/disabling OpenChoreo functionality
   # These can be controlled via Helm values: backstage.features.*

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -187,6 +187,15 @@ openchoreo:
     frequency: 300 # seconds between runs (default: 300, the periodic full sync acts as a safety net behind the event-forwarder's real-time deltas)
     timeout: 120 # seconds for timeout (default: 120)
 
+  # Observability tuning (optional).
+  # Hard cap (seconds) on a single wirelogs SSE stream before the backend ends
+  # it; the UI shows soft warnings at ~1/3 and ~2/3 of this value and a toast
+  # when the server stops it. Default is 900 (15 minutes). Lower it to watch
+  # the timeout flow quickly during local testing.
+  # observability:
+  #   wirelogs:
+  #     streamTimeoutSeconds: 900
+
   # Feature flags for enabling/disabling OpenChoreo functionality
   # These can be controlled via Helm values: backstage.features.*
   # Environment variables: OPENCHOREO_FEATURES_WORKFLOWS_ENABLED, OPENCHOREO_FEATURES_OBSERVABILITY_ENABLED, OPENCHOREO_FEATURES_AUTH_ENABLED, OPENCHOREO_FEATURES_AUTHZ_ENABLED, OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -78,6 +78,14 @@ export const choreoPlugin = createBackendPlugin({
         const authEnabled =
           config.getOptionalBoolean('openchoreo.features.auth.enabled') ?? true;
 
+        // Hard cap on a single wirelogs SSE stream. Wirelogs have no upstream
+        // timeout (the openchoreo-api disables the write deadline for SSE), so
+        // the backend proxy enforces one to stop runaway streams. Default 15m.
+        const wirelogsStreamTimeoutMs =
+          (config.getOptionalNumber(
+            'openchoreo.observability.wirelogs.streamTimeoutSeconds',
+          ) ?? 900) * 1000;
+
         // All services use user tokens forwarded from the frontend
         // No default token - services require token parameter for each API call
         const environmentInfoService = new EnvironmentInfoService(
@@ -213,6 +221,7 @@ export const choreoPlugin = createBackendPlugin({
             auth,
             tokenService,
             authEnabled,
+            wirelogsStreamTimeoutMs,
             logger,
           }),
         );

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -81,10 +81,17 @@ export const choreoPlugin = createBackendPlugin({
         // Hard cap on a single wirelogs SSE stream. Wirelogs have no upstream
         // timeout (the openchoreo-api disables the write deadline for SSE), so
         // the backend proxy enforces one to stop runaway streams. Default 15m.
-        const wirelogsStreamTimeoutMs =
-          (config.getOptionalNumber(
+        // Guard against a non-positive value (would abort streams instantly)
+        // and against overflowing setTimeout's max delay.
+        const configuredWirelogsTimeoutSeconds =
+          config.getOptionalNumber(
             'openchoreo.observability.wirelogs.streamTimeoutSeconds',
-          ) ?? 900) * 1000;
+          ) ?? 900;
+        const wirelogsStreamTimeoutMs =
+          Number.isFinite(configuredWirelogsTimeoutSeconds) &&
+          configuredWirelogsTimeoutSeconds > 0
+            ? Math.min(configuredWirelogsTimeoutSeconds * 1000, 2_147_483_647)
+            : 900_000;
 
         // All services use user tokens forwarded from the frontend
         // No default token - services require token parameter for each API call

--- a/plugins/openchoreo-backend/src/router.test.ts
+++ b/plugins/openchoreo-backend/src/router.test.ts
@@ -136,6 +136,7 @@ function createMockServices() {
       hasServiceCredentials: jest.fn().mockReturnValue(false),
     } as jest.Mocked<OpenChoreoTokenService>,
     authEnabled: true,
+    wirelogsStreamTimeoutMs: 900_000,
     logger: {
       info: jest.fn(),
       warn: jest.fn(),
@@ -1101,6 +1102,9 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/text\/event-stream/);
       expect(response.headers['cache-control']).toMatch(/no-cache/);
+      // The stream opens with a `meta` frame advertising the hard cap.
+      expect(response.text).toContain('event: meta');
+      expect(response.text).toContain('hardTimeoutMs');
       expect(response.text).toContain('"uuid":"a"');
       expect(response.text).toContain('"uuid":"b"');
 
@@ -1154,6 +1158,50 @@ describe('createRouter', () => {
       expect(response.text).toContain('event: error');
       expect(response.text).toContain('"status":502');
       expect(response.text).toContain('bad gateway');
+    });
+
+    it('ends the stream with a timeout SSE frame when the hard cap is hit', async () => {
+      // Fresh router with a tiny cap; the upstream never produces data and
+      // only settles when the composed signal aborts (as a real fetch body
+      // would), so the hard timeout is the only thing that can end it.
+      const localServices = createMockServices();
+      localServices.wirelogsStreamTimeoutMs = 50;
+      localServices.wirelogsInfoService.openStream.mockImplementation(
+        async (_req: any, _token: any, signal: AbortSignal) => {
+          const reader = {
+            read: jest.fn(
+              () =>
+                new Promise((_resolve, reject) => {
+                  signal.addEventListener(
+                    'abort',
+                    () => reject(new DOMException('aborted', 'AbortError')),
+                    { once: true },
+                  );
+                }),
+            ),
+            cancel: jest.fn().mockResolvedValue(undefined),
+          };
+          return {
+            ok: true,
+            status: 200,
+            body: { getReader: () => reader },
+            text: jest.fn().mockResolvedValue(''),
+          } as unknown as Response;
+        },
+      );
+      const localApp = express();
+      localApp.use(await createRouter(localServices as any));
+      localApp.use(mockErrorHandler());
+
+      const response = await request(localApp).get('/wirelogs/stream').query({
+        namespaceName: 'ns',
+        environmentName: 'dev',
+        projectName: 'proj',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('event: timeout');
+      expect(response.text).toContain('hardTimeoutMs');
     });
   });
 });

--- a/plugins/openchoreo-backend/src/router.test.ts
+++ b/plugins/openchoreo-backend/src/router.test.ts
@@ -1203,5 +1203,35 @@ describe('createRouter', () => {
       expect(response.text).toContain('event: timeout');
       expect(response.text).toContain('hardTimeoutMs');
     });
+
+    it('emits a timeout frame (not an error) when the cap is hit before the upstream opens', async () => {
+      const localServices = createMockServices();
+      localServices.wirelogsStreamTimeoutMs = 50;
+      // openStream never resolves; it rejects only once the hard-timeout abort
+      // fires — exercising the pre-open abort branch in the catch.
+      localServices.wirelogsInfoService.openStream.mockImplementation(
+        (_req: any, _token: any, signal: AbortSignal) =>
+          new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => reject(new DOMException('aborted', 'AbortError')),
+              { once: true },
+            );
+          }),
+      );
+      const localApp = express();
+      localApp.use(await createRouter(localServices as any));
+      localApp.use(mockErrorHandler());
+
+      const response = await request(localApp).get('/wirelogs/stream').query({
+        namespaceName: 'ns',
+        environmentName: 'dev',
+        projectName: 'proj',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('event: timeout');
+      expect(response.text).not.toContain('Failed to open wirelogs stream');
+    });
   });
 });

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -2271,6 +2271,28 @@ export async function createRouter({
     } catch (err) {
       clearTimeout(timeoutHandle);
       res.off('close', onClientClose);
+      // The abort fired before the upstream finished opening: either the hard
+      // timeout (emit a timeout frame, matching the mid-stream path) or a
+      // client disconnect (nothing to write to — just end quietly). Only a
+      // genuine open failure falls through to the error frame.
+      if (abortController.signal.aborted) {
+        if (timedOut && !res.writableEnded && !res.destroyed) {
+          try {
+            res.write(
+              `event: timeout\ndata: ${JSON.stringify({
+                hardTimeoutMs: wirelogsStreamTimeoutMs,
+                message: `Wirelogs stream stopped after ${Math.round(
+                  wirelogsStreamTimeoutMs / 60000,
+                )} minutes`,
+              })}\n\n`,
+            );
+          } catch {
+            // client vanished between the check and the write — nothing to do
+          }
+        }
+        res.end();
+        return;
+      }
       logger.error(
         `Failed to open wirelogs upstream: ${(err as Error).message}`,
       );

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -105,6 +105,7 @@ export async function createRouter({
   auth,
   tokenService,
   authEnabled,
+  wirelogsStreamTimeoutMs,
   logger,
 }: {
   environmentInfoService: EnvironmentInfoService;
@@ -132,6 +133,8 @@ export async function createRouter({
   auth: AuthService;
   tokenService: OpenChoreoTokenService;
   authEnabled: boolean;
+  /** Hard cap (ms) on a single wirelogs SSE stream before the server ends it. */
+  wirelogsStreamTimeoutMs: number;
   logger: LoggerService;
 }): Promise<express.Router> {
   const router = Router();
@@ -2230,9 +2233,28 @@ export async function createRouter({
       res.flushHeaders();
     }
 
+    // A single AbortController ends the stream on either client disconnect or
+    // the hard timeout; `timedOut` records which, so on a timeout we can send
+    // the client an explicit `timeout` frame (the connection is still open),
+    // whereas on a client disconnect there's nothing to write to. Listen on
+    // `res` 'close' (not `req`) to avoid the race where the request stream
+    // closes before the upstream fetch is even established.
     const abortController = new AbortController();
+    let timedOut = false;
     const onClientClose = () => abortController.abort();
-    req.on('close', onClientClose);
+    res.on('close', onClientClose);
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      abortController.abort();
+    }, wirelogsStreamTimeoutMs);
+
+    // Announce the hard cap up front so the UI can warn the user before it
+    // hits and label the eventual stop accurately.
+    res.write(
+      `event: meta\ndata: ${JSON.stringify({
+        hardTimeoutMs: wirelogsStreamTimeoutMs,
+      })}\n\n`,
+    );
 
     let upstream: Response;
     try {
@@ -2247,6 +2269,8 @@ export async function createRouter({
         abortController.signal,
       );
     } catch (err) {
+      clearTimeout(timeoutHandle);
+      res.off('close', onClientClose);
       logger.error(
         `Failed to open wirelogs upstream: ${(err as Error).message}`,
       );
@@ -2260,6 +2284,8 @@ export async function createRouter({
     }
 
     if (!upstream.ok || !upstream.body) {
+      clearTimeout(timeoutHandle);
+      res.off('close', onClientClose);
       const status = upstream.status;
       const errorText = await upstream.text().catch(() => '');
       logger.warn(
@@ -2286,16 +2312,18 @@ export async function createRouter({
         }
         if (!res.write(Buffer.from(value))) {
           await new Promise<void>(resolve => {
-            const cleanup = (handler: () => void) => {
-              res.off('drain', handler);
-              res.off('close', handler);
-            };
             const onSettled = () => {
-              cleanup(onSettled);
+              res.off('drain', onSettled);
+              res.off('close', onSettled);
+              abortController.signal.removeEventListener('abort', onSettled);
               resolve();
             };
             res.once('drain', onSettled);
             res.once('close', onSettled);
+            // Unblock a stalled backpressure wait when the hard timeout fires.
+            abortController.signal.addEventListener('abort', onSettled, {
+              once: true,
+            });
           });
           if (abortController.signal.aborted) {
             streaming = false;
@@ -2308,11 +2336,32 @@ export async function createRouter({
         logger.warn(`Wirelogs stream interrupted: ${(err as Error).message}`);
       }
     } finally {
-      req.off('close', onClientClose);
+      clearTimeout(timeoutHandle);
+      res.off('close', onClientClose);
       try {
         await reader.cancel();
       } catch {
         // ignore
+      }
+      // Hard timeout (client still connected): tell the UI explicitly so it
+      // can show a "stopped by server" message rather than a generic error.
+      if (timedOut && !res.writableEnded) {
+        logger.info(
+          `Wirelogs stream hit hard timeout after ${wirelogsStreamTimeoutMs}ms ` +
+            `(namespace=${namespaceName} environment=${environmentName})`,
+        );
+        try {
+          res.write(
+            `event: timeout\ndata: ${JSON.stringify({
+              hardTimeoutMs: wirelogsStreamTimeoutMs,
+              message: `Wirelogs stream stopped after ${Math.round(
+                wirelogsStreamTimeoutMs / 60000,
+              )} minutes`,
+            })}\n\n`,
+          );
+        } catch {
+          // client vanished between the check and the write — nothing to do
+        }
       }
       res.end();
     }

--- a/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.test.tsx
@@ -45,6 +45,29 @@ jest.mock('@openchoreo/backstage-plugin-common', () => ({
   CHOREO_ANNOTATIONS: { COMPONENT: 'openchoreo.io/component' },
 }));
 
+// The page calls useApi(alertApiRef); the plain `render` here has no
+// Backstage API context, so override only useApi (keeping the real module
+// otherwise, so core-components still loads) and expose the alert post spy.
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  const alertPost = jest.fn();
+  return {
+    ...actual,
+    useApi: jest.fn(() => ({ post: alertPost })),
+    __alertPost: alertPost,
+  };
+});
+
+// The soft-timeout dialog is covered by its own logic; render it as a no-op
+// here so the page test stays focused on layout/state.
+jest.mock('./WirelogsStreamTimeoutDialog', () => ({
+  __esModule: true,
+  WirelogsStreamTimeoutDialog: () => null,
+}));
+
+const alertPost = (jest.requireMock('@backstage/core-plugin-api') as any)
+  .__alertPost as jest.Mock;
+
 const mockUseGetNamespaceAndProjectByEntity = jest.fn().mockReturnValue({
   namespace: 'ns',
   project: 'proj',
@@ -110,6 +133,9 @@ interface StreamState {
   status: string;
   error: string | null;
   totalReceived: number;
+  startedAt: number | null;
+  hardTimeoutMs: number | null;
+  closedReason: 'user' | 'timeout' | 'error' | 'ended' | null;
   start: jest.Mock;
   stop: jest.Mock;
   clear: jest.Mock;
@@ -125,6 +151,9 @@ function defaultStream(): StreamState {
     status: 'idle',
     error: null,
     totalReceived: 0,
+    startedAt: null,
+    hardTimeoutMs: null,
+    closedReason: null,
     start: startMock,
     stop: stopMock,
     clear: clearMock,
@@ -226,6 +255,23 @@ describe('ObservabilityWirelogsPage', () => {
     setupStream({ status: 'error', error: 'kaboom' });
     render(<ObservabilityWirelogsPage />);
     expect(screen.getByText('kaboom')).toBeInTheDocument();
+  });
+
+  it('posts a toast when the stream closes due to the hard timeout', () => {
+    setupStream({ status: 'closed', closedReason: 'timeout' });
+    render(<ObservabilityWirelogsPage />);
+    expect(alertPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'info',
+        message: expect.stringContaining('maximum duration'),
+      }),
+    );
+  });
+
+  it('does not post the timeout toast for a user-stopped stream', () => {
+    setupStream({ status: 'closed', closedReason: 'user' });
+    render(<ObservabilityWirelogsPage />);
+    expect(alertPost).not.toHaveBeenCalled();
   });
 
   it('shows a compact forbidden state for the selected environment when scoped permission is denied', async () => {

--- a/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/ObservabilityWirelogsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Alert } from '@material-ui/lab';
 import { Box, Tooltip, Typography } from '@material-ui/core';
 import { Progress } from '@backstage/core-components';
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import {
@@ -15,12 +16,14 @@ import {
 import { WirelogsFilter } from './WirelogsFilter';
 import { WirelogsStats } from './WirelogsStats';
 import { WirelogsTable, matchesSearch } from './WirelogsTable';
+import { WirelogsStreamTimeoutDialog } from './WirelogsStreamTimeoutDialog';
 import { useWirelogsStream } from './useWirelogsStream';
 import { useWirelogsStyles } from './styles';
 import type { WirelogsFilters } from './types';
 
 const ObservabilityWirelogsContent = () => {
   const classes = useWirelogsStyles();
+  const alertApi = useApi(alertApiRef);
   const { entity } = useEntity();
   const { namespace, project } = useGetNamespaceAndProjectByEntity(entity);
   const componentName =
@@ -72,7 +75,11 @@ const ObservabilityWirelogsContent = () => {
     componentName,
   });
 
-  const { status: streamStatus, stop: stopStream } = stream;
+  const {
+    status: streamStatus,
+    stop: stopStream,
+    closedReason: streamClosedReason,
+  } = stream;
   useEffect(() => {
     if (
       !environmentsLoading &&
@@ -90,6 +97,20 @@ const ObservabilityWirelogsContent = () => {
     streamStatus,
     stopStream,
   ]);
+
+  // When the server ends the stream at the hard cap, surface a toast — the
+  // `timeout` SSE frame distinguishes this from a generic error. The Start
+  // stream button (shown once closed) is the one-click way to resume.
+  useEffect(() => {
+    if (streamStatus === 'closed' && streamClosedReason === 'timeout') {
+      alertApi.post({
+        message:
+          'Wirelogs streaming stopped after reaching the maximum duration. Select "Start stream" to resume.',
+        severity: 'info',
+        display: 'transient',
+      });
+    }
+  }, [streamStatus, streamClosedReason, alertApi]);
 
   // Component scoping is applied upstream via the Hubble filter; only the
   // free-text search box is applied client-side here.
@@ -187,6 +208,13 @@ const ObservabilityWirelogsContent = () => {
       ) : (
         toolbar
       )}
+
+      <WirelogsStreamTimeoutDialog
+        status={stream.status}
+        startedAt={stream.startedAt}
+        hardTimeoutMs={stream.hardTimeoutMs}
+        onStop={stream.stop}
+      />
 
       {stream.error && (
         <Alert severity="error" className={classes.errorContainer}>

--- a/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsStreamTimeoutDialog.tsx
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/WirelogsStreamTimeoutDialog.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from '@material-ui/core';
+import type { WirelogStreamStatus } from './types';
+
+export interface WirelogsStreamTimeoutDialogProps {
+  status: WirelogStreamStatus;
+  /** Epoch ms when the stream began, from useWirelogsStream. */
+  startedAt: number | null;
+  /** Hard cap (ms) advertised by the backend `meta` frame. */
+  hardTimeoutMs: number | null;
+  /** Stop the stream (the user chose not to continue). */
+  onStop: () => void;
+}
+
+/** "5 minutes" / "45 seconds" — for human-readable durations in the prompts. */
+function humanizeDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  if (totalSeconds < 90) {
+    return `${totalSeconds} second${totalSeconds === 1 ? '' : 's'}`;
+  }
+  const minutes = Math.round(totalSeconds / 60);
+  return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+}
+
+/**
+ * Graduated soft-timeout warnings layered over the hard server cap. While a
+ * stream is running it surfaces two confirmations — at one-third and
+ * two-thirds of the hard cap — so the user can stop early or knowingly let it
+ * approach the limit. Thresholds are proportional to the backend's
+ * `hardTimeoutMs`, so the default 15-minute cap warns at ~5 and ~10 minutes,
+ * and a lowered cap (e.g. for local testing) scales down with it.
+ *
+ * The hard stop itself is enforced by the backend; this component is purely
+ * the heads-up. Each stage shows once per stream session.
+ */
+export const WirelogsStreamTimeoutDialog = ({
+  status,
+  startedAt,
+  hardTimeoutMs,
+  onStop,
+}: WirelogsStreamTimeoutDialogProps) => {
+  const isStreaming = status === 'streaming';
+  const [now, setNow] = useState(() => Date.now());
+  // Highest warning stage the user has already acknowledged this session.
+  const [dismissedStage, setDismissedStage] = useState(0);
+
+  // Tick once a second while streaming so elapsed time stays current.
+  useEffect(() => {
+    if (!isStreaming || !startedAt) {
+      return undefined;
+    }
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [isStreaming, startedAt]);
+
+  // New stream session (or restart) resets acknowledged stages.
+  useEffect(() => {
+    setDismissedStage(0);
+  }, [startedAt]);
+
+  if (!isStreaming || !startedAt || !hardTimeoutMs) {
+    return null;
+  }
+
+  const elapsed = now - startedAt;
+  const stage1At = hardTimeoutMs / 3;
+  const stage2At = (hardTimeoutMs * 2) / 3;
+
+  let stage = 0;
+  if (elapsed >= stage2At) {
+    stage = 2;
+  } else if (elapsed >= stage1At) {
+    stage = 1;
+  }
+
+  const open = stage > dismissedStage;
+  if (!open) {
+    return null;
+  }
+
+  const dismiss = () => setDismissedStage(stage);
+  const remaining = Math.max(0, hardTimeoutMs - elapsed);
+  const isFinalWarning = stage === 2;
+
+  return (
+    <Dialog
+      open
+      onClose={dismiss}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="wirelogs-stream-timeout-dialog-title"
+    >
+      <DialogTitle id="wirelogs-stream-timeout-dialog-title">
+        {isFinalWarning
+          ? 'Wirelogs stream will stop soon'
+          : 'Wirelogs stream still running'}
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body1" gutterBottom>
+          This wirelogs stream has been running for about{' '}
+          {humanizeDuration(elapsed)}.
+        </Typography>
+        <Typography variant="body2" color="textSecondary">
+          {isFinalWarning
+            ? `It will stop automatically in about ${humanizeDuration(
+                remaining,
+              )} (after ${humanizeDuration(
+                hardTimeoutMs,
+              )} total) to conserve resources. Keep streaming until then, or stop now?`
+            : `It will stop automatically after ${humanizeDuration(
+                hardTimeoutMs,
+              )} to conserve resources. Keep streaming, or stop now?`}
+        </Typography>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onStop} color="secondary">
+          Stop stream
+        </Button>
+        <Button onClick={dismiss} color="primary" variant="contained">
+          Keep streaming
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/Wirelogs/types.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/types.ts
@@ -79,3 +79,10 @@ export type WirelogStreamStatus =
   | 'streaming'
   | 'error'
   | 'closed';
+
+/**
+ * Why a stream reached a terminal (`closed`/`error`) state. Drives UI
+ * messaging — notably `'timeout'`, which the server signals via a `timeout`
+ * SSE frame when it hits the hard stream cap.
+ */
+export type WirelogStreamClosedReason = 'user' | 'timeout' | 'error' | 'ended';

--- a/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.test.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.test.ts
@@ -262,5 +262,40 @@ describe('useWirelogsStream', () => {
     await waitFor(() => expect(result.current.status).toBe('connecting'));
     act(() => result.current.stop());
     expect(result.current.status).toBe('closed');
+    expect(result.current.closedReason).toBe('user');
+  });
+
+  it('captures the hard timeout from a meta frame', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(
+      streamingResponse([
+        'event: meta\ndata: {"hardTimeoutMs":900000}\n\n',
+        'data: {"flow":{"uuid":"a"}}\n\n',
+      ]),
+    );
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.hardTimeoutMs).toBe(900000));
+  });
+
+  it('marks closedReason=timeout when the server sends a timeout frame', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(
+      streamingResponse(['event: timeout\ndata: {"message":"stopped"}\n\n']),
+    );
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.status).toBe('closed'));
+    // The trailing natural-end must not overwrite the timeout reason.
+    expect(result.current.closedReason).toBe('timeout');
+  });
+
+  it('marks closedReason=ended when the stream ends naturally', async () => {
+    const { fetch } = makeApis();
+    fetch.mockResolvedValueOnce(streamingResponse([]));
+    const { result } = renderHook(() => useWirelogsStream(args));
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.status).toBe('closed'));
+    expect(result.current.closedReason).toBe('ended');
   });
 });

--- a/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.ts
@@ -4,7 +4,11 @@ import {
   discoveryApiRef,
   fetchApiRef,
 } from '@backstage/core-plugin-api';
-import type { WirelogEvent, WirelogStreamStatus } from './types';
+import type {
+  WirelogEvent,
+  WirelogStreamStatus,
+  WirelogStreamClosedReason,
+} from './types';
 
 interface UseWirelogsStreamArgs {
   namespaceName: string | undefined;
@@ -19,6 +23,12 @@ interface UseWirelogsStreamResult {
   status: WirelogStreamStatus;
   error: string | null;
   totalReceived: number;
+  /** Epoch ms when the current stream entered `streaming`, else null. */
+  startedAt: number | null;
+  /** Server-advertised hard cap (ms) for a single stream, from the `meta` frame. */
+  hardTimeoutMs: number | null;
+  /** Why the stream last reached a terminal state (null while active/idle). */
+  closedReason: WirelogStreamClosedReason | null;
   start: () => void;
   stop: () => void;
   clear: () => void;
@@ -34,6 +44,11 @@ const DEFAULT_MAX_BUFFER = 500;
  * middleware expects. The body is parsed as text/event-stream client-side:
  * SSE frames are separated by blank lines, and each `data:` line is a JSON
  * object matching the `WirelogEvent` shape.
+ *
+ * The backend also emits two control frames: `meta` (carries the hard stream
+ * timeout so the UI can warn before it hits) and `timeout` (sent right before
+ * the server ends a stream that reached the cap, so the UI can label the stop
+ * accurately rather than as a generic error).
  *
  * Older flows are evicted past `maxBuffer` to keep the table responsive on
  * busy clusters — Hubble can emit 100s of flows/sec in a steady state.
@@ -52,10 +67,21 @@ export function useWirelogsStream({
   const [status, setStatus] = useState<WirelogStreamStatus>('idle');
   const [error, setError] = useState<string | null>(null);
   const [totalReceived, setTotalReceived] = useState(0);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [hardTimeoutMs, setHardTimeoutMs] = useState<number | null>(null);
+  const [closedReason, setClosedReason] =
+    useState<WirelogStreamClosedReason | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
   const stopRequestedRef = useRef(false);
   const eventCounterRef = useRef(0);
+
+  // First terminal reason wins for a given session (e.g. a server `timeout`
+  // frame shouldn't be overwritten by the `ended` that follows when the
+  // backend closes the connection, nor by an unmount-triggered stop()).
+  const markClosedReason = useCallback((reason: WirelogStreamClosedReason) => {
+    setClosedReason(prev => prev ?? reason);
+  }, []);
 
   const stop = useCallback(() => {
     stopRequestedRef.current = true;
@@ -66,12 +92,14 @@ export function useWirelogsStream({
     setStatus(prev =>
       prev === 'streaming' || prev === 'connecting' ? 'closed' : prev,
     );
-  }, []);
+    markClosedReason('user');
+  }, [markClosedReason]);
 
   const clear = useCallback(() => {
     setFlows([]);
     setTotalReceived(0);
     setError(null);
+    setClosedReason(null);
   }, []);
 
   const start = useCallback(() => {
@@ -89,6 +117,8 @@ export function useWirelogsStream({
 
     setStatus('connecting');
     setError(null);
+    setClosedReason(null);
+    setStartedAt(null);
 
     (async () => {
       try {
@@ -119,6 +149,7 @@ export function useWirelogsStream({
         }
 
         setStatus('streaming');
+        setStartedAt(Date.now());
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
@@ -157,6 +188,14 @@ export function useWirelogsStream({
             } else if (parsed?.kind === 'error') {
               setError(parsed.message);
               setStatus('error');
+              markClosedReason('error');
+            } else if (parsed?.kind === 'meta') {
+              setHardTimeoutMs(parsed.hardTimeoutMs);
+            } else if (parsed?.kind === 'timeout') {
+              // The server is about to end the stream because it hit the hard
+              // cap. Record the reason; status flips to `closed` when the
+              // backend closes and `done` fires below.
+              markClosedReason('timeout');
             }
 
             separatorIdx = buffer.indexOf('\n\n');
@@ -164,11 +203,13 @@ export function useWirelogsStream({
         }
         if (!stopRequestedRef.current) {
           setStatus('closed');
+          markClosedReason('ended');
         }
       } catch (err) {
         if (controller.signal.aborted) return;
         setError((err as Error).message || 'Stream failed');
         setStatus('error');
+        markClosedReason('error');
       } finally {
         if (abortRef.current === controller) {
           abortRef.current = null;
@@ -183,6 +224,7 @@ export function useWirelogsStream({
     environmentName,
     componentName,
     maxBuffer,
+    markClosedReason,
   ]);
 
   useEffect(() => () => stop(), [stop]);
@@ -201,6 +243,9 @@ export function useWirelogsStream({
     status,
     error,
     totalReceived,
+    startedAt,
+    hardTimeoutMs,
+    closedReason,
     start,
     stop,
     clear,
@@ -210,6 +255,8 @@ export function useWirelogsStream({
 type ParsedFrame =
   | { kind: 'data'; event: WirelogEvent }
   | { kind: 'error'; message: string }
+  | { kind: 'meta'; hardTimeoutMs: number | null }
+  | { kind: 'timeout'; message: string }
   | undefined;
 
 function parseSseFrame(frame: string): ParsedFrame {
@@ -225,16 +272,30 @@ function parseSseFrame(frame: string): ParsedFrame {
   }
   if (dataLines.length === 0) return undefined;
   const payload = dataLines.join('\n');
+  let parsed: any;
   try {
-    const parsed = JSON.parse(payload);
-    if (eventType === 'error') {
-      return { kind: 'error', message: parsed.message || 'Stream error' };
-    }
-    if (parsed && typeof parsed === 'object' && parsed.flow) {
-      return { kind: 'data', event: parsed as WirelogEvent };
-    }
+    parsed = JSON.parse(payload);
   } catch {
-    // ignore malformed frame
+    return undefined; // ignore malformed frame
+  }
+  if (eventType === 'error') {
+    return { kind: 'error', message: parsed.message || 'Stream error' };
+  }
+  if (eventType === 'meta') {
+    return {
+      kind: 'meta',
+      hardTimeoutMs:
+        typeof parsed.hardTimeoutMs === 'number' ? parsed.hardTimeoutMs : null,
+    };
+  }
+  if (eventType === 'timeout') {
+    return {
+      kind: 'timeout',
+      message: parsed.message || 'Stream stopped by server',
+    };
+  }
+  if (parsed && typeof parsed === 'object' && parsed.flow) {
+    return { kind: 'data', event: parsed as WirelogEvent };
   }
   return undefined;
 }

--- a/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.ts
+++ b/plugins/openchoreo-observability/src/components/Wirelogs/useWirelogsStream.ts
@@ -119,6 +119,7 @@ export function useWirelogsStream({
     setError(null);
     setClosedReason(null);
     setStartedAt(null);
+    setHardTimeoutMs(null);
 
     (async () => {
       try {


### PR DESCRIPTION
## Purpose

Wirelogs (Cilium Hubble flows) stream over SSE and had **no timeout anywhere** — the openchoreo-api wirelogs handler disables the server write deadline, and the gateway TrafficPolicy for the route is `request: 0s` / `streamIdle: 24h`. A wirelogs tab left open therefore holds an SSE connection indefinitely, consuming CPU/network/an open connection and eventually degrading the browser. This PR bounds a stream's lifetime with a server-enforced hard cap plus graduated UI warnings, so a forgotten stream is cleaned up and the user is told why.

Related: https://github.com/openchoreo/openchoreo/issues/3978

## Goals

- Stop a single wirelogs stream from running unbounded.
- Enforce the limit server-side (reliable even if the tab is backgrounded), and make it configurable.
- Warn the user *before* the cap so they can stop early or knowingly continue, and clearly explain when the server ends the stream.

## Approach

- **Backend hard cap** (`plugins/openchoreo-backend`). `/wirelogs/stream` composes the client-disconnect abort with a hard timeout (default **15 min**, configurable via `openchoreo.observability.wirelogs.streamTimeoutSeconds`). It opens the stream with a `meta` SSE frame advertising `hardTimeoutMs`, and on hitting the cap sends a `timeout` SSE frame before closing — so the cause is unambiguous to the client. Client-disconnect detection moved to `res.on('close')`.
- **Frontend** (`plugins/openchoreo-observability`). `useWirelogsStream` parses the new `meta`/`timeout` frames and exposes `startedAt`, `hardTimeoutMs` and `closedReason`. A new `WirelogsStreamTimeoutDialog` shows confirmation dialogs at ~1/3 and ~2/3 of the cap (= ~5 and ~10 min at the default, auto-scaling for testing) with **Keep streaming / Stop**, and the page posts a toast when the server ends the stream. The existing **Start stream** button resumes a fresh session.
- **No gateway change needed in this repo.** The OpenChoreo gateway already exempts the wirelogs route from request timeouts (`request: 0s` / `streamIdle: 24h`), so the backend proxy is the right and sufficient enforcement point for the Backstage path.

Verified end-to-end against a live cluster to confirm the warning dialogs, the auto-stop, the toast, and the backend log line.

Screenshots:
<img width="1512" height="884" alt="Screenshot 2026-06-23 at 11 32 42" src="https://github.com/user-attachments/assets/135b3ff8-ef74-4f21-a69c-58aa2a19e5bb" />

<img width="1512" height="846" alt="Screenshot 2026-06-23 at 11 53 07" src="https://github.com/user-attachments/assets/14c50262-3d2c-430b-9978-a13ebde1a423" />

<img width="1512" height="843" alt="Screenshot 2026-06-23 at 11 42 10" src="https://github.com/user-attachments/assets/c2530ca4-1c6e-4b0c-a5aa-dbed4d56c451" />

<img width="1512" height="803" alt="Screenshot 2026-06-23 at 11 42 39" src="https://github.com/user-attachments/assets/82c4d13c-ffda-45d8-bd0f-6aab1e1d0638" />


## User stories

- As a developer debugging traffic, I'm warned that my wirelogs stream has been running a while and can stop it or continue — and if I walk away, it's cleaned up automatically instead of running forever.
- As a platform operator, I can tune (or effectively disable) the cap per environment via a single config key.

## Release note

Wirelogs streams are now bounded by a configurable server-side hard timeout (default 15 minutes) with graduated in-UI warnings and a clear notice when the server ends a stream, preventing forgotten streams from holding connections open indefinitely.

## Documentation

Documented the new `openchoreo.observability.wirelogs.streamTimeoutSeconds` option in `app-config.yaml` and `app-config.local.yaml.example`. No external docs changes required.

## Training

N/A

## Certification

N/A

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Wirelogs stream now enforces a configurable hard timeout (default: 15 minutes) for the SSE connection and communicates the limit to the UI.
* Added graduated warning dialogs as the hard timeout approaches, with clear “Stop stream” guidance.

**Bug Fixes**
* When the server stops the stream due to the hard cap, the UI now shows an informational toast and prompts the user to start again in a fresh session.

**Documentation**
* Documented `openchoreo.observability.wirelogs.streamTimeoutSeconds` in example and production configuration.

**Tests**
* Expanded backend and UI test coverage for hard-timeout frames and stream closure reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->