### PR TITLE
feat: provide a unified right drawer to RCA agent chat

### DIFF
--- a/.changeset/clever-mice-film.md
+++ b/.changeset/clever-mice-film.md
@@ -1,0 +1,6 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+'@openchoreo/backstage-plugin-openchoreo-portal-assistant': patch
+---
+
+Convert the RCA chat to a right drawer where previously it was inbuild to the page

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/RCAReportView.test.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/RCAReportView.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RCAReportView } from './RCAReportView';
+import type { AIRCAAgentComponents } from '@openchoreo/backstage-plugin-common';
+import type { RCAAgentApi } from '../../../api/RCAAgentApi';
+
+type RCAReportDetailed = AIRCAAgentComponents['schemas']['RCAReportDetailed'];
+
+// Container test: stub the section children (one — PatchTabContent via
+// QuickFixesPanelSection — needs a fetchApi) so we exercise RCAReportView's
+// own wiring (panel state, Quick Fixes toggle, chat drawer mount) directly.
+jest.mock('@backstage/core-components', () => ({
+  InfoCard: ({ children }: any) => <div>{children}</div>,
+}));
+jest.mock('./sections/RCAChatDrawer', () => ({
+  RCAChatDrawer: () => <div data-testid="rca-chat-drawer" />,
+}));
+jest.mock('./sections/QuickFixesPanelSection', () => ({
+  QuickFixesPanelSection: () => <div data-testid="quick-fixes-panel" />,
+}));
+jest.mock('./sections/PatchTabContent', () => ({
+  allActionsResolved: () => false,
+}));
+jest.mock('./sections/IncidentOverviewSection', () => ({
+  IncidentOverviewSection: () => <div />,
+}));
+jest.mock('./sections/AssessmentSection', () => ({
+  AssessmentSection: () => <div />,
+}));
+jest.mock('./sections/RootCausesSection', () => ({
+  RootCausesSection: () => <div />,
+}));
+jest.mock('./sections/ExcludedCausesSection', () => ({
+  ExcludedCausesSection: () => <div />,
+}));
+jest.mock('./sections/RecommendationsSection', () => ({
+  RecommendationsSection: () => <div />,
+}));
+jest.mock('./sections/VisibilityImprovementsSection', () => ({
+  VisibilityImprovementsSection: () => <div />,
+}));
+jest.mock('./sections/SystemTimelineSection', () => ({
+  SystemTimelineSection: () => <div />,
+}));
+jest.mock('./sections/InvestigationPathSection', () => ({
+  InvestigationPathSection: () => <div />,
+}));
+
+const chatContext = {
+  namespaceName: 'ns',
+  environmentName: 'env',
+  projectName: 'proj',
+  rcaAgentApi: {
+    streamRCAChat: jest.fn(),
+    updateActionStatuses: jest.fn(),
+  } as unknown as RCAAgentApi,
+};
+
+const reportWithoutFixes = {
+  reportId: 'rep-1',
+  timestamp: '2026-01-01T10:00:00Z',
+  report: {
+    summary: 'A failure happened',
+    result: {
+      type: 'no_root_cause_identified',
+      recommendations: { recommended_actions: [] },
+    },
+  },
+} as unknown as RCAReportDetailed;
+
+const reportWithFixes = {
+  reportId: 'rep-2',
+  timestamp: '2026-01-02T10:00:00Z',
+  report: {
+    summary: 'Root cause found',
+    result: {
+      type: 'root_cause_identified',
+      timeline: [],
+      root_causes: [],
+      excluded_causes: [],
+      recommendations: {
+        recommended_actions: [{ status: 'revised', change: { kind: 'env' } }],
+        observability_recommendations: [],
+      },
+    },
+  },
+} as unknown as RCAReportDetailed;
+
+describe('RCAReportView', () => {
+  it('always mounts the RCA chat drawer and hides Quick Fixes when there are none', () => {
+    render(
+      <RCAReportView
+        report={reportWithoutFixes}
+        reportId="rep-1"
+        onBack={jest.fn()}
+        chatContext={chatContext}
+      />,
+    );
+
+    expect(screen.getByText('RCA Report')).toBeInTheDocument();
+    expect(screen.getByTestId('rca-chat-drawer')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /quick fixes/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the Quick Fixes panel for revised actions and toggles it off', async () => {
+    const user = userEvent.setup();
+    render(
+      <RCAReportView
+        report={reportWithFixes}
+        reportId="rep-2"
+        onBack={jest.fn()}
+        chatContext={chatContext}
+      />,
+    );
+
+    // Panel auto-opens (unresolved revised actions) and the drawer is mounted.
+    expect(screen.getByTestId('rca-chat-drawer')).toBeInTheDocument();
+    expect(screen.getByTestId('quick-fixes-panel')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /quick fixes/i }));
+
+    expect(screen.queryByTestId('quick-fixes-panel')).not.toBeInTheDocument();
+  });
+
+  it('calls onBack when the back button is clicked', async () => {
+    const user = userEvent.setup();
+    const onBack = jest.fn();
+    render(
+      <RCAReportView
+        report={reportWithoutFixes}
+        reportId="rep-1"
+        onBack={onBack}
+        chatContext={chatContext}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: /back to rca reports/i }),
+    );
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/RCAReportView.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/RCAReportView.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Typography, Grid, Box, IconButton, Button } from '@material-ui/core';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
-import ChatOutlinedIcon from '@material-ui/icons/ChatOutlined';
 import AutorenewIcon from '@material-ui/icons/Autorenew';
 import { InfoCard } from '@backstage/core-components';
 import BugReportOutlinedIcon from '@material-ui/icons/BugReportOutlined';
@@ -18,7 +17,7 @@ import { RecommendationsSection } from './sections/RecommendationsSection';
 import { VisibilityImprovementsSection } from './sections/VisibilityImprovementsSection';
 import { IncidentOverviewSection } from './sections/IncidentOverviewSection';
 import { AssessmentSection } from './sections/AssessmentSection';
-import { ChatPanelSection } from './sections/ChatPanelSection';
+import { RCAChatDrawer } from './sections/RCAChatDrawer';
 import { QuickFixesPanelSection } from './sections/QuickFixesPanelSection';
 import { allActionsResolved } from './sections/PatchTabContent';
 import { useRCAReportStyles } from './styles';
@@ -78,13 +77,20 @@ export const RCAReportView = ({
 
   const hasRevised = revisedActions.length > 0;
 
-  const [activePanel, setActivePanel] = useState<'chat' | 'fixes' | null>(
-    () => {
-      if (!hasRevised) return null;
-      if (allActionsResolved(revisedActions)) return null;
-      return 'fixes';
-    },
-  );
+  const [activePanel, setActivePanel] = useState<'fixes' | null>(null);
+
+  // Keep the panel in sync with the current report's recommendations.
+  // Runs on mount and whenever the revised-actions set changes, so the
+  // panel reflects the latest report data. It does not fight the manual
+  // Quick Fixes toggle below: clicking that button changes neither
+  // hasRevised nor revisedActions, so this effect won't re-run.
+  useEffect(() => {
+    if (!hasRevised || allActionsResolved(revisedActions)) {
+      setActivePanel(null);
+      return;
+    }
+    setActivePanel('fixes');
+  }, [hasRevised, revisedActions]);
 
   const formatTimestamp = (timestamp?: string): string => {
     if (!timestamp) return 'N/A';
@@ -208,8 +214,8 @@ export const RCAReportView = ({
               )}
             </Box>
           </Box>
-          <Box display="flex" style={{ gap: 8 }}>
-            {hasRevised && (
+          {hasRevised && (
+            <Box display="flex" style={{ gap: 8 }}>
               <Button
                 variant={activePanel === 'fixes' ? 'contained' : 'outlined'}
                 color="primary"
@@ -221,19 +227,8 @@ export const RCAReportView = ({
               >
                 Quick Fixes
               </Button>
-            )}
-            <Button
-              variant={activePanel === 'chat' ? 'contained' : 'outlined'}
-              color="primary"
-              size="small"
-              startIcon={<ChatOutlinedIcon />}
-              onClick={() =>
-                setActivePanel(prev => (prev === 'chat' ? null : 'chat'))
-              }
-            >
-              Chat
-            </Button>
-          </Box>
+            </Box>
+          )}
         </Box>
         <Box className={classes.content}>
           <Grid container spacing={1}>
@@ -326,12 +321,6 @@ export const RCAReportView = ({
               style={{ flex: '0 0 38%', maxWidth: '38%' }}
               className={classes.sidebarColumn}
             >
-              {activePanel === 'chat' && (
-                <ChatPanelSection
-                  reportId={reportId}
-                  chatContext={chatContext}
-                />
-              )}
               {activePanel === 'fixes' && (
                 <QuickFixesPanelSection
                   reportId={reportId}
@@ -372,6 +361,15 @@ export const RCAReportView = ({
             </Grid>
           </Grid>
         </Box>
+        {/* key on reportId: the drawer loads its conversation from storage
+            only on mount, so it must remount when the route switches to a
+            different report — otherwise the prior report's messages persist
+            (and get written back under the new report's key). */}
+        <RCAChatDrawer
+          key={reportId}
+          reportId={reportId}
+          chatContext={chatContext}
+        />
       </Box>
     </EntityLinkContext.Provider>
   );

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RCAChatDrawer.test.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RCAChatDrawer.test.tsx
@@ -1,0 +1,287 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RCAChatDrawer } from './RCAChatDrawer';
+import type { RCAAgentApi, StreamEvent } from '../../../../api/RCAAgentApi';
+
+// FormattedText pulls in EntityLinkContext; stub it to plain text so the
+// drawer renders without a provider (mirrors CostAnalysisReportView.test).
+jest.mock('../FormattedText', () => ({
+  FormattedText: ({ text }: any) => <span>{text}</span>,
+}));
+
+// Narrow helper so test events don't have to satisfy the full generated
+// StreamEvent union — the drawer only reads type/content/activeForm/message.
+const ev = (o: Record<string, unknown>): StreamEvent =>
+  o as unknown as StreamEvent;
+
+const makeApi = (
+  stream: RCAAgentApi['streamRCAChat'],
+): jest.Mocked<RCAAgentApi> => ({
+  streamRCAChat: jest.fn(stream),
+  updateActionStatuses: jest.fn(),
+});
+
+const chatContext = (api: RCAAgentApi) => ({
+  namespaceName: 'ns',
+  environmentName: 'env',
+  projectName: 'proj',
+  rcaAgentApi: api,
+});
+
+const openDrawer = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(
+    screen.getByRole('button', { name: /chat with rca agent/i }),
+  );
+};
+
+describe('RCAChatDrawer', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('shows the FAB and opens the drawer with an empty state', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async () => {});
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+
+    // Drawer content is not mounted until the FAB is clicked.
+    expect(
+      screen.queryByPlaceholderText('Message RCA Agent'),
+    ).not.toBeInTheDocument();
+
+    await openDrawer(user);
+
+    expect(screen.getByText(/ask follow-up questions/i)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Message RCA Agent'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the launcher FAB while the drawer is open', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async () => {});
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+
+    // FAB is the only way in while closed; once open it must not overlap
+    // the drawer (its z-index sits above the modal layer).
+    expect(
+      screen.getByRole('button', { name: /chat with rca agent/i }),
+    ).toBeInTheDocument();
+
+    await openDrawer(user);
+
+    expect(
+      screen.queryByRole('button', { name: /chat with rca agent/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('streams a reply (Enter to send) and forwards the report scope', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async (_req, _routing, onEvent) => {
+      onEvent(ev({ type: 'tool_call', activeForm: 'Digging deeper...' }));
+      onEvent(ev({ type: 'message_chunk', content: 'Hello ' }));
+      onEvent(ev({ type: 'message_chunk', content: 'world' }));
+      onEvent(ev({ type: 'actions', actions: [] }));
+      onEvent(ev({ type: 'mystery_event' })); // unrecognized → ignored
+      onEvent(ev({ type: 'done', message: 'Hello world' }));
+    });
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    await user.type(
+      screen.getByPlaceholderText('Message RCA Agent'),
+      'why did it fail?{Enter}',
+    );
+
+    // User turn + finalized assistant turn both rendered.
+    expect(screen.getByText('why did it fail?')).toBeInTheDocument();
+    expect(await screen.findByText('Hello world')).toBeInTheDocument();
+
+    // Report-scoped request + routing context forwarded to the agent.
+    expect(api.streamRCAChat).toHaveBeenCalledTimes(1);
+    const [request, routing] = api.streamRCAChat.mock.calls[0];
+    expect(request).toMatchObject({
+      reportId: 'rep-1',
+      namespace: 'ns',
+      project: 'proj',
+      environment: 'env',
+    });
+    expect(routing).toEqual({ namespaceName: 'ns', environmentName: 'env' });
+  });
+
+  it('persists the conversation and clears it on demand', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async (_req, _routing, onEvent) => {
+      onEvent(ev({ type: 'done', message: 'persisted reply' }));
+    });
+    render(<RCAChatDrawer reportId="rep-7" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    await user.type(screen.getByPlaceholderText('Message RCA Agent'), 'hi');
+    await user.click(screen.getByRole('button', { name: /send message/i }));
+
+    expect(await screen.findByText('persisted reply')).toBeInTheDocument();
+    expect(localStorage.getItem('rca-chat:rep-7')).toContain('persisted reply');
+
+    await user.click(
+      screen.getByRole('button', { name: /clear conversation/i }),
+    );
+
+    expect(screen.queryByText('persisted reply')).not.toBeInTheDocument();
+    expect(screen.getByText(/ask follow-up questions/i)).toBeInTheDocument();
+    expect(localStorage.getItem('rca-chat:rep-7')).toBeNull();
+  });
+
+  it('loads a previously persisted conversation on mount', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      'rca-chat:rep-9',
+      JSON.stringify([{ role: 'assistant', content: 'earlier answer' }]),
+    );
+    const api = makeApi(async () => {});
+    render(<RCAChatDrawer reportId="rep-9" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    expect(screen.getByText('earlier answer')).toBeInTheDocument();
+  });
+
+  it('surfaces an error event from the agent', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async (_req, _routing, onEvent) => {
+      onEvent(ev({ type: 'error', message: 'agent exploded' }));
+    });
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    await user.type(
+      screen.getByPlaceholderText('Message RCA Agent'),
+      'boom{Enter}',
+    );
+
+    expect(await screen.findByText('agent exploded')).toBeInTheDocument();
+  });
+
+  it('aborts the in-flight stream when Stop is clicked', async () => {
+    const user = userEvent.setup();
+    let captured: AbortSignal | undefined;
+    const api = makeApi(
+      (_req, _routing, onEvent, signal) =>
+        new Promise<void>((_resolve, reject) => {
+          // Emit partial output, then stay in-flight until aborted and
+          // reject like a real fetch would when its signal fires —
+          // exercising the AbortError branch (and the partial-content
+          // recovery) of the catch.
+          captured = signal;
+          onEvent(ev({ type: 'message_chunk', content: 'partial answer' }));
+          signal?.addEventListener('abort', () => {
+            const abortErr = new Error('aborted');
+            abortErr.name = 'AbortError';
+            reject(abortErr);
+          });
+        }),
+    );
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    await user.type(
+      screen.getByPlaceholderText('Message RCA Agent'),
+      'long task{Enter}',
+    );
+
+    const stop = await screen.findByRole('button', { name: /stop/i });
+    await user.click(stop);
+
+    await waitFor(() => expect(captured?.aborted).toBe(true));
+    // Partial output is preserved (marked cancelled) and the composer
+    // returns to its idle (send) state without surfacing an error.
+    expect(
+      await screen.findByText('partial answer (cancelled)'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /send message/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an error when the stream throws', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async () => {
+      throw new Error('network down');
+    });
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    await user.type(
+      screen.getByPlaceholderText('Message RCA Agent'),
+      'boom{Enter}',
+    );
+
+    expect(await screen.findByText('network down')).toBeInTheDocument();
+  });
+
+  it('closes the drawer from the header close button', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async () => {});
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+    expect(
+      screen.getByPlaceholderText('Message RCA Agent'),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: /close rca agent chat/i }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByPlaceholderText('Message RCA Agent'),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('closes the drawer on Escape', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async () => {});
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+    expect(
+      screen.getByPlaceholderText('Message RCA Agent'),
+    ).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(
+        screen.queryByPlaceholderText('Message RCA Agent'),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('renders inline markdown in assistant replies', async () => {
+    const user = userEvent.setup();
+    const api = makeApi(async (_req, _routing, onEvent) => {
+      onEvent(ev({ type: 'done', message: 'see the **bold** word' }));
+    });
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    await user.type(
+      screen.getByPlaceholderText('Message RCA Agent'),
+      'hi{Enter}',
+    );
+
+    // Bold span proves the markdown pipeline (and the non-string branch
+    // of processChildren) ran.
+    expect(await screen.findByText('bold')).toBeInTheDocument();
+  });
+
+  it('falls back to an empty conversation when stored data is corrupt', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('rca-chat:rep-bad', '{not valid json');
+    const api = makeApi(async () => {});
+    render(<RCAChatDrawer reportId="rep-bad" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    expect(screen.getByText(/ask follow-up questions/i)).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RCAChatDrawer.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RCAChatDrawer.tsx
@@ -12,12 +12,16 @@ import {
   IconButton,
   TextField,
   InputAdornment,
+  Drawer,
+  Fab,
+  Tooltip,
+  makeStyles,
 } from '@material-ui/core';
 import ChatOutlinedIcon from '@material-ui/icons/ChatOutlined';
 import SendIcon from '@material-ui/icons/Send';
 import StopIcon from '@material-ui/icons/Stop';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
-import { InfoCard } from '@backstage/core-components';
+import CloseIcon from '@material-ui/icons/Close';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remend from 'remend';
@@ -88,6 +92,57 @@ const markdownComponents = {
   ),
 };
 
+const DRAWER_WIDTH = 440;
+
+const useStyles = makeStyles(theme => ({
+  fabRoot: {
+    position: 'fixed',
+    right: theme.spacing(3),
+    bottom: theme.spacing(3),
+    // One step below ``theme.zIndex.snackbar`` so real snackbars always
+    // render above this launcher, matching the portal assistant FAB.
+    zIndex: theme.zIndex.snackbar - 1,
+  },
+  fab: {
+    boxShadow: theme.shadows[6],
+  },
+  drawerPaper: {
+    width: DRAWER_WIDTH,
+    maxWidth: '90vw',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  drawerHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: theme.spacing(1.5, 2),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  drawerHeaderActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  },
+  headerTitle: {
+    fontWeight: 600,
+  },
+  composer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1.5, 2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  // Tool-call / "Thinking..." status. Right-aligned (under the user's
+  // latest turn) rather than centered, so the agent's progress reads as
+  // a continuation of the conversation flow on the user side.
+  statusStrip: {
+    padding: theme.spacing(0.25, 2, 0, 2),
+    textAlign: 'left',
+  },
+}));
+
 interface ChatContext {
   namespaceName: string;
   environmentName: string;
@@ -95,13 +150,25 @@ interface ChatContext {
   rcaAgentApi: RCAAgentApi;
 }
 
-interface ChatPanelProps {
+interface RCAChatDrawerProps {
   reportId: string;
   chatContext: ChatContext;
 }
 
-export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
+/**
+ * Floating chat-icon launcher (bottom-right) that opens a right-anchored
+ * drawer holding the RCA agent chat — mirroring the portal assistant's
+ * FAB → drawer experience, but wired to {@link RCAAgentApi} and scoped to
+ * a single RCA report. The conversation persists to localStorage per
+ * report so closing/reopening the drawer keeps the timeline.
+ */
+export const RCAChatDrawer = ({
+  reportId,
+  chatContext,
+}: RCAChatDrawerProps) => {
   const classes = useRCAReportStyles();
+  const drawerClasses = useStyles();
+  const [open, setOpen] = useState(false);
   const [chatMessage, setChatMessage] = useState('');
   const [isSending, setIsSending] = useState(false);
   const [streamingContent, setStreamingContent] = useState('');
@@ -130,12 +197,13 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
     }
   }, [messages, chatStorageKey]);
 
-  // Auto-scroll chat pane to bottom when messages change or streaming content updates
+  // Auto-scroll chat pane to bottom when messages change or streaming content
+  // updates — only meaningful while the drawer is open and the ref is mounted.
   useEffect(() => {
     if (chatMessagesRef.current) {
       chatMessagesRef.current.scrollTop = chatMessagesRef.current.scrollHeight;
     }
-  }, [messages, streamingContent]);
+  }, [messages, streamingContent, open]);
 
   const handleSendMessage = useCallback(async () => {
     if (!chatMessage.trim() || isSending) return;
@@ -161,6 +229,12 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
     const controller = new AbortController();
     abortControllerRef.current = controller;
 
+    // Local mirror of the streamed text. The streamingContent STATE can't
+    // be read back inside this same invocation (the closure captured its
+    // value — '' — at send time), so accumulate here to preserve partial
+    // output if the user cancels mid-stream.
+    let assembled = '';
+
     try {
       await chatContext.rcaAgentApi.streamRCAChat(
         {
@@ -177,6 +251,7 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
         (event: StreamEvent) => {
           switch (event.type) {
             case 'message_chunk':
+              assembled += event.content;
               setStreamingContent(prev => prev + event.content);
               setToolStatus(null);
               break;
@@ -210,10 +285,10 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
         // User cancelled - add partial content as message if any
-        if (streamingContent) {
+        if (assembled) {
           setMessages(prev => [
             ...prev,
-            { role: 'assistant', content: `${streamingContent} (cancelled)` },
+            { role: 'assistant', content: `${assembled} (cancelled)` },
           ]);
         }
       } else {
@@ -227,14 +302,7 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
       setToolStatus(null);
       abortControllerRef.current = null;
     }
-  }, [
-    chatMessage,
-    isSending,
-    messages,
-    chatContext,
-    reportId,
-    streamingContent,
-  ]);
+  }, [chatMessage, isSending, messages, chatContext, reportId]);
 
   const handleCancelSend = useCallback(() => {
     abortControllerRef.current?.abort();
@@ -253,7 +321,7 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
     localStorage.removeItem(chatStorageKey);
   }, [chatStorageKey]);
 
-  const handleKeyPress = useCallback(
+  const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
@@ -264,28 +332,58 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
   );
 
   return (
-    <Box className={classes.chatPanelWrapper}>
-      <InfoCard
-        title={
-          <span className={classes.cardTitle}>
-            <ChatOutlinedIcon className={classes.cardTitleIcon} />
+    <>
+      {/* Only mount the launcher while the drawer is closed. Its z-index
+          (snackbar - 1) sits above the temporary drawer's modal layer, so
+          leaving it mounted would overlap the composer and intercept
+          clicks at the bottom-right. The header close button handles
+          dismissal. */}
+      {!open && (
+        <Tooltip title="Chat with RCA Agent" placement="left">
+          <Fab
+            color="primary"
+            size="medium"
+            className={drawerClasses.fab}
+            classes={{ root: drawerClasses.fabRoot }}
+            onClick={() => setOpen(true)}
+            aria-label="Chat with RCA Agent"
+          >
+            <ChatOutlinedIcon />
+          </Fab>
+        </Tooltip>
+      )}
+      <Drawer
+        anchor="right"
+        open={open}
+        onClose={() => setOpen(false)}
+        classes={{ paper: drawerClasses.drawerPaper }}
+      >
+        <Box className={drawerClasses.drawerHeader}>
+          <Typography variant="subtitle1" className={drawerClasses.headerTitle}>
             Chat with RCA Agent
-          </span>
-        }
-        action={
-          <Box display="flex" alignItems="center" height="100%">
+          </Typography>
+          <Box className={drawerClasses.drawerHeaderActions}>
+            <Tooltip title="Clear conversation">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={handleClearChat}
+                  aria-label="Clear conversation"
+                  disabled={isSending || messages.length === 0}
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
             <IconButton
               size="small"
-              onClick={handleClearChat}
-              title="Clear chat"
-              style={{ padding: 4 }}
+              onClick={() => setOpen(false)}
+              aria-label="Close RCA Agent chat"
             >
-              <DeleteOutlineIcon fontSize="small" />
+              <CloseIcon fontSize="small" />
             </IconButton>
           </Box>
-        }
-        className={classes.chatPanel}
-      >
+        </Box>
         <Box className={classes.chatContent}>
           <div className={classes.chatMessages} ref={chatMessagesRef}>
             {/* To push messages to bottom */}
@@ -338,21 +436,23 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
             </Box>
           )}
           {isSending && !streamingContent && (
-            <Box className={classes.statusStrip}>
+            <Box className={drawerClasses.statusStrip}>
               <Typography variant="caption" className={classes.statusText}>
                 {toolStatus || 'Thinking...'}
               </Typography>
             </Box>
           )}
-          <Box className={classes.chatInputArea}>
+          <Box className={drawerClasses.composer}>
             <TextField
               fullWidth
+              multiline
+              maxRows={4}
               variant="outlined"
               size="small"
-              placeholder="Type your question..."
+              placeholder="Message RCA Agent"
               value={chatMessage}
               onChange={e => setChatMessage(e.target.value)}
-              onKeyPress={handleKeyPress}
+              onKeyDown={handleKeyDown}
               disabled={isSending}
               className={
                 isSending && !streamingContent
@@ -363,27 +463,34 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
                 endAdornment: (
                   <InputAdornment position="end">
                     {isSending ? (
-                      <IconButton
-                        size="small"
-                        onClick={handleCancelSend}
-                        title="Cancel"
-                        className={
-                          isSending && !streamingContent
-                            ? classes.buttonPulsing
-                            : undefined
-                        }
-                      >
-                        <StopIcon fontSize="small" />
-                      </IconButton>
+                      <Tooltip title="Stop">
+                        <IconButton
+                          size="small"
+                          onClick={handleCancelSend}
+                          aria-label="Stop"
+                          className={
+                            isSending && !streamingContent
+                              ? classes.buttonPulsing
+                              : undefined
+                          }
+                        >
+                          <StopIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
                     ) : (
-                      <IconButton
-                        size="small"
-                        color="primary"
-                        disabled={!chatMessage.trim()}
-                        onClick={handleSendMessage}
-                      >
-                        <SendIcon />
-                      </IconButton>
+                      <Tooltip title="Send (Enter)">
+                        <span>
+                          <IconButton
+                            size="small"
+                            color="primary"
+                            disabled={!chatMessage.trim()}
+                            onClick={handleSendMessage}
+                            aria-label="Send message"
+                          >
+                            <SendIcon fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
                     )}
                   </InputAdornment>
                 ),
@@ -391,7 +498,7 @@ export const ChatPanelSection = ({ reportId, chatContext }: ChatPanelProps) => {
             />
           </Box>
         </Box>
-      </InfoCard>
-    </Box>
+      </Drawer>
+    </>
   );
 };

--- a/plugins/openchoreo-portal-assistant/src/components/AssistantChatDrawer/AssistantChatDrawer.tsx
+++ b/plugins/openchoreo-portal-assistant/src/components/AssistantChatDrawer/AssistantChatDrawer.tsx
@@ -759,14 +759,17 @@ export const AssistantChatDrawer = ({
                   {expandedPrompts.has(i) && (
                     // Preview lives OUTSIDE the banner so its tinted
                     // background visually anchors to the banner above
-                    // (same accent, square top corners). Text is set
-                    // to pre-wrap so paragraph breaks the agent
-                    // included survive, but long lines wrap so a wide
-                    // repo URL or stack-trace line doesn't introduce
-                    // horizontal scroll inside the narrow drawer.
-                    <pre className={classes.fixPromptPreview}>
-                      {item.fixPrompt}
-                    </pre>
+                    // (same accent, square top corners). Rendered as
+                    // markdown (same renderer as the chat messages) so the
+                    // agent's backticks show as styled inline-code pills
+                    // instead of literally. The Copy button above still
+                    // copies the RAW fix_prompt verbatim — only this
+                    // on-screen preview is prettified.
+                    <Box className={classes.fixPromptPreview}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        {item.fixPrompt}
+                      </ReactMarkdown>
+                    </Box>
                   )}
                 </>
               )}

--- a/plugins/openchoreo-portal-assistant/src/components/AssistantChatDrawer/styles.ts
+++ b/plugins/openchoreo-portal-assistant/src/components/AssistantChatDrawer/styles.ts
@@ -239,27 +239,56 @@ export const useStyles = makeStyles(theme => ({
   },
   // Inline preview revealed by the chevron. Visually continuous with
   // the banner above (same hover-tint background, square top corners,
-  // matching border) so the two read as one expandable unit.
-  // pre-wrap keeps the agent's paragraph breaks intact while allowing
-  // long lines (stack-trace excerpts, repo URLs) to wrap inside the
-  // narrow drawer instead of introducing horizontal scroll.
+  // matching border) so the two read as one expandable unit. Rendered
+  // as markdown (same as the chat messages) so the agent's backticks
+  // become styled inline-code pills instead of showing literally; the
+  // Copy button still copies the raw fix_prompt verbatim. Block-level
+  // monospace/pre-wrap is intentionally dropped — structure now comes
+  // from the markdown elements (paragraphs, lists, code spans), with
+  // long tokens still wrapping via wordBreak.
   fixPromptPreview: {
     margin: 0,
-    padding: theme.spacing(1),
+    padding: theme.spacing(1, 1.25),
     backgroundColor: theme.palette.action.hover,
     border: `1px solid ${theme.palette.divider}`,
     borderTop: 'none',
     borderBottomLeftRadius: theme.shape.borderRadius,
     borderBottomRightRadius: theme.shape.borderRadius,
-    fontFamily:
-      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-    fontSize: 11.5,
-    lineHeight: 1.45,
+    fontSize: 12.5,
+    lineHeight: 1.5,
     color: theme.palette.text.primary,
-    whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
     maxHeight: 280,
     overflowY: 'auto',
+    '& p': { margin: 0 },
+    '& p + p': { marginTop: theme.spacing(0.75) },
+    '& ul, & ol': {
+      margin: theme.spacing(0.5, 0),
+      paddingLeft: theme.spacing(2.5),
+    },
+    '& li + li': { marginTop: theme.spacing(0.25) },
+    // Inline code → subtle monospace pill, matching the RCA chat look.
+    '& code': {
+      fontFamily:
+        'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+      fontSize: '0.9em',
+      padding: '0.08em 0.35em',
+      borderRadius: 4,
+      backgroundColor: theme.palette.action.selected,
+    },
+    // Fenced blocks get their own surface; nested code drops the pill.
+    '& pre': {
+      margin: theme.spacing(0.5, 0),
+      padding: theme.spacing(1),
+      borderRadius: theme.shape.borderRadius,
+      backgroundColor: theme.palette.background.paper,
+      overflowX: 'auto',
+    },
+    '& pre code': {
+      padding: 0,
+      backgroundColor: 'transparent',
+      fontSize: '0.85em',
+    },
   },
   evidenceSummary: {
     cursor: 'pointer',


### PR DESCRIPTION
## Purpose

Currently RCA agent chat is inbuild to the page as follows and we need to provide a unified view.

https://github.com/user-attachments/assets/da4d5aaf-ac05-4504-9993-bf98e1509854

## Goals

Provide an overall unified chat view.

## Approach

Fix was as follows. 

https://github.com/user-attachments/assets/d3acbae2-ddff-49e0-bb64-1130589717c5

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reworked RCA chat into a floating action button with a right-anchored drawer (with route-based remounting)
  * Added streaming status (“Thinking…”) and a Stop control during message generation
  * Fix prompt previews now render as Markdown (including inline code and fenced code blocks)

* **UI/UX Improvements**
  * “Quick Fixes” now appears only when revised actions are available; chat panel/toggle was removed
  * Enter sends (multiline with Shift+Enter), and partial streamed replies are retained on cancellation as “(cancelled)”

* **Tests**
  * Added RTL/Jest coverage for RCA report view panel wiring and full chat drawer lifecycle (streaming, persistence, errors, clear/corrupt storage)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->