### PR TITLE
feat(openchoreo-react): labeled save/discard footer in workload editor rows

### DIFF
--- a/.changeset/prominent-save-discard-actions.md
+++ b/.changeset/prominent-save-discard-actions.md
@@ -1,5 +1,6 @@
 ---
 '@openchoreo/backstage-plugin': patch
+'@openchoreo/backstage-design-system': patch
 ---
 
 Replace the small icon-only save/discard/delete controls in the Workload

--- a/.changeset/prominent-save-discard-actions.md
+++ b/.changeset/prominent-save-discard-actions.md
@@ -3,8 +3,9 @@
 '@openchoreo/backstage-design-system': patch
 ---
 
-Replace the small icon-only save/discard/delete controls in the Workload
-editor rows (endpoints, dependencies, environment variables, and file mounts)
-with a labeled footer action bar (Save / Cancel / Delete), so committing or
-discarding inline edits is clearly visible. Adds a reusable `EditRowActions`
+Clarify the save/discard/delete controls in the Workload editor rows
+(endpoints, dependencies, environment variables, and file mounts). While
+editing a row, a labeled footer bar (Save / Cancel / Delete) makes committing
+or discarding clearly visible; read-only rows keep their compact inline
+Edit / Delete buttons on a single line. Adds a reusable `EditRowActions`
 design-system component shared by all of those row editors.

--- a/.changeset/prominent-save-discard-actions.md
+++ b/.changeset/prominent-save-discard-actions.md
@@ -1,0 +1,9 @@
+---
+'@openchoreo/backstage-plugin': patch
+---
+
+Replace the small icon-only save/discard/delete controls in the Workload
+editor rows (endpoints, dependencies, environment variables, and file mounts)
+with a labeled footer action bar (Save / Cancel / Delete), so committing or
+discarding inline edits is clearly visible. Adds a reusable `EditRowActions`
+design-system component shared by all of those row editors.

--- a/packages/design-system/src/components/EditRowActions/EditRowActions.test.tsx
+++ b/packages/design-system/src/components/EditRowActions/EditRowActions.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EditRowActions } from './EditRowActions';
+
+const handlers = () => ({
+  onEdit: jest.fn(),
+  onApply: jest.fn(),
+  onCancel: jest.fn(),
+  onRemove: jest.fn(),
+});
+
+describe('EditRowActions', () => {
+  describe('read-only mode', () => {
+    it('shows Edit and Delete, not Save/Cancel', () => {
+      render(<EditRowActions isEditing={false} {...handlers()} />);
+
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /remove/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /save changes/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /cancel editing/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('fires onEdit and onRemove on click', () => {
+      const h = handlers();
+      render(<EditRowActions isEditing={false} {...h} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+      expect(h.onEdit).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+      expect(h.onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables Edit when editDisabled and Delete when deleteDisabled', () => {
+      render(
+        <EditRowActions
+          isEditing={false}
+          editDisabled
+          deleteDisabled
+          {...handlers()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /edit/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /remove/i })).toBeDisabled();
+    });
+  });
+
+  describe('edit mode', () => {
+    it('shows Save, Cancel and Delete, not Edit', () => {
+      render(<EditRowActions isEditing {...handlers()} />);
+
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /cancel editing/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /remove/i }),
+      ).toBeInTheDocument();
+      // The only labels containing "edit" in edit mode are "Cancel editing";
+      // there is no bare "Edit"/"Edit <item>" button.
+      expect(
+        screen.queryByRole('button', { name: /^edit/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('fires onApply, onCancel and onRemove on click', () => {
+      const h = handlers();
+      render(<EditRowActions isEditing {...h} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+      expect(h.onApply).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel editing/i }));
+      expect(h.onCancel).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+      expect(h.onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables only Save when applyDisabled', () => {
+      render(<EditRowActions isEditing applyDisabled {...handlers()} />);
+
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: /cancel editing/i }),
+      ).not.toBeDisabled();
+    });
+
+    it('hides Cancel when hideCancel is set', () => {
+      render(<EditRowActions isEditing hideCancel {...handlers()} />);
+
+      expect(
+        screen.queryByRole('button', { name: /cancel editing/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('disables all actions when disabled', () => {
+    render(<EditRowActions isEditing disabled {...handlers()} />);
+
+    expect(
+      screen.getByRole('button', { name: /save changes/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /cancel editing/i }),
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: /remove/i })).toBeDisabled();
+  });
+
+  it('builds accessible labels from itemLabel', () => {
+    render(
+      <EditRowActions isEditing={false} itemLabel="endpoint" {...handlers()} />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Edit endpoint' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remove endpoint' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides Delete when hideDelete is set', () => {
+    render(<EditRowActions isEditing={false} hideDelete {...handlers()} />);
+
+    expect(
+      screen.queryByRole('button', { name: /remove/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('renders a custom edit label and its accessible name', () => {
+    render(
+      <EditRowActions
+        isEditing={false}
+        itemLabel="environment variable"
+        editLabel="Override"
+        {...handlers()}
+      />,
+    );
+
+    const btn = screen.getByRole('button', {
+      name: 'Override environment variable',
+    });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent('Override');
+    expect(
+      screen.queryByRole('button', { name: /^edit/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/EditRowActions/EditRowActions.test.tsx
+++ b/packages/design-system/src/components/EditRowActions/EditRowActions.test.tsx
@@ -36,6 +36,17 @@ describe('EditRowActions', () => {
       expect(h.onRemove).toHaveBeenCalledTimes(1);
     });
 
+    it('renders Edit and Delete as labeled inline buttons', () => {
+      render(<EditRowActions isEditing={false} {...handlers()} />);
+
+      expect(screen.getByRole('button', { name: /edit/i })).toHaveTextContent(
+        'Edit',
+      );
+      expect(screen.getByRole('button', { name: /remove/i })).toHaveTextContent(
+        'Delete',
+      );
+    });
+
     it('disables Edit when editDisabled and Delete when deleteDisabled', () => {
       render(
         <EditRowActions

--- a/packages/design-system/src/components/EditRowActions/EditRowActions.tsx
+++ b/packages/design-system/src/components/EditRowActions/EditRowActions.tsx
@@ -36,17 +36,15 @@ export interface EditRowActionsProps {
   hideDelete?: boolean;
   /** Text for the read-only edit button, e.g. "Override". @default "Edit" */
   editLabel?: string;
-  /** Variant for the read-only edit button. @default "outlined" */
-  editVariant?: 'outlined' | 'contained';
 }
 
 /**
- * EditRowActions — the action footer for an inline-editable list row.
+ * EditRowActions — the action controls for an inline-editable list row.
  *
- * Renders a full-width bar at the bottom of an editor card. The destructive
- * Delete action sits on the left; the primary actions sit on the right. In edit
- * mode it shows labeled Save (contained) and Cancel (outlined) buttons so the
- * commit/discard choice is unmistakable; read-only it shows an Edit button.
+ * Read-only: a compact inline group (Edit/Override + Delete, both outlined) that
+ * sits on the same line as the row content. Edit mode: a full-width footer bar —
+ * destructive Delete on the left, labeled Save (contained) and Cancel (outlined)
+ * on the right — so the commit/discard choice is unmistakable.
  *
  * @example
  * ```tsx
@@ -75,67 +73,84 @@ export const EditRowActions: FC<EditRowActionsProps> = ({
   hideCancel = false,
   hideDelete = false,
   editLabel = 'Edit',
-  editVariant = 'outlined',
 }) => {
   const classes = useStyles();
 
-  return (
-    <Box className={classes.footer}>
-      {!hideDelete ? (
-        <Button
-          onClick={onRemove}
-          variant="text"
-          color="secondary"
-          size="small"
-          startIcon={<DeleteIcon />}
-          disabled={disabled || (!isEditing && deleteDisabled)}
-          aria-label={`Remove ${itemLabel}`}
-        >
-          Delete
-        </Button>
-      ) : (
-        <span />
-      )}
-      <Box className={classes.primaryActions}>
-        {isEditing ? (
-          <>
-            {!hideCancel && (
-              <Button
-                onClick={onCancel}
-                variant="outlined"
-                size="small"
-                startIcon={<CloseIcon />}
-                disabled={disabled}
-                aria-label="Cancel editing"
-              >
-                Cancel
-              </Button>
-            )}
-            <Button
-              onClick={onApply}
-              variant="contained"
-              color="primary"
-              size="small"
-              startIcon={<CheckIcon />}
-              disabled={disabled || applyDisabled}
-              aria-label="Save changes"
-            >
-              Save
-            </Button>
-          </>
-        ) : (
+  // Read-only: compact inline group (Delete + Edit/Override) on the row's line.
+  // Delete is leftmost so the destructive action is consistently positioned
+  // furthest from the primary action in both modes.
+  if (!isEditing) {
+    return (
+      <Box className={classes.inlineActions}>
+        {!hideDelete && (
           <Button
-            onClick={onEdit}
-            variant={editVariant}
-            color={editVariant === 'contained' ? 'primary' : undefined}
+            onClick={onRemove}
+            variant="outlined"
+            color="secondary"
             size="small"
-            startIcon={<EditIcon />}
-            disabled={disabled || editDisabled}
-            aria-label={`${editLabel} ${itemLabel}`}
+            startIcon={<DeleteIcon />}
+            disabled={disabled || deleteDisabled}
+            aria-label={`Remove ${itemLabel}`}
           >
-            {editLabel}
+            Delete
           </Button>
         )}
+        <Button
+          onClick={onEdit}
+          variant="outlined"
+          size="small"
+          startIcon={<EditIcon />}
+          disabled={disabled || editDisabled}
+          aria-label={`${editLabel} ${itemLabel}`}
+        >
+          {editLabel}
+        </Button>
+      </Box>
+    );
+  }
+
+  // Edit mode: full-width footer bar with all actions grouped on the right.
+  // Delete is leftmost of the group so the destructive action stays furthest
+  // from the primary Save.
+  return (
+    <Box className={classes.footer}>
+      <Box className={classes.primaryActions}>
+        {!hideDelete && (
+          <Button
+            onClick={onRemove}
+            variant="outlined"
+            color="secondary"
+            size="small"
+            startIcon={<DeleteIcon />}
+            disabled={disabled || deleteDisabled}
+            aria-label={`Remove ${itemLabel}`}
+          >
+            Delete
+          </Button>
+        )}
+        {!hideCancel && (
+          <Button
+            onClick={onCancel}
+            variant="outlined"
+            size="small"
+            startIcon={<CloseIcon />}
+            disabled={disabled}
+            aria-label="Cancel editing"
+          >
+            Cancel
+          </Button>
+        )}
+        <Button
+          onClick={onApply}
+          variant="contained"
+          color="primary"
+          size="small"
+          startIcon={<CheckIcon />}
+          disabled={disabled || applyDisabled}
+          aria-label="Save changes"
+        >
+          Save
+        </Button>
       </Box>
     </Box>
   );

--- a/packages/design-system/src/components/EditRowActions/EditRowActions.tsx
+++ b/packages/design-system/src/components/EditRowActions/EditRowActions.tsx
@@ -1,0 +1,142 @@
+import type { FC } from 'react';
+import { Box, Button } from '@material-ui/core';
+import CheckIcon from '@material-ui/icons/Check';
+import CloseIcon from '@material-ui/icons/Close';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
+import { useStyles } from './styles';
+
+export interface EditRowActionsProps {
+  /** Whether the row is currently in edit mode. */
+  isEditing: boolean;
+  /** Begin editing this row (shown read-only). */
+  onEdit: () => void;
+  /** Commit the buffered edits ("Save", shown while editing). */
+  onApply: () => void;
+  /** Discard the buffered edits ("Cancel", shown while editing). */
+  onCancel: () => void;
+  /** Remove the row entirely ("Delete", shown in both modes). */
+  onRemove: () => void;
+  /** Disable every action. */
+  disabled?: boolean;
+  /** Disable only Edit (e.g. another row is currently editing). */
+  editDisabled?: boolean;
+  /** Disable only Delete (e.g. another row is currently editing). */
+  deleteDisabled?: boolean;
+  /** Disable only Save (e.g. validation is failing). */
+  applyDisabled?: boolean;
+  /**
+   * Singular noun used to build accessible labels, e.g. "endpoint" yields
+   * "Remove endpoint". @default "item"
+   */
+  itemLabel?: string;
+  /** Hide the Cancel button while editing. @default false */
+  hideCancel?: boolean;
+  /** Hide the Delete button entirely (e.g. inherited rows that can't be deleted). @default false */
+  hideDelete?: boolean;
+  /** Text for the read-only edit button, e.g. "Override". @default "Edit" */
+  editLabel?: string;
+  /** Variant for the read-only edit button. @default "outlined" */
+  editVariant?: 'outlined' | 'contained';
+}
+
+/**
+ * EditRowActions — the action footer for an inline-editable list row.
+ *
+ * Renders a full-width bar at the bottom of an editor card. The destructive
+ * Delete action sits on the left; the primary actions sit on the right. In edit
+ * mode it shows labeled Save (contained) and Cancel (outlined) buttons so the
+ * commit/discard choice is unmistakable; read-only it shows an Edit button.
+ *
+ * @example
+ * ```tsx
+ * <EditRowActions
+ *   isEditing={isEditing}
+ *   itemLabel="endpoint"
+ *   onEdit={onEdit}
+ *   onApply={onApply}
+ *   onCancel={onCancel}
+ *   onRemove={onRemove}
+ *   applyDisabled={!isValid}
+ * />
+ * ```
+ */
+export const EditRowActions: FC<EditRowActionsProps> = ({
+  isEditing,
+  onEdit,
+  onApply,
+  onCancel,
+  onRemove,
+  disabled = false,
+  editDisabled = false,
+  deleteDisabled = false,
+  applyDisabled = false,
+  itemLabel = 'item',
+  hideCancel = false,
+  hideDelete = false,
+  editLabel = 'Edit',
+  editVariant = 'outlined',
+}) => {
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.footer}>
+      {!hideDelete ? (
+        <Button
+          onClick={onRemove}
+          variant="text"
+          color="secondary"
+          size="small"
+          startIcon={<DeleteIcon />}
+          disabled={disabled || (!isEditing && deleteDisabled)}
+          aria-label={`Remove ${itemLabel}`}
+        >
+          Delete
+        </Button>
+      ) : (
+        <span />
+      )}
+      <Box className={classes.primaryActions}>
+        {isEditing ? (
+          <>
+            {!hideCancel && (
+              <Button
+                onClick={onCancel}
+                variant="outlined"
+                size="small"
+                startIcon={<CloseIcon />}
+                disabled={disabled}
+                aria-label="Cancel editing"
+              >
+                Cancel
+              </Button>
+            )}
+            <Button
+              onClick={onApply}
+              variant="contained"
+              color="primary"
+              size="small"
+              startIcon={<CheckIcon />}
+              disabled={disabled || applyDisabled}
+              aria-label="Save changes"
+            >
+              Save
+            </Button>
+          </>
+        ) : (
+          <Button
+            onClick={onEdit}
+            variant={editVariant}
+            color={editVariant === 'contained' ? 'primary' : undefined}
+            size="small"
+            startIcon={<EditIcon />}
+            disabled={disabled || editDisabled}
+            aria-label={`${editLabel} ${itemLabel}`}
+          >
+            {editLabel}
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/packages/design-system/src/components/EditRowActions/index.ts
+++ b/packages/design-system/src/components/EditRowActions/index.ts
@@ -1,0 +1,2 @@
+export { EditRowActions } from './EditRowActions';
+export type { EditRowActionsProps } from './EditRowActions';

--- a/packages/design-system/src/components/EditRowActions/styles.ts
+++ b/packages/design-system/src/components/EditRowActions/styles.ts
@@ -2,11 +2,10 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 
 export const useStyles = makeStyles((theme: Theme) => ({
   // Footer action bar: full-width, separated from the form body above by a
-  // top border, with destructive action pushed left and primary actions right.
+  // top border, with all actions grouped on the right (see primaryActions).
   footer: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
     gap: theme.spacing(1),
     marginTop: theme.spacing(1.5),
     paddingTop: theme.spacing(1.5),
@@ -17,5 +16,14 @@ export const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     gap: theme.spacing(1),
     marginLeft: 'auto',
+  },
+  // Read-only inline action group: Edit + Delete sit on the same line as the
+  // row content, grouped to the right. No divider/top-margin (that's the footer).
+  inlineActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginLeft: theme.spacing(1),
+    flexShrink: 0,
   },
 }));

--- a/packages/design-system/src/components/EditRowActions/styles.ts
+++ b/packages/design-system/src/components/EditRowActions/styles.ts
@@ -1,0 +1,21 @@
+import { makeStyles, Theme } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles((theme: Theme) => ({
+  // Footer action bar: full-width, separated from the form body above by a
+  // top border, with destructive action pushed left and primary actions right.
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1.5),
+    paddingTop: theme.spacing(1.5),
+    borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  primaryActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginLeft: 'auto',
+  },
+}));

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -38,6 +38,8 @@ export type {
   FormYamlMode,
 } from './components/FormYamlToggle';
 export { SplitButton } from './components/SplitButton';
+export { EditRowActions } from './components/EditRowActions';
+export type { EditRowActionsProps } from './components/EditRowActions';
 export {
   ArrayFieldTemplate,
   DescriptionFieldTemplate,

--- a/plugins/openchoreo-react/src/components/DependencyEditor/DependencyEditor.tsx
+++ b/plugins/openchoreo-react/src/components/DependencyEditor/DependencyEditor.tsx
@@ -22,6 +22,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(1),
     backgroundColor: theme.palette.background.default,
   },
+  // Read-only row: content + inline actions share one line.
+  readOnlyContainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
   containerEditing: {
     padding: theme.spacing(1.5),
     border: `1px solid ${theme.palette.primary.main}`,
@@ -151,7 +156,11 @@ export const DependencyEditor: FC<DependencyEditorProps> = ({
   // Read-only display
   if (!isEditing) {
     return (
-      <Box className={className || classes.container}>
+      <Box
+        className={
+          className || `${classes.container} ${classes.readOnlyContainer}`
+        }
+      >
         <Box flex={1} className={classes.readOnlyContent}>
           <Typography className={classes.readOnlyName}>
             {dependency.component || '(no component)'}

--- a/plugins/openchoreo-react/src/components/DependencyEditor/DependencyEditor.tsx
+++ b/plugins/openchoreo-react/src/components/DependencyEditor/DependencyEditor.tsx
@@ -1,11 +1,9 @@
 import type { FC } from 'react';
 import {
   TextField,
-  IconButton,
   Grid,
   Box,
   Typography,
-  Button,
   Select,
   MenuItem,
   FormControl,
@@ -13,10 +11,7 @@ import {
   Chip,
 } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import DeleteIcon from '@material-ui/icons/Delete';
-import EditIcon from '@material-ui/icons/Edit';
-import CheckIcon from '@material-ui/icons/Check';
-import CloseIcon from '@material-ui/icons/Close';
+import { EditRowActions } from '@openchoreo/backstage-design-system';
 import type { Dependency } from '@openchoreo/backstage-plugin-common';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -34,9 +29,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(1),
     backgroundColor: theme.palette.background.default,
     boxShadow: `0 0 0 1px ${theme.palette.primary.main}`,
-  },
-  actionButton: {
-    marginLeft: theme.spacing(0.5),
   },
   readOnlyName: {
     fontWeight: 600,
@@ -160,42 +152,31 @@ export const DependencyEditor: FC<DependencyEditorProps> = ({
   if (!isEditing) {
     return (
       <Box className={className || classes.container}>
-        <Box display="flex" alignItems="center">
-          <Box flex={1} className={classes.readOnlyContent}>
-            <Typography className={classes.readOnlyName}>
-              {dependency.component || '(no component)'}
-            </Typography>
-            <Chip
-              label="Component"
-              size="small"
-              variant="outlined"
-              className={classes.typeChip}
-            />
-            <Typography className={classes.readOnlyDetails}>
-              {formatDependencySummary()}
-            </Typography>
-          </Box>
-          <Button
+        <Box flex={1} className={classes.readOnlyContent}>
+          <Typography className={classes.readOnlyName}>
+            {dependency.component || '(no component)'}
+          </Typography>
+          <Chip
+            label="Component"
             size="small"
             variant="outlined"
-            startIcon={<EditIcon />}
-            onClick={onEdit}
-            disabled={disabled || editDisabled}
-            className={classes.actionButton}
-          >
-            Edit
-          </Button>
-          <IconButton
-            onClick={onRemove}
-            color="secondary"
-            size="small"
-            disabled={disabled || deleteDisabled}
-            className={classes.actionButton}
-            aria-label="Remove dependency"
-          >
-            <DeleteIcon />
-          </IconButton>
+            className={classes.typeChip}
+          />
+          <Typography className={classes.readOnlyDetails}>
+            {formatDependencySummary()}
+          </Typography>
         </Box>
+        <EditRowActions
+          isEditing={false}
+          itemLabel="dependency"
+          onEdit={onEdit}
+          onApply={onApply}
+          onCancel={onCancel ?? (() => {})}
+          onRemove={onRemove}
+          disabled={disabled}
+          editDisabled={editDisabled}
+          deleteDisabled={deleteDisabled}
+        />
       </Box>
     );
   }
@@ -203,180 +184,152 @@ export const DependencyEditor: FC<DependencyEditorProps> = ({
   // Edit mode
   return (
     <Box className={className || classes.containerEditing}>
-      <Box display="flex" alignItems="flex-start">
-        <Box flex={1}>
-          <Grid container spacing={1}>
-            <Grid item xs={6}>
-              <FormControl fullWidth variant="outlined" size="small">
-                <InputLabel>Project</InputLabel>
-                <Select
-                  value={dependency.project || ''}
-                  onChange={e => onProjectChange(e.target.value as string)}
-                  label="Project"
-                  disabled={disabled}
-                >
-                  {projects.map(project => (
-                    <MenuItem key={project.name} value={project.name}>
-                      {project.name}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={6}>
-              <FormControl fullWidth variant="outlined" size="small">
-                <InputLabel>Component</InputLabel>
-                <Select
-                  value={dependency.component || ''}
-                  onChange={e => onComponentChange(e.target.value as string)}
-                  label="Component"
-                  disabled={disabled || !dependency.project}
-                >
-                  {components.map(component => (
-                    <MenuItem key={component.name} value={component.name}>
-                      {component.name}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={6}>
-              <FormControl fullWidth variant="outlined" size="small">
-                <InputLabel>Endpoint</InputLabel>
-                <Select
-                  value={dependency.name || ''}
-                  onChange={e => onEndpointChange(e.target.value as string)}
-                  label="Endpoint"
-                  disabled={disabled || !dependency.component}
-                >
-                  {endpoints.map(endpoint => (
-                    <MenuItem key={endpoint.name} value={endpoint.name}>
-                      {endpoint.name}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={6}>
-              <FormControl fullWidth variant="outlined" size="small">
-                <InputLabel>Visibility</InputLabel>
-                <Select
-                  value={
-                    dependency.visibility &&
-                    availableVisibilities.includes(dependency.visibility)
-                      ? dependency.visibility
-                      : ''
-                  }
-                  onChange={e =>
-                    onVisibilityChange(
-                      e.target.value as 'project' | 'namespace',
-                    )
-                  }
-                  label="Visibility"
-                  disabled={disabled || availableVisibilities.length === 0}
-                >
-                  {availableVisibilities.includes('project') && (
-                    <MenuItem value="project">Project</MenuItem>
-                  )}
-                  {availableVisibilities.includes('namespace') && (
-                    <MenuItem value="namespace">Namespace</MenuItem>
-                  )}
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={12}>
-              <Typography variant="caption" color="textSecondary">
-                Environment Variable Bindings
-              </Typography>
-            </Grid>
-            <Grid item xs={6}>
-              <TextField
-                label="Address Env Var"
-                value={dependency.envBindings?.address || ''}
-                onChange={e => onEnvBindingChange('address', e.target.value)}
-                fullWidth
-                variant="outlined"
-                size="small"
-                disabled={disabled}
-                placeholder="e.g. SVC_ADDRESS"
-                helperText="Full connection string"
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <TextField
-                label="Host Env Var"
-                value={dependency.envBindings?.host || ''}
-                onChange={e => onEnvBindingChange('host', e.target.value)}
-                fullWidth
-                variant="outlined"
-                size="small"
-                disabled={disabled}
-                placeholder="e.g. SVC_HOST"
-                helperText="Hostname only"
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <TextField
-                label="Port Env Var"
-                value={dependency.envBindings?.port || ''}
-                onChange={e => onEnvBindingChange('port', e.target.value)}
-                fullWidth
-                variant="outlined"
-                size="small"
-                disabled={disabled}
-                placeholder="e.g. SVC_PORT"
-                helperText="Port number only"
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <TextField
-                label="Base Path Env Var"
-                value={dependency.envBindings?.basePath || ''}
-                onChange={e => onEnvBindingChange('basePath', e.target.value)}
-                fullWidth
-                variant="outlined"
-                size="small"
-                disabled={disabled}
-                placeholder="e.g. SVC_BASE_PATH"
-                helperText="Base path only"
-              />
-            </Grid>
-          </Grid>
-        </Box>
-        <Box display="flex" flexDirection="column" ml={1}>
-          <IconButton
-            onClick={onApply}
-            color="primary"
-            size="small"
-            disabled={disabled || applyDisabled}
-            className={classes.actionButton}
-            aria-label="Apply changes"
-          >
-            <CheckIcon />
-          </IconButton>
-          {onCancel && (
-            <IconButton
-              onClick={onCancel}
-              size="small"
+      <Grid container spacing={1}>
+        <Grid item xs={6}>
+          <FormControl fullWidth variant="outlined" size="small">
+            <InputLabel>Project</InputLabel>
+            <Select
+              value={dependency.project || ''}
+              onChange={e => onProjectChange(e.target.value as string)}
+              label="Project"
               disabled={disabled}
-              className={classes.actionButton}
-              aria-label="Cancel editing"
             >
-              <CloseIcon />
-            </IconButton>
-          )}
-          <IconButton
-            onClick={onRemove}
-            color="secondary"
+              {projects.map(project => (
+                <MenuItem key={project.name} value={project.name}>
+                  {project.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={6}>
+          <FormControl fullWidth variant="outlined" size="small">
+            <InputLabel>Component</InputLabel>
+            <Select
+              value={dependency.component || ''}
+              onChange={e => onComponentChange(e.target.value as string)}
+              label="Component"
+              disabled={disabled || !dependency.project}
+            >
+              {components.map(component => (
+                <MenuItem key={component.name} value={component.name}>
+                  {component.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={6}>
+          <FormControl fullWidth variant="outlined" size="small">
+            <InputLabel>Endpoint</InputLabel>
+            <Select
+              value={dependency.name || ''}
+              onChange={e => onEndpointChange(e.target.value as string)}
+              label="Endpoint"
+              disabled={disabled || !dependency.component}
+            >
+              {endpoints.map(endpoint => (
+                <MenuItem key={endpoint.name} value={endpoint.name}>
+                  {endpoint.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={6}>
+          <FormControl fullWidth variant="outlined" size="small">
+            <InputLabel>Visibility</InputLabel>
+            <Select
+              value={
+                dependency.visibility &&
+                availableVisibilities.includes(dependency.visibility)
+                  ? dependency.visibility
+                  : ''
+              }
+              onChange={e =>
+                onVisibilityChange(e.target.value as 'project' | 'namespace')
+              }
+              label="Visibility"
+              disabled={disabled || availableVisibilities.length === 0}
+            >
+              {availableVisibilities.includes('project') && (
+                <MenuItem value="project">Project</MenuItem>
+              )}
+              {availableVisibilities.includes('namespace') && (
+                <MenuItem value="namespace">Namespace</MenuItem>
+              )}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="caption" color="textSecondary">
+            Environment Variable Bindings
+          </Typography>
+        </Grid>
+        <Grid item xs={6}>
+          <TextField
+            label="Address Env Var"
+            value={dependency.envBindings?.address || ''}
+            onChange={e => onEnvBindingChange('address', e.target.value)}
+            fullWidth
+            variant="outlined"
             size="small"
             disabled={disabled}
-            className={classes.actionButton}
-            aria-label="Remove dependency"
-          >
-            <DeleteIcon />
-          </IconButton>
-        </Box>
-      </Box>
+            placeholder="e.g. SVC_ADDRESS"
+            helperText="Full connection string"
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <TextField
+            label="Host Env Var"
+            value={dependency.envBindings?.host || ''}
+            onChange={e => onEnvBindingChange('host', e.target.value)}
+            fullWidth
+            variant="outlined"
+            size="small"
+            disabled={disabled}
+            placeholder="e.g. SVC_HOST"
+            helperText="Hostname only"
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <TextField
+            label="Port Env Var"
+            value={dependency.envBindings?.port || ''}
+            onChange={e => onEnvBindingChange('port', e.target.value)}
+            fullWidth
+            variant="outlined"
+            size="small"
+            disabled={disabled}
+            placeholder="e.g. SVC_PORT"
+            helperText="Port number only"
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <TextField
+            label="Base Path Env Var"
+            value={dependency.envBindings?.basePath || ''}
+            onChange={e => onEnvBindingChange('basePath', e.target.value)}
+            fullWidth
+            variant="outlined"
+            size="small"
+            disabled={disabled}
+            placeholder="e.g. SVC_BASE_PATH"
+            helperText="Base path only"
+          />
+        </Grid>
+      </Grid>
+      <EditRowActions
+        isEditing
+        itemLabel="dependency"
+        onEdit={onEdit}
+        onApply={onApply}
+        onCancel={onCancel ?? (() => {})}
+        onRemove={onRemove}
+        disabled={disabled}
+        applyDisabled={applyDisabled}
+        hideCancel={!onCancel}
+      />
     </Box>
   );
 };

--- a/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.test.tsx
+++ b/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { WorkloadEndpoint } from '@openchoreo/backstage-plugin-common';
+import { EndpointEditor } from './EndpointEditor';
+
+function renderEditor(
+  overrides: Partial<{
+    endpointName: string;
+    endpoint: WorkloadEndpoint;
+    isEditing: boolean;
+    editDisabled: boolean;
+    deleteDisabled: boolean;
+    applyDisabled: boolean;
+  }> = {},
+) {
+  const handlers = {
+    onEdit: jest.fn(),
+    onApply: jest.fn(),
+    onCancel: jest.fn(),
+    onRemove: jest.fn(),
+    onChange: jest.fn(),
+    onNameChange: jest.fn(),
+  };
+  render(
+    <EndpointEditor
+      endpointName={overrides.endpointName ?? 'http'}
+      endpoint={
+        overrides.endpoint ?? {
+          type: 'HTTP',
+          port: 8080,
+          visibility: ['project', 'external'],
+        }
+      }
+      isEditing={overrides.isEditing ?? false}
+      editDisabled={overrides.editDisabled}
+      deleteDisabled={overrides.deleteDisabled}
+      applyDisabled={overrides.applyDisabled}
+      {...handlers}
+    />,
+  );
+  return handlers;
+}
+
+describe('EndpointEditor', () => {
+  describe('read-only mode', () => {
+    it('renders the endpoint summary with Edit and Delete', () => {
+      renderEditor();
+
+      expect(screen.getByText('http')).toBeInTheDocument();
+      expect(screen.getByText(/HTTP/)).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /edit endpoint/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove endpoint')).toBeInTheDocument();
+    });
+
+    it('invokes onEdit and onRemove from the footer', () => {
+      const { onEdit, onRemove } = renderEditor();
+
+      fireEvent.click(screen.getByRole('button', { name: /edit endpoint/i }));
+      expect(onEdit).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByLabelText('Remove endpoint'));
+      expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables Edit and Delete when the row is locked', () => {
+      renderEditor({ editDisabled: true, deleteDisabled: true });
+
+      expect(
+        screen.getByRole('button', { name: /edit endpoint/i }),
+      ).toBeDisabled();
+      expect(screen.getByLabelText('Remove endpoint')).toBeDisabled();
+    });
+  });
+
+  describe('edit mode', () => {
+    it('renders the name field and Save / Cancel / Delete footer', () => {
+      renderEditor({ isEditing: true });
+
+      expect(screen.getByDisplayValue('http')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /cancel editing/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove endpoint')).toBeInTheDocument();
+    });
+
+    it('emits onNameChange when the name field changes', () => {
+      const { onNameChange } = renderEditor({ isEditing: true });
+      fireEvent.change(screen.getByDisplayValue('http'), {
+        target: { value: 'https' },
+      });
+      expect(onNameChange).toHaveBeenCalledWith('https');
+    });
+
+    it('fires onApply / onCancel from the footer', () => {
+      const { onApply, onCancel } = renderEditor({ isEditing: true });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+      fireEvent.click(screen.getByRole('button', { name: /cancel editing/i }));
+      expect(onApply).toHaveBeenCalledTimes(1);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables Save when applyDisabled is set', () => {
+      renderEditor({ isEditing: true, applyDisabled: true });
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeDisabled();
+    });
+  });
+});

--- a/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.tsx
+++ b/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.tsx
@@ -41,6 +41,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(1),
     backgroundColor: theme.palette.background.default,
   },
+  // Read-only row: content + inline actions share one line.
+  readOnlyContainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
   containerEditing: {
     padding: theme.spacing(1.5),
     border: `1px solid ${theme.palette.primary.main}`,
@@ -292,7 +297,11 @@ export const EndpointEditor: FC<EndpointEditorProps> = ({
   // Read-only display
   if (!isEditing) {
     return (
-      <Box className={className || classes.container}>
+      <Box
+        className={
+          className || `${classes.container} ${classes.readOnlyContainer}`
+        }
+      >
         <Box flex={1} className={classes.readOnlyContent}>
           <Typography className={classes.readOnlyName}>
             {endpointName || '(no name)'}

--- a/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.tsx
+++ b/plugins/openchoreo-react/src/components/EndpointEditor/EndpointEditor.tsx
@@ -20,10 +20,7 @@ import {
   DialogActions,
 } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
-import CheckIcon from '@material-ui/icons/Check';
-import CloseIcon from '@material-ui/icons/Close';
 import CodeMirror from '@uiw/react-codemirror';
 import { StreamLanguage } from '@codemirror/language';
 import type { StreamParser } from '@codemirror/language';
@@ -31,7 +28,10 @@ import { yaml as yamlMode } from '@codemirror/legacy-modes/mode/yaml';
 import { protobuf as protobufMode } from '@codemirror/legacy-modes/mode/protobuf';
 import { graphql as graphqlMode } from 'codemirror-graphql/cm6-legacy/mode';
 import type { WorkloadEndpoint } from '@openchoreo/backstage-plugin-common';
-import { useChoreoTokens } from '@openchoreo/backstage-design-system';
+import {
+  useChoreoTokens,
+  EditRowActions,
+} from '@openchoreo/backstage-design-system';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -48,9 +48,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(1),
     backgroundColor: theme.palette.background.default,
     boxShadow: `0 0 0 1px ${theme.palette.primary.main}`,
-  },
-  actionButton: {
-    marginLeft: theme.spacing(0.5),
   },
   readOnlyName: {
     fontWeight: 600,
@@ -296,49 +293,38 @@ export const EndpointEditor: FC<EndpointEditorProps> = ({
   if (!isEditing) {
     return (
       <Box className={className || classes.container}>
-        <Box display="flex" alignItems="center">
-          <Box flex={1} className={classes.readOnlyContent}>
-            <Typography className={classes.readOnlyName}>
-              {endpointName || '(no name)'}
-            </Typography>
-            <Typography className={classes.readOnlyDetails}>
-              {endpoint.type} : {endpoint.port}
-              {(() => {
-                const vis = endpoint.visibility ?? [];
-                const displayVis = vis.includes('project')
-                  ? vis
-                  : ['project', ...vis];
-                return displayVis.length > 0 ? (
-                  <>
-                    {' '}
-                    &middot;{' '}
-                    {displayVis.map(v => VISIBILITY_LABELS[v] ?? v).join(', ')}
-                  </>
-                ) : null;
-              })()}
-            </Typography>
-          </Box>
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<EditIcon />}
-            onClick={onEdit}
-            disabled={disabled || editDisabled}
-            className={classes.actionButton}
-          >
-            Edit
-          </Button>
-          <IconButton
-            onClick={onRemove}
-            color="secondary"
-            size="small"
-            disabled={disabled || deleteDisabled}
-            className={classes.actionButton}
-            aria-label="Remove endpoint"
-          >
-            <DeleteIcon />
-          </IconButton>
+        <Box flex={1} className={classes.readOnlyContent}>
+          <Typography className={classes.readOnlyName}>
+            {endpointName || '(no name)'}
+          </Typography>
+          <Typography className={classes.readOnlyDetails}>
+            {endpoint.type} : {endpoint.port}
+            {(() => {
+              const vis = endpoint.visibility ?? [];
+              const displayVis = vis.includes('project')
+                ? vis
+                : ['project', ...vis];
+              return displayVis.length > 0 ? (
+                <>
+                  {' '}
+                  &middot;{' '}
+                  {displayVis.map(v => VISIBILITY_LABELS[v] ?? v).join(', ')}
+                </>
+              ) : null;
+            })()}
+          </Typography>
         </Box>
+        <EditRowActions
+          isEditing={false}
+          itemLabel="endpoint"
+          onEdit={onEdit}
+          onApply={onApply}
+          onCancel={onCancel ?? (() => {})}
+          onRemove={onRemove}
+          disabled={disabled}
+          editDisabled={editDisabled}
+          deleteDisabled={deleteDisabled}
+        />
       </Box>
     );
   }
@@ -346,192 +332,164 @@ export const EndpointEditor: FC<EndpointEditorProps> = ({
   // Edit mode
   return (
     <Box className={className || classes.containerEditing}>
-      <Box display="flex" alignItems="flex-start">
-        <Box flex={1}>
+      <TextField
+        label="Endpoint Name"
+        value={endpointName || ''}
+        onChange={e => onNameChange(e.target.value)}
+        fullWidth
+        variant="outlined"
+        size="small"
+        disabled={disabled}
+        className={classes.nameField}
+      />
+      <Grid container spacing={1} alignItems="center">
+        <Grid item xs={6}>
+          <FormControl fullWidth variant="outlined" size="small">
+            <InputLabel>Type</InputLabel>
+            <Select
+              value={endpoint.type || 'HTTP'}
+              onChange={e => {
+                const newType = e.target.value as string;
+                onChange('type', newType);
+                const suggestedSchemaType =
+                  ENDPOINT_TYPE_TO_SCHEMA_TYPE[newType];
+                if (suggestedSchemaType) {
+                  onChange('schema', {
+                    ...endpoint.schema,
+                    type: suggestedSchemaType,
+                  });
+                }
+              }}
+              label="Type"
+              disabled={disabled}
+            >
+              {PROTOCOL_TYPES.map(type => (
+                <MenuItem key={type} value={type}>
+                  {type}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={6}>
           <TextField
-            label="Endpoint Name"
-            value={endpointName || ''}
-            onChange={e => onNameChange(e.target.value)}
+            label="Port"
+            type="number"
+            value={endpoint.port || ''}
+            onChange={e => onChange('port', parseInt(e.target.value, 10) || 0)}
             fullWidth
             variant="outlined"
             size="small"
             disabled={disabled}
-            className={classes.nameField}
           />
-          <Grid container spacing={1} alignItems="center">
-            <Grid item xs={6}>
-              <FormControl fullWidth variant="outlined" size="small">
-                <InputLabel>Type</InputLabel>
-                <Select
-                  value={endpoint.type || 'HTTP'}
-                  onChange={e => {
-                    const newType = e.target.value as string;
-                    onChange('type', newType);
-                    const suggestedSchemaType =
-                      ENDPOINT_TYPE_TO_SCHEMA_TYPE[newType];
-                    if (suggestedSchemaType) {
-                      onChange('schema', {
-                        ...endpoint.schema,
-                        type: suggestedSchemaType,
-                      });
-                    }
-                  }}
-                  label="Type"
-                  disabled={disabled}
-                >
-                  {PROTOCOL_TYPES.map(type => (
-                    <MenuItem key={type} value={type}>
-                      {type}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={6}>
-              <TextField
-                label="Port"
-                type="number"
-                value={endpoint.port || ''}
-                onChange={e =>
-                  onChange('port', parseInt(e.target.value, 10) || 0)
-                }
-                fullWidth
-                variant="outlined"
-                size="small"
-                disabled={disabled}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <FormControl
-                component="fieldset"
-                size="small"
-                fullWidth
-                disabled={disabled}
-                className={classes.visibilityFieldset}
-              >
-                <FormLabel
-                  component="legend"
-                  style={{ fontSize: '0.75rem', padding: '0 4px' }}
-                >
-                  Visibility
-                </FormLabel>
-                <FormGroup row>
-                  {VISIBILITY_OPTIONS.map(opt => {
-                    const currentVisibility = endpoint.visibility ?? [];
-                    const isChecked =
-                      opt.alwaysSelected ||
-                      (currentVisibility as string[]).includes(opt.value);
-                    return (
-                      <FormControlLabel
-                        key={opt.value}
-                        control={
-                          <Checkbox
-                            checked={isChecked}
-                            onChange={() => {
-                              if (opt.alwaysSelected || opt.disabled) return;
-                              const next = isChecked
-                                ? currentVisibility.filter(v => v !== opt.value)
-                                : [...currentVisibility, opt.value];
-                              onChange('visibility', next);
-                            }}
-                            size="small"
-                            color="primary"
-                          />
-                        }
-                        label={opt.label}
-                        disabled={disabled || opt.disabled}
-                      />
-                    );
-                  })}
-                </FormGroup>
-              </FormControl>
-            </Grid>
-            <Grid item xs={12}>
-              <Box className={classes.schemaContentField}>
-                <TextField
-                  label="Schema Content"
-                  value={
-                    endpoint.schema?.content
-                      ? `${endpoint.schema.content.substring(0, 60)}${
-                          endpoint.schema.content.length > 60 ? '...' : ''
-                        }`
-                      : ''
-                  }
-                  fullWidth
-                  variant="outlined"
-                  size="small"
-                  disabled
-                  placeholder={
-                    schemaDisplayName
-                      ? `Paste your ${schemaDisplayName} schema`
-                      : 'Optional - click to add'
-                  }
-                  error={isSchemaRequired && !endpoint.schema?.content?.trim()}
-                  helperText={schemaHelperText}
-                  InputProps={{
-                    readOnly: true,
-                  }}
-                />
-                <IconButton
-                  size="small"
-                  onClick={() => setSchemaDialogOpen(true)}
-                  disabled={disabled}
-                  aria-label="Edit schema"
-                >
-                  <EditIcon fontSize="small" />
-                </IconButton>
-              </Box>
-              <SchemaContentDialog
-                open={schemaDialogOpen}
-                content={endpoint.schema?.content || ''}
-                schemaType={endpoint.schema?.type}
-                required={isSchemaRequired}
-                onApply={content => {
-                  onChange('schema', {
-                    ...endpoint.schema,
-                    content,
-                  });
-                  setSchemaDialogOpen(false);
-                }}
-                onClose={() => setSchemaDialogOpen(false)}
-              />
-            </Grid>
-          </Grid>
-        </Box>
-        <Box display="flex" flexDirection="column" ml={1}>
-          <IconButton
-            onClick={onApply}
-            color="primary"
+        </Grid>
+        <Grid item xs={12}>
+          <FormControl
+            component="fieldset"
             size="small"
-            disabled={disabled || applyDisabled}
-            className={classes.actionButton}
-            aria-label="Apply changes"
-          >
-            <CheckIcon />
-          </IconButton>
-          {onCancel && (
-            <IconButton
-              onClick={onCancel}
-              size="small"
-              disabled={disabled}
-              className={classes.actionButton}
-              aria-label="Cancel editing"
-            >
-              <CloseIcon />
-            </IconButton>
-          )}
-          <IconButton
-            onClick={onRemove}
-            color="secondary"
-            size="small"
+            fullWidth
             disabled={disabled}
-            className={classes.actionButton}
-            aria-label="Remove endpoint"
+            className={classes.visibilityFieldset}
           >
-            <DeleteIcon />
-          </IconButton>
-        </Box>
-      </Box>
+            <FormLabel
+              component="legend"
+              style={{ fontSize: '0.75rem', padding: '0 4px' }}
+            >
+              Visibility
+            </FormLabel>
+            <FormGroup row>
+              {VISIBILITY_OPTIONS.map(opt => {
+                const currentVisibility = endpoint.visibility ?? [];
+                const isChecked =
+                  opt.alwaysSelected ||
+                  (currentVisibility as string[]).includes(opt.value);
+                return (
+                  <FormControlLabel
+                    key={opt.value}
+                    control={
+                      <Checkbox
+                        checked={isChecked}
+                        onChange={() => {
+                          if (opt.alwaysSelected || opt.disabled) return;
+                          const next = isChecked
+                            ? currentVisibility.filter(v => v !== opt.value)
+                            : [...currentVisibility, opt.value];
+                          onChange('visibility', next);
+                        }}
+                        size="small"
+                        color="primary"
+                      />
+                    }
+                    label={opt.label}
+                    disabled={disabled || opt.disabled}
+                  />
+                );
+              })}
+            </FormGroup>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12}>
+          <Box className={classes.schemaContentField}>
+            <TextField
+              label="Schema Content"
+              value={
+                endpoint.schema?.content
+                  ? `${endpoint.schema.content.substring(0, 60)}${
+                      endpoint.schema.content.length > 60 ? '...' : ''
+                    }`
+                  : ''
+              }
+              fullWidth
+              variant="outlined"
+              size="small"
+              disabled
+              placeholder={
+                schemaDisplayName
+                  ? `Paste your ${schemaDisplayName} schema`
+                  : 'Optional - click to add'
+              }
+              error={isSchemaRequired && !endpoint.schema?.content?.trim()}
+              helperText={schemaHelperText}
+              InputProps={{
+                readOnly: true,
+              }}
+            />
+            <IconButton
+              size="small"
+              onClick={() => setSchemaDialogOpen(true)}
+              disabled={disabled}
+              aria-label="Edit schema"
+            >
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <SchemaContentDialog
+            open={schemaDialogOpen}
+            content={endpoint.schema?.content || ''}
+            schemaType={endpoint.schema?.type}
+            required={isSchemaRequired}
+            onApply={content => {
+              onChange('schema', {
+                ...endpoint.schema,
+                content,
+              });
+              setSchemaDialogOpen(false);
+            }}
+            onClose={() => setSchemaDialogOpen(false)}
+          />
+        </Grid>
+      </Grid>
+      <EditRowActions
+        isEditing
+        itemLabel="endpoint"
+        onEdit={onEdit}
+        onApply={onApply}
+        onCancel={onCancel ?? (() => {})}
+        onRemove={onRemove}
+        disabled={disabled}
+        applyDisabled={applyDisabled}
+        hideCancel={!onCancel}
+      />
     </Box>
   );
 };

--- a/plugins/openchoreo-react/src/components/EnvVarEditor/EnvVarEditor.test.tsx
+++ b/plugins/openchoreo-react/src/components/EnvVarEditor/EnvVarEditor.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { EnvVar } from '@openchoreo/backstage-plugin-common';
+import { EnvVarEditor } from './EnvVarEditor';
+
+function renderEditor(
+  overrides: Partial<{
+    envVar: EnvVar;
+    mode: 'plain' | 'secret';
+    isEditing: boolean;
+    editButtonLabel: string;
+    hideDelete: boolean;
+    applyDisabled: boolean;
+    baseValue: EnvVar;
+  }> = {},
+) {
+  const handlers = {
+    onEdit: jest.fn(),
+    onApply: jest.fn(),
+    onCancel: jest.fn(),
+    onRemove: jest.fn(),
+    onChange: jest.fn(),
+    onModeChange: jest.fn(),
+  };
+  render(
+    <EnvVarEditor
+      envVar={overrides.envVar ?? { key: 'PORT', value: '8080' }}
+      secrets={[]}
+      mode={overrides.mode ?? 'plain'}
+      isEditing={overrides.isEditing ?? false}
+      editButtonLabel={overrides.editButtonLabel}
+      hideDelete={overrides.hideDelete}
+      applyDisabled={overrides.applyDisabled}
+      baseValue={overrides.baseValue}
+      {...handlers}
+    />,
+  );
+  return handlers;
+}
+
+describe('EnvVarEditor', () => {
+  describe('read-only mode', () => {
+    it('renders key/value with Edit and Delete actions', () => {
+      renderEditor({ envVar: { key: 'PORT', value: '8080' } });
+
+      expect(screen.getByText('PORT')).toBeInTheDocument();
+      expect(screen.getByText(/8080/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('Remove environment variable'),
+      ).toBeInTheDocument();
+    });
+
+    it('invokes onEdit and onRemove from the footer', () => {
+      const { onEdit, onRemove } = renderEditor();
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+      expect(onEdit).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByLabelText('Remove environment variable'));
+      expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('masks sensitive values', () => {
+      renderEditor({ envVar: { key: 'API_SECRET', value: 'supersecret' } });
+      expect(screen.getByText(/••••••••/)).toBeInTheDocument();
+    });
+
+    it('renders an inline diff when a baseValue is provided', () => {
+      renderEditor({
+        envVar: { key: 'PORT', value: '9090' },
+        baseValue: { key: 'PORT', value: '8080' },
+      });
+      expect(screen.getByText('8080')).toBeInTheDocument();
+    });
+
+    it('shows an "Override" button and hides Delete for inherited rows', () => {
+      renderEditor({ editButtonLabel: 'Override', hideDelete: true });
+
+      expect(
+        screen.getByRole('button', { name: /override/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Remove environment variable'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('edit mode', () => {
+    it('renders Name/Value fields with Save, Cancel and Delete', () => {
+      renderEditor({ isEditing: true });
+
+      expect(screen.getByDisplayValue('PORT')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('8080')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /cancel editing/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('emits onChange when the value field changes', () => {
+      const { onChange } = renderEditor({ isEditing: true });
+      fireEvent.change(screen.getByDisplayValue('8080'), {
+        target: { value: '9090' },
+      });
+      expect(onChange).toHaveBeenCalledWith('value', '9090');
+    });
+
+    it('fires onApply / onCancel from the footer', () => {
+      const { onApply, onCancel } = renderEditor({ isEditing: true });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+      fireEvent.click(screen.getByRole('button', { name: /cancel editing/i }));
+      expect(onApply).toHaveBeenCalledTimes(1);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables Save when applyDisabled is set', () => {
+      renderEditor({ isEditing: true, applyDisabled: true });
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeDisabled();
+    });
+
+    it('renders the secret selector in secret mode', () => {
+      renderEditor({
+        isEditing: true,
+        mode: 'secret',
+        envVar: {
+          key: 'TOKEN',
+          valueFrom: { secretKeyRef: { name: 's', key: 'k' } },
+        },
+      });
+      expect(screen.getByDisplayValue('TOKEN')).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/openchoreo-react/src/components/EnvVarEditor/EnvVarEditor.tsx
+++ b/plugins/openchoreo-react/src/components/EnvVarEditor/EnvVarEditor.tsx
@@ -1,21 +1,11 @@
 import type { FC } from 'react';
-import {
-  TextField,
-  IconButton,
-  Grid,
-  Box,
-  Typography,
-  Button,
-} from '@material-ui/core';
+import { TextField, Grid, Box, Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import DeleteIcon from '@material-ui/icons/Delete';
-import EditIcon from '@material-ui/icons/Edit';
-import CheckIcon from '@material-ui/icons/Check';
-import CloseIcon from '@material-ui/icons/Close';
 import type { EnvVar } from '@openchoreo/backstage-plugin-common';
 import {
   DualModeInput,
   SecretSelector,
+  EditRowActions,
   type SecretOption,
 } from '@openchoreo/backstage-design-system';
 
@@ -34,9 +24,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(1),
     backgroundColor: theme.palette.background.default,
     boxShadow: `0 0 0 1px ${theme.palette.primary.main}`,
-  },
-  actionButton: {
-    marginLeft: theme.spacing(0.5),
   },
   readOnlyKey: {
     fontWeight: 600,
@@ -224,55 +211,44 @@ export const EnvVarEditor: FC<EnvVarEditorProps> = ({
   if (!isEditing) {
     return (
       <Box className={className || classes.container}>
-        <Box display="flex" alignItems="center">
-          <Box flex={1} className={classes.readOnlyContent}>
-            <Typography className={classes.readOnlyKey}>
-              {envVar.key || '(no name)'}
-            </Typography>
-            <Typography className={classes.readOnlyValue}>
-              = {getDisplayValue() || '(empty)'}
-            </Typography>
-            {mode === 'secret' && (
-              <Typography className={classes.secretIndicator}>🔒</Typography>
-            )}
-            {/* Inline diff for overridden values */}
-            {baseValue && (
-              <Box className={classes.inlineDiff}>
-                <Typography component="span" className={classes.diffArrow}>
-                  ←
-                </Typography>
-                <Typography
-                  component="span"
-                  className={classes.baseValueStruck}
-                >
-                  {formatDisplayValue(baseValue, baseValueMode)}
-                </Typography>
-              </Box>
-            )}
-          </Box>
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<EditIcon />}
-            onClick={onEdit}
-            disabled={disabled || editDisabled}
-            className={classes.actionButton}
-          >
-            {editButtonLabel}
-          </Button>
-          {!hideDelete && (
-            <IconButton
-              onClick={onRemove}
-              color="secondary"
-              size="small"
-              disabled={disabled || deleteDisabled}
-              className={classes.actionButton}
-              aria-label="Remove environment variable"
-            >
-              <DeleteIcon />
-            </IconButton>
+        <Box flex={1} className={classes.readOnlyContent}>
+          <Typography className={classes.readOnlyKey}>
+            {envVar.key || '(no name)'}
+          </Typography>
+          <Typography className={classes.readOnlyValue}>
+            = {getDisplayValue() || '(empty)'}
+          </Typography>
+          {mode === 'secret' && (
+            <Typography className={classes.secretIndicator}>🔒</Typography>
+          )}
+          {/* Inline diff for overridden values */}
+          {baseValue && (
+            <Box className={classes.inlineDiff}>
+              <Typography component="span" className={classes.diffArrow}>
+                ←
+              </Typography>
+              <Typography component="span" className={classes.baseValueStruck}>
+                {formatDisplayValue(baseValue, baseValueMode)}
+              </Typography>
+            </Box>
           )}
         </Box>
+        <EditRowActions
+          isEditing={false}
+          itemLabel="environment variable"
+          editLabel={editButtonLabel}
+          editVariant={
+            editButtonLabel === 'Override' ? 'contained' : 'outlined'
+          }
+          onEdit={onEdit}
+          onApply={onApply}
+          onCancel={onCancel ?? (() => {})}
+          onRemove={onRemove}
+          disabled={disabled}
+          editDisabled={editDisabled}
+          deleteDisabled={deleteDisabled}
+          hideDelete={hideDelete}
+        />
       </Box>
     );
   }
@@ -336,58 +312,23 @@ export const EnvVarEditor: FC<EnvVarEditorProps> = ({
 
   return (
     <Box className={className || classes.containerEditing}>
-      <Box display="flex" alignItems="center">
-        <Box flex={1}>
-          <DualModeInput
-            mode={mode}
-            onModeChange={handleModeChange}
-            plainContent={plainContent}
-            secretContent={secretContent}
-            disabled={disabled || lockMode}
-            tooltipPlain={
-              lockMode
-                ? 'Mode cannot be changed for overrides'
-                : 'Click to switch to secret reference'
-            }
-            tooltipSecret={
-              lockMode
-                ? 'Mode cannot be changed for overrides'
-                : 'Click to switch to plain value'
-            }
-          />
-        </Box>
-        <IconButton
-          onClick={onApply}
-          color="primary"
-          size="small"
-          disabled={disabled || applyDisabled}
-          className={classes.actionButton}
-          aria-label="Apply changes"
-        >
-          <CheckIcon />
-        </IconButton>
-        {onCancel && (
-          <IconButton
-            onClick={onCancel}
-            size="small"
-            disabled={disabled}
-            className={classes.actionButton}
-            aria-label="Cancel editing"
-          >
-            <CloseIcon />
-          </IconButton>
-        )}
-        <IconButton
-          onClick={onRemove}
-          color="secondary"
-          size="small"
-          disabled={disabled}
-          className={classes.actionButton}
-          aria-label="Remove environment variable"
-        >
-          <DeleteIcon />
-        </IconButton>
-      </Box>
+      <DualModeInput
+        mode={mode}
+        onModeChange={handleModeChange}
+        plainContent={plainContent}
+        secretContent={secretContent}
+        disabled={disabled || lockMode}
+        tooltipPlain={
+          lockMode
+            ? 'Mode cannot be changed for overrides'
+            : 'Click to switch to secret reference'
+        }
+        tooltipSecret={
+          lockMode
+            ? 'Mode cannot be changed for overrides'
+            : 'Click to switch to plain value'
+        }
+      />
       {/* Show base value hint in edit mode for overridden items */}
       {baseValue && (
         <Box className={classes.baseValueInline}>
@@ -396,6 +337,17 @@ export const EnvVarEditor: FC<EnvVarEditorProps> = ({
           </Typography>
         </Box>
       )}
+      <EditRowActions
+        isEditing
+        itemLabel="environment variable"
+        onEdit={onEdit}
+        onApply={onApply}
+        onCancel={onCancel ?? (() => {})}
+        onRemove={onRemove}
+        disabled={disabled}
+        applyDisabled={applyDisabled}
+        hideCancel={!onCancel}
+      />
     </Box>
   );
 };

--- a/plugins/openchoreo-react/src/components/EnvVarEditor/EnvVarEditor.tsx
+++ b/plugins/openchoreo-react/src/components/EnvVarEditor/EnvVarEditor.tsx
@@ -11,6 +11,8 @@ import {
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
+    display: 'flex',
+    alignItems: 'center',
     padding: theme.spacing(1.5),
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: 6,
@@ -237,9 +239,6 @@ export const EnvVarEditor: FC<EnvVarEditorProps> = ({
           isEditing={false}
           itemLabel="environment variable"
           editLabel={editButtonLabel}
-          editVariant={
-            editButtonLabel === 'Override' ? 'contained' : 'outlined'
-          }
           onEdit={onEdit}
           onApply={onApply}
           onCancel={onCancel ?? (() => {})}

--- a/plugins/openchoreo-react/src/components/FileVarEditor/FileVarEditor.test.tsx
+++ b/plugins/openchoreo-react/src/components/FileVarEditor/FileVarEditor.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { FileVar } from '@openchoreo/backstage-plugin-common';
+import { FileVarEditor } from './FileVarEditor';
+
+function renderEditor(
+  overrides: Partial<{
+    fileVar: FileVar;
+    mode: 'plain' | 'secret';
+    isEditing: boolean;
+    editButtonLabel: string;
+    hideDelete: boolean;
+    applyDisabled: boolean;
+  }> = {},
+) {
+  const handlers = {
+    onEdit: jest.fn(),
+    onApply: jest.fn(),
+    onCancel: jest.fn(),
+    onRemove: jest.fn(),
+    onChange: jest.fn(),
+    onModeChange: jest.fn(),
+  };
+  render(
+    <FileVarEditor
+      fileVar={
+        overrides.fileVar ?? { key: 'config.yaml', mountPath: '/etc/app' }
+      }
+      id="fv-1"
+      secrets={[]}
+      mode={overrides.mode ?? 'plain'}
+      isEditing={overrides.isEditing ?? false}
+      editButtonLabel={overrides.editButtonLabel}
+      hideDelete={overrides.hideDelete}
+      applyDisabled={overrides.applyDisabled}
+      {...handlers}
+    />,
+  );
+  return handlers;
+}
+
+describe('FileVarEditor', () => {
+  describe('read-only mode', () => {
+    it('renders filename → mount path with Edit and Delete', () => {
+      renderEditor({
+        fileVar: { key: 'config.yaml', mountPath: '/etc/app' },
+      });
+
+      expect(screen.getByText('config.yaml')).toBeInTheDocument();
+      expect(screen.getByText(/\/etc\/app/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove file mount')).toBeInTheDocument();
+    });
+
+    it('invokes onEdit and onRemove from the footer', () => {
+      const { onEdit, onRemove } = renderEditor();
+
+      fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+      expect(onEdit).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByLabelText('Remove file mount'));
+      expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows an "Override" button and hides Delete for inherited rows', () => {
+      renderEditor({ editButtonLabel: 'Override', hideDelete: true });
+
+      expect(
+        screen.getByRole('button', { name: /override/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('Remove file mount'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('edit mode', () => {
+    it('renders File Name / Mount Path fields with Save, Cancel and Delete', () => {
+      renderEditor({ isEditing: true });
+
+      expect(screen.getByDisplayValue('config.yaml')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('/etc/app')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /cancel editing/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove file mount')).toBeInTheDocument();
+    });
+
+    it('emits onChange when the mount path changes', () => {
+      const { onChange } = renderEditor({ isEditing: true });
+      fireEvent.change(screen.getByDisplayValue('/etc/app'), {
+        target: { value: '/etc/other' },
+      });
+      expect(onChange).toHaveBeenCalledWith('mountPath', '/etc/other');
+    });
+
+    it('fires onApply / onCancel from the footer', () => {
+      const { onApply, onCancel } = renderEditor({ isEditing: true });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+      fireEvent.click(screen.getByRole('button', { name: /cancel editing/i }));
+      expect(onApply).toHaveBeenCalledTimes(1);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables Save when applyDisabled is set', () => {
+      renderEditor({ isEditing: true, applyDisabled: true });
+      expect(
+        screen.getByRole('button', { name: /save changes/i }),
+      ).toBeDisabled();
+    });
+
+    it('toggles to secret mode via the mode button', () => {
+      const { onModeChange } = renderEditor({ isEditing: true, mode: 'plain' });
+      fireEvent.click(
+        screen.getByRole('button', { name: /switch to secret reference/i }),
+      );
+      expect(onModeChange).toHaveBeenCalledWith('secret');
+    });
+  });
+});

--- a/plugins/openchoreo-react/src/components/FileVarEditor/FileVarEditor.tsx
+++ b/plugins/openchoreo-react/src/components/FileVarEditor/FileVarEditor.tsx
@@ -392,6 +392,19 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
                 </Typography>
               )}
             </Box>
+            <EditRowActions
+              isEditing={false}
+              itemLabel="file mount"
+              editLabel={editButtonLabel}
+              onEdit={onEdit}
+              onApply={onApply}
+              onCancel={onCancel ?? (() => {})}
+              onRemove={onRemove}
+              disabled={disabled}
+              editDisabled={editDisabled}
+              deleteDisabled={deleteDisabled}
+              hideDelete={hideDelete}
+            />
           </Box>
           {/* Inline diff for overridden values */}
           {baseValue && (
@@ -411,22 +424,6 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
               {getContentPreview(fileVar.value!)}
             </Box>
           )}
-          <EditRowActions
-            isEditing={false}
-            itemLabel="file mount"
-            editLabel={editButtonLabel}
-            editVariant={
-              editButtonLabel === 'Override' ? 'contained' : 'outlined'
-            }
-            onEdit={onEdit}
-            onApply={onApply}
-            onCancel={onCancel ?? (() => {})}
-            onRemove={onRemove}
-            disabled={disabled}
-            editDisabled={editDisabled}
-            deleteDisabled={deleteDisabled}
-            hideDelete={hideDelete}
-          />
         </Paper>
 
         <Snackbar

--- a/plugins/openchoreo-react/src/components/FileVarEditor/FileVarEditor.tsx
+++ b/plugins/openchoreo-react/src/components/FileVarEditor/FileVarEditor.tsx
@@ -12,18 +12,15 @@ import {
   Snackbar,
 } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import DeleteIcon from '@material-ui/icons/Delete';
 import AttachFileIcon from '@material-ui/icons/AttachFile';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import LockIcon from '@material-ui/icons/Lock';
 import LockOpenIcon from '@material-ui/icons/LockOpen';
-import EditIcon from '@material-ui/icons/Edit';
-import CheckIcon from '@material-ui/icons/Check';
-import CloseIcon from '@material-ui/icons/Close';
 import { Alert } from '@material-ui/lab';
 import type { FileVar } from '@openchoreo/backstage-plugin-common';
 import {
   SecretSelector,
+  EditRowActions,
   type SecretOption,
   darkTokens,
 } from '@openchoreo/backstage-design-system';
@@ -97,9 +94,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     textOverflow: 'ellipsis',
     marginTop: theme.spacing(1),
     maxHeight: 60,
-  },
-  actionButton: {
-    marginLeft: theme.spacing(0.5),
   },
   baseValueInline: {
     marginTop: theme.spacing(1),
@@ -398,28 +392,6 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
                 </Typography>
               )}
             </Box>
-            <Button
-              size="small"
-              variant="outlined"
-              startIcon={<EditIcon />}
-              onClick={onEdit}
-              disabled={disabled || editDisabled}
-              className={classes.actionButton}
-            >
-              {editButtonLabel}
-            </Button>
-            {!hideDelete && (
-              <IconButton
-                onClick={onRemove}
-                color="secondary"
-                size="small"
-                disabled={disabled || deleteDisabled}
-                className={classes.actionButton}
-                aria-label="Remove file mount"
-              >
-                <DeleteIcon />
-              </IconButton>
-            )}
           </Box>
           {/* Inline diff for overridden values */}
           {baseValue && (
@@ -439,6 +411,22 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
               {getContentPreview(fileVar.value!)}
             </Box>
           )}
+          <EditRowActions
+            isEditing={false}
+            itemLabel="file mount"
+            editLabel={editButtonLabel}
+            editVariant={
+              editButtonLabel === 'Override' ? 'contained' : 'outlined'
+            }
+            onEdit={onEdit}
+            onApply={onApply}
+            onCancel={onCancel ?? (() => {})}
+            onRemove={onRemove}
+            disabled={disabled}
+            editDisabled={editDisabled}
+            deleteDisabled={deleteDisabled}
+            hideDelete={hideDelete}
+          />
         </Paper>
 
         <Snackbar
@@ -519,40 +507,6 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
                   />
                 </Grid>
               </Grid>
-            </Grid>
-
-            <Grid item style={{ display: 'flex', alignItems: 'center' }}>
-              <IconButton
-                onClick={onApply}
-                color="primary"
-                size="small"
-                disabled={disabled || applyDisabled}
-                className={classes.actionButton}
-                aria-label="Apply changes"
-              >
-                <CheckIcon />
-              </IconButton>
-              {onCancel && (
-                <IconButton
-                  onClick={onCancel}
-                  size="small"
-                  disabled={disabled}
-                  className={classes.actionButton}
-                  aria-label="Cancel editing"
-                >
-                  <CloseIcon />
-                </IconButton>
-              )}
-              <IconButton
-                onClick={onRemove}
-                color="secondary"
-                size="small"
-                disabled={disabled}
-                className={classes.actionButton}
-                aria-label="Remove file mount"
-              >
-                <DeleteIcon />
-              </IconButton>
             </Grid>
           </Grid>
         </Box>
@@ -670,6 +624,17 @@ export const FileVarEditor: FC<FileVarEditorProps> = ({
             </Typography>
           </Box>
         )}
+        <EditRowActions
+          isEditing
+          itemLabel="file mount"
+          onEdit={onEdit}
+          onApply={onApply}
+          onCancel={onCancel ?? (() => {})}
+          onRemove={onRemove}
+          disabled={disabled}
+          applyDisabled={applyDisabled}
+          hideCancel={!onCancel}
+        />
       </Paper>
 
       <Snackbar

--- a/plugins/openchoreo-react/src/components/OverrideEnvVarList/OverrideEnvVarList.tsx
+++ b/plugins/openchoreo-react/src/components/OverrideEnvVarList/OverrideEnvVarList.tsx
@@ -19,6 +19,8 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(1),
   },
   inheritedRow: {
+    display: 'flex',
+    alignItems: 'center',
     padding: theme.spacing(1.5),
     backgroundColor: theme.palette.grey[50],
     borderRadius: 6,

--- a/plugins/openchoreo-react/src/components/ResourceDependencyEditor/ResourceDependencyEditor.test.tsx
+++ b/plugins/openchoreo-react/src/components/ResourceDependencyEditor/ResourceDependencyEditor.test.tsx
@@ -112,10 +112,10 @@ describe('ResourceDependencyEditor', () => {
       expect(screen.getByTestId('binding-row-caCert')).toBeInTheDocument();
     });
 
-    it('renders Apply / Cancel buttons in the footer', () => {
+    it('renders Save / Cancel buttons in the footer', () => {
       renderEditor({ isEditing: true });
       expect(
-        screen.getByRole('button', { name: /Apply changes/i }),
+        screen.getByRole('button', { name: /Save changes/i }),
       ).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: /Cancel editing/i }),
@@ -124,7 +124,7 @@ describe('ResourceDependencyEditor', () => {
 
     it('invokes onApply / onCancel via footer buttons', () => {
       const { onApply, onCancel } = renderEditor({ isEditing: true });
-      fireEvent.click(screen.getByRole('button', { name: /Apply changes/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
       fireEvent.click(screen.getByRole('button', { name: /Cancel editing/i }));
       expect(onApply).toHaveBeenCalledTimes(1);
       expect(onCancel).toHaveBeenCalledTimes(1);
@@ -326,7 +326,7 @@ describe('ResourceDependencyEditor', () => {
       });
     });
 
-    it('disables Apply when applyDisabled is true', () => {
+    it('disables Save when applyDisabled is true', () => {
       render(
         <ResourceDependencyEditor
           dependency={{ ref: 'orders-db' }}
@@ -341,7 +341,7 @@ describe('ResourceDependencyEditor', () => {
         />,
       );
       expect(
-        screen.getByRole('button', { name: /Apply changes/i }),
+        screen.getByRole('button', { name: /Save changes/i }),
       ).toBeDisabled();
     });
   });

--- a/plugins/openchoreo-react/src/components/ResourceDependencyEditor/ResourceDependencyEditor.tsx
+++ b/plugins/openchoreo-react/src/components/ResourceDependencyEditor/ResourceDependencyEditor.tsx
@@ -30,6 +30,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(1),
     backgroundColor: theme.palette.background.default,
   },
+  // Read-only row: content + inline actions share one line.
+  readOnlyContainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
   containerEditing: {
     padding: theme.spacing(1.5),
     border: `1px solid ${theme.palette.primary.main}`,
@@ -283,7 +288,7 @@ export const ResourceDependencyEditor: FC<ResourceDependencyEditorProps> = ({
 
   if (!isEditing) {
     return (
-      <Box className={classes.container}>
+      <Box className={`${classes.container} ${classes.readOnlyContainer}`}>
         <Box flex={1} className={classes.readOnlyContent}>
           <Typography className={classes.readOnlyName}>
             {dependency.ref || '(no resource)'}

--- a/plugins/openchoreo-react/src/components/ResourceDependencyEditor/ResourceDependencyEditor.tsx
+++ b/plugins/openchoreo-react/src/components/ResourceDependencyEditor/ResourceDependencyEditor.tsx
@@ -14,10 +14,9 @@ import {
 } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
-import CheckIcon from '@material-ui/icons/Check';
 import CloseIcon from '@material-ui/icons/Close';
 import DeleteIcon from '@material-ui/icons/Delete';
-import EditIcon from '@material-ui/icons/Edit';
+import { EditRowActions } from '@openchoreo/backstage-design-system';
 import type {
   ResourceDependency,
   ResourceTypeOutput,
@@ -58,9 +57,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   typeChip: {
     height: 20,
     fontSize: '0.7rem',
-  },
-  actionButton: {
-    marginLeft: theme.spacing(0.5),
   },
   header: {
     display: 'flex',
@@ -288,42 +284,29 @@ export const ResourceDependencyEditor: FC<ResourceDependencyEditorProps> = ({
   if (!isEditing) {
     return (
       <Box className={classes.container}>
-        <Box display="flex" alignItems="center">
-          <Box flex={1} className={classes.readOnlyContent}>
-            <Typography className={classes.readOnlyName}>
-              {dependency.ref || '(no resource)'}
-            </Typography>
-            <Chip
-              label="Resource"
-              size="small"
-              variant="outlined"
-              className={classes.typeChip}
-            />
-            <Typography className={classes.readOnlyDetails}>
-              {summary}
-            </Typography>
-          </Box>
-          <Button
+        <Box flex={1} className={classes.readOnlyContent}>
+          <Typography className={classes.readOnlyName}>
+            {dependency.ref || '(no resource)'}
+          </Typography>
+          <Chip
+            label="Resource"
             size="small"
             variant="outlined"
-            startIcon={<EditIcon />}
-            onClick={onEdit}
-            disabled={disabled || editDisabled}
-            className={classes.actionButton}
-          >
-            Edit
-          </Button>
-          <IconButton
-            onClick={onRemove}
-            color="secondary"
-            size="small"
-            disabled={disabled || deleteDisabled}
-            className={classes.actionButton}
-            aria-label="Remove resource dependency"
-          >
-            <DeleteIcon />
-          </IconButton>
+            className={classes.typeChip}
+          />
+          <Typography className={classes.readOnlyDetails}>{summary}</Typography>
         </Box>
+        <EditRowActions
+          isEditing={false}
+          itemLabel="resource dependency"
+          onEdit={onEdit}
+          onApply={onApply}
+          onCancel={onCancel}
+          onRemove={onRemove}
+          disabled={disabled}
+          editDisabled={editDisabled}
+          deleteDisabled={deleteDisabled}
+        />
       </Box>
     );
   }
@@ -407,235 +390,198 @@ export const ResourceDependencyEditor: FC<ResourceDependencyEditorProps> = ({
       className={classes.containerEditing}
       data-testid="resource-dependency-editor"
     >
-      <Box display="flex" alignItems="flex-start">
-        <Box flex={1}>
-          <Box className={classes.header}>
-            <FormControl
-              variant="outlined"
-              size="small"
-              className={classes.refSelect}
-            >
-              <InputLabel>Resource</InputLabel>
-              <Select
-                value={dependency.ref || ''}
-                onChange={e => handleRefChange(e.target.value as string)}
-                label="Resource"
-                disabled={disabled}
-                inputProps={{ 'data-testid': 'resource-ref-select' }}
-              >
-                {refOptions.map(option => (
-                  <MenuItem key={option.name} value={option.name}>
-                    {option.name}
-                    {option.resourceType && (
-                      <Typography
-                        variant="caption"
-                        color="textSecondary"
-                        style={{ marginLeft: 8 }}
-                      >
-                        {option.resourceType}
-                      </Typography>
-                    )}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Box>
-
-          <Box className={classes.bindingsList}>
-            {wiredOutputNames.length === 0 ? (
-              <Typography className={classes.emptyHint}>
-                No bindings yet. Add a binding to wire an output into the
-                container.
-              </Typography>
-            ) : (
-              wiredOutputNames.map(name => {
-                const output = outputByName.get(name);
-                const kind = output ? outputKind(output) : 'unknown';
-                const hasEnvBinding = name in envBindings;
-                const hasFileBinding = name in fileBindings;
-                return (
-                  <Box
-                    key={name}
-                    className={classes.bindingRow}
-                    data-testid={`binding-row-${name}`}
+      <Box className={classes.header}>
+        <FormControl
+          variant="outlined"
+          size="small"
+          className={classes.refSelect}
+        >
+          <InputLabel>Resource</InputLabel>
+          <Select
+            value={dependency.ref || ''}
+            onChange={e => handleRefChange(e.target.value as string)}
+            label="Resource"
+            disabled={disabled}
+            inputProps={{ 'data-testid': 'resource-ref-select' }}
+          >
+            {refOptions.map(option => (
+              <MenuItem key={option.name} value={option.name}>
+                {option.name}
+                {option.resourceType && (
+                  <Typography
+                    variant="caption"
+                    color="textSecondary"
+                    style={{ marginLeft: 8 }}
                   >
-                    <Box className={classes.bindingHeader}>
-                      <Typography className={classes.bindingName}>
-                        {name}
-                      </Typography>
-                      <Chip
-                        label={kind}
-                        size="small"
+                    {option.resourceType}
+                  </Typography>
+                )}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      <Box className={classes.bindingsList}>
+        {wiredOutputNames.length === 0 ? (
+          <Typography className={classes.emptyHint}>
+            No bindings yet. Add a binding to wire an output into the container.
+          </Typography>
+        ) : (
+          wiredOutputNames.map(name => {
+            const output = outputByName.get(name);
+            const kind = output ? outputKind(output) : 'unknown';
+            const hasEnvBinding = name in envBindings;
+            const hasFileBinding = name in fileBindings;
+            return (
+              <Box
+                key={name}
+                className={classes.bindingRow}
+                data-testid={`binding-row-${name}`}
+              >
+                <Box className={classes.bindingHeader}>
+                  <Typography className={classes.bindingName}>
+                    {name}
+                  </Typography>
+                  <Chip
+                    label={kind}
+                    size="small"
+                    variant="outlined"
+                    className={classes.kindChip}
+                  />
+                  <IconButton
+                    size="small"
+                    onClick={() => handleRemoveBinding(name)}
+                    disabled={disabled}
+                    aria-label={`Remove binding ${name}`}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+                <Box className={classes.fields}>
+                  {hasEnvBinding && (
+                    <Box className={classes.fieldWithRemove}>
+                      <TextField
+                        label="Env var"
                         variant="outlined"
-                        className={classes.kindChip}
+                        size="small"
+                        className={classes.field}
+                        value={envBindings[name] ?? ''}
+                        disabled={disabled}
+                        onChange={e => handleEnvChange(name, e.target.value)}
+                        placeholder="e.g. DB_HOST"
+                        inputProps={{
+                          'data-testid': `env-input-${name}`,
+                        }}
                       />
                       <IconButton
                         size="small"
-                        onClick={() => handleRemoveBinding(name)}
+                        onClick={() => handleRemoveEnvBinding(name)}
                         disabled={disabled}
-                        aria-label={`Remove binding ${name}`}
+                        aria-label={`Remove env binding ${name}`}
                       >
-                        <DeleteIcon fontSize="small" />
+                        <CloseIcon fontSize="small" />
                       </IconButton>
                     </Box>
-                    <Box className={classes.fields}>
-                      {hasEnvBinding && (
-                        <Box className={classes.fieldWithRemove}>
-                          <TextField
-                            label="Env var"
-                            variant="outlined"
-                            size="small"
-                            className={classes.field}
-                            value={envBindings[name] ?? ''}
-                            disabled={disabled}
-                            onChange={e =>
-                              handleEnvChange(name, e.target.value)
-                            }
-                            placeholder="e.g. DB_HOST"
-                            inputProps={{
-                              'data-testid': `env-input-${name}`,
-                            }}
-                          />
-                          <IconButton
-                            size="small"
-                            onClick={() => handleRemoveEnvBinding(name)}
-                            disabled={disabled}
-                            aria-label={`Remove env binding ${name}`}
-                          >
-                            <CloseIcon fontSize="small" />
-                          </IconButton>
-                        </Box>
-                      )}
-                      {hasFileBinding && (
-                        <Box className={classes.fieldWithRemove}>
-                          <TextField
-                            label="Mount path"
-                            variant="outlined"
-                            size="small"
-                            className={classes.field}
-                            value={fileBindings[name] ?? ''}
-                            disabled={disabled}
-                            onChange={e =>
-                              handleMountChange(name, e.target.value)
-                            }
-                            placeholder="e.g. /etc/secrets/db"
-                            inputProps={{
-                              'data-testid': `mount-input-${name}`,
-                            }}
-                          />
-                          <IconButton
-                            size="small"
-                            onClick={() => handleRemoveFileBinding(name)}
-                            disabled={disabled}
-                            aria-label={`Remove file mount ${name}`}
-                          >
-                            <CloseIcon fontSize="small" />
-                          </IconButton>
-                        </Box>
-                      )}
+                  )}
+                  {hasFileBinding && (
+                    <Box className={classes.fieldWithRemove}>
+                      <TextField
+                        label="Mount path"
+                        variant="outlined"
+                        size="small"
+                        className={classes.field}
+                        value={fileBindings[name] ?? ''}
+                        disabled={disabled}
+                        onChange={e => handleMountChange(name, e.target.value)}
+                        placeholder="e.g. /etc/secrets/db"
+                        inputProps={{
+                          'data-testid': `mount-input-${name}`,
+                        }}
+                      />
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRemoveFileBinding(name)}
+                        disabled={disabled}
+                        aria-label={`Remove file mount ${name}`}
+                      >
+                        <CloseIcon fontSize="small" />
+                      </IconButton>
                     </Box>
-                  </Box>
-                );
-              })
-            )}
-          </Box>
-
-          <Box className={classes.addButtonRow}>
-            <Button
-              startIcon={<AddIcon />}
-              onClick={e => setEnvAddAnchor(e.currentTarget)}
-              variant="outlined"
-              size="small"
-              disabled={disabled || envUnboundOutputs.length === 0}
-            >
-              Add env binding
-            </Button>
-            <Button
-              startIcon={<AddIcon />}
-              onClick={e => setFileAddAnchor(e.currentTarget)}
-              variant="outlined"
-              size="small"
-              disabled={disabled || fileUnboundOutputs.length === 0}
-            >
-              Add file mount
-            </Button>
-            <Menu
-              anchorEl={envAddAnchor}
-              open={Boolean(envAddAnchor)}
-              onClose={() => setEnvAddAnchor(null)}
-            >
-              {envUnboundOutputs.map(o => (
-                <MenuItem
-                  key={o.name}
-                  onClick={() => handleAddEnvBinding(o.name)}
-                >
-                  {o.name}{' '}
-                  <Typography
-                    variant="caption"
-                    color="textSecondary"
-                    style={{ marginLeft: 8 }}
-                  >
-                    {outputKind(o)}
-                  </Typography>
-                </MenuItem>
-              ))}
-            </Menu>
-            <Menu
-              anchorEl={fileAddAnchor}
-              open={Boolean(fileAddAnchor)}
-              onClose={() => setFileAddAnchor(null)}
-            >
-              {fileUnboundOutputs.map(o => (
-                <MenuItem
-                  key={o.name}
-                  onClick={() => handleAddFileBinding(o.name)}
-                >
-                  {o.name}{' '}
-                  <Typography
-                    variant="caption"
-                    color="textSecondary"
-                    style={{ marginLeft: 8 }}
-                  >
-                    {outputKind(o)}
-                  </Typography>
-                </MenuItem>
-              ))}
-            </Menu>
-          </Box>
-        </Box>
-
-        <Box display="flex" flexDirection="column" ml={1}>
-          <IconButton
-            onClick={onApply}
-            color="primary"
-            size="small"
-            disabled={disabled || applyDisabled}
-            className={classes.actionButton}
-            aria-label="Apply changes"
-          >
-            <CheckIcon />
-          </IconButton>
-          <IconButton
-            onClick={onCancel}
-            size="small"
-            disabled={disabled}
-            className={classes.actionButton}
-            aria-label="Cancel editing"
-          >
-            <CloseIcon />
-          </IconButton>
-          <IconButton
-            onClick={onRemove}
-            color="secondary"
-            size="small"
-            disabled={disabled}
-            className={classes.actionButton}
-            aria-label="Remove resource dependency"
-          >
-            <DeleteIcon />
-          </IconButton>
-        </Box>
+                  )}
+                </Box>
+              </Box>
+            );
+          })
+        )}
       </Box>
+
+      <Box className={classes.addButtonRow}>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={e => setEnvAddAnchor(e.currentTarget)}
+          variant="outlined"
+          size="small"
+          disabled={disabled || envUnboundOutputs.length === 0}
+        >
+          Add env binding
+        </Button>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={e => setFileAddAnchor(e.currentTarget)}
+          variant="outlined"
+          size="small"
+          disabled={disabled || fileUnboundOutputs.length === 0}
+        >
+          Add file mount
+        </Button>
+        <Menu
+          anchorEl={envAddAnchor}
+          open={Boolean(envAddAnchor)}
+          onClose={() => setEnvAddAnchor(null)}
+        >
+          {envUnboundOutputs.map(o => (
+            <MenuItem key={o.name} onClick={() => handleAddEnvBinding(o.name)}>
+              {o.name}{' '}
+              <Typography
+                variant="caption"
+                color="textSecondary"
+                style={{ marginLeft: 8 }}
+              >
+                {outputKind(o)}
+              </Typography>
+            </MenuItem>
+          ))}
+        </Menu>
+        <Menu
+          anchorEl={fileAddAnchor}
+          open={Boolean(fileAddAnchor)}
+          onClose={() => setFileAddAnchor(null)}
+        >
+          {fileUnboundOutputs.map(o => (
+            <MenuItem key={o.name} onClick={() => handleAddFileBinding(o.name)}>
+              {o.name}{' '}
+              <Typography
+                variant="caption"
+                color="textSecondary"
+                style={{ marginLeft: 8 }}
+              >
+                {outputKind(o)}
+              </Typography>
+            </MenuItem>
+          ))}
+        </Menu>
+      </Box>
+      <EditRowActions
+        isEditing
+        itemLabel="resource dependency"
+        onEdit={onEdit}
+        onApply={onApply}
+        onCancel={onCancel}
+        onRemove={onRemove}
+        disabled={disabled}
+        applyDisabled={applyDisabled}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
  Closes openchoreo/openchoreo#3878
  
  ## Problem
  In the Workload editor's endpoint, dependency, environment-variable, and
  file-mount rows, the save/discard/delete controls were a stack of small
  icon-only buttons (✓ / ✕ / 🗑). They were easy to miss and unlabeled, so it
  wasn't obvious how to commit or discard an inline edit.

  Introduces a reusable `EditRowActions` design-system component and wires it
  into all five row editors (endpoint, dependency, resource-dependency,
  environment-variable, file-mount), removing the duplicated icon-stack JSX.
  Existing behavior is preserved: one-row-at-a-time editing, validation-gated
  Save, the override "Base value" hint, secret/file mode toggles, and all
  aria-labels


https://github.com/user-attachments/assets/e6f1fc5c-ef36-4ee7-a61e-d718ea1cc9fb






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared, reusable row action footer for inline editors, standardizing edit controls across multiple Workload editor row types.

* **UI Updates**
  * Replaced icon-only inline buttons with a labeled footer action bar (Save / Cancel / Delete) for endpoints, dependencies, environment variables, and file mounts, making commit/discard behavior more visible.
  * Updated expanded resource dependency actions to use “Save changes” terminology.

* **Tests**
  * Added and expanded test coverage to verify action visibility, labels, disabled states, and click behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->