### PR TITLE
feat: add Project "Deploy" tab for the project-release lifecycle

### DIFF
--- a/.changeset/project-deploy-experience.md
+++ b/.changeset/project-deploy-experience.md
@@ -1,0 +1,11 @@
+---
+'@openchoreo/backstage-plugin': patch
+'@openchoreo/backstage-plugin-backend': patch
+'@openchoreo/backstage-plugin-common': patch
+---
+
+Add a "Deploy" tab to the Project entity page for the project-release lifecycle.
+
+The tab renders the project's deployment pipeline as a DAG of environments with live status and drives deploy/promote through `ProjectRelease` / `ProjectReleaseBinding`. A "Set up" card opens a **Configure & Deploy** wizard: step 1 edits `Project.spec.parameters` against the `(Cluster)ProjectType` parameters schema (saving cuts a new `ProjectRelease`), step 2 pins the first environment's binding and edits its `environmentConfigs` overrides. Each environment node supports **Promote** (copy the pinned release forward to the next environment) and **Configure overrides**; all mutating actions gate on the project-update permission.
+
+Backed by new BFF endpoints (`/project-environment-info`, `/project-release-bindings`, `/update-project-release-binding`, `/project-release-schema`) and matching `OpenChoreoClient` methods.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -112,6 +112,7 @@ import {
   ComponentWorkflowOverviewCard,
   ResourceDefinitionTab,
   ResourceEnvironments,
+  ProjectEnvironments,
 } from '@openchoreo/backstage-plugin';
 import { EntityLayoutWithDelete } from './EntityLayoutWithDelete';
 
@@ -729,6 +730,9 @@ const systemPage = (
     </EntityLayout.Route>
     <EntityLayout.Route path="/definition" title="Definition">
       <ResourceDefinitionTab />
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/deploy" title="Deploy">
+      <ProjectEnvironments />
     </EntityLayout.Route>
     <EntityLayout.Route path="/cell-diagram" title="Cell Diagram">
       <CellDiagram />

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -17,6 +17,7 @@ import { ClusterComponentTypeInfoService } from './services/ClusterComponentType
 import { ResourceTypeInfoService } from './services/ResourceTypeService/ResourceTypeInfoService';
 import { ClusterResourceTypeInfoService } from './services/ClusterResourceTypeService/ClusterResourceTypeInfoService';
 import { ResourceReleaseInfoService } from './services/ResourceReleaseService/ResourceReleaseInfoService';
+import { ProjectReleaseInfoService } from './services/ProjectReleaseService/ProjectReleaseInfoService';
 import { SecretReferencesService } from './services/SecretReferencesService/SecretReferencesService';
 import { SecretsService } from './services/SecretsService/SecretsService';
 import { AuthzService } from './services/AuthzService/AuthzService';
@@ -139,6 +140,11 @@ export const choreoPlugin = createBackendPlugin({
           baseUrl,
         );
 
+        const projectReleaseInfoService = new ProjectReleaseInfoService(
+          logger,
+          baseUrl,
+        );
+
         const secretReferencesInfoService = new SecretReferencesService(
           logger,
           baseUrl,
@@ -216,6 +222,7 @@ export const choreoPlugin = createBackendPlugin({
             resourceTypeInfoService,
             clusterResourceTypeInfoService,
             resourceReleaseInfoService,
+            projectReleaseInfoService,
             secretReferencesInfoService,
             secretsService,
             authzService,

--- a/plugins/openchoreo-backend/src/router.test.ts
+++ b/plugins/openchoreo-backend/src/router.test.ts
@@ -32,6 +32,9 @@ function createMockServices() {
       fetchResourceEnvironmentInfo: jest.fn(),
       updateResourceReleaseBinding: jest.fn(),
       deleteResourceReleaseBinding: jest.fn(),
+      fetchProjectEnvironmentInfo: jest.fn(),
+      fetchProjectReleaseBindings: jest.fn(),
+      updateProjectReleaseBinding: jest.fn(),
     },
     cellDiagramInfoService: {
       fetchProjectInfo: jest.fn(),
@@ -83,6 +86,10 @@ function createMockServices() {
     resourceReleaseInfoService: {
       fetchResourceRelease: jest.fn(),
       fetchResourceReleaseSchema: jest.fn(),
+    },
+    projectReleaseInfoService: {
+      fetchProjectRelease: jest.fn(),
+      fetchProjectReleaseSchema: jest.fn(),
     },
     secretReferencesInfoService: {
       fetchSecretReferences: jest.fn(),
@@ -1036,6 +1043,218 @@ describe('createRouter', () => {
           message: expect.stringContaining(
             'resourceName, projectName and namespaceName are required',
           ),
+        }),
+      });
+    });
+  });
+
+  describe('GET /project-environment-info', () => {
+    it('returns env-info for a project on success', async () => {
+      const mockEnvInfo = [
+        {
+          name: 'dev',
+          bindingName: 'my-project-dev',
+          projectRelease: 'my-project-abc',
+          latestRelease: 'my-project-abc',
+          namespace: 'dp-ns-my-project-dev-abc',
+          promotionTargets: [{ name: 'staging', resourceName: 'staging' }],
+        },
+        { name: 'staging', latestRelease: 'my-project-abc' },
+      ];
+      services.environmentInfoService.fetchProjectEnvironmentInfo.mockResolvedValue(
+        mockEnvInfo,
+      );
+
+      const response = await request(app)
+        .get('/project-environment-info')
+        .query({
+          projectName: 'my-project',
+          namespaceName: 'my-namespace',
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockEnvInfo);
+      expect(
+        services.environmentInfoService.fetchProjectEnvironmentInfo,
+      ).toHaveBeenCalledWith(
+        {
+          projectName: 'my-project',
+          namespaceName: 'my-namespace',
+        },
+        'mock-user-token',
+      );
+    });
+
+    it('returns 400 when required query parameters are missing', async () => {
+      const response = await request(app)
+        .get('/project-environment-info')
+        .query({ projectName: 'my-project' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'projectName and namespaceName are required',
+          ),
+        }),
+      });
+    });
+  });
+
+  describe('GET /project-release-bindings', () => {
+    it('returns transformed binding items wrapped in success envelope', async () => {
+      services.environmentInfoService.fetchProjectReleaseBindings.mockResolvedValue(
+        {
+          items: [
+            {
+              metadata: {
+                name: 'my-project-dev',
+                namespace: 'my-namespace',
+                creationTimestamp: '2025-01-06T11:00:00Z',
+              },
+              spec: {
+                owner: { projectName: 'my-project' },
+                environment: 'dev',
+                projectRelease: 'my-project-abc',
+                environmentConfigs: { replicas: 2 },
+              },
+              status: {
+                conditions: [
+                  { type: 'Ready', status: 'True', reason: 'Ready' },
+                ],
+                namespace: 'dp-ns-my-project-dev-abc',
+              },
+            },
+          ],
+        },
+      );
+
+      const response = await request(app)
+        .get('/project-release-bindings')
+        .query({
+          projectName: 'my-project',
+          namespaceName: 'my-namespace',
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        success: true,
+        data: {
+          items: [
+            expect.objectContaining({
+              name: 'my-project-dev',
+              projectName: 'my-project',
+              environment: 'dev',
+              releaseName: 'my-project-abc',
+              namespace: 'dp-ns-my-project-dev-abc',
+              status: 'Ready',
+            }),
+          ],
+        },
+      });
+    });
+
+    it('returns 400 when required query parameters are missing', async () => {
+      const response = await request(app)
+        .get('/project-release-bindings')
+        .query({ projectName: 'my-project' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'projectName and namespaceName are required',
+          ),
+        }),
+      });
+    });
+  });
+
+  describe('PUT /update-project-release-binding', () => {
+    it('forwards the request to updateProjectReleaseBinding', async () => {
+      services.environmentInfoService.updateProjectReleaseBinding.mockResolvedValue(
+        { ok: true },
+      );
+
+      const response = await request(app)
+        .put('/update-project-release-binding')
+        .send({
+          projectName: 'my-project',
+          namespaceName: 'my-namespace',
+          environment: 'dev',
+          releaseName: 'my-project-new',
+          environmentConfigs: { replicas: 3 },
+        });
+
+      expect(response.status).toBe(200);
+      expect(
+        services.environmentInfoService.updateProjectReleaseBinding,
+      ).toHaveBeenCalledWith(
+        {
+          projectName: 'my-project',
+          namespaceName: 'my-namespace',
+          environment: 'dev',
+          releaseName: 'my-project-new',
+          environmentConfigs: { replicas: 3 },
+        },
+        'mock-user-token',
+      );
+    });
+
+    it('returns 400 when required body fields are missing', async () => {
+      const response = await request(app)
+        .put('/update-project-release-binding')
+        .send({ projectName: 'my-project' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'projectName, namespaceName, environment and releaseName are required',
+          ),
+        }),
+      });
+    });
+  });
+
+  describe('GET /project-release-schema', () => {
+    it('forwards the request to fetchProjectReleaseSchema', async () => {
+      services.projectReleaseInfoService.fetchProjectReleaseSchema.mockResolvedValue(
+        { success: true, data: { type: 'object' } },
+      );
+
+      const response = await request(app).get('/project-release-schema').query({
+        namespaceName: 'my-namespace',
+        releaseName: 'my-project-abc',
+        section: 'environmentConfigs',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        data: { type: 'object' },
+      });
+      expect(
+        services.projectReleaseInfoService.fetchProjectReleaseSchema,
+      ).toHaveBeenCalledWith(
+        'my-namespace',
+        'my-project-abc',
+        'environmentConfigs',
+        'mock-user-token',
+      );
+    });
+
+    it('returns 400 when section is not an allowed value', async () => {
+      const response = await request(app).get('/project-release-schema').query({
+        namespaceName: 'my-namespace',
+        releaseName: 'my-project-abc',
+        section: 'bogus',
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: expect.objectContaining({
+          message: expect.stringContaining('section must be one of'),
         }),
       });
     });

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -27,6 +27,10 @@ import {
   ResourceReleaseInfoService,
   type ResourceReleaseSchemaSection,
 } from './services/ResourceReleaseService/ResourceReleaseInfoService';
+import {
+  ProjectReleaseInfoService,
+  type ProjectReleaseSchemaSection,
+} from './services/ProjectReleaseService/ProjectReleaseInfoService';
 import { PlatformResourceService } from './services/PlatformResourceService/PlatformResourceService';
 import { WirelogsInfoService } from './services/WirelogsService/WirelogsInfoService';
 import { AuthzService } from './services/AuthzService/AuthzService';
@@ -44,6 +48,7 @@ import type { AnnotationStore } from '@openchoreo/backstage-plugin-catalog-backe
 import {
   transformReleaseBinding,
   transformResourceReleaseBinding,
+  transformProjectReleaseBinding,
 } from './services/transformers';
 
 const CLUSTER_SCOPED_KINDS = [
@@ -93,6 +98,7 @@ export async function createRouter({
   resourceTypeInfoService,
   clusterResourceTypeInfoService,
   resourceReleaseInfoService,
+  projectReleaseInfoService,
   secretReferencesInfoService,
   secretsService,
   authzService,
@@ -121,6 +127,7 @@ export async function createRouter({
   resourceTypeInfoService: ResourceTypeInfoService;
   clusterResourceTypeInfoService: ClusterResourceTypeInfoService;
   resourceReleaseInfoService: ResourceReleaseInfoService;
+  projectReleaseInfoService: ProjectReleaseInfoService;
   secretReferencesInfoService: SecretReferencesService;
   secretsService: SecretsService;
   authzService: AuthzService;
@@ -1144,6 +1151,125 @@ export async function createRouter({
           projectName: projectName as string,
           namespaceName: namespaceName as string,
         },
+        userToken,
+      ),
+    );
+  });
+
+  router.get('/project-environment-info', async (req, res) => {
+    const { projectName, namespaceName } = req.query;
+
+    if (!projectName || !namespaceName) {
+      throw new InputError(
+        'projectName and namespaceName are required query parameters',
+      );
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    res.json(
+      await environmentInfoService.fetchProjectEnvironmentInfo(
+        {
+          projectName: projectName as string,
+          namespaceName: namespaceName as string,
+        },
+        userToken,
+      ),
+    );
+  });
+
+  router.get('/project-release-bindings', async (req, res) => {
+    const { projectName, namespaceName } = req.query;
+
+    if (!projectName || !namespaceName) {
+      throw new InputError(
+        'projectName and namespaceName are required query parameters',
+      );
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    const rawBindings =
+      await environmentInfoService.fetchProjectReleaseBindings(
+        {
+          projectName: projectName as string,
+          namespaceName: namespaceName as string,
+        },
+        userToken,
+      );
+    const items = ((rawBindings as any)?.items ?? []).map((binding: any) =>
+      transformProjectReleaseBinding(binding),
+    );
+    res.json({ success: true, data: { items } });
+  });
+
+  router.put(
+    '/update-project-release-binding',
+    requireAuth,
+    async (req, res) => {
+      const {
+        projectName,
+        namespaceName,
+        environment,
+        releaseName,
+        environmentConfigs,
+      } = req.body;
+
+      if (!projectName || !namespaceName || !environment || !releaseName) {
+        throw new InputError(
+          'projectName, namespaceName, environment and releaseName are required in request body',
+        );
+      }
+
+      const userToken = getUserTokenFromRequest(req);
+
+      res.json(
+        await environmentInfoService.updateProjectReleaseBinding(
+          {
+            projectName: projectName as string,
+            namespaceName: namespaceName as string,
+            environment: environment as string,
+            releaseName: releaseName as string,
+            environmentConfigs,
+          },
+          userToken,
+        ),
+      );
+    },
+  );
+
+  // Endpoint for fetching a frozen schema section snapshotted on a
+  // ProjectRelease. Pinned-release flows (the override wizard) use this so
+  // form validation matches what the release was actually cut against, not
+  // the live (Cluster)ProjectType which may have drifted.
+  router.get('/project-release-schema', async (req, res) => {
+    const { namespaceName, releaseName, section } = req.query;
+    const allowedSections: ProjectReleaseSchemaSection[] = [
+      'parameters',
+      'environmentConfigs',
+    ];
+
+    if (!namespaceName || !releaseName) {
+      throw new InputError(
+        'namespaceName and releaseName are required query parameters',
+      );
+    }
+    if (
+      !section ||
+      !allowedSections.includes(section as ProjectReleaseSchemaSection)
+    ) {
+      throw new InputError(
+        `section must be one of: ${allowedSections.join(', ')}`,
+      );
+    }
+
+    const userToken = getUserTokenFromRequest(req);
+
+    res.json(
+      await projectReleaseInfoService.fetchProjectReleaseSchema(
+        namespaceName as string,
+        releaseName as string,
+        section as ProjectReleaseSchemaSection,
         userToken,
       ),
     );

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
@@ -1118,4 +1118,402 @@ describe('EnvironmentInfoService', () => {
       expect(result).toHaveLength(5);
     });
   });
+
+  describe('fetchProjectEnvironmentInfo', () => {
+    function prbBinding(
+      projectName: string,
+      environment: string,
+      release: string,
+    ) {
+      return {
+        metadata: {
+          name: `${projectName}-${environment}`,
+          namespace: 'test-ns',
+          creationTimestamp: '2025-01-06T11:00:00Z',
+        },
+        spec: {
+          owner: { projectName },
+          environment,
+          projectRelease: release,
+          environmentConfigs: { replicas: 2 },
+        },
+        status: {
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'True',
+              reason: 'Ready',
+              lastTransitionTime: '2025-01-06T11:05:00Z',
+            },
+          ],
+          namespace: `dp-test-ns-${projectName}-${environment}-abc`,
+        },
+      };
+    }
+
+    const k8sProjectWithRelease = {
+      metadata: { name: 'my-project', namespace: 'test-ns' },
+      spec: { deploymentPipelineRef: { name: 'default-pipeline' } },
+      status: {
+        latestRelease: { name: 'my-project-zzz', hash: 'zzz' },
+      },
+    };
+
+    it('returns one entry per pipeline environment with binding + latestRelease joined', async () => {
+      // env list
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [makeK8sEnvironment('dev'), makeK8sEnvironment('staging')],
+          pagination: {},
+        }),
+      );
+      // project release bindings (dev only)
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [prbBinding('my-project', 'dev', 'my-project-abc')],
+        }),
+      );
+      // project (pipeline ref)
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      // project (latestRelease)
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      // pipeline
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sPipeline));
+
+      const service = createService();
+      const result = await service.fetchProjectEnvironmentInfo(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+        },
+        'token-123',
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.map(e => e.name)).toEqual(['dev', 'staging']);
+
+      expect(result[0].bindingName).toBe('my-project-dev');
+      expect(result[0].projectRelease).toBe('my-project-abc');
+      expect(result[0].status).toBe('Ready');
+      expect(result[0].namespace).toBe('dp-test-ns-my-project-dev-abc');
+      expect(result[0].latestRelease).toBe('my-project-zzz');
+      expect(result[0].promotionTargets).toEqual([
+        { name: 'staging', resourceName: 'staging' },
+      ]);
+
+      expect(result[1].bindingName).toBeUndefined();
+      expect(result[1].projectRelease).toBeUndefined();
+      expect(result[1].latestRelease).toBe('my-project-zzz');
+    });
+
+    it('filters bindings to the owning project', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [makeK8sEnvironment('dev')],
+          pagination: {},
+        }),
+      );
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [
+            prbBinding('my-project', 'dev', 'rel-mine'),
+            prbBinding('other-project', 'dev', 'rel-theirs'),
+          ],
+        }),
+      );
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sPipeline));
+
+      const service = createService();
+      const result = await service.fetchProjectEnvironmentInfo(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+        },
+        'token-123',
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].projectRelease).toBe('rel-mine');
+    });
+
+    it('returns environments with no bindings when none exist', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [makeK8sEnvironment('dev'), makeK8sEnvironment('staging')],
+          pagination: {},
+        }),
+      );
+      mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sPipeline));
+
+      const service = createService();
+      const result = await service.fetchProjectEnvironmentInfo(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+        },
+        'token-123',
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.every(e => e.bindingName === undefined)).toBe(true);
+      expect(result.every(e => e.latestRelease === 'my-project-zzz')).toBe(
+        true,
+      );
+    });
+
+    it('falls back to default ordering when project has no pipeline', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [makeK8sEnvironment('dev'), makeK8sEnvironment('staging')],
+          pagination: {},
+        }),
+      );
+      mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
+      // project without deploymentPipelineRef (pipeline fetch)
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectNoPipeline));
+      // project (latestRelease fetch)
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectNoPipeline));
+
+      const service = createService();
+      const result = await service.fetchProjectEnvironmentInfo(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+        },
+        'token-123',
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.every(e => e.promotionTargets === undefined)).toBe(true);
+    });
+
+    it('returns env-info without latestRelease when project fetch errors', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [makeK8sEnvironment('dev')],
+          pagination: {},
+        }),
+      );
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [prbBinding('my-project', 'dev', 'rel-1')],
+        }),
+      );
+      // pipeline's project fetch ok (has pipelineRef)
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      // latestRelease project fetch errors
+      mockGET.mockResolvedValueOnce(createErrorResponse());
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sPipeline));
+
+      const service = createService();
+      const result = await service.fetchProjectEnvironmentInfo(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+        },
+        'token-123',
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].projectRelease).toBe('rel-1');
+      expect(result[0].latestRelease).toBeUndefined();
+    });
+  });
+
+  describe('fetchProjectReleaseBindings', () => {
+    function prb(projectName: string, environment: string, release: string) {
+      return {
+        metadata: {
+          name: `${projectName}-${environment}`,
+          namespace: 'test-ns',
+        },
+        spec: { owner: { projectName }, environment, projectRelease: release },
+        status: {},
+      };
+    }
+
+    it('returns bindings filtered to the requested project', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [
+            prb('my-project', 'dev', 'rel-1'),
+            prb('other-project', 'dev', 'rel-2'),
+          ],
+        }),
+      );
+
+      const service = createService();
+      const result = (await service.fetchProjectReleaseBindings(
+        { projectName: 'my-project', namespaceName: 'test-ns' },
+        'token-123',
+      )) as { items: any[] };
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].spec.owner.projectName).toBe('my-project');
+    });
+
+    it('passes the project query to the openchoreo-api', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
+
+      const service = createService();
+      await service.fetchProjectReleaseBindings(
+        { projectName: 'my-project', namespaceName: 'test-ns' },
+        'token-123',
+      );
+
+      const call = mockGET.mock.calls[0];
+      expect(call[0]).toBe(
+        '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
+      );
+      expect(call[1].params.query).toEqual({ project: 'my-project' });
+    });
+  });
+
+  describe('updateProjectReleaseBinding', () => {
+    const existingBinding = {
+      metadata: {
+        name: 'my-project-dev',
+        namespace: 'test-ns',
+        creationTimestamp: '2025-01-06T11:00:00Z',
+        resourceVersion: '42',
+      },
+      spec: {
+        owner: { projectName: 'my-project' },
+        environment: 'dev',
+        projectRelease: 'my-project-old',
+      },
+      status: { conditions: [] },
+    };
+
+    it('GETs the existing binding then PUTs with the new projectRelease, preserving owner + environment', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(existingBinding));
+      mockPUT.mockResolvedValueOnce(createOkResponse({ ...existingBinding }));
+
+      const service = createService();
+      await service.updateProjectReleaseBinding(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+          environment: 'dev',
+          releaseName: 'my-project-new',
+        },
+        'token-123',
+      );
+
+      expect(mockGET).toHaveBeenCalledTimes(1);
+      expect(mockPUT).toHaveBeenCalledTimes(1);
+      const putCall = mockPUT.mock.calls[0];
+      expect(putCall[0]).toBe(
+        '/api/v1/namespaces/{namespaceName}/projectreleasebindings/{projectReleaseBindingName}',
+      );
+      expect(putCall[1].body.spec.projectRelease).toBe('my-project-new');
+      // owner + environment are immutable and must be carried over untouched
+      expect(putCall[1].body.spec.owner).toEqual({ projectName: 'my-project' });
+      expect(putCall[1].body.spec.environment).toBe('dev');
+    });
+
+    it('passes environmentConfigs into the spec when provided', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(existingBinding));
+      mockPUT.mockResolvedValueOnce(createOkResponse({ ...existingBinding }));
+
+      const service = createService();
+      await service.updateProjectReleaseBinding(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+          environment: 'dev',
+          releaseName: 'my-project-new',
+          environmentConfigs: { replicas: 3 },
+        },
+        'token-123',
+      );
+
+      expect(mockPUT.mock.calls[0][1].body.spec.environmentConfigs).toEqual({
+        replicas: 3,
+      });
+    });
+
+    it('POSTs a new binding when GET returns 404 (owner carries only projectName)', async () => {
+      mockGET.mockResolvedValueOnce(createErrorResponse(404));
+      mockPOST.mockResolvedValueOnce(
+        createOkResponse({ metadata: { name: 'my-project-dev' } }),
+      );
+
+      const service = createService();
+      await service.updateProjectReleaseBinding(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+          environment: 'dev',
+          releaseName: 'my-project-new',
+          environmentConfigs: { replicas: 1 },
+        },
+        'token-123',
+      );
+
+      expect(mockPUT).not.toHaveBeenCalled();
+      expect(mockPOST).toHaveBeenCalledTimes(1);
+      const postCall = mockPOST.mock.calls[0];
+      expect(postCall[0]).toBe(
+        '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
+      );
+      const body = postCall[1].body;
+      expect(body.metadata.name).toBe('my-project-dev');
+      expect(body.spec.owner).toEqual({ projectName: 'my-project' });
+      expect(body.spec.owner).not.toHaveProperty('resourceName');
+      expect(body.spec.environment).toBe('dev');
+      expect(body.spec.projectRelease).toBe('my-project-new');
+      expect(body.spec.environmentConfigs).toEqual({ replicas: 1 });
+    });
+
+    it('refetches the binding when POST returns 409', async () => {
+      mockGET.mockResolvedValueOnce(createErrorResponse(404));
+      mockPOST.mockResolvedValueOnce(createErrorResponse(409));
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          metadata: { name: 'my-project-dev' },
+          spec: { projectRelease: 'rel-from-conflict' },
+        }),
+      );
+
+      const service = createService();
+      const result = await service.updateProjectReleaseBinding(
+        {
+          projectName: 'my-project',
+          namespaceName: 'test-ns',
+          environment: 'dev',
+          releaseName: 'my-project-new',
+        },
+        'token-123',
+      );
+
+      expect((result as any)?.metadata?.name).toBe('my-project-dev');
+      expect((result as any)?.spec?.projectRelease).toBe('rel-from-conflict');
+    });
+
+    it('throws when GET returns a non-404 error', async () => {
+      mockGET.mockResolvedValueOnce(createErrorResponse(500));
+
+      const service = createService();
+      await expect(
+        service.updateProjectReleaseBinding(
+          {
+            projectName: 'my-project',
+            namespaceName: 'test-ns',
+            environment: 'dev',
+            releaseName: 'my-project-new',
+          },
+          'token-123',
+        ),
+      ).rejects.toThrow(/Failed to fetch project release binding/);
+
+      expect(mockPUT).not.toHaveBeenCalled();
+      expect(mockPOST).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
@@ -1323,6 +1323,79 @@ describe('EnvironmentInfoService', () => {
       expect(result[0].projectRelease).toBe('rel-1');
       expect(result[0].latestRelease).toBeUndefined();
     });
+
+    it('returns an empty array when there are no environments', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({ items: [], pagination: {} }),
+      );
+      mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sPipeline));
+
+      const service = createService();
+      const result = await service.fetchProjectEnvironmentInfo(
+        { projectName: 'my-project', namespaceName: 'test-ns' },
+        'token-123',
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('tolerates a bindings fetch failure and returns unbound envs', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [makeK8sEnvironment('dev'), makeK8sEnvironment('staging')],
+          pagination: {},
+        }),
+      );
+      // bindings fetch fails — the env-info join should soft-fail to no bindings
+      mockGET.mockResolvedValueOnce(createErrorResponse());
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sPipeline));
+
+      const service = createService();
+      const result = await service.fetchProjectEnvironmentInfo(
+        { projectName: 'my-project', namespaceName: 'test-ns' },
+        'token-123',
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.every(e => e.bindingName === undefined)).toBe(true);
+    });
+
+    it('appends bound environments that are not in the pipeline (drift)', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [
+            makeK8sEnvironment('dev'),
+            makeK8sEnvironment('staging'),
+            makeK8sEnvironment('legacy'),
+          ],
+          pagination: {},
+        }),
+      );
+      // 'legacy' has a binding but the pipeline only covers dev -> staging.
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          items: [prbBinding('my-project', 'legacy', 'rel-legacy')],
+        }),
+      );
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectWithRelease));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sPipeline));
+
+      const service = createService();
+      const result = await service.fetchProjectEnvironmentInfo(
+        { projectName: 'my-project', namespaceName: 'test-ns' },
+        'token-123',
+      );
+
+      const legacy = result.find(e => e.name === 'legacy');
+      expect(legacy).toBeDefined();
+      expect(legacy?.projectRelease).toBe('rel-legacy');
+    });
   });
 
   describe('fetchProjectReleaseBindings', () => {
@@ -1371,6 +1444,18 @@ describe('EnvironmentInfoService', () => {
         '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
       );
       expect(call[1].params.query).toEqual({ project: 'my-project' });
+    });
+
+    it('throws when the bindings API errors', async () => {
+      mockGET.mockResolvedValueOnce(createErrorResponse(500));
+
+      const service = createService();
+      await expect(
+        service.fetchProjectReleaseBindings(
+          { projectName: 'my-project', namespaceName: 'test-ns' },
+          'token-123',
+        ),
+      ).rejects.toThrow();
     });
   });
 

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -5,6 +5,7 @@ import {
   EndpointInfo,
   ResourceEnvironment,
   ResourceBindingOutput,
+  ProjectEnvironment,
 } from '../../types';
 import {
   createOpenChoreoApiClient,
@@ -31,6 +32,11 @@ type NewResourceReleaseBinding =
   OpenChoreoComponents['schemas']['ResourceReleaseBinding'];
 
 type NewResource = OpenChoreoComponents['schemas']['ResourceInstance'];
+
+type NewProjectReleaseBinding =
+  OpenChoreoComponents['schemas']['ProjectReleaseBinding'];
+
+type NewProject = OpenChoreoComponents['schemas']['Project'];
 
 /**
  * Extracts the environment name from a sourceEnvironmentRef which may be
@@ -2023,6 +2029,676 @@ export class EnvironmentInfoService implements EnvironmentService {
       const totalTime = Date.now() - startTime;
       this.logger.error(
         `Error deleting resource release binding for ${request.resourceName} from ${request.environment} (${totalTime}ms):`,
+        error as Error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Fetches per-environment deploy state for a Project. Joins environments,
+   * the project's deployment pipeline, ProjectReleaseBindings owned by the
+   * project, and the Project's status.latestRelease. Returns one entry per
+   * pipeline environment, including environments where no binding exists yet
+   * (so a Deploy/Promote affordance can render against them).
+   *
+   * Built around the Project lifecycle: a ProjectReleaseBinding pins an
+   * environment to a ProjectRelease (spec.projectRelease) and carries the
+   * per-environment overrides (spec.environmentConfigs). Mirrors the join in
+   * fetchResourceEnvironmentInfo, without resource outputs or retain policy.
+   */
+  async fetchProjectEnvironmentInfo(
+    request: {
+      projectName: string;
+      namespaceName: string;
+    },
+    token?: string,
+  ): Promise<ProjectEnvironment[]> {
+    const startTime = Date.now();
+    try {
+      this.logger.debug(
+        `Starting project environment fetch for: ${request.projectName}`,
+      );
+
+      const createTimedPromise = <T>(promise: Promise<T>, name: string) => {
+        const start = Date.now();
+        return promise
+          .then(result => ({
+            type: name,
+            result,
+            duration: Date.now() - start,
+          }))
+          .catch(error => {
+            if (
+              error.name === 'NotAllowedError' ||
+              error.name === 'AuthenticationError'
+            ) {
+              throw error;
+            }
+            const duration = Date.now() - start;
+            if (name === 'bindings') {
+              this.logger.warn(
+                `Failed to fetch project bindings for ${request.projectName}: ${error}`,
+              );
+              return { type: name, result: [] as any, duration };
+            } else if (name === 'pipeline') {
+              this.logger.warn(
+                `No deployment pipeline found for project ${request.projectName}, using default ordering`,
+              );
+              return { type: name, result: null as any, duration };
+            } else if (name === 'project') {
+              this.logger.warn(
+                `Failed to fetch project ${request.projectName}: ${error}`,
+              );
+              return { type: name, result: null as any, duration };
+            }
+            throw error;
+          });
+      };
+
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      const environmentsPromise = createTimedPromise(
+        fetchAllPages(cursor =>
+          client
+            .GET('/api/v1/namespaces/{namespaceName}/environments', {
+              params: {
+                path: { namespaceName: request.namespaceName },
+                query: { limit: 100, cursor },
+              },
+            })
+            .then(res => {
+              assertApiResponse(res, 'fetch environments');
+              return res.data;
+            }),
+        ),
+        'environments',
+      );
+
+      const bindingsPromise = createTimedPromise(
+        (async () => {
+          const { data, error, response } = await client.GET(
+            '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
+            {
+              params: {
+                path: { namespaceName: request.namespaceName },
+                query: { project: request.projectName },
+              },
+            },
+          );
+          assertApiResponse(
+            { data, error, response },
+            'fetch project release bindings',
+          );
+          // The list endpoint filters by project name, but guard against an
+          // older API that ignores the query param so bindings owned by other
+          // projects never bleed into this project's view.
+          const items = (data?.items ?? []).filter(
+            (b: NewProjectReleaseBinding) =>
+              b.spec?.owner?.projectName === request.projectName,
+          );
+          return items;
+        })(),
+        'bindings',
+      );
+
+      const pipelinePromise = createTimedPromise(
+        (async () => {
+          const {
+            data: project,
+            error: projectError,
+            response: projectResponse,
+          } = await client.GET(
+            '/api/v1/namespaces/{namespaceName}/projects/{projectName}',
+            {
+              params: {
+                path: {
+                  namespaceName: request.namespaceName,
+                  projectName: request.projectName,
+                },
+              },
+            },
+          );
+          if (
+            projectError ||
+            !projectResponse.ok ||
+            !project?.spec?.deploymentPipelineRef?.name
+          ) {
+            return null;
+          }
+
+          const pipelineName = project.spec.deploymentPipelineRef.name;
+          const { data, error, response } = await client.GET(
+            '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
+            {
+              params: {
+                path: {
+                  namespaceName: request.namespaceName,
+                  deploymentPipelineName: pipelineName,
+                },
+              },
+            },
+          );
+          if (error || !response.ok) {
+            return null;
+          }
+          return transformDeploymentPipeline(data!);
+        })(),
+        'pipeline',
+      );
+
+      const projectPromise = createTimedPromise(
+        (async () => {
+          const { data, error, response } = await client.GET(
+            '/api/v1/namespaces/{namespaceName}/projects/{projectName}',
+            {
+              params: {
+                path: {
+                  namespaceName: request.namespaceName,
+                  projectName: request.projectName,
+                },
+              },
+            },
+          );
+          if (error || !response.ok) {
+            return null;
+          }
+          return data as NewProject;
+        })(),
+        'project',
+      );
+
+      const [
+        environmentsResult,
+        bindingsResult,
+        pipelineResult,
+        projectResult,
+      ] = await Promise.all([
+        environmentsPromise,
+        bindingsPromise,
+        pipelinePromise,
+        projectPromise,
+      ]);
+
+      this.logger.debug(
+        `Project env-info API timings - Environments: ${environmentsResult.duration}ms, ` +
+          `Bindings: ${bindingsResult.duration}ms, ` +
+          `Pipeline: ${pipelineResult.duration}ms, ` +
+          `Project: ${projectResult.duration}ms`,
+      );
+
+      const newEnvironments = environmentsResult.result;
+      const bindings =
+        (bindingsResult.result as NewProjectReleaseBinding[]) ?? [];
+      const deploymentPipeline = pipelineResult.result;
+      const project = projectResult.result as NewProject | null;
+
+      if (!newEnvironments || newEnvironments.length === 0) {
+        this.logger.warn('No environments found in API response');
+        return [];
+      }
+
+      const environments = newEnvironments.map(transformEnvironment);
+      const latestRelease = project?.status?.latestRelease?.name;
+
+      const result = this.transformProjectEnvironmentData(
+        environments,
+        bindings,
+        deploymentPipeline,
+        latestRelease,
+      );
+
+      const totalTime = Date.now() - startTime;
+      this.logger.debug(
+        `Project env-info completed for ${request.projectName}: Total: ${totalTime}ms`,
+      );
+
+      return result;
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        (error.name === 'NotAllowedError' ||
+          error.name === 'AuthenticationError')
+      ) {
+        throw error;
+      }
+      const totalTime = Date.now() - startTime;
+      this.logger.error(
+        `Error fetching project environment info for ${request.projectName} (${totalTime}ms):`,
+        error as Error,
+      );
+      return [];
+    }
+  }
+
+  private transformProjectEnvironmentData(
+    environmentData: ModelsEnvironment[],
+    bindings: NewProjectReleaseBinding[],
+    deploymentPipeline: any | null,
+    latestRelease: string | undefined,
+  ): ProjectEnvironment[] {
+    const envMap = new Map<string, ModelsEnvironment>();
+    const envNameMap = new Map<string, string>();
+    const bindingsByEnv = new Map<string, NewProjectReleaseBinding>();
+
+    for (const env of environmentData) {
+      const displayName = env.displayName || env.name;
+      envMap.set(displayName, env);
+      envMap.set(displayName.toLowerCase(), env);
+      envNameMap.set(displayName.toLowerCase(), displayName);
+      if (env.name && env.name.toLowerCase() !== displayName.toLowerCase()) {
+        envMap.set(env.name, env);
+        envMap.set(env.name.toLowerCase(), env);
+        envNameMap.set(env.name.toLowerCase(), displayName);
+      }
+    }
+
+    for (const binding of bindings) {
+      const envKey = binding.spec?.environment;
+      if (!envKey) continue;
+      const envName = envNameMap.get(envKey.toLowerCase()) || envKey;
+      bindingsByEnv.set(envName, binding);
+    }
+
+    if (
+      !deploymentPipeline ||
+      !deploymentPipeline.promotionPaths ||
+      deploymentPipeline.promotionPaths.length === 0
+    ) {
+      this.logger.debug(
+        'No deployment pipeline found for project, using default ordering',
+      );
+      return environmentData.map(env => {
+        const envName = env.displayName || env.name;
+        const binding = bindingsByEnv.get(envName);
+        return this.createProjectEnvironment(
+          env,
+          binding,
+          undefined,
+          latestRelease,
+        );
+      });
+    }
+
+    const promotionMap = new Map<string, any[]>();
+    for (const path of deploymentPipeline.promotionPaths) {
+      const sourceRef = getSourceEnvName(path.sourceEnvironmentRef);
+      const sourceEnv = envNameMap.get(sourceRef.toLowerCase()) || sourceRef;
+      const targets = path.targetEnvironmentRefs.map((ref: any) => ({
+        ...ref,
+        name: envNameMap.get(ref.name.toLowerCase()) || ref.name,
+        resourceName: ref.name,
+      }));
+      const existing = promotionMap.get(sourceEnv);
+      if (existing) {
+        existing.push(...targets);
+      } else {
+        promotionMap.set(sourceEnv, targets);
+      }
+    }
+
+    const orderedEnvNames = this.getEnvironmentOrder(
+      deploymentPipeline.promotionPaths,
+      envNameMap,
+    );
+
+    const ordered: ProjectEnvironment[] = [];
+    const processed = new Set<string>();
+
+    for (const envName of orderedEnvNames) {
+      const envData = envMap.get(envName);
+      if (envData && !processed.has(envName)) {
+        processed.add(envName);
+        const binding = bindingsByEnv.get(envName);
+        const promotionTargets = promotionMap.get(envName);
+        ordered.push(
+          this.createProjectEnvironment(
+            envData,
+            binding,
+            promotionTargets,
+            latestRelease,
+          ),
+        );
+      }
+    }
+
+    // Append any environments referenced by bindings but not in the pipeline
+    // so the UI surfaces drift instead of silently hiding them.
+    for (const [envName, binding] of bindingsByEnv.entries()) {
+      if (!processed.has(envName)) {
+        const envData = envMap.get(envName);
+        if (envData) {
+          processed.add(envName);
+          ordered.push(
+            this.createProjectEnvironment(
+              envData,
+              binding,
+              undefined,
+              latestRelease,
+            ),
+          );
+        }
+      }
+    }
+
+    return ordered;
+  }
+
+  private createProjectEnvironment(
+    envData: ModelsEnvironment,
+    binding: NewProjectReleaseBinding | undefined,
+    promotionTargets: any[] | undefined,
+    latestRelease: string | undefined,
+  ): ProjectEnvironment {
+    const envName = envData.displayName || envData.name;
+    const envResourceName = envData.name;
+
+    let status: 'Ready' | 'NotReady' | 'Failed' | undefined;
+    let statusReason: string | undefined;
+    let statusMessage: string | undefined;
+    let lastDeployed: string | undefined;
+    let projectRelease: string | undefined;
+    let bindingName: string | undefined;
+    let namespace: string | undefined;
+
+    if (binding) {
+      bindingName = binding.metadata?.name;
+      projectRelease = binding.spec?.projectRelease;
+      namespace = binding.status?.namespace;
+      // Use the Ready condition's lastTransitionTime as the deploy timestamp;
+      // it flips whenever Synced / NamespaceReady / ResourcesReady transition,
+      // so promotes bump it naturally. Falls back to creationTimestamp on
+      // bindings the controller has not yet reconciled.
+      const readyCond = (
+        binding.status?.conditions as
+          | Array<{ type?: string; lastTransitionTime?: string }>
+          | undefined
+      )?.find(c => c.type === 'Ready');
+      lastDeployed =
+        readyCond?.lastTransitionTime ?? binding.metadata?.creationTimestamp;
+
+      const derived = deriveBindingStatusDetailed(binding as any);
+      if (derived) {
+        status = derived.status;
+        statusReason = derived.reason;
+        statusMessage = derived.message;
+      }
+    }
+
+    const result: ProjectEnvironment = {
+      uid: envData.uid,
+      name: envName,
+      resourceName: envResourceName,
+      dataPlaneRef: envData.dataPlaneRef?.name,
+      dataPlaneKind: envData.dataPlaneRef?.kind as
+        | 'DataPlane'
+        | 'ClusterDataPlane'
+        | undefined,
+      bindingName,
+      projectRelease,
+      status,
+      statusReason,
+      statusMessage,
+      lastDeployed,
+      namespace,
+      latestRelease,
+    };
+
+    if (promotionTargets && promotionTargets.length > 0) {
+      result.promotionTargets = promotionTargets.map((ref: any) => ({
+        name: ref.name,
+        resourceName: ref.resourceName,
+      }));
+    }
+
+    return result;
+  }
+
+  /**
+   * Fetches ProjectReleaseBindings owned by a project. The openchoreo-api
+   * endpoint filters by project name; a defensive client-side filter is
+   * applied so an older API that ignores the query param does not surface
+   * bindings owned by other projects.
+   */
+  async fetchProjectReleaseBindings(
+    request: {
+      projectName: string;
+      namespaceName: string;
+    },
+    token?: string,
+  ) {
+    const startTime = Date.now();
+    this.logger.debug(
+      `Fetching project release bindings for project ${request.projectName}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      const { data, error, response } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
+        {
+          params: {
+            path: { namespaceName: request.namespaceName },
+            query: { project: request.projectName },
+          },
+        },
+      );
+
+      assertApiResponse(
+        { data, error, response },
+        'fetch project release bindings',
+      );
+
+      const filtered = {
+        ...(data as any),
+        items: ((data as any)?.items ?? []).filter(
+          (b: any) => b?.spec?.owner?.projectName === request.projectName,
+        ),
+      };
+
+      const totalTime = Date.now() - startTime;
+      this.logger.debug(
+        `Project release bindings fetched for ${request.projectName}: Total: ${totalTime}ms`,
+      );
+
+      return filtered;
+    } catch (error: unknown) {
+      const totalTime = Date.now() - startTime;
+      this.logger.error(
+        `Failed to fetch project release bindings for ${request.projectName}: ${
+          error instanceof Error ? error.message : String(error)
+        } (${totalTime}ms)`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Creates or updates a ProjectReleaseBinding for deploy/promote actions.
+   * GET → PUT when the binding already exists; GET 404 → POST a new binding;
+   * return-existing on a 409 create conflict.
+   *
+   * The binding owner carries only `projectName` (no resourceName) and the
+   * override field is `environmentConfigs`. spec.owner and spec.environment
+   * are immutable on the CRD, so the PUT path preserves them via spread and
+   * only advances spec.projectRelease (the promote/deploy pin) and
+   * spec.environmentConfigs. Used for both Deploy (pin first env) and Promote
+   * (pin next env to the source env's release).
+   */
+  async updateProjectReleaseBinding(
+    request: {
+      projectName: string;
+      namespaceName: string;
+      environment: string;
+      releaseName: string;
+      environmentConfigs?: any;
+    },
+    token?: string,
+  ) {
+    const startTime = Date.now();
+    this.logger.debug(
+      `Updating project release binding for ${request.projectName} in ${request.environment}`,
+    );
+
+    try {
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        token,
+        logger: this.logger,
+      });
+
+      const bindingName = `${request.projectName}-${request.environment}`;
+
+      const {
+        data: existing,
+        error: getError,
+        response: getResponse,
+      } = await client.GET(
+        '/api/v1/namespaces/{namespaceName}/projectreleasebindings/{projectReleaseBindingName}',
+        {
+          params: {
+            path: {
+              namespaceName: request.namespaceName,
+              projectReleaseBindingName: bindingName,
+            },
+          },
+        },
+      );
+
+      if (getResponse.ok && existing) {
+        const updated = {
+          ...existing,
+          spec: {
+            ...existing.spec!,
+            projectRelease: request.releaseName,
+            ...(request.environmentConfigs !== undefined
+              ? { environmentConfigs: request.environmentConfigs }
+              : {}),
+          },
+        };
+
+        const { data, error, response } = await client.PUT(
+          '/api/v1/namespaces/{namespaceName}/projectreleasebindings/{projectReleaseBindingName}',
+          {
+            params: {
+              path: {
+                namespaceName: request.namespaceName,
+                projectReleaseBindingName: bindingName,
+              },
+            },
+            body: updated,
+          },
+        );
+
+        assertApiResponse(
+          { data, error, response },
+          'update project release binding',
+        );
+
+        const totalTime = Date.now() - startTime;
+        this.logger.debug(
+          `Project release binding updated for ${request.projectName} in ${request.environment}: Total: ${totalTime}ms`,
+        );
+
+        return data;
+      }
+
+      if (getResponse.status !== 404) {
+        const errorDetail = getError ? JSON.stringify(getError) : '';
+        throw new Error(
+          `Failed to fetch project release binding ${bindingName}: ${
+            getResponse.status
+          } ${getResponse.statusText}${errorDetail ? ` ${errorDetail}` : ''}`,
+        );
+      }
+
+      const newBinding = {
+        metadata: {
+          name: bindingName,
+          namespace: request.namespaceName,
+        },
+        spec: {
+          owner: {
+            projectName: request.projectName,
+          },
+          environment: request.environment,
+          projectRelease: request.releaseName,
+          ...(request.environmentConfigs !== undefined
+            ? { environmentConfigs: request.environmentConfigs }
+            : {}),
+        },
+      };
+
+      const {
+        data: createData,
+        error: createError,
+        response: createResponse,
+      } = await client.POST(
+        '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
+        {
+          params: {
+            path: { namespaceName: request.namespaceName },
+          },
+          body: newBinding,
+        },
+      );
+
+      // Concurrent create produced a 409 — refetch and return the existing
+      // binding so the caller sees a consistent result.
+      if (createResponse.status === 409) {
+        this.logger.debug(
+          `Project release binding ${bindingName} already exists (409 conflict), fetching existing`,
+        );
+        const {
+          data: conflictExisting,
+          error: conflictGetError,
+          response: conflictGetResponse,
+        } = await client.GET(
+          '/api/v1/namespaces/{namespaceName}/projectreleasebindings/{projectReleaseBindingName}',
+          {
+            params: {
+              path: {
+                namespaceName: request.namespaceName,
+                projectReleaseBindingName: bindingName,
+              },
+            },
+          },
+        );
+        assertApiResponse(
+          {
+            data: conflictExisting,
+            error: conflictGetError,
+            response: conflictGetResponse,
+          },
+          'fetch project release binding after 409 conflict',
+        );
+        return conflictExisting;
+      }
+
+      assertApiResponse(
+        { data: createData, error: createError, response: createResponse },
+        'create project release binding',
+      );
+
+      const totalTime = Date.now() - startTime;
+      this.logger.debug(
+        `Project release binding created for ${request.projectName} in ${request.environment}: Total: ${totalTime}ms`,
+      );
+
+      return createData;
+    } catch (error: unknown) {
+      const totalTime = Date.now() - startTime;
+      this.logger.error(
+        `Error updating project release binding for ${request.projectName} in ${request.environment} (${totalTime}ms):`,
         error as Error,
       );
       throw error;

--- a/plugins/openchoreo-backend/src/services/ProjectReleaseService/ProjectReleaseInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/ProjectReleaseService/ProjectReleaseInfoService.test.ts
@@ -1,0 +1,146 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { ProjectReleaseInfoService } from './ProjectReleaseInfoService';
+import { createOkResponse, createErrorResponse } from '@openchoreo/test-utils';
+
+const mockGET = jest.fn();
+
+jest.mock('@openchoreo/openchoreo-client-node', () => ({
+  ...jest.requireActual('@openchoreo/openchoreo-client-node'),
+  createOpenChoreoApiClient: jest.fn(() => ({
+    GET: mockGET,
+  })),
+}));
+
+const mockLogger = mockServices.logger.mock();
+
+function createService() {
+  return new ProjectReleaseInfoService(mockLogger, 'http://test:8080');
+}
+
+// A frozen ProjectRelease snapshot carrying both schema sections on the
+// inlined (Cluster)ProjectType spec.
+const projectRelease = {
+  metadata: { name: 'my-project-abc', namespace: 'test-ns' },
+  spec: {
+    owner: { projectName: 'my-project' },
+    projectType: {
+      kind: 'ClusterProjectType',
+      name: 'web-application',
+      spec: {
+        parameters: {
+          openAPIV3Schema: {
+            type: 'object',
+            properties: { appName: { type: 'string' } },
+          },
+        },
+        environmentConfigs: {
+          openAPIV3Schema: {
+            type: 'object',
+            properties: { replicas: { type: 'integer' } },
+          },
+        },
+      },
+    },
+    parameters: { appName: 'my-app' },
+  },
+};
+
+describe('ProjectReleaseInfoService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchProjectRelease', () => {
+    it('returns the full release CR', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(projectRelease));
+
+      const service = createService();
+      const result = await service.fetchProjectRelease(
+        'test-ns',
+        'my-project-abc',
+        'token-123',
+      );
+
+      expect(result.success).toBe(true);
+      expect((result.data as any)?.spec?.parameters).toEqual({
+        appName: 'my-app',
+      });
+      const call = mockGET.mock.calls[0];
+      expect(call[0]).toBe(
+        '/api/v1/namespaces/{namespaceName}/projectreleases/{projectReleaseName}',
+      );
+      expect(call[1].params.path).toEqual({
+        namespaceName: 'test-ns',
+        projectReleaseName: 'my-project-abc',
+      });
+    });
+
+    it('throws when the API errors', async () => {
+      mockGET.mockResolvedValueOnce(createErrorResponse(404));
+
+      const service = createService();
+      await expect(
+        service.fetchProjectRelease('test-ns', 'missing', 'token-123'),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('fetchProjectReleaseSchema', () => {
+    it('extracts the parameters openAPIV3Schema from the snapshot', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(projectRelease));
+
+      const service = createService();
+      const result = await service.fetchProjectReleaseSchema(
+        'test-ns',
+        'my-project-abc',
+        'parameters',
+        'token-123',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        type: 'object',
+        properties: { appName: { type: 'string' } },
+      });
+    });
+
+    it('extracts the environmentConfigs openAPIV3Schema from the snapshot', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(projectRelease));
+
+      const service = createService();
+      const result = await service.fetchProjectReleaseSchema(
+        'test-ns',
+        'my-project-abc',
+        'environmentConfigs',
+        'token-123',
+      );
+
+      expect(result.data).toEqual({
+        type: 'object',
+        properties: { replicas: { type: 'integer' } },
+      });
+    });
+
+    it('returns an empty schema when the section is not defined', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({
+          metadata: { name: 'my-project-abc' },
+          spec: {
+            owner: { projectName: 'my-project' },
+            projectType: { kind: 'ProjectType', name: 'minimal', spec: {} },
+          },
+        }),
+      );
+
+      const service = createService();
+      const result = await service.fetchProjectReleaseSchema(
+        'test-ns',
+        'my-project-abc',
+        'environmentConfigs',
+        'token-123',
+      );
+
+      expect(result.data).toEqual({});
+    });
+  });
+});

--- a/plugins/openchoreo-backend/src/services/ProjectReleaseService/ProjectReleaseInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/ProjectReleaseService/ProjectReleaseInfoService.ts
@@ -1,0 +1,118 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  createOpenChoreoApiClient,
+  assertApiResponse,
+} from '@openchoreo/openchoreo-client-node';
+import type { APIResponse } from '@openchoreo/backstage-plugin-common';
+
+type ProjectReleaseSchemaResponse = APIResponse & {
+  data?: {
+    [key: string]: unknown;
+  };
+};
+
+export type ProjectReleaseSchemaSection = 'parameters' | 'environmentConfigs';
+
+/**
+ * BFF service for ProjectRelease reads. Frozen snapshots that the Project
+ * controller cuts whenever Project.spec.parameters or the referenced
+ * (Cluster)ProjectType.spec change. Reads here surface the snapshot
+ * (Cluster)ProjectType schemas so the override wizard can validate against
+ * what a release was actually cut against, not the live type which may have
+ * drifted.
+ */
+export class ProjectReleaseInfoService {
+  private logger: LoggerService;
+  private baseUrl: string;
+
+  constructor(logger: LoggerService, baseUrl: string) {
+    this.logger = logger;
+    this.baseUrl = baseUrl;
+  }
+
+  /**
+   * Returns the full ProjectRelease CR. Used by the Deploy tab so users can
+   * inspect the frozen snapshot pinned to an env without dropping to kubectl.
+   */
+  async fetchProjectRelease(
+    namespaceName: string,
+    releaseName: string,
+    token?: string,
+  ): Promise<APIResponse & { data?: Record<string, unknown> }> {
+    this.logger.debug(
+      `Fetching project release: ${releaseName} in namespace: ${namespaceName}`,
+    );
+
+    const client = createOpenChoreoApiClient({
+      baseUrl: this.baseUrl,
+      token,
+      logger: this.logger,
+    });
+
+    const { data, error, response } = await client.GET(
+      '/api/v1/namespaces/{namespaceName}/projectreleases/{projectReleaseName}',
+      {
+        params: {
+          path: { namespaceName, projectReleaseName: releaseName },
+        },
+      },
+    );
+
+    assertApiResponse({ data, error, response }, 'fetch project release');
+
+    return {
+      success: true,
+      data: data as Record<string, unknown>,
+    };
+  }
+
+  /**
+   * Returns the requested schema section from the frozen snapshot stored on a
+   * ProjectRelease. `parameters` is the developer-facing schema bound to
+   * Project.spec.parameters; `environmentConfigs` is the per-env override
+   * schema bound to ProjectReleaseBinding.spec.environmentConfigs.
+   */
+  async fetchProjectReleaseSchema(
+    namespaceName: string,
+    releaseName: string,
+    section: ProjectReleaseSchemaSection,
+    token?: string,
+  ): Promise<ProjectReleaseSchemaResponse> {
+    this.logger.debug(
+      `Fetching snapshot schema (${section}) for project release: ${releaseName} in namespace: ${namespaceName}`,
+    );
+
+    const client = createOpenChoreoApiClient({
+      baseUrl: this.baseUrl,
+      token,
+      logger: this.logger,
+    });
+
+    const { data, error, response } = await client.GET(
+      '/api/v1/namespaces/{namespaceName}/projectreleases/{projectReleaseName}',
+      {
+        params: {
+          path: { namespaceName, projectReleaseName: releaseName },
+        },
+      },
+    );
+
+    assertApiResponse({ data, error, response }, 'fetch project release');
+
+    const release = data as Record<string, unknown> | undefined;
+    const spec = (release?.spec as Record<string, unknown>) || {};
+    const projectType = (spec.projectType as Record<string, unknown>) || {};
+    const typeSpec = (projectType.spec as Record<string, unknown>) || {};
+    const sectionBlock = typeSpec[section] as
+      | { openAPIV3Schema?: Record<string, unknown> }
+      | undefined;
+    const schema = sectionBlock?.openAPIV3Schema;
+
+    return {
+      success: true,
+      // Empty schema when the section isn't defined — keeps the caller's form
+      // code uniform; it renders an empty-state message in that case.
+      data: (schema ?? {}) as ProjectReleaseSchemaResponse['data'],
+    };
+  }
+}

--- a/plugins/openchoreo-backend/src/services/transformers/index.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/index.ts
@@ -26,3 +26,4 @@ export {
   deriveBindingStatus,
 } from './release-binding';
 export { transformResourceReleaseBinding } from './resource-release-binding';
+export { transformProjectReleaseBinding } from './project-release-binding';

--- a/plugins/openchoreo-backend/src/services/transformers/project-release-binding.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/project-release-binding.test.ts
@@ -1,0 +1,104 @@
+import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
+import { transformProjectReleaseBinding } from './project-release-binding';
+
+type ProjectReleaseBinding =
+  OpenChoreoComponents['schemas']['ProjectReleaseBinding'];
+
+function makeBinding(overrides: Partial<ProjectReleaseBinding> = {}) {
+  return {
+    metadata: {
+      name: 'shop-dev',
+      namespace: 'acme',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+    },
+    spec: {
+      owner: { projectName: 'shop' },
+      environment: 'dev',
+      projectRelease: 'shop-abc123',
+      environmentConfigs: { replicas: 2 },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'Ready',
+          message: 'binding is ready',
+          observedGeneration: 1,
+        },
+      ],
+      namespace: 'dp-acme-shop-dev-abc',
+    },
+    ...overrides,
+  } as ProjectReleaseBinding;
+}
+
+describe('transformProjectReleaseBinding', () => {
+  it('maps the basic spec and metadata fields', () => {
+    const result = transformProjectReleaseBinding(makeBinding());
+
+    expect(result.name).toBe('shop-dev');
+    expect(result.projectName).toBe('shop');
+    expect(result.namespaceName).toBe('acme');
+    expect(result.environment).toBe('dev');
+    expect(result.releaseName).toBe('shop-abc123');
+    expect(result.environmentConfigs).toEqual({ replicas: 2 });
+    expect(result.namespace).toBe('dp-acme-shop-dev-abc');
+    expect(result.createdAt).toBe('2025-01-01T00:00:00Z');
+  });
+
+  it('derives Ready status from conditions', () => {
+    const result = transformProjectReleaseBinding(makeBinding());
+    expect(result.status).toBe('Ready');
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions?.[0].type).toBe('Ready');
+  });
+
+  it('omits environmentConfigs and namespace when absent', () => {
+    const result = transformProjectReleaseBinding(
+      makeBinding({
+        spec: {
+          owner: { projectName: 'shop' },
+          environment: 'dev',
+          projectRelease: 'shop-abc123',
+        },
+        status: { conditions: [] },
+      } as Partial<ProjectReleaseBinding>),
+    );
+
+    expect(result.environmentConfigs).toBeUndefined();
+    expect(result.namespace).toBeUndefined();
+  });
+
+  it('falls back to empty strings when owner/spec fields are missing', () => {
+    const result = transformProjectReleaseBinding({
+      metadata: { name: 'orphan', namespace: 'acme' },
+    } as ProjectReleaseBinding);
+
+    expect(result.name).toBe('orphan');
+    expect(result.projectName).toBe('');
+    expect(result.environment).toBe('');
+    expect(result.releaseName).toBe('');
+  });
+
+  it('defaults required condition fields when a condition is partially populated', () => {
+    const result = transformProjectReleaseBinding(
+      makeBinding({
+        status: {
+          // A malformed condition missing the required type/status fields,
+          // but carrying the optional ones.
+          conditions: [
+            { reason: 'Reconciling', message: 'still working' } as any,
+          ],
+        },
+      } as Partial<ProjectReleaseBinding>),
+    );
+
+    expect(result.conditions).toHaveLength(1);
+    const condition = result.conditions![0];
+    expect(condition.type).toBe('');
+    expect(condition.status).toBe('');
+    expect(condition.reason).toBe('Reconciling');
+    expect(condition.message).toBe('still working');
+  });
+});

--- a/plugins/openchoreo-backend/src/services/transformers/project-release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/project-release-binding.ts
@@ -1,0 +1,56 @@
+import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
+import type {
+  ProjectReleaseBindingResponse,
+  ReleaseBindingCondition,
+} from '@openchoreo/backstage-plugin-common';
+import { getName, getNamespace, getCreatedAt } from './common';
+import { deriveBindingStatusDetailed } from './release-binding';
+
+type NewProjectReleaseBinding =
+  OpenChoreoComponents['schemas']['ProjectReleaseBinding'];
+
+/**
+ * Transforms a K8s-style ProjectReleaseBinding into the flat
+ * ProjectReleaseBindingResponse shape expected by the frontend. Reuses the
+ * same Ready-condition derivation as the other bindings because the project
+ * binding carries an aggregate Ready condition with identical vocabulary
+ * (Synced / NamespaceReady / ResourcesReady / Ready).
+ */
+export function transformProjectReleaseBinding(
+  binding: NewProjectReleaseBinding,
+): ProjectReleaseBindingResponse {
+  const derived = deriveBindingStatusDetailed(binding as any);
+
+  return {
+    name: getName(binding) ?? '',
+    projectName: binding.spec?.owner?.projectName ?? '',
+    namespaceName: getNamespace(binding) ?? '',
+    environment: binding.spec?.environment ?? '',
+    releaseName: binding.spec?.projectRelease ?? '',
+    environmentConfigs: binding.spec?.environmentConfigs as
+      | Record<string, unknown>
+      | undefined,
+    namespace: binding.status?.namespace,
+    createdAt: getCreatedAt(binding) ?? '',
+    status: derived?.status,
+    statusReason: derived?.reason,
+    statusMessage: derived?.message,
+    conditions: (() => {
+      const raw = binding.status?.conditions;
+      if (!Array.isArray(raw)) return undefined;
+      return raw.map(
+        (c: any): ReleaseBindingCondition => ({
+          // `type` and `status` are required on ReleaseBindingCondition;
+          // default them since the source is untyped and a malformed
+          // condition could otherwise leave required fields undefined.
+          type: c.type ?? '',
+          status: c.status ?? '',
+          reason: c.reason,
+          message: c.message,
+          lastTransitionTime: c.lastTransitionTime,
+          observedGeneration: c.observedGeneration,
+        }),
+      );
+    })(),
+  };
+}

--- a/plugins/openchoreo-backend/src/types.ts
+++ b/plugins/openchoreo-backend/src/types.ts
@@ -66,6 +66,19 @@ export interface EnvironmentService {
     namespaceName: string;
     environment: string;
   }): Promise<unknown>;
+
+  fetchProjectEnvironmentInfo(request: {
+    projectName: string;
+    namespaceName: string;
+  }): Promise<ProjectEnvironment[]>;
+
+  updateProjectReleaseBinding(request: {
+    projectName: string;
+    namespaceName: string;
+    environment: string;
+    releaseName: string;
+    environmentConfigs?: any;
+  }): Promise<unknown>;
 }
 
 export interface EndpointURLDetails {
@@ -141,6 +154,35 @@ export interface ResourceEnvironment {
     resourceName?: string;
   }[];
   /** Latest ResourceRelease cut by the Resource controller, if any. */
+  latestRelease?: string;
+}
+
+/**
+ * Per-environment view of a Project's deploy state. One entry per environment
+ * in the project's deployment pipeline, including environments where no
+ * ProjectReleaseBinding exists yet (so the UI can render a Deploy affordance
+ * against them).
+ */
+export interface ProjectEnvironment {
+  uid?: string;
+  name: string;
+  resourceName?: string;
+  dataPlaneRef?: string;
+  dataPlaneKind?: 'DataPlane' | 'ClusterDataPlane';
+  bindingName?: string;
+  /** The ProjectRelease pinned to this environment (binding.spec.projectRelease). */
+  projectRelease?: string;
+  status?: 'Ready' | 'NotReady' | 'Failed';
+  statusReason?: string;
+  statusMessage?: string;
+  lastDeployed?: string;
+  /** The data-plane namespace owned by this binding (binding.status.namespace). */
+  namespace?: string;
+  promotionTargets?: {
+    name: string;
+    resourceName?: string;
+  }[];
+  /** Latest ProjectRelease cut by the Project controller, if any. */
   latestRelease?: string;
 }
 

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -196,6 +196,7 @@ export type {
   ReleaseBindingResponse,
   ReleaseBindingCondition,
   ResourceReleaseBindingResponse,
+  ProjectReleaseBindingResponse,
   ResolvedResourceOutput,
   ResourceSecretKeyRef,
   ResourceConfigMapKeyRef,

--- a/plugins/openchoreo-common/src/types/bff-types.ts
+++ b/plugins/openchoreo-common/src/types/bff-types.ts
@@ -639,6 +639,31 @@ export interface ResourceReleaseBindingResponse {
   outputs?: ResolvedResourceOutput[];
 }
 
+export interface ProjectReleaseBindingResponse {
+  name: string;
+  projectName: string;
+  namespaceName: string;
+  environment: string;
+  /** The pinned ProjectRelease name (spec.projectRelease). */
+  releaseName: string;
+  /**
+   * Per-environment values layered over the project-level parameters when
+   * the (Cluster)ProjectType resources are rendered for this environment
+   * (spec.environmentConfigs).
+   */
+  environmentConfigs?: Record<string, unknown>;
+  /** The data-plane namespace owned by this binding (status.namespace). */
+  namespace?: string;
+  /** Format: date-time */
+  createdAt: string;
+  status?: 'Ready' | 'NotReady' | 'Failed';
+  /** The Ready condition's reason */
+  statusReason?: string;
+  /** The Ready condition's human-readable message */
+  statusMessage?: string;
+  conditions?: ReleaseBindingCondition[];
+}
+
 export interface WorkloadOverrides {
   container?: ContainerOverride;
 }

--- a/plugins/openchoreo/src/api/OpenChoreoClient.test.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.test.ts
@@ -334,3 +334,172 @@ describe('OpenChoreoClient — deleteResourceReleaseBinding', () => {
     });
   });
 });
+
+// A Project entity is catalog kind System: the project name is the entity
+// name and the OpenChoreo namespace is annotated.
+const PROJECT_ENTITY = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'System',
+  metadata: {
+    name: 'shop',
+    namespace: 'default',
+    annotations: {
+      'openchoreo.io/namespace': 'test-ns',
+      'openchoreo.io/project-type': 'web-application',
+      'openchoreo.io/project-type-kind': 'ClusterProjectType',
+    },
+  },
+  spec: {},
+};
+
+describe('OpenChoreoClient — project environment info', () => {
+  const fetchMock = jest.fn();
+  const discovery = { getBaseUrl: jest.fn().mockResolvedValue(BASE_URL) };
+  const fetchApi = { fetch: fetchMock };
+  let client: OpenChoreoClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    discovery.getBaseUrl.mockResolvedValue(BASE_URL);
+    client = new OpenChoreoClient(discovery as any, fetchApi as any);
+  });
+
+  it('GETs /project-environment-info with project entity params', async () => {
+    const payload = [
+      { name: 'dev', latestRelease: 'shop-abc' },
+      { name: 'staging', latestRelease: 'shop-abc' },
+    ];
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(payload));
+
+    const result = await client.fetchProjectEnvironmentInfo(
+      PROJECT_ENTITY as any,
+    );
+
+    expect(result).toEqual(payload);
+    const [calledUrl, opts] = fetchMock.mock.calls[0];
+    expect(calledUrl).toContain('/project-environment-info');
+    expect(calledUrl).toContain('projectName=shop');
+    expect(calledUrl).toContain('namespaceName=test-ns');
+    expect(opts.method ?? 'GET').toBe('GET');
+  });
+
+  it('throws when the namespace annotation is missing on the entity', async () => {
+    const bareEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'System',
+      metadata: { name: 'shop', namespace: 'default', annotations: {} },
+      spec: {},
+    };
+
+    await expect(
+      client.fetchProjectEnvironmentInfo(bareEntity as any),
+    ).rejects.toThrow(/Missing required OpenChoreo annotations/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('OpenChoreoClient — fetchProjectReleaseBindings', () => {
+  const fetchMock = jest.fn();
+  const discovery = { getBaseUrl: jest.fn().mockResolvedValue(BASE_URL) };
+  const fetchApi = { fetch: fetchMock };
+  let client: OpenChoreoClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    discovery.getBaseUrl.mockResolvedValue(BASE_URL);
+    client = new OpenChoreoClient(discovery as any, fetchApi as any);
+  });
+
+  it('GETs /project-release-bindings with project entity params', async () => {
+    const payload = { success: true, data: { items: [] } };
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(payload));
+
+    const result = await client.fetchProjectReleaseBindings(
+      PROJECT_ENTITY as any,
+    );
+
+    expect(result).toEqual(payload);
+    const [calledUrl, opts] = fetchMock.mock.calls[0];
+    expect(calledUrl).toContain('/project-release-bindings');
+    expect(calledUrl).toContain('projectName=shop');
+    expect(calledUrl).toContain('namespaceName=test-ns');
+    expect(opts.method ?? 'GET').toBe('GET');
+  });
+});
+
+describe('OpenChoreoClient — updateProjectReleaseBinding', () => {
+  const fetchMock = jest.fn();
+  const discovery = { getBaseUrl: jest.fn().mockResolvedValue(BASE_URL) };
+  const fetchApi = { fetch: fetchMock };
+  let client: OpenChoreoClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    discovery.getBaseUrl.mockResolvedValue(BASE_URL);
+    client = new OpenChoreoClient(discovery as any, fetchApi as any);
+  });
+
+  it('PUTs to /update-project-release-binding with project metadata + new release', async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse({ ok: true }));
+
+    await client.updateProjectReleaseBinding(PROJECT_ENTITY as any, 'dev', {
+      projectRelease: 'shop-new',
+    });
+
+    const [calledUrl, opts] = fetchMock.mock.calls[0];
+    expect(calledUrl).toContain('/update-project-release-binding');
+    expect(opts.method).toBe('PUT');
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({
+      projectName: 'shop',
+      namespaceName: 'test-ns',
+      environment: 'dev',
+      releaseName: 'shop-new',
+    });
+  });
+
+  it('forwards optional environmentConfigs', async () => {
+    fetchMock.mockResolvedValueOnce(makeJsonResponse({ ok: true }));
+
+    await client.updateProjectReleaseBinding(PROJECT_ENTITY as any, 'dev', {
+      projectRelease: 'shop-new',
+      environmentConfigs: { replicas: 3 },
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.environmentConfigs).toEqual({ replicas: 3 });
+  });
+});
+
+describe('OpenChoreoClient — fetchProjectReleaseSchema', () => {
+  const fetchMock = jest.fn();
+  const discovery = { getBaseUrl: jest.fn().mockResolvedValue(BASE_URL) };
+  const fetchApi = { fetch: fetchMock };
+  let client: OpenChoreoClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    discovery.getBaseUrl.mockResolvedValue(BASE_URL);
+    client = new OpenChoreoClient(discovery as any, fetchApi as any);
+  });
+
+  it('GETs /project-release-schema with namespace, release and section', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({ success: true, data: { type: 'object' } }),
+    );
+
+    const result = await client.fetchProjectReleaseSchema(
+      'test-ns',
+      'shop-abc',
+      'environmentConfigs',
+    );
+
+    expect(result).toEqual({ success: true, data: { type: 'object' } });
+    const [calledUrl, opts] = fetchMock.mock.calls[0];
+    expect(calledUrl).toContain('/project-release-schema');
+    expect(calledUrl).toContain('namespaceName=test-ns');
+    expect(calledUrl).toContain('releaseName=shop-abc');
+    expect(calledUrl).toContain('section=environmentConfigs');
+    expect(opts.method ?? 'GET').toBe('GET');
+  });
+});

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -17,6 +17,8 @@ import type {
   ReleaseBindingsResponse,
   ResourceReleaseResponse,
   ResourceReleaseBindingsResponse,
+  ProjectReleaseBindingsResponse,
+  ProjectEnvironment,
   WorkflowSchemaResponse,
   ComponentInfo,
   SecretReferencesResponse,
@@ -70,6 +72,10 @@ const API_ENDPOINTS = {
   RESOURCE_ENVIRONMENT_INFO: '/resource-environment-info',
   UPDATE_RESOURCE_RELEASE_BINDING: '/update-resource-release-binding',
   DELETE_RESOURCE_RELEASE_BINDING: '/delete-resource-release-binding',
+  PROJECT_RELEASE_BINDINGS: '/project-release-bindings',
+  PROJECT_ENVIRONMENT_INFO: '/project-environment-info',
+  UPDATE_PROJECT_RELEASE_BINDING: '/update-project-release-binding',
+  PROJECT_RELEASE_SCHEMA: '/project-release-schema',
   COMPONENT_RELEASES: '/component-releases',
   UPDATE_RELEASE_BINDING: '/update-release-binding',
   PATCH_RELEASE_BINDING: '/patch-release-binding',
@@ -181,6 +187,28 @@ function extractResourceEntityMetadata(entity: Entity): ResourceEntityMetadata {
   }
 
   return { resourceName, projectName, namespaceName };
+}
+
+interface ProjectEntityMetadata {
+  projectName: string;
+  namespaceName: string;
+}
+
+function extractProjectEntityMetadata(entity: Entity): ProjectEntityMetadata {
+  // A Project entity (catalog kind System) carries its project name as the
+  // entity name; the OpenChoreo namespace is annotated.
+  const projectName = entity.metadata.name;
+  const namespaceName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
+
+  if (!projectName || !namespaceName) {
+    throw new Error(
+      'Missing required OpenChoreo annotations on Project entity. ' +
+        `Required: project name and ${CHOREO_ANNOTATIONS.NAMESPACE}`,
+    );
+  }
+
+  return { projectName, namespaceName };
 }
 
 // ============================================
@@ -504,6 +532,66 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
         namespaceName,
         environment,
       },
+    });
+  }
+
+  async fetchProjectEnvironmentInfo(
+    entity: Entity,
+  ): Promise<ProjectEnvironment[]> {
+    const { projectName, namespaceName } = extractProjectEntityMetadata(entity);
+
+    return this.apiFetch<ProjectEnvironment[]>(
+      API_ENDPOINTS.PROJECT_ENVIRONMENT_INFO,
+      {
+        params: { projectName, namespaceName },
+      },
+    );
+  }
+
+  async fetchProjectReleaseBindings(
+    entity: Entity,
+  ): Promise<ProjectReleaseBindingsResponse> {
+    const { projectName, namespaceName } = extractProjectEntityMetadata(entity);
+
+    return this.apiFetch<ProjectReleaseBindingsResponse>(
+      API_ENDPOINTS.PROJECT_RELEASE_BINDINGS,
+      {
+        params: { projectName, namespaceName },
+      },
+    );
+  }
+
+  async updateProjectReleaseBinding(
+    entity: Entity,
+    environment: string,
+    options: {
+      projectRelease: string;
+      environmentConfigs?: unknown;
+    },
+  ): Promise<unknown> {
+    const { projectName, namespaceName } = extractProjectEntityMetadata(entity);
+
+    return this.apiFetch(API_ENDPOINTS.UPDATE_PROJECT_RELEASE_BINDING, {
+      method: 'PUT',
+      body: {
+        projectName,
+        namespaceName,
+        environment,
+        releaseName: options.projectRelease,
+        ...(options.environmentConfigs !== undefined
+          ? { environmentConfigs: options.environmentConfigs }
+          : {}),
+      },
+    });
+  }
+
+  async fetchProjectReleaseSchema(
+    namespaceName: string,
+    releaseName: string,
+    section: 'parameters' | 'environmentConfigs',
+  ): Promise<{ success: boolean; data?: Record<string, unknown> }> {
+    return this.apiFetch(API_ENDPOINTS.PROJECT_RELEASE_SCHEMA, {
+      params: { namespaceName, releaseName, section },
     });
   }
 

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -213,6 +213,79 @@ export interface ResourceEnvironment {
   latestRelease?: string;
 }
 
+/** A single condition on a ProjectReleaseBinding. */
+export interface ProjectReleaseBindingCondition {
+  type: string;
+  status: string;
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+  observedGeneration?: number;
+}
+
+/**
+ * Project release binding item — one per environment for a given Project.
+ * Fields the BFF transformer always emits (possibly as empty strings) are
+ * required here; truly per-status fields are optional. Matches the
+ * `ProjectReleaseBindingResponse` shape in `@openchoreo/backstage-plugin-common`.
+ */
+export interface ProjectReleaseBinding {
+  name: string;
+  environment: string;
+  projectName: string;
+  namespaceName: string;
+  releaseName: string;
+  createdAt: string;
+  /**
+   * Per-environment overrides layered over the project-level parameters
+   * when the (Cluster)ProjectType resources are rendered.
+   */
+  environmentConfigs?: Record<string, unknown>;
+  /** Data-plane namespace owned by this binding (status.namespace). */
+  namespace?: string;
+  status?: 'Ready' | 'NotReady' | 'Failed';
+  statusReason?: string;
+  statusMessage?: string;
+  conditions?: ProjectReleaseBindingCondition[];
+}
+
+/** Project release bindings response */
+export interface ProjectReleaseBindingsResponse {
+  success: boolean;
+  data?: {
+    items: ProjectReleaseBinding[];
+  };
+}
+
+/**
+ * Per-environment deploy view of a Project. One entry per environment defined
+ * in the project's deployment pipeline, including environments with no binding
+ * (so the UI can render a Deploy/Promote affordance). Matches the backend
+ * `ProjectEnvironment` shape in `plugins/openchoreo-backend/src/types.ts`.
+ */
+export interface ProjectEnvironment {
+  uid?: string;
+  name: string;
+  resourceName?: string;
+  dataPlaneRef?: string;
+  dataPlaneKind?: 'DataPlane' | 'ClusterDataPlane';
+  bindingName?: string;
+  /** The ProjectRelease pinned to this environment (binding.spec.projectRelease). */
+  projectRelease?: string;
+  status?: 'Ready' | 'NotReady' | 'Failed';
+  statusReason?: string;
+  statusMessage?: string;
+  lastDeployed?: string;
+  /** Data-plane namespace owned by this binding (binding.status.namespace). */
+  namespace?: string;
+  promotionTargets?: {
+    name: string;
+    resourceName?: string;
+  }[];
+  /** Latest ProjectRelease cut by the Project controller, if any. */
+  latestRelease?: string;
+}
+
 /** Create release response */
 export interface CreateReleaseResponse {
   success: boolean;
@@ -673,6 +746,50 @@ export interface OpenChoreoClientApi {
     entity: Entity,
     environment: string,
   ): Promise<unknown>;
+
+  /**
+   * Fetch per-environment deploy info for a Project entity. Returns one entry
+   * per environment in the project's deployment pipeline (including
+   * environments without bindings yet), joined with the project's latest
+   * release.
+   */
+  fetchProjectEnvironmentInfo(entity: Entity): Promise<ProjectEnvironment[]>;
+
+  /**
+   * Fetch all project release bindings for a Project entity. Filters by the
+   * owning project, returning one binding per environment.
+   */
+  fetchProjectReleaseBindings(
+    entity: Entity,
+  ): Promise<ProjectReleaseBindingsResponse>;
+
+  /**
+   * Create or update a ProjectReleaseBinding for the given environment.
+   * Creates a new binding when none exists; otherwise advances
+   * `spec.projectRelease` (the deploy/promote pin). `environmentConfigs` is
+   * written when present, left untouched when omitted.
+   */
+  updateProjectReleaseBinding(
+    entity: Entity,
+    environment: string,
+    options: {
+      projectRelease: string;
+      environmentConfigs?: unknown;
+    },
+  ): Promise<unknown>;
+
+  /**
+   * Fetch a schema section from the frozen snapshot stored on a
+   * ProjectRelease. `parameters` returns the project-level schema;
+   * `environmentConfigs` returns the per-env override schema. Pinned-release
+   * flows use this so form validation matches what the release was actually
+   * cut against, not the live (Cluster)ProjectType which may have drifted.
+   */
+  fetchProjectReleaseSchema(
+    namespaceName: string,
+    releaseName: string,
+    section: 'parameters' | 'environmentConfigs',
+  ): Promise<{ success: boolean; data?: Record<string, unknown> }>;
 
   /** List all component releases for a component (sorted newest first by caller) */
   listComponentReleases(entity: Entity): Promise<ComponentReleasesResponse>;

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectDeployFlowCanvas.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectDeployFlowCanvas.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProjectDeployFlowCanvas } from './ProjectDeployFlowCanvas';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  useChoreoTokens: () => ({ graph: { canvasDotPattern: 'dots' } }),
+}));
+
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  MINI_ENV_NODE_WIDTH: 200,
+  MINI_ENV_NODE_HEIGHT: 100,
+  MINI_SETUP_NODE_WIDTH: 150,
+  MINI_SETUP_NODE_HEIGHT: 80,
+  buildEnvPipelineNodes: (envs: any) => envs,
+  computePipelineLayout: () => ({
+    width: 500,
+    height: 300,
+    nodes: [
+      { id: '__setup__', isSetup: true, x: 0, y: 0, width: 150, height: 80 },
+      { id: 'dev', isSetup: false, x: 200, y: 0, width: 200, height: 100 },
+    ],
+    edges: [{ from: '__setup__', to: 'dev' }],
+  }),
+  PipelineEdge: () => <div data-testid="edge" />,
+  GraphControls: ({ onFitToView }: any) => (
+    <button onClick={onFitToView}>fit</button>
+  ),
+  useHtmlGraphZoom: () => ({
+    containerRef: { current: null },
+    contentRef: { current: null },
+    containerSize: { width: 800, height: 600 },
+    zoomIn: jest.fn(),
+    zoomOut: jest.fn(),
+    fitToView: jest.fn(),
+    resetZoom: jest.fn(),
+  }),
+}));
+
+jest.mock('./ProjectMiniEnvironmentNode', () => ({
+  ProjectMiniEnvironmentNode: ({ env, onSelect }: any) => (
+    <button onClick={onSelect}>mini-{env.name}</button>
+  ),
+}));
+
+jest.mock('./ProjectSetupCard', () => ({
+  ProjectSetupCard: ({ selected }: any) => (
+    <div>setup-card-{String(selected)}</div>
+  ),
+}));
+
+const environments: ProjectEnvironment[] = [{ name: 'dev' }];
+
+function renderCanvas(overrides: Partial<any> = {}) {
+  const props = {
+    environments,
+    selectedEnvName: null,
+    selectedSetup: false,
+    onSelectEnv: jest.fn(),
+    onSelectSetup: jest.fn(),
+    onClearSelection: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<ProjectDeployFlowCanvas {...props} />) };
+}
+
+describe('ProjectDeployFlowCanvas', () => {
+  it('renders the setup card, env tiles and pipeline edges', () => {
+    renderCanvas();
+    expect(screen.getByText('setup-card-false')).toBeInTheDocument();
+    expect(screen.getByText('mini-dev')).toBeInTheDocument();
+    expect(screen.getByTestId('edge')).toBeInTheDocument();
+  });
+
+  it('selects the setup tile', () => {
+    const { props } = renderCanvas();
+    fireEvent.click(screen.getByRole('button', { name: /select setup/i }));
+    expect(props.onSelectSetup).toHaveBeenCalled();
+  });
+
+  it('selects an environment tile', () => {
+    const { props } = renderCanvas();
+    fireEvent.click(screen.getByText('mini-dev'));
+    expect(props.onSelectEnv).toHaveBeenCalledWith('dev');
+  });
+
+  it('clears the selection on a background click', () => {
+    const { props } = renderCanvas();
+    fireEvent.click(screen.getByTestId('project-deploy-flow-canvas'));
+    expect(props.onClearSelection).toHaveBeenCalled();
+  });
+
+  it('renders nothing when there are no environments', () => {
+    const { container } = renderCanvas({ environments: [] });
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectDeployFlowCanvas.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectDeployFlowCanvas.tsx
@@ -1,0 +1,222 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
+import { Box, useMediaQuery, useTheme } from '@material-ui/core';
+import { useChoreoTokens } from '@openchoreo/backstage-design-system';
+import {
+  buildEnvPipelineNodes,
+  computePipelineLayout,
+  GraphControls,
+  MINI_ENV_NODE_HEIGHT,
+  MINI_ENV_NODE_WIDTH,
+  MINI_SETUP_NODE_HEIGHT,
+  MINI_SETUP_NODE_WIDTH,
+  PipelineEdge,
+  useHtmlGraphZoom,
+} from '@openchoreo/backstage-plugin-react';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+import { useProjectDeployFlowCanvasStyles } from './styles';
+import { ProjectMiniEnvironmentNode } from './ProjectMiniEnvironmentNode';
+import { ProjectSetupCard } from './ProjectSetupCard';
+
+const SETUP_NODE_ID = '__setup__';
+
+interface ProjectDeployFlowCanvasProps {
+  environments: ProjectEnvironment[];
+  selectedEnvName: string | null;
+  selectedSetup: boolean;
+  onSelectEnv: (envName: string | null) => void;
+  onSelectSetup: () => void;
+  onClearSelection: () => void;
+}
+
+/**
+ * Pipeline DAG for a Project's environments. Lays out a leading Set up
+ * tile plus compact env tiles via the shared dagre helpers from
+ * @openchoreo/backstage-plugin-react and pans/zooms via a CSS-transform
+ * layer. Click a tile to select it; the detail panel mounts the full
+ * action surface separately.
+ */
+export const ProjectDeployFlowCanvas = ({
+  environments,
+  selectedEnvName,
+  selectedSetup,
+  onSelectEnv,
+  onSelectSetup,
+  onClearSelection,
+}: ProjectDeployFlowCanvasProps) => {
+  const classes = useProjectDeployFlowCanvasStyles();
+  const tokens = useChoreoTokens();
+  const theme = useTheme();
+  const isNarrow = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const direction = isNarrow ? 'TB' : 'LR';
+  const layout = useMemo(() => {
+    if (environments.length === 0) return null;
+    const nodes = buildEnvPipelineNodes(environments);
+    return computePipelineLayout(nodes, {
+      direction,
+      defaultWidth: MINI_ENV_NODE_WIDTH,
+      defaultHeight: MINI_ENV_NODE_HEIGHT,
+      nodeSize: node => ({
+        width: node.isSetup ? MINI_SETUP_NODE_WIDTH : MINI_ENV_NODE_WIDTH,
+        height: node.isSetup ? MINI_SETUP_NODE_HEIGHT : MINI_ENV_NODE_HEIGHT,
+      }),
+      nodesep: 24,
+      ranksep: 60,
+    });
+  }, [environments, direction]);
+
+  const contentWidth = layout?.width ?? 0;
+  const contentHeight = layout?.height ?? 0;
+
+  const {
+    containerRef,
+    contentRef,
+    containerSize,
+    zoomIn,
+    zoomOut,
+    fitToView,
+    resetZoom,
+  } = useHtmlGraphZoom({ contentWidth, contentHeight });
+
+  // One-shot auto-fit after the container has been measured and dagre
+  // has produced non-zero dims. Hidden until the fit lands to avoid a
+  // flash of un-positioned tiles at the canvas origin.
+  const didAutoFitRef = useRef(false);
+  const [hasFitted, setHasFitted] = useState(false);
+  useEffect(() => {
+    if (didAutoFitRef.current) return;
+    if (
+      contentWidth === 0 ||
+      contentHeight === 0 ||
+      containerSize.width === 0 ||
+      containerSize.height === 0
+    ) {
+      return;
+    }
+    didAutoFitRef.current = true;
+    fitToView();
+    setHasFitted(true);
+  }, [
+    contentWidth,
+    contentHeight,
+    containerSize.width,
+    containerSize.height,
+    fitToView,
+  ]);
+
+  const setupNode = layout?.nodes.find(n => n.id === SETUP_NODE_ID);
+  const envNodes = (layout?.nodes ?? []).filter(n => !n.isSetup);
+
+  const envMap = useMemo(() => {
+    const map = new Map<string, ProjectEnvironment>();
+    for (const env of environments) map.set(env.name, env);
+    return map;
+  }, [environments]);
+
+  const handleBackgroundClick = (e: ReactMouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClearSelection();
+    }
+  };
+
+  if (!layout) {
+    return null;
+  }
+
+  return (
+    <Box
+      className={classes.canvasFrame}
+      style={{
+        ['--canvas-dots' as string]: tokens.graph.canvasDotPattern,
+      }}
+    >
+      {/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div
+        data-testid="project-deploy-flow-canvas"
+        className={classes.canvasContainer}
+        ref={containerRef}
+        onClick={handleBackgroundClick}
+      >
+        <div
+          className={classes.canvasContent}
+          ref={contentRef}
+          style={{
+            width: contentWidth,
+            height: contentHeight,
+            opacity: hasFitted ? 1 : 0,
+            transition: hasFitted ? 'opacity 120ms ease-in' : undefined,
+          }}
+          onClick={handleBackgroundClick}
+        >
+          {layout.edges.map(edge => (
+            <PipelineEdge key={`${edge.from}-${edge.to}`} edge={edge} />
+          ))}
+
+          {setupNode && (
+            <Box
+              className={classes.setupNodeWrapper}
+              role="button"
+              tabIndex={0}
+              aria-pressed={selectedSetup}
+              aria-label="Select setup"
+              onClick={onSelectSetup}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onSelectSetup();
+                }
+              }}
+              style={{
+                left: setupNode.x,
+                top: setupNode.y,
+                width: setupNode.width,
+                height: setupNode.height,
+              }}
+            >
+              <ProjectSetupCard selected={selectedSetup} />
+            </Box>
+          )}
+
+          {envNodes.map(node => {
+            const env = envMap.get(node.id);
+            if (!env) return null;
+            return (
+              <Box
+                key={node.id}
+                className={classes.nodeWrapper}
+                style={{
+                  left: node.x,
+                  top: node.y,
+                  width: node.width,
+                  height: node.height,
+                }}
+              >
+                <ProjectMiniEnvironmentNode
+                  env={env}
+                  selected={selectedEnvName === env.name}
+                  onSelect={() => onSelectEnv(env.name)}
+                />
+              </Box>
+            );
+          })}
+        </div>
+      </div>
+      {/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+
+      <Box className={classes.controlsOverlay}>
+        <GraphControls
+          onZoomIn={zoomIn}
+          onZoomOut={zoomOut}
+          onFitToView={fitToView}
+          onResetZoom={resetZoom}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentDetailPanel.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentDetailPanel.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProjectEnvironmentDetailPanel } from './ProjectEnvironmentDetailPanel';
+import {
+  ProjectEnvironmentsProvider,
+  type ProjectEnvironmentsContextValue,
+} from './ProjectEnvironmentsContext';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  StatusBadge: ({ status }: any) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
+}));
+
+const mockUpdatePerm = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  formatRelativeTime: () => 'just now',
+  useProjectUpdatePermission: () => mockUpdatePerm(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+function makeCtx(
+  overrides: Partial<ProjectEnvironmentsContextValue> = {},
+): ProjectEnvironmentsContextValue {
+  return {
+    environments: [],
+    loading: false,
+    refetch: jest.fn(),
+    selectedEnvName: null,
+    setSelectedEnvName: jest.fn(),
+    pendingAction: null,
+    onPromote: jest.fn(),
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  env: ProjectEnvironment | null,
+  ctxOverrides: Partial<ProjectEnvironmentsContextValue> = {},
+) {
+  return render(
+    <MemoryRouter>
+      <ProjectEnvironmentsProvider value={makeCtx(ctxOverrides)}>
+        <ProjectEnvironmentDetailPanel env={env} onClose={() => {}} />
+      </ProjectEnvironmentsProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdatePerm.mockReturnValue({
+    canUpdate: true,
+    loading: false,
+    updateDeniedTooltip: '',
+  });
+});
+
+describe('ProjectEnvironmentDetailPanel', () => {
+  it('shows a hint when no env is selected', () => {
+    renderPanel(null);
+    expect(
+      screen.getByText(/select an environment to view details/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the no-binding message for an unbound env without actions', () => {
+    renderPanel({ name: 'staging', latestRelease: 'rel-1' });
+
+    expect(screen.getByText('staging')).toBeInTheDocument();
+    expect(
+      screen.getByText(/no binding in this environment yet/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /configure overrides/i }),
+    ).toBeNull();
+  });
+
+  it('renders release meta and Configure overrides for a bound env', () => {
+    renderPanel({
+      name: 'dev',
+      resourceName: 'development',
+      bindingName: 'my-app-development',
+      projectRelease: 'my-app-abc',
+      status: 'Ready',
+      latestRelease: 'my-app-abc',
+    });
+
+    expect(screen.getByText('Release')).toBeInTheDocument();
+    expect(screen.getByText('my-app-abc')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+
+    // Configure overrides navigates to the per-env wizard using the env's
+    // K8s resource name.
+    fireEvent.click(
+      screen.getByRole('button', { name: /configure overrides/i }),
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('overrides/development');
+  });
+
+  it('URL-encodes the env segment when falling back to the display name', () => {
+    renderPanel({
+      name: 'My Env',
+      bindingName: 'my-app-my-env',
+      projectRelease: 'my-app-abc',
+      status: 'Ready',
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /configure overrides/i }),
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('overrides/My%20Env');
+  });
+
+  it('promotes this env release to the eligible target', () => {
+    const onPromote = jest.fn();
+    const dev: ProjectEnvironment = {
+      name: 'dev',
+      resourceName: 'development',
+      bindingName: 'my-app-development',
+      projectRelease: 'my-app-abc',
+      status: 'Ready',
+      promotionTargets: [{ name: 'Staging', resourceName: 'staging' }],
+    };
+    const staging: ProjectEnvironment = {
+      name: 'Staging',
+      resourceName: 'staging',
+      bindingName: 'my-app-staging',
+      projectRelease: 'my-app-old',
+      status: 'Ready',
+    };
+
+    renderPanel(dev, { environments: [dev, staging], onPromote });
+
+    fireEvent.click(screen.getByRole('button', { name: /^promote$/i }));
+    // Promote pins the target env (by K8s resource name) to this env's release.
+    expect(onPromote).toHaveBeenCalledWith('staging', 'my-app-abc');
+  });
+
+  it('disables Configure overrides when the user lacks project-update permission', () => {
+    mockUpdatePerm.mockReturnValue({
+      canUpdate: false,
+      loading: false,
+      updateDeniedTooltip: 'nope',
+    });
+    renderPanel({
+      name: 'dev',
+      resourceName: 'development',
+      bindingName: 'my-app-development',
+      projectRelease: 'my-app-abc',
+      status: 'Ready',
+    });
+
+    expect(
+      screen.getByRole('button', { name: /configure overrides/i }),
+    ).toBeDisabled();
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentDetailPanel.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentDetailPanel.tsx
@@ -1,0 +1,328 @@
+import { useCallback } from 'react';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import AllInboxOutlinedIcon from '@material-ui/icons/AllInboxOutlined';
+import CloseIcon from '@material-ui/icons/Close';
+import CloudIcon from '@material-ui/icons/Cloud';
+import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import SettingsOutlinedIcon from '@material-ui/icons/SettingsOutlined';
+import { useNavigate } from 'react-router-dom';
+import { StatusBadge } from '@openchoreo/backstage-design-system';
+import {
+  formatRelativeTime,
+  useProjectUpdatePermission,
+} from '@openchoreo/backstage-plugin-react';
+import { useNotification } from '../../hooks';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+import { useProjectEnvironmentDetailPanelStyles } from './styles';
+import { useProjectEnvironmentsContext } from './ProjectEnvironmentsContext';
+import { deriveProjectEnvBadgeStatus } from './badgeStatus';
+
+interface ProjectEnvironmentDetailPanelProps {
+  env: ProjectEnvironment | null;
+  onClose: () => void;
+}
+
+export const ProjectEnvironmentDetailPanel = ({
+  env,
+  onClose,
+}: ProjectEnvironmentDetailPanelProps) => {
+  const classes = useProjectEnvironmentDetailPanelStyles();
+
+  if (!env) {
+    return (
+      <Box className={classes.panel}>
+        <Box className={classes.emptyState}>
+          <AllInboxOutlinedIcon className={classes.emptyIcon} />
+          <Typography variant="body2">
+            Select an environment to view details, or click{' '}
+            <strong>Set up</strong> to update configuration.
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
+
+  return <ProjectEnvironmentDetailContent env={env} onClose={onClose} />;
+};
+
+interface ContentProps {
+  env: ProjectEnvironment;
+  onClose: () => void;
+}
+
+function ProjectEnvironmentDetailContent({ env, onClose }: ContentProps) {
+  const classes = useProjectEnvironmentDetailPanelStyles();
+  const navigate = useNavigate();
+  const notification = useNotification();
+  const { environments, pendingAction, refetch, onPromote } =
+    useProjectEnvironmentsContext();
+  const {
+    canUpdate,
+    loading: permLoading,
+    updateDeniedTooltip,
+  } = useProjectUpdatePermission();
+
+  const hasBinding = Boolean(env.bindingName);
+  const badgeStatus = deriveProjectEnvBadgeStatus(env);
+
+  // Promote eligibility: shows when this env has a binding + release + at
+  // least one promotion target that doesn't already have this release.
+  // Promote copies this env's release pin forward to the next env's
+  // binding; the pipeline-defined `promotionTargets` enforces ordering
+  // (the terminal env has no targets, so the button never appears there).
+  const promotionTargets = env.promotionTargets ?? [];
+  const eligibleTargets = env.projectRelease
+    ? promotionTargets.filter(t => {
+        const targetEnv = environments.find(e => e.name === t.name);
+        return targetEnv?.projectRelease !== env.projectRelease;
+      })
+    : [];
+  const allTargetsInSync =
+    promotionTargets.length > 0 && eligibleTargets.length === 0;
+  const isPromoting = promotionTargets.some(
+    t =>
+      pendingAction?.kind === 'promote' &&
+      pendingAction.env === (t.resourceName ?? t.name),
+  );
+  const showPromote =
+    hasBinding &&
+    Boolean(env.projectRelease) &&
+    env.status === 'Ready' &&
+    promotionTargets.length > 0;
+
+  // Hide the status MESSAGE row on the happy path; show it only when the
+  // binding isn't Ready so the user has the context to debug.
+  const showStatusMessage = env.status !== 'Ready';
+
+  const copyToClipboard = useCallback(
+    async (text: string, label: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        notification.showSuccess(`Copied ${label}`);
+      } catch {
+        notification.showError('Failed to copy to clipboard');
+      }
+    },
+    [notification],
+  );
+
+  const handlePromoteSingle = () => {
+    const target = eligibleTargets[0];
+    if (!target || !env.projectRelease) return;
+    // Promote needs the K8s-safe resource name (lowercase, RFC 1123).
+    // target.name is the display name (e.g. "Production").
+    void onPromote(target.resourceName ?? target.name, env.projectRelease);
+  };
+
+  const promoteDisabled = isPromoting || permLoading || !canUpdate;
+  const promoteTooltip =
+    !canUpdate && !permLoading
+      ? updateDeniedTooltip
+      : `Promote to ${eligibleTargets[0]?.name ?? ''}`;
+  const overridesDisabled = permLoading || !canUpdate;
+  const overridesTooltip =
+    !canUpdate && !permLoading
+      ? updateDeniedTooltip
+      : 'Edit per-environment overrides for this binding';
+
+  return (
+    <Box className={classes.panel}>
+      <Box className={classes.header}>
+        <Box className={classes.headerTopRow}>
+          <Box className={classes.headerNameRow}>
+            <CloudIcon
+              className={classes.headerKindIcon}
+              fontSize="small"
+              aria-hidden
+            />
+            <Typography className={classes.envName}>{env.name}</Typography>
+          </Box>
+          <Box>
+            <IconButton
+              size="small"
+              onClick={() => void refetch()}
+              aria-label="Refresh environment status"
+            >
+              <RefreshIcon fontSize="small" />
+            </IconButton>
+            <IconButton
+              size="small"
+              onClick={onClose}
+              aria-label="Close detail panel"
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        </Box>
+        <Box className={classes.headerStatusRow}>
+          <StatusBadge status={badgeStatus} />
+        </Box>
+      </Box>
+
+      <Box className={classes.body}>
+        {!hasBinding ? (
+          <Box className={classes.section}>
+            <Typography variant="body2" color="textSecondary">
+              No binding in this environment yet. Use <strong>Set up</strong> on
+              the pipeline canvas to deploy this project for the first time,
+              then promote forward through the environments.
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <Box className={classes.section}>
+              <Box className={classes.releaseNameRow}>
+                <Typography
+                  variant="caption"
+                  className={classes.releaseNameLabel}
+                >
+                  Release
+                </Typography>
+                <Tooltip
+                  title={env.projectRelease || ''}
+                  disableHoverListener={!env.projectRelease}
+                >
+                  <Typography variant="caption" className={classes.releaseName}>
+                    {env.projectRelease || '(unset)'}
+                  </Typography>
+                </Tooltip>
+                {env.projectRelease && (
+                  <Tooltip
+                    title="Copy release name"
+                    PopperProps={{ disablePortal: true }}
+                  >
+                    <IconButton
+                      size="small"
+                      aria-label="Copy release name"
+                      onClick={() =>
+                        copyToClipboard(env.projectRelease!, 'release name')
+                      }
+                    >
+                      <FileCopyOutlinedIcon fontSize="inherit" />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </Box>
+              {env.lastDeployed && (
+                <Box className={classes.deployedRow}>
+                  <Typography
+                    variant="caption"
+                    className={classes.releaseNameLabel}
+                  >
+                    Deployed
+                  </Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    {formatRelativeTime(env.lastDeployed)}
+                  </Typography>
+                </Box>
+              )}
+              {env.namespace && (
+                <Box className={classes.releaseNameRow}>
+                  <Typography
+                    variant="caption"
+                    className={classes.releaseNameLabel}
+                  >
+                    Namespace
+                  </Typography>
+                  <Tooltip title={env.namespace}>
+                    <Typography
+                      variant="caption"
+                      className={classes.releaseName}
+                    >
+                      {env.namespace}
+                    </Typography>
+                  </Tooltip>
+                </Box>
+              )}
+              {showStatusMessage && env.statusMessage && (
+                <Box className={classes.releaseNameRow}>
+                  <Typography
+                    variant="caption"
+                    className={classes.releaseNameLabel}
+                  >
+                    Message
+                  </Typography>
+                  <Tooltip title={env.statusMessage}>
+                    <Typography
+                      variant="caption"
+                      className={classes.statusMessage}
+                    >
+                      {env.statusMessage}
+                    </Typography>
+                  </Tooltip>
+                </Box>
+              )}
+            </Box>
+
+            <Box className={classes.section}>
+              <Box className={classes.sectionTitleRow}>
+                <Typography className={classes.sectionHeading}>
+                  Actions
+                </Typography>
+                <Box className={classes.actionsRow}>
+                  {showPromote &&
+                    (allTargetsInSync ? (
+                      <Button size="small" variant="contained" disabled>
+                        Promoted
+                      </Button>
+                    ) : (
+                      <Tooltip
+                        title={promoteTooltip}
+                        disableHoverListener={!promoteTooltip}
+                      >
+                        <span>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="primary"
+                            onClick={handlePromoteSingle}
+                            disabled={promoteDisabled}
+                            startIcon={
+                              isPromoting ? (
+                                <CircularProgress size={14} color="inherit" />
+                              ) : undefined
+                            }
+                          >
+                            {isPromoting ? 'Promoting...' : 'Promote'}
+                          </Button>
+                        </span>
+                      </Tooltip>
+                    ))}
+                  <Tooltip title={overridesTooltip}>
+                    <span>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color="primary"
+                        startIcon={<SettingsOutlinedIcon fontSize="small" />}
+                        onClick={() =>
+                          navigate(
+                            `overrides/${encodeURIComponent(
+                              env.resourceName ?? env.name,
+                            )}`,
+                          )
+                        }
+                        disabled={overridesDisabled}
+                        style={{ textTransform: 'none' }}
+                      >
+                        Configure overrides
+                      </Button>
+                    </span>
+                  </Tooltip>
+                </Box>
+              </Box>
+            </Box>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentOverridesPage.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentOverridesPage.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ProjectEnvironmentOverridesPage } from './ProjectEnvironmentOverridesPage';
+
+const mockClient = {
+  fetchProjectEnvironmentInfo: jest.fn(),
+  fetchProjectReleaseBindings: jest.fn(),
+  fetchProjectReleaseSchema: jest.fn(),
+  updateProjectReleaseBinding: jest.fn(),
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: () => mockClient,
+  createApiRef: (def: { id: string }) => ({ id: def?.id ?? 'ref' }),
+  discoveryApiRef: { id: 'discovery' },
+  fetchApiRef: { id: 'fetch' },
+}));
+
+const entity = {
+  kind: 'System',
+  metadata: {
+    name: 'my-app',
+    annotations: {
+      'openchoreo.io/namespace': 'test-ns',
+      'openchoreo.io/project-type': 'web-application',
+    },
+  },
+};
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({ entity }),
+}));
+
+const mockUpdatePerm = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useProjectUpdatePermission: () => mockUpdatePerm(),
+  DetailPageLayout: ({ title, subtitle, actions, children, onBack }: any) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      <button onClick={onBack}>back</button>
+      <div>{actions}</div>
+      <div>{children}</div>
+    </div>
+  ),
+  ForbiddenState: ({ message }: any) => (
+    <div data-testid="forbidden">{message}</div>
+  ),
+}));
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  RjsfForm: ({ onChange }: any) => (
+    <button
+      data-testid="rjsf-change"
+      onClick={() => onChange({ formData: { replicas: 5 } })}
+    >
+      change
+    </button>
+  ),
+}));
+
+jest.mock('../../utils/errorUtils', () => ({
+  isForbiddenError: (e: any) => e?.__forbidden === true,
+  getErrorMessage: (e: any) => String(e?.message ?? e),
+}));
+
+const SCHEMA = {
+  success: true,
+  data: {
+    type: 'object',
+    properties: { replicas: { type: 'integer' } },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdatePerm.mockReturnValue({
+    canUpdate: true,
+    loading: false,
+    updateDeniedTooltip: '',
+  });
+  mockClient.fetchProjectReleaseSchema.mockResolvedValue(SCHEMA);
+  mockClient.updateProjectReleaseBinding.mockResolvedValue({ ok: true });
+});
+
+describe('ProjectEnvironmentOverridesPage (deploy mode)', () => {
+  beforeEach(() => {
+    mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([
+      { name: 'dev', resourceName: 'development', latestRelease: 'rel-2' },
+    ]);
+    mockClient.fetchProjectReleaseBindings.mockResolvedValue({
+      data: { items: [] },
+    });
+  });
+
+  it('deploys the pinned release with the entered overrides', async () => {
+    const onSaved = jest.fn();
+    render(
+      <ProjectEnvironmentOverridesPage
+        envName="development"
+        releaseFromUrl="rel-2"
+        onBack={jest.fn()}
+        onSaved={onSaved}
+      />,
+    );
+
+    const deploy = await screen.findByRole('button', { name: /^deploy$/i });
+    fireEvent.click(await screen.findByTestId('rjsf-change'));
+    fireEvent.click(deploy);
+
+    await waitFor(() =>
+      expect(mockClient.updateProjectReleaseBinding).toHaveBeenCalledWith(
+        entity,
+        'development',
+        { projectRelease: 'rel-2', environmentConfigs: { replicas: 5 } },
+      ),
+    );
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    // The release-snapshot schema is read for the pinned release.
+    expect(mockClient.fetchProjectReleaseSchema).toHaveBeenCalledWith(
+      'test-ns',
+      'rel-2',
+      'environmentConfigs',
+    );
+  });
+
+  it('shows the empty-state when the release has no environmentConfigs schema', async () => {
+    mockClient.fetchProjectReleaseSchema.mockResolvedValue({
+      success: true,
+      data: {},
+    });
+
+    render(
+      <ProjectEnvironmentOverridesPage
+        envName="development"
+        releaseFromUrl="rel-2"
+        onBack={jest.fn()}
+        onSaved={jest.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        /web-application declares no environment-configs/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('ProjectEnvironmentOverridesPage (edit mode)', () => {
+  it('shows an info banner when the env has no binding yet', async () => {
+    mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([
+      { name: 'dev', resourceName: 'development', latestRelease: 'rel-2' },
+    ]);
+    mockClient.fetchProjectReleaseBindings.mockResolvedValue({
+      data: { items: [] },
+    });
+
+    render(
+      <ProjectEnvironmentOverridesPage
+        envName="development"
+        onBack={jest.fn()}
+        onSaved={jest.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/no binding exists for dev yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it('clears overrides on an existing binding', async () => {
+    const onSaved = jest.fn();
+    mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([
+      {
+        name: 'dev',
+        resourceName: 'development',
+        bindingName: 'my-app-development',
+        projectRelease: 'rel-2',
+        latestRelease: 'rel-2',
+      },
+    ]);
+    mockClient.fetchProjectReleaseBindings.mockResolvedValue({
+      data: {
+        items: [
+          { environment: 'development', environmentConfigs: { replicas: 2 } },
+        ],
+      },
+    });
+
+    render(
+      <ProjectEnvironmentOverridesPage
+        envName="development"
+        onBack={jest.fn()}
+        onSaved={onSaved}
+      />,
+    );
+
+    const clear = await screen.findByRole('button', {
+      name: /clear overrides/i,
+    });
+    expect(clear).toBeEnabled();
+    fireEvent.click(clear);
+
+    await waitFor(() =>
+      expect(mockClient.updateProjectReleaseBinding).toHaveBeenCalledWith(
+        entity,
+        'development',
+        { projectRelease: 'rel-2', environmentConfigs: {} },
+      ),
+    );
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+  });
+
+  it('renders the ForbiddenState when the load is forbidden', async () => {
+    const forbidden = Object.assign(new Error('forbidden'), {
+      __forbidden: true,
+    });
+    mockClient.fetchProjectEnvironmentInfo.mockRejectedValue(forbidden);
+    mockClient.fetchProjectReleaseBindings.mockRejectedValue(forbidden);
+
+    render(
+      <ProjectEnvironmentOverridesPage
+        envName="development"
+        onBack={jest.fn()}
+        onSaved={jest.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId('forbidden')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentOverridesPage.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentOverridesPage.tsx
@@ -1,0 +1,420 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Tooltip,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+import { Alert, Skeleton } from '@material-ui/lab';
+import type { JSONSchema7 } from 'json-schema';
+import { useApi } from '@backstage/core-plugin-api';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import {
+  DetailPageLayout,
+  ForbiddenState,
+  useProjectUpdatePermission,
+} from '@openchoreo/backstage-plugin-react';
+import { RjsfForm } from '@openchoreo/backstage-design-system';
+import {
+  openChoreoClientApiRef,
+  type ProjectEnvironment,
+} from '../../api/OpenChoreoClientApi';
+import { isForbiddenError, getErrorMessage } from '../../utils/errorUtils';
+import { useNotification } from '../../hooks';
+import { NotificationBanner } from '../Environments/components';
+
+const useStyles = makeStyles(theme => ({
+  loadingContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    padding: theme.spacing(4),
+  },
+  formCard: {
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: 12,
+    padding: theme.spacing(3),
+  },
+  formHint: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.body2.fontSize,
+    marginBottom: theme.spacing(2),
+  },
+  actionsRow: {
+    display: 'flex',
+    gap: theme.spacing(1),
+    alignItems: 'center',
+  },
+  emptyState: {
+    color: theme.palette.text.secondary,
+    fontStyle: 'italic',
+    padding: theme.spacing(4),
+    textAlign: 'center',
+  },
+}));
+
+export interface ProjectEnvironmentOverridesPageProps {
+  envName: string;
+  /**
+   * When set, the wizard runs in deploy mode: the binding is pinned to
+   * this release on save and the primary action reads "Deploy". Comes from
+   * the wizard chain that follows a project parameter edit.
+   */
+  releaseFromUrl?: string;
+  onBack: () => void;
+  onSaved: () => void;
+}
+
+/**
+ * Edits `ProjectReleaseBinding.spec.environmentConfigs` for a single
+ * environment. Saving issues an upsert against the binding via the BFF —
+ * the controller re-renders the namespace resources with the new
+ * env-specific values layered over the project-level parameters.
+ *
+ * The schema comes from the snapshot stored on the pinned ProjectRelease
+ * (not the live (Cluster)ProjectType) so the form validates against what
+ * the release was actually cut against — the live type may have drifted.
+ */
+export const ProjectEnvironmentOverridesPage = ({
+  envName,
+  releaseFromUrl,
+  onBack,
+  onSaved,
+}: ProjectEnvironmentOverridesPageProps) => {
+  const classes = useStyles();
+  const { entity } = useEntity();
+  const client = useApi(openChoreoClientApiRef);
+  const notification = useNotification();
+  const {
+    canUpdate,
+    loading: permLoading,
+    updateDeniedTooltip,
+  } = useProjectUpdatePermission();
+
+  const [envInfo, setEnvInfo] = useState<ProjectEnvironment | null>(null);
+  const [schema, setSchema] = useState<JSONSchema7 | null>(null);
+  const [overrides, setOverrides] = useState<Record<string, unknown>>({});
+  const [initialOverrides, setInitialOverrides] = useState<
+    Record<string, unknown>
+  >({});
+  /**
+   * True when the binding had a non-empty environmentConfigs map. Distinct
+   * from `hasChanges` because RJSF auto-fills defaults from the schema on
+   * mount; we use the backend's perspective to gate the Clear Overrides
+   * action.
+   */
+  const [hasActualOverrides, setHasActualOverrides] = useState(false);
+  /**
+   * When the backend has no stored overrides, RJSF auto-fills schema
+   * defaults on its first onChange and we adopt that normalized snapshot as
+   * the baseline (otherwise hasChanges would flip true on mount). When the
+   * backend already has values, those values ARE the baseline and we skip
+   * the capture so a real user edit isn't mistaken for initial state.
+   */
+  const formInitializedRef = useRef(true);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<Error | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const projectTypeName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT_TYPE] ||
+    'this project';
+  const envDisplayName = envInfo?.name ?? envName;
+  const hasBinding = Boolean(envInfo?.bindingName);
+  const isDeployMode = Boolean(releaseFromUrl);
+
+  const effectiveRelease =
+    releaseFromUrl ?? envInfo?.projectRelease ?? envInfo?.latestRelease ?? '';
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+
+    const load = async () => {
+      try {
+        const [envs, bindings] = await Promise.all([
+          client.fetchProjectEnvironmentInfo(entity),
+          client.fetchProjectReleaseBindings(entity),
+        ]);
+        if (cancelled) return;
+
+        const matchingEnv =
+          envs.find(e => e.resourceName === envName || e.name === envName) ??
+          null;
+        setEnvInfo(matchingEnv);
+
+        const envRef = matchingEnv?.resourceName ?? envName;
+        const matchingBinding =
+          bindings?.data?.items?.find(b => b.environment === envRef) ?? null;
+        const backendOverrides =
+          (matchingBinding?.environmentConfigs as
+            | Record<string, unknown>
+            | undefined) ?? {};
+        const backendOverridesCopy = JSON.parse(
+          JSON.stringify(backendOverrides),
+        );
+
+        // If the backend has stored values, those are the baseline; skip the
+        // RJSF normalization capture so the user's first edit isn't mistaken
+        // for initial state. Empty backend → allow capture to absorb
+        // schema-default expansion.
+        formInitializedRef.current = Object.keys(backendOverrides).length > 0;
+        setOverrides(backendOverridesCopy);
+        setInitialOverrides(backendOverridesCopy);
+        setHasActualOverrides(Object.keys(backendOverrides).length > 0);
+
+        const releaseForSchema =
+          releaseFromUrl ??
+          matchingEnv?.projectRelease ??
+          matchingEnv?.latestRelease ??
+          '';
+
+        if (!releaseForSchema) {
+          setSchema({} as JSONSchema7);
+          return;
+        }
+
+        const namespaceName =
+          entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE] || '';
+        const schemaResult = await client.fetchProjectReleaseSchema(
+          namespaceName,
+          releaseForSchema,
+          'environmentConfigs',
+        );
+        if (cancelled) return;
+
+        setSchema((schemaResult?.data as JSONSchema7) ?? ({} as JSONSchema7));
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, entity, envName, releaseFromUrl]);
+
+  const hasChanges = useMemo(
+    () => JSON.stringify(overrides) !== JSON.stringify(initialOverrides),
+    [overrides, initialOverrides],
+  );
+
+  const hasFields =
+    !!schema?.properties && Object.keys(schema.properties).length > 0;
+
+  const persist = useCallback(
+    async (next: Record<string, unknown>) => {
+      if (!effectiveRelease) {
+        throw new Error(
+          'No release available to bind. Save project parameters first to cut a release.',
+        );
+      }
+      const envRef = envInfo?.resourceName ?? envName;
+      await client.updateProjectReleaseBinding(entity, envRef, {
+        projectRelease: effectiveRelease,
+        environmentConfigs: next,
+      });
+    },
+    [client, effectiveRelease, entity, envInfo?.resourceName, envName],
+  );
+
+  const handlePrimary = useCallback(async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await persist(overrides);
+      notification.showSuccess(
+        isDeployMode
+          ? `Deployed ${effectiveRelease} to ${envDisplayName}.`
+          : `Saved overrides for ${envDisplayName}.`,
+      );
+      onSaved();
+    } catch (err: unknown) {
+      setSaveError(getErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    effectiveRelease,
+    envDisplayName,
+    isDeployMode,
+    notification,
+    onSaved,
+    overrides,
+    persist,
+  ]);
+
+  const handleClear = useCallback(async () => {
+    setClearing(true);
+    setSaveError(null);
+    try {
+      await persist({});
+      notification.showSuccess(`Cleared overrides for ${envDisplayName}.`);
+      onSaved();
+    } catch (err: unknown) {
+      setSaveError(getErrorMessage(err));
+    } finally {
+      setClearing(false);
+    }
+  }, [envDisplayName, notification, onSaved, persist]);
+
+  const permDenied = !permLoading && !canUpdate;
+  const canPrimary = isDeployMode ? Boolean(effectiveRelease) : hasBinding;
+  const primaryDisabled =
+    saving ||
+    clearing ||
+    permLoading ||
+    !canUpdate ||
+    !canPrimary ||
+    (!isDeployMode && !hasChanges);
+  let primaryLabel: string;
+  if (isDeployMode) {
+    primaryLabel = saving ? 'Deploying' : 'Deploy';
+  } else {
+    primaryLabel = saving ? 'Saving' : 'Save Overrides';
+  }
+
+  const headerActions = !loading && !loadError && (
+    <Box className={classes.actionsRow}>
+      {!isDeployMode && (
+        <Button
+          onClick={handleClear}
+          disabled={
+            saving ||
+            clearing ||
+            permLoading ||
+            !canUpdate ||
+            !hasActualOverrides ||
+            !hasBinding
+          }
+        >
+          {clearing ? 'Clearing' : 'Clear Overrides'}
+        </Button>
+      )}
+      <Tooltip
+        title={permDenied ? updateDeniedTooltip : ''}
+        disableHoverListener={!permDenied}
+      >
+        <span>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handlePrimary}
+            disabled={primaryDisabled}
+            startIcon={
+              saving ? (
+                <CircularProgress size={20} color="inherit" />
+              ) : undefined
+            }
+          >
+            {primaryLabel}
+          </Button>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+
+  const subtitle = isDeployMode
+    ? `Pin ${envDisplayName} to ${effectiveRelease} and set any ${envDisplayName}-specific overrides.`
+    : `Set ${envDisplayName}-specific values that override the ${projectTypeName} defaults for this binding only.`;
+
+  if (isForbiddenError(loadError)) {
+    return (
+      <ForbiddenState
+        message="You do not have permission to configure overrides for this environment."
+        minHeight="400px"
+      />
+    );
+  }
+
+  return (
+    <DetailPageLayout
+      title={`Configure Environment Overrides — ${envDisplayName}`}
+      subtitle={subtitle}
+      onBack={onBack}
+      actions={headerActions}
+    >
+      <NotificationBanner notification={notification.notification} />
+
+      {loading && (
+        <Box className={classes.loadingContainer}>
+          <Skeleton variant="rect" width="100%" height={64} />
+          <Skeleton variant="rect" width="100%" height={120} />
+        </Box>
+      )}
+
+      {loadError && !loading && (
+        <Box mb={2}>
+          <Alert severity="error">
+            Failed to load overrides: {getErrorMessage(loadError)}
+          </Alert>
+        </Box>
+      )}
+
+      {!loading && !loadError && !isDeployMode && !hasBinding && (
+        <Box mb={2}>
+          <Alert severity="info">
+            No binding exists for {envDisplayName} yet. Deploy this project to{' '}
+            {envDisplayName} before configuring overrides.
+          </Alert>
+        </Box>
+      )}
+
+      {saveError && !loading && (
+        <Box mb={2}>
+          <Alert severity="error" onClose={() => setSaveError(null)}>
+            {saveError}
+          </Alert>
+        </Box>
+      )}
+
+      {!loading && !loadError && (isDeployMode || hasBinding) && (
+        <Box className={classes.formCard}>
+          {hasFields ? (
+            <>
+              <Typography className={classes.formHint}>
+                Only fields you fill in here are persisted as overrides on this
+                binding. Empty fields inherit from the project&apos;s own
+                parameters.
+              </Typography>
+              <RjsfForm
+                schema={schema as any}
+                uiSchema={{}}
+                formData={overrides}
+                onChange={data => {
+                  const next = (data.formData ?? {}) as Record<string, unknown>;
+                  setOverrides(next);
+                  // RJSF normalizes formData on first render (e.g. injects
+                  // schema defaults). Treat that normalized snapshot as the
+                  // baseline so the user's actual edits surface as changes;
+                  // without this, hasChanges flips true on mount.
+                  if (!formInitializedRef.current) {
+                    setInitialOverrides(next);
+                    formInitializedRef.current = true;
+                  }
+                }}
+                tagName="div"
+              />
+            </>
+          ) : (
+            <Typography className={classes.emptyState}>
+              {projectTypeName} declares no environment-configs schema, so
+              per-env overrides are not applicable for this release.
+            </Typography>
+          )}
+        </Box>
+      )}
+    </DetailPageLayout>
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentOverridesWrapper.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentOverridesWrapper.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ProjectEnvironmentOverridesWrapper } from './ProjectEnvironmentOverridesWrapper';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+// Stub the page so we can read the props the wrapper computes from the route.
+jest.mock('./ProjectEnvironmentOverridesPage', () => ({
+  ProjectEnvironmentOverridesPage: ({
+    envName,
+    releaseFromUrl,
+    onBack,
+  }: any) => (
+    <div>
+      <span data-testid="envName">{envName}</span>
+      <span data-testid="release">{releaseFromUrl ?? '(none)'}</span>
+      <button onClick={onBack}>back</button>
+    </div>
+  ),
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/overrides/:envName"
+          element={<ProjectEnvironmentOverridesWrapper />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProjectEnvironmentOverridesWrapper', () => {
+  it('passes releaseFromUrl in deploy mode', () => {
+    renderAt('/overrides/development?action=deploy&release=rel-2');
+    expect(screen.getByTestId('envName').textContent).toBe('development');
+    expect(screen.getByTestId('release').textContent).toBe('rel-2');
+  });
+
+  it('omits releaseFromUrl when action is not deploy', () => {
+    renderAt('/overrides/development?release=rel-2');
+    expect(screen.getByTestId('release').textContent).toBe('(none)');
+  });
+
+  it('navigates back up two segments on Back', () => {
+    renderAt('/overrides/development?action=deploy&release=rel-2');
+    fireEvent.click(screen.getByText('back'));
+    expect(mockNavigate).toHaveBeenCalledWith('../..', { relative: 'path' });
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentOverridesWrapper.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentOverridesWrapper.tsx
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { Box, Typography } from '@material-ui/core';
+import { ProjectEnvironmentOverridesPage } from './ProjectEnvironmentOverridesPage';
+
+/**
+ * Routing wrapper for `ProjectEnvironmentOverridesPage`. Mounted at
+ * `/deploy/overrides/:envName` by the entity tab's router.
+ *
+ * Search params:
+ * - `release`: when present (and `action=deploy`), the wizard runs in
+ *   deploy mode and pins the binding to this release. Used by the wizard
+ *   chain that follows a project parameter edit.
+ * - `action`: `deploy` selects deploy mode; any other value runs the
+ *   default edit-existing-overrides mode.
+ */
+export const ProjectEnvironmentOverridesWrapper = () => {
+  const navigate = useNavigate();
+  const { envName } = useParams<{ envName: string }>();
+  const [searchParams] = useSearchParams();
+
+  // Path-relative so `..` strips a URL segment instead of climbing the
+  // parent route hierarchy.
+  const back = useCallback(
+    () => navigate('../..', { relative: 'path' }),
+    [navigate],
+  );
+
+  if (!envName) {
+    return (
+      <Box p={3}>
+        <Typography color="error">
+          Missing environment name in the route.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const action = searchParams.get('action');
+  const release = searchParams.get('release') ?? undefined;
+  const releaseFromUrl = action === 'deploy' ? release : undefined;
+
+  return (
+    <ProjectEnvironmentOverridesPage
+      envName={envName}
+      releaseFromUrl={releaseFromUrl}
+      onBack={back}
+      onSaved={back}
+    />
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironments.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironments.tsx
@@ -1,0 +1,26 @@
+import { Routes, Route } from 'react-router-dom';
+import { ProjectEnvironmentsList } from './ProjectEnvironmentsList';
+import { ProjectParametersConfigWrapper } from './ProjectParametersConfigWrapper';
+import { ProjectEnvironmentOverridesWrapper } from './ProjectEnvironmentOverridesWrapper';
+
+/**
+ * Router for the Project entity's `/deploy` tab.
+ *
+ * Sub-routes:
+ * - `/` — deploy view (pipeline DAG + detail panel)
+ * - `/parameters-config` — Configure Project wizard
+ * - `/overrides/:envName` — per-env override wizard
+ */
+export const ProjectEnvironments = () => (
+  <Routes>
+    <Route path="/" element={<ProjectEnvironmentsList />} />
+    <Route
+      path="/parameters-config"
+      element={<ProjectParametersConfigWrapper />}
+    />
+    <Route
+      path="/overrides/:envName"
+      element={<ProjectEnvironmentOverridesWrapper />}
+    />
+  </Routes>
+);

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsContext.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsContext.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+
+export type ActionKind = 'promote';
+
+export interface ProjectEnvironmentsContextValue {
+  environments: ProjectEnvironment[];
+  loading: boolean;
+  refetch: () => void | Promise<void>;
+
+  selectedEnvName: string | null;
+  setSelectedEnvName: (name: string | null) => void;
+
+  pendingAction: { env: string; kind: ActionKind } | null;
+
+  /**
+   * Copy the source env's pinned ProjectRelease forward to the target
+   * env's binding (the promote flow). `environment` is the target env's
+   * K8s resource name; `releaseName` is the release to pin.
+   */
+  onPromote: (environment: string, releaseName: string) => void | Promise<void>;
+}
+
+const ProjectEnvironmentsContext =
+  createContext<ProjectEnvironmentsContextValue | null>(null);
+
+interface ProviderProps {
+  value: ProjectEnvironmentsContextValue;
+  children: ReactNode;
+}
+
+export const ProjectEnvironmentsProvider = ({
+  value,
+  children,
+}: ProviderProps) => (
+  <ProjectEnvironmentsContext.Provider value={value}>
+    {children}
+  </ProjectEnvironmentsContext.Provider>
+);
+
+export function useProjectEnvironmentsContext(): ProjectEnvironmentsContextValue {
+  const ctx = useContext(ProjectEnvironmentsContext);
+  if (!ctx) {
+    throw new Error(
+      'useProjectEnvironmentsContext must be called inside <ProjectEnvironmentsProvider>',
+    );
+  }
+  return ctx;
+}

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsList.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsList.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ProjectEnvironmentsList } from './ProjectEnvironmentsList';
+
+const mockClient = {
+  fetchProjectEnvironmentInfo: jest.fn(),
+  updateProjectReleaseBinding: jest.fn(),
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: () => mockClient,
+  createApiRef: (def: { id: string }) => ({ id: def?.id ?? 'ref' }),
+  discoveryApiRef: { id: 'discovery' },
+  fetchApiRef: { id: 'fetch' },
+}));
+
+const entity = {
+  kind: 'System',
+  metadata: { name: 'my-app', annotations: {} },
+};
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({ entity }),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@backstage/core-components', () => ({
+  Progress: () => <div data-testid="progress">loading</div>,
+}));
+
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  ForbiddenState: ({ message }: any) => (
+    <div data-testid="forbidden">{message}</div>
+  ),
+}));
+
+jest.mock('../../utils/errorUtils', () => ({
+  isForbiddenError: (e: any) => e?.__forbidden === true,
+  getErrorMessage: (e: any) => String(e?.message ?? e),
+}));
+
+jest.mock('../../hooks', () => ({
+  useNotification: () => ({
+    notification: null,
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+  }),
+}));
+
+jest.mock('../Environments/components', () => ({
+  NotificationBanner: () => null,
+}));
+
+jest.mock('../Environments/hooks', () => ({
+  useEnvironmentPolling: () => {},
+}));
+
+// Canvas stub consumes the context so we can drive selection + promote
+// without rendering the real dagre/zoom layer.
+jest.mock('./ProjectDeployFlowCanvas', () => ({
+  ProjectDeployFlowCanvas: ({
+    onSelectEnv,
+    onSelectSetup,
+    environments,
+  }: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const {
+      useProjectEnvironmentsContext,
+    } = require('./ProjectEnvironmentsContext');
+    const { onPromote } = useProjectEnvironmentsContext();
+    return (
+      <div data-testid="canvas">
+        {environments.map((e: any) => (
+          <button key={e.name} onClick={() => onSelectEnv(e.name)}>
+            select-{e.name}
+          </button>
+        ))}
+        <button onClick={onSelectSetup}>select-setup</button>
+        <button onClick={() => onPromote('staging', 'rel-x')}>promote</button>
+      </div>
+    );
+  },
+}));
+
+jest.mock('./ProjectEnvironmentDetailPanel', () => ({
+  ProjectEnvironmentDetailPanel: ({ env }: any) => (
+    <div data-testid="detail">{env ? env.name : 'none'}</div>
+  ),
+}));
+
+jest.mock('./ProjectSetupDetailPane', () => ({
+  ProjectSetupDetailPane: ({ onConfigureDeploy }: any) => (
+    <button onClick={onConfigureDeploy}>configure-deploy</button>
+  ),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockClient.updateProjectReleaseBinding.mockResolvedValue({ ok: true });
+});
+
+describe('ProjectEnvironmentsList', () => {
+  it('renders the canvas + empty detail panel after a successful load', async () => {
+    mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([
+      { name: 'dev' },
+      { name: 'staging' },
+    ]);
+
+    render(<ProjectEnvironmentsList />);
+
+    expect(await screen.findByTestId('canvas')).toBeInTheDocument();
+    expect(screen.getByTestId('detail').textContent).toBe('none');
+  });
+
+  it('selects an environment and shows it in the detail panel', async () => {
+    mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([{ name: 'dev' }]);
+    render(<ProjectEnvironmentsList />);
+
+    fireEvent.click(await screen.findByText('select-dev'));
+    expect(screen.getByTestId('detail').textContent).toBe('dev');
+  });
+
+  it('navigates to the parameters wizard from the setup pane', async () => {
+    mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([{ name: 'dev' }]);
+    render(<ProjectEnvironmentsList />);
+
+    fireEvent.click(await screen.findByText('select-setup'));
+    fireEvent.click(screen.getByText('configure-deploy'));
+    expect(mockNavigate).toHaveBeenCalledWith('parameters-config');
+  });
+
+  it('promotes through the context handler', async () => {
+    mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([{ name: 'dev' }]);
+    render(<ProjectEnvironmentsList />);
+
+    fireEvent.click(await screen.findByText('promote'));
+    await waitFor(() =>
+      expect(mockClient.updateProjectReleaseBinding).toHaveBeenCalledWith(
+        entity,
+        'staging',
+        { projectRelease: 'rel-x' },
+      ),
+    );
+  });
+
+  it('shows an empty-state when the pipeline has no environments', async () => {
+    mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([]);
+    render(<ProjectEnvironmentsList />);
+    expect(
+      await screen.findByText(/no environments configured/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an error message when the load fails', async () => {
+    mockClient.fetchProjectEnvironmentInfo.mockRejectedValue(new Error('boom'));
+    render(<ProjectEnvironmentsList />);
+    expect(
+      await screen.findByText(/failed to load environments/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the ForbiddenState on a forbidden load', async () => {
+    mockClient.fetchProjectEnvironmentInfo.mockRejectedValue(
+      Object.assign(new Error('forbidden'), { __forbidden: true }),
+    );
+    render(<ProjectEnvironmentsList />);
+    expect(await screen.findByTestId('forbidden')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsList.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsList.tsx
@@ -1,0 +1,234 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Typography, makeStyles } from '@material-ui/core';
+import { useNavigate } from 'react-router-dom';
+import { Progress } from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { ForbiddenState } from '@openchoreo/backstage-plugin-react';
+import {
+  openChoreoClientApiRef,
+  type ProjectEnvironment,
+} from '../../api/OpenChoreoClientApi';
+import { isForbiddenError, getErrorMessage } from '../../utils/errorUtils';
+import { useNotification } from '../../hooks';
+import { NotificationBanner } from '../Environments/components';
+import { useEnvironmentPolling } from '../Environments/hooks';
+import { ProjectDeployFlowCanvas } from './ProjectDeployFlowCanvas';
+import { ProjectEnvironmentDetailPanel } from './ProjectEnvironmentDetailPanel';
+import { ProjectSetupDetailPane } from './ProjectSetupDetailPane';
+import {
+  ProjectEnvironmentsProvider,
+  type ActionKind,
+} from './ProjectEnvironmentsContext';
+import { useProjectDeployFlowCanvasStyles } from './styles';
+
+const useStyles = makeStyles(theme => ({
+  error: {
+    color: theme.palette.error.main,
+  },
+  empty: {
+    color: theme.palette.text.secondary,
+    fontStyle: 'italic',
+  },
+}));
+
+/**
+ * Deploy view mounted at the `/` sub-route of the Project entity's
+ * `/deploy` tab. Renders the pipeline DAG with the Set up tile + env
+ * tiles on the left and the selected tile's detail panel on the right.
+ * The `parameters-config` sub-route hosts the Step 1 wizard reachable
+ * from the Set up detail pane's Configure & Deploy button.
+ */
+export const ProjectEnvironmentsList = () => {
+  const classes = useStyles();
+  const canvasClasses = useProjectDeployFlowCanvasStyles();
+  const { entity } = useEntity();
+  const client = useApi(openChoreoClientApiRef);
+  const notification = useNotification();
+  const navigate = useNavigate();
+
+  const [envs, setEnvs] = useState<ProjectEnvironment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [pendingAction, setPendingAction] = useState<{
+    env: string;
+    kind: ActionKind;
+  } | null>(null);
+  const [selectedEnvName, setSelectedEnvNameState] = useState<string | null>(
+    null,
+  );
+  const [selectedSetup, setSelectedSetup] = useState(false);
+  const cancelledRef = useRef(false);
+
+  // Selecting an env clears the Setup selection and vice versa — the
+  // right pane shows at most one of them.
+  const setSelectedEnvName = useCallback((name: string | null) => {
+    setSelectedEnvNameState(name);
+    if (name !== null) setSelectedSetup(false);
+  }, []);
+
+  const handleSelectSetup = useCallback(() => {
+    setSelectedSetup(true);
+    setSelectedEnvNameState(null);
+  }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedSetup(false);
+    setSelectedEnvNameState(null);
+  }, []);
+
+  const handleConfigureDeploy = useCallback(() => {
+    navigate('parameters-config');
+  }, [navigate]);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  const fetchEnvs = useCallback(
+    async (opts: { showProgress?: boolean } = {}) => {
+      if (opts.showProgress) setLoading(true);
+      try {
+        const res = await client.fetchProjectEnvironmentInfo(entity);
+        if (cancelledRef.current) return;
+        setEnvs(res ?? []);
+        setError(null);
+      } catch (err: unknown) {
+        if (cancelledRef.current) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!cancelledRef.current && opts.showProgress) setLoading(false);
+      }
+    },
+    [client, entity],
+  );
+
+  useEffect(() => {
+    fetchEnvs({ showProgress: true });
+  }, [fetchEnvs]);
+
+  // Keep the current selection valid across refreshes. The detail panel
+  // starts empty so the user picks a tile explicitly, and clicking empty
+  // canvas space deselects. If the previously selected env disappears
+  // between refreshes (e.g. the project's deployment pipeline changed),
+  // clear the stale reference.
+  useEffect(() => {
+    if (!selectedEnvName) return;
+    const stillPresent = envs.some(e => e.name === selectedEnvName);
+    if (!stillPresent) {
+      setSelectedEnvNameState(null);
+    }
+  }, [envs, selectedEnvName]);
+
+  // Background poll while any binding is mid-rollout. Pin advances kick the
+  // controller into a Progressing state that flips back to Ready once the
+  // underlying RenderedRelease is reconciled.
+  const isAnyPending = envs.some(e => e.status === 'NotReady');
+  useEnvironmentPolling(isAnyPending, fetchEnvs);
+
+  const handlePromote = useCallback(
+    async (environment: string, releaseName: string) => {
+      setPendingAction({ env: environment, kind: 'promote' });
+      try {
+        await client.updateProjectReleaseBinding(entity, environment, {
+          projectRelease: releaseName,
+        });
+        if (cancelledRef.current) return;
+        notification.showSuccess(`Promoted ${environment} to ${releaseName}`);
+        await fetchEnvs();
+      } catch (err: unknown) {
+        if (cancelledRef.current) return;
+        notification.showError(
+          `Failed to promote ${environment}: ${getErrorMessage(err)}`,
+        );
+      } finally {
+        if (!cancelledRef.current) setPendingAction(null);
+      }
+    },
+    [client, entity, notification, fetchEnvs],
+  );
+
+  const selectedEnv = envs.find(e => e.name === selectedEnvName) ?? null;
+
+  const contextValue = useMemo(
+    () => ({
+      environments: envs,
+      loading,
+      refetch: fetchEnvs,
+      selectedEnvName,
+      setSelectedEnvName,
+      pendingAction,
+      onPromote: handlePromote,
+    }),
+    [
+      envs,
+      loading,
+      fetchEnvs,
+      selectedEnvName,
+      setSelectedEnvName,
+      pendingAction,
+      handlePromote,
+    ],
+  );
+
+  if (isForbiddenError(error)) {
+    return (
+      <ForbiddenState
+        message="You do not have permission to view environments for this project."
+        minHeight="400px"
+      />
+    );
+  }
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return (
+      <Typography variant="body1" className={classes.error}>
+        Failed to load environments: {getErrorMessage(error)}
+      </Typography>
+    );
+  }
+
+  if (envs.length === 0) {
+    return (
+      <Typography variant="body1" className={classes.empty}>
+        No environments configured in the project's deployment pipeline.
+      </Typography>
+    );
+  }
+
+  return (
+    <ProjectEnvironmentsProvider value={contextValue}>
+      <NotificationBanner notification={notification.notification} />
+      <Box className={canvasClasses.splitContainer}>
+        <ProjectDeployFlowCanvas
+          environments={envs}
+          selectedEnvName={selectedEnvName}
+          selectedSetup={selectedSetup}
+          onSelectEnv={setSelectedEnvName}
+          onSelectSetup={handleSelectSetup}
+          onClearSelection={handleClearSelection}
+        />
+        <Box className={canvasClasses.detailPanelFrame}>
+          {selectedSetup ? (
+            <ProjectSetupDetailPane
+              onConfigureDeploy={handleConfigureDeploy}
+              onClose={handleClearSelection}
+            />
+          ) : (
+            <ProjectEnvironmentDetailPanel
+              env={selectedEnv}
+              onClose={() => setSelectedEnvName(null)}
+            />
+          )}
+        </Box>
+      </Box>
+    </ProjectEnvironmentsProvider>
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectMiniEnvironmentNode.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectMiniEnvironmentNode.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProjectMiniEnvironmentNode } from './ProjectMiniEnvironmentNode';
+import {
+  ProjectEnvironmentsProvider,
+  type ProjectEnvironmentsContextValue,
+} from './ProjectEnvironmentsContext';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  StatusBadge: ({ status }: any) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
+}));
+
+const mockUpdatePerm = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  formatRelativeTime: () => 'just now',
+  useProjectUpdatePermission: () => mockUpdatePerm(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdatePerm.mockReturnValue({
+    canUpdate: true,
+    loading: false,
+    updateDeniedTooltip: '',
+  });
+});
+
+function bound(): ProjectEnvironment {
+  return {
+    name: 'dev',
+    resourceName: 'development',
+    bindingName: 'my-app-development',
+    projectRelease: 'my-app-abc',
+    status: 'Ready',
+    latestRelease: 'my-app-abc',
+    lastDeployed: '2026-01-01T00:00:00Z',
+  };
+}
+
+function makeCtx(
+  overrides: Partial<ProjectEnvironmentsContextValue> = {},
+): ProjectEnvironmentsContextValue {
+  return {
+    environments: [],
+    loading: false,
+    refetch: jest.fn(),
+    selectedEnvName: null,
+    setSelectedEnvName: jest.fn(),
+    pendingAction: null,
+    onPromote: jest.fn(),
+    ...overrides,
+  };
+}
+
+function renderTile(
+  env: ProjectEnvironment,
+  selected = false,
+  onSelect: () => void = () => {},
+  ctxOverrides: Partial<ProjectEnvironmentsContextValue> = {},
+) {
+  return render(
+    <MemoryRouter>
+      <ProjectEnvironmentsProvider value={makeCtx(ctxOverrides)}>
+        <ProjectMiniEnvironmentNode
+          env={env}
+          selected={selected}
+          onSelect={onSelect}
+        />
+      </ProjectEnvironmentsProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProjectMiniEnvironmentNode', () => {
+  it('renders env name + active badge + deployed timestamp for a bound env', () => {
+    renderTile(bound());
+
+    expect(screen.getByText('dev')).toBeInTheDocument();
+    expect(screen.getByTestId('status-badge').textContent).toBe('active');
+    expect(screen.getByText(/deployed/i)).toBeInTheDocument();
+    expect(screen.getByText('just now')).toBeInTheDocument();
+  });
+
+  it('shows the not-deployed badge and omits timestamp when no binding', () => {
+    renderTile({ name: 'staging' });
+    expect(screen.getByTestId('status-badge').textContent).toBe('not-deployed');
+    expect(screen.queryByText(/deployed:/i)).toBeNull();
+  });
+
+  it('calls onSelect when the tile body is clicked and on Enter/Space', () => {
+    const onSelect = jest.fn();
+    renderTile(bound(), false, onSelect);
+    const tile = screen.getByRole('button', {
+      name: /select environment dev/i,
+    });
+    fireEvent.click(tile);
+    fireEvent.keyDown(tile, { key: 'Enter' });
+    fireEvent.keyDown(tile, { key: ' ' });
+    expect(onSelect).toHaveBeenCalledTimes(3);
+  });
+
+  it('marks itself aria-pressed when selected', () => {
+    renderTile(bound(), true);
+    expect(
+      screen.getByRole('button', { name: /select environment dev/i }),
+    ).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  describe('actions menu', () => {
+    it('opens the menu and invokes refetch from Refresh', () => {
+      const refetch = jest.fn();
+      const onSelect = jest.fn();
+      renderTile(bound(), false, onSelect, { refetch });
+
+      fireEvent.click(screen.getByRole('button', { name: /actions for dev/i }));
+      expect(
+        screen.getByRole('menuitem', { name: /refresh/i }),
+      ).toBeInTheDocument();
+      // Opening the menu must not select the tile.
+      expect(onSelect).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole('menuitem', { name: /refresh/i }));
+      expect(refetch).toHaveBeenCalled();
+    });
+
+    it('navigates to the overrides wizard from Configure overrides', () => {
+      renderTile(bound());
+      fireEvent.click(screen.getByRole('button', { name: /actions for dev/i }));
+      fireEvent.click(
+        screen.getByRole('menuitem', { name: /configure overrides/i }),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith('overrides/development');
+    });
+
+    it('disables Configure overrides when there is no binding', () => {
+      renderTile({ name: 'staging' });
+      fireEvent.click(
+        screen.getByRole('button', { name: /actions for staging/i }),
+      );
+      expect(
+        screen.getByRole('menuitem', { name: /configure overrides/i }),
+      ).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('inline promote action', () => {
+    const env: ProjectEnvironment = {
+      ...bound(),
+      promotionTargets: [{ name: 'Staging', resourceName: 'staging' }],
+    };
+    const stagingBehind: ProjectEnvironment = {
+      name: 'Staging',
+      resourceName: 'staging',
+      projectRelease: 'my-app-old',
+      status: 'NotReady',
+    };
+    const stagingInSync: ProjectEnvironment = {
+      name: 'Staging',
+      resourceName: 'staging',
+      projectRelease: 'my-app-abc',
+      status: 'Ready',
+    };
+
+    it('shows Promote when the next env is behind this env release', () => {
+      renderTile(env, false, () => {}, { environments: [env, stagingBehind] });
+      expect(
+        screen.getByRole('button', { name: /promote dev to staging/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows a disabled Promoted button when the next env is in sync', () => {
+      renderTile(env, false, () => {}, { environments: [env, stagingInSync] });
+      const button = screen.getByRole('button', { name: /^promoted$/i });
+      expect(button).toBeInTheDocument();
+      expect(button).toBeDisabled();
+    });
+
+    it('calls onPromote with the target resource name and this env release', () => {
+      const onPromote = jest.fn();
+      renderTile(env, false, () => {}, {
+        environments: [env, stagingBehind],
+        onPromote,
+      });
+      fireEvent.click(
+        screen.getByRole('button', { name: /promote dev to staging/i }),
+      );
+      expect(onPromote).toHaveBeenCalledWith('staging', 'my-app-abc');
+    });
+
+    it('disables Promote when the user lacks project-update permission', () => {
+      mockUpdatePerm.mockReturnValue({
+        canUpdate: false,
+        loading: false,
+        updateDeniedTooltip: 'nope',
+      });
+      renderTile(env, false, () => {}, { environments: [env, stagingBehind] });
+      expect(
+        screen.getByRole('button', { name: /promote dev to staging/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe('multi-target promote menu', () => {
+    const env: ProjectEnvironment = {
+      ...bound(),
+      promotionTargets: [
+        { name: 'Staging', resourceName: 'staging' },
+        { name: 'QA', resourceName: 'qa' },
+      ],
+    };
+    const others: ProjectEnvironment[] = [
+      { name: 'Staging', resourceName: 'staging', projectRelease: 'old' },
+      { name: 'QA', resourceName: 'qa', projectRelease: 'old' },
+    ];
+
+    it('opens a per-target menu and promotes the chosen target', () => {
+      const onPromote = jest.fn();
+      renderTile(env, false, () => {}, {
+        environments: [env, ...others],
+        onPromote,
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /^promote dev$/i }));
+      fireEvent.click(screen.getByRole('menuitem', { name: /promote to qa/i }));
+      expect(onPromote).toHaveBeenCalledWith('qa', 'my-app-abc');
+    });
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectMiniEnvironmentNode.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectMiniEnvironmentNode.tsx
@@ -1,0 +1,354 @@
+import {
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
+import {
+  Box,
+  Button,
+  Divider,
+  IconButton,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import CloudIcon from '@material-ui/icons/Cloud';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import SettingsOutlinedIcon from '@material-ui/icons/SettingsOutlined';
+import clsx from 'clsx';
+import { useNavigate } from 'react-router-dom';
+import { StatusBadge } from '@openchoreo/backstage-design-system';
+import {
+  formatRelativeTime,
+  useProjectUpdatePermission,
+} from '@openchoreo/backstage-plugin-react';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+import { useProjectMiniEnvironmentNodeStyles } from './styles';
+import { useProjectEnvironmentsContext } from './ProjectEnvironmentsContext';
+import { deriveProjectEnvBadgeStatus } from './badgeStatus';
+
+interface ProjectMiniEnvironmentNodeProps {
+  env: ProjectEnvironment;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+export const ProjectMiniEnvironmentNode = ({
+  env,
+  selected,
+  onSelect,
+}: ProjectMiniEnvironmentNodeProps) => {
+  const classes = useProjectMiniEnvironmentNodeStyles();
+  const navigate = useNavigate();
+  const { environments, pendingAction, refetch, onPromote } =
+    useProjectEnvironmentsContext();
+  const {
+    canUpdate,
+    loading: permLoading,
+    updateDeniedTooltip,
+  } = useProjectUpdatePermission();
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [promoteAnchor, setPromoteAnchor] = useState<HTMLElement | null>(null);
+
+  const hasBinding = Boolean(env.bindingName);
+  const hasRelease = Boolean(env.projectRelease);
+  const badgeStatus = deriveProjectEnvBadgeStatus(env);
+  const relativeDeployed = env.lastDeployed
+    ? formatRelativeTime(env.lastDeployed)
+    : null;
+
+  // Card Promote copies this env's release pin forward to the next env's
+  // binding. The pipeline-defined `promotionTargets` enforces ordering: the
+  // terminal env has no targets, so the button never appears there. There
+  // is no skip-the-pipeline "jump to latest" operation by design.
+  const promotionTargets = env.promotionTargets ?? [];
+  const hasPromotionTargets = promotionTargets.length > 0;
+  const eligibleTargets = hasRelease
+    ? promotionTargets.filter(t => {
+        const targetEnv = environments.find(e => e.name === t.name);
+        return targetEnv?.projectRelease !== env.projectRelease;
+      })
+    : [];
+  const isReady = env.status === 'Ready';
+  const isPromoting = promotionTargets.some(
+    t =>
+      pendingAction?.kind === 'promote' &&
+      pendingAction.env === (t.resourceName ?? t.name),
+  );
+  const showPromote =
+    hasBinding && hasRelease && isReady && hasPromotionTargets;
+  const allTargetsInSync = hasPromotionTargets && eligibleTargets.length === 0;
+  const promoteDisabledByPerm = permLoading || !canUpdate;
+  const promoteTooltip = !canUpdate && !permLoading ? updateDeniedTooltip : '';
+
+  // Promote needs the K8s-safe resource name (lowercase, RFC 1123).
+  // target.name carries the display name (e.g. "Production") which the
+  // BFF would otherwise stitch into a `metadata.name` like
+  // "my-app-Production" and get 422'd by the apiserver.
+  const handlePromoteSingle = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    const target = eligibleTargets[0];
+    if (!target || !env.projectRelease) return;
+    void onPromote(target.resourceName ?? target.name, env.projectRelease);
+  };
+
+  const openPromoteMenu = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setPromoteAnchor(e.currentTarget);
+  };
+  const closePromoteMenu = () => setPromoteAnchor(null);
+
+  const handlePromoteTo = (target: { name: string; resourceName?: string }) => {
+    closePromoteMenu();
+    if (!env.projectRelease) return;
+    void onPromote(target.resourceName ?? target.name, env.projectRelease);
+  };
+
+  const isTargetAlreadyPromoted = (targetName: string) => {
+    const targetEnv = environments.find(e => e.name === targetName);
+    return targetEnv?.projectRelease === env.projectRelease;
+  };
+
+  const isTargetInFlight = (targetName: string) =>
+    pendingAction?.kind === 'promote' && pendingAction.env === targetName;
+
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect();
+    }
+  };
+
+  const stopAndOpenMenu = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setMenuAnchor(e.currentTarget);
+  };
+
+  const closeMenu = () => setMenuAnchor(null);
+
+  const handleRefresh = () => {
+    closeMenu();
+    void refetch();
+  };
+
+  const handleConfigureOverrides = () => {
+    closeMenu();
+    navigate(`overrides/${encodeURIComponent(env.resourceName ?? env.name)}`);
+  };
+
+  let overridesTooltip = '';
+  if (!hasBinding) {
+    overridesTooltip = 'No binding in this environment yet.';
+  } else if (!canUpdate && !permLoading) {
+    overridesTooltip = updateDeniedTooltip;
+  }
+
+  const renderPromoteButton = () => {
+    if (allTargetsInSync) {
+      return (
+        <Button
+          size="small"
+          variant="contained"
+          disabled
+          className={classes.primaryButton}
+        >
+          Promoted
+        </Button>
+      );
+    }
+    const label = isPromoting ? 'Promoting...' : 'Promote';
+    if (promotionTargets.length === 1) {
+      return (
+        <Tooltip
+          title={promoteTooltip}
+          disableHoverListener={!promoteTooltip}
+          PopperProps={{ disablePortal: true }}
+        >
+          <span>
+            <Button
+              size="small"
+              variant="contained"
+              color="primary"
+              className={classes.primaryButton}
+              onClick={handlePromoteSingle}
+              disabled={isPromoting || promoteDisabledByPerm}
+              aria-label={`Promote ${env.name} to ${eligibleTargets[0]?.name}`}
+            >
+              {label}
+            </Button>
+          </span>
+        </Tooltip>
+      );
+    }
+    return (
+      <Tooltip
+        title={promoteTooltip}
+        disableHoverListener={!promoteTooltip}
+        PopperProps={{ disablePortal: true }}
+      >
+        <span>
+          <Button
+            size="small"
+            variant="contained"
+            color="primary"
+            className={classes.primaryButton}
+            endIcon={<ArrowDropDownIcon fontSize="small" />}
+            onClick={openPromoteMenu}
+            disabled={isPromoting || promoteDisabledByPerm}
+            aria-haspopup="true"
+            aria-label={`Promote ${env.name}`}
+          >
+            {label}
+          </Button>
+        </span>
+      </Tooltip>
+    );
+  };
+
+  return (
+    <Box
+      role="button"
+      tabIndex={0}
+      aria-pressed={selected}
+      aria-label={`Select environment ${env.name}`}
+      className={clsx(classes.card, selected && classes.cardSelected)}
+      onClick={onSelect}
+      onKeyDown={handleKeyDown}
+    >
+      <Box display="flex" height="100%" minWidth={0}>
+        <Box
+          aria-hidden
+          className={clsx(classes.statusStripe, {
+            [classes.statusStripeActive]: badgeStatus === 'active',
+            [classes.statusStripePending]: badgeStatus === 'pending',
+            [classes.statusStripeFailed]: badgeStatus === 'failed',
+            [classes.statusStripeIdle]:
+              badgeStatus !== 'active' &&
+              badgeStatus !== 'pending' &&
+              badgeStatus !== 'failed',
+          })}
+        />
+        <Box className={classes.body}>
+          <Box className={classes.topRow}>
+            <Box className={classes.nameWrap}>
+              <CloudIcon
+                aria-hidden
+                className={classes.kindIcon}
+                fontSize="small"
+              />
+              <Tooltip
+                title={env.name}
+                disableHoverListener={env.name.length < 20}
+                PopperProps={{ disablePortal: true }}
+              >
+                <Typography className={classes.envName}>{env.name}</Typography>
+              </Tooltip>
+            </Box>
+            <Tooltip title="More actions" PopperProps={{ disablePortal: true }}>
+              <IconButton
+                size="small"
+                className={classes.menuButton}
+                onClick={stopAndOpenMenu}
+                aria-label={`Actions for ${env.name}`}
+              >
+                <MoreVertIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+
+          <Box className={classes.metaRow}>
+            <span className={classes.meta}>STATUS:</span>
+            <StatusBadge status={badgeStatus} />
+          </Box>
+
+          {relativeDeployed && (
+            <Box className={classes.metaRow}>
+              <span className={classes.meta}>DEPLOYED:</span>
+              <Typography className={classes.timeText} variant="caption">
+                {relativeDeployed}
+              </Typography>
+            </Box>
+          )}
+
+          {showPromote && (
+            <Box className={classes.actionRow}>{renderPromoteButton()}</Box>
+          )}
+        </Box>
+      </Box>
+
+      <Menu
+        anchorEl={menuAnchor}
+        keepMounted
+        open={Boolean(menuAnchor)}
+        onClose={closeMenu}
+        getContentAnchorEl={null}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        onClick={e => e.stopPropagation()}
+      >
+        <MenuItem onClick={handleRefresh}>
+          <RefreshIcon fontSize="small" style={{ marginRight: 8 }} />
+          Refresh
+        </MenuItem>
+        <Divider />
+        <Tooltip
+          title={overridesTooltip}
+          placement="left"
+          PopperProps={{ disablePortal: true }}
+        >
+          <span>
+            <MenuItem
+              onClick={handleConfigureOverrides}
+              disabled={!hasBinding || permLoading || !canUpdate}
+            >
+              <SettingsOutlinedIcon
+                fontSize="small"
+                style={{ marginRight: 8 }}
+              />
+              Configure overrides
+            </MenuItem>
+          </span>
+        </Tooltip>
+      </Menu>
+
+      {/* Per-target promote menu, only mounted when the env has more than
+          one promotion target (parallel branches). Single-target case uses
+          the direct button above. */}
+      <Menu
+        anchorEl={promoteAnchor}
+        keepMounted
+        open={Boolean(promoteAnchor)}
+        onClose={closePromoteMenu}
+        getContentAnchorEl={null}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        onClick={e => e.stopPropagation()}
+      >
+        {promotionTargets.map(target => {
+          const promoted = isTargetAlreadyPromoted(target.name);
+          const inFlight = isTargetInFlight(target.resourceName ?? target.name);
+          let itemLabel: string;
+          if (promoted) {
+            itemLabel = `Promoted to ${target.name}`;
+          } else if (inFlight) {
+            itemLabel = `Promoting to ${target.name}...`;
+          } else {
+            itemLabel = `Promote to ${target.name}`;
+          }
+          return (
+            <MenuItem
+              key={target.name}
+              disabled={promoted || inFlight || promoteDisabledByPerm}
+              onClick={() => handlePromoteTo(target)}
+            >
+              {itemLabel}
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    </Box>
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectParametersConfigPage.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectParametersConfigPage.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ProjectParametersConfigPage } from './ProjectParametersConfigPage';
+
+const mockClient = {
+  getResourceDefinition: jest.fn(),
+  fetchProjectEnvironmentInfo: jest.fn(),
+  updateResourceDefinition: jest.fn(),
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: () => mockClient,
+  createApiRef: (def: { id: string }) => ({ id: def?.id ?? 'ref' }),
+  discoveryApiRef: { id: 'discovery' },
+  fetchApiRef: { id: 'fetch' },
+}));
+
+const entity = {
+  kind: 'System',
+  metadata: {
+    name: 'my-app',
+    annotations: {
+      'openchoreo.io/namespace': 'test-ns',
+      'openchoreo.io/project-type': 'web-application',
+      'openchoreo.io/project-type-kind': 'ClusterProjectType',
+    },
+  },
+};
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  useEntity: () => ({ entity }),
+}));
+
+const mockUpdatePerm = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useProjectUpdatePermission: () => mockUpdatePerm(),
+  DetailPageLayout: ({ title, subtitle, actions, children, onBack }: any) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      <button onClick={onBack}>back</button>
+      <div>{actions}</div>
+      <div>{children}</div>
+    </div>
+  ),
+  ForbiddenState: ({ message }: any) => (
+    <div data-testid="forbidden">{message}</div>
+  ),
+}));
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  RjsfForm: ({ onChange }: any) => (
+    <button
+      data-testid="rjsf-change"
+      onClick={() => onChange({ formData: { appName: 'changed' } })}
+    >
+      change
+    </button>
+  ),
+}));
+
+jest.mock('../../utils/errorUtils', () => ({
+  isForbiddenError: (e: any) => e?.__forbidden === true,
+  getErrorMessage: (e: any) => String(e?.message ?? e),
+}));
+
+const PT_DEF = {
+  spec: {
+    parameters: {
+      openAPIV3Schema: {
+        type: 'object',
+        properties: { appName: { type: 'string' } },
+      },
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdatePerm.mockReturnValue({
+    canUpdate: true,
+    loading: false,
+    updateDeniedTooltip: '',
+  });
+  mockClient.getResourceDefinition.mockImplementation((kind: string) => {
+    if (kind === 'clusterprojecttypes' || kind === 'projecttypes') {
+      return Promise.resolve(PT_DEF);
+    }
+    // 'projects'
+    return Promise.resolve({
+      metadata: { name: 'my-app' },
+      spec: { parameters: { appName: 'original' } },
+    });
+  });
+  mockClient.fetchProjectEnvironmentInfo.mockResolvedValue([
+    { name: 'dev', resourceName: 'development', latestRelease: 'rel-1' },
+  ]);
+  mockClient.updateResourceDefinition.mockResolvedValue({ success: true });
+});
+
+describe('ProjectParametersConfigPage', () => {
+  it('loads the ProjectType schema + project params and renders the form', async () => {
+    render(
+      <ProjectParametersConfigPage onBack={jest.fn()} onContinue={jest.fn()} />,
+    );
+
+    expect(await screen.findByRole('button', { name: /next/i })).toBeEnabled();
+    expect(screen.getByText('Configure Project')).toBeInTheDocument();
+    expect(
+      screen.getByText(/fill in the parameters defined by web-application/i),
+    ).toBeInTheDocument();
+    // Cluster project types are read via the cluster-scoped endpoint.
+    expect(mockClient.getResourceDefinition).toHaveBeenCalledWith(
+      'clusterprojecttypes',
+      'test-ns',
+      'web-application',
+    );
+  });
+
+  it('skips the PUT and reuses the baseline release when params are unchanged', async () => {
+    const onContinue = jest.fn();
+    render(
+      <ProjectParametersConfigPage
+        onBack={jest.fn()}
+        onContinue={onContinue}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /next/i }));
+
+    await waitFor(() =>
+      expect(onContinue).toHaveBeenCalledWith('development', 'rel-1'),
+    );
+    expect(mockClient.updateResourceDefinition).not.toHaveBeenCalled();
+  });
+
+  it('PUTs changed params, waits for the new release, then continues', async () => {
+    const onContinue = jest.fn();
+    // Load returns rel-1; the post-save poll returns rel-2.
+    mockClient.fetchProjectEnvironmentInfo
+      .mockResolvedValueOnce([
+        { name: 'dev', resourceName: 'development', latestRelease: 'rel-1' },
+      ])
+      .mockResolvedValue([
+        { name: 'dev', resourceName: 'development', latestRelease: 'rel-2' },
+      ]);
+
+    render(
+      <ProjectParametersConfigPage
+        onBack={jest.fn()}
+        onContinue={onContinue}
+      />,
+    );
+
+    // Edit a parameter so hasChanges flips true.
+    fireEvent.click(await screen.findByTestId('rjsf-change'));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() =>
+      expect(mockClient.updateResourceDefinition).toHaveBeenCalledWith(
+        'projects',
+        'test-ns',
+        'my-app',
+        expect.objectContaining({
+          spec: expect.objectContaining({
+            parameters: { appName: 'changed' },
+          }),
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(onContinue).toHaveBeenCalledWith('development', 'rel-2'),
+    );
+  });
+
+  it('shows the empty-state when the type declares no parameters', async () => {
+    mockClient.getResourceDefinition.mockImplementation((kind: string) => {
+      if (kind === 'clusterprojecttypes' || kind === 'projecttypes') {
+        return Promise.resolve({ spec: {} });
+      }
+      return Promise.resolve({ spec: { parameters: {} } });
+    });
+
+    render(
+      <ProjectParametersConfigPage onBack={jest.fn()} onContinue={jest.fn()} />,
+    );
+
+    expect(
+      await screen.findByText(
+        /web-application has no configurable parameters/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the ForbiddenState when the load is forbidden', async () => {
+    const forbidden = Object.assign(new Error('forbidden'), {
+      __forbidden: true,
+    });
+    mockClient.getResourceDefinition.mockRejectedValue(forbidden);
+
+    render(
+      <ProjectParametersConfigPage onBack={jest.fn()} onContinue={jest.fn()} />,
+    );
+
+    expect(await screen.findByTestId('forbidden')).toBeInTheDocument();
+  });
+
+  it('disables Next when the user lacks project-update permission', async () => {
+    mockUpdatePerm.mockReturnValue({
+      canUpdate: false,
+      loading: false,
+      updateDeniedTooltip: 'nope',
+    });
+
+    render(
+      <ProjectParametersConfigPage onBack={jest.fn()} onContinue={jest.fn()} />,
+    );
+
+    expect(await screen.findByRole('button', { name: /next/i })).toBeDisabled();
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectParametersConfigPage.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectParametersConfigPage.tsx
@@ -1,0 +1,433 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Tooltip,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+import { Alert, Skeleton } from '@material-ui/lab';
+import type { JSONSchema7 } from 'json-schema';
+import { useApi } from '@backstage/core-plugin-api';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import {
+  DetailPageLayout,
+  ForbiddenState,
+  useProjectUpdatePermission,
+} from '@openchoreo/backstage-plugin-react';
+import { RjsfForm } from '@openchoreo/backstage-design-system';
+import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
+import { isForbiddenError, getErrorMessage } from '../../utils/errorUtils';
+import { useNotification } from '../../hooks';
+import { NotificationBanner } from '../Environments/components';
+
+const useStyles = makeStyles(theme => ({
+  loadingContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    padding: theme.spacing(4),
+  },
+  formCard: {
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: 12,
+    padding: theme.spacing(3),
+  },
+  formHint: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.body2.fontSize,
+    marginBottom: theme.spacing(2),
+  },
+  emptyState: {
+    color: theme.palette.text.secondary,
+    fontStyle: 'italic',
+    padding: theme.spacing(4),
+    textAlign: 'center',
+  },
+}));
+
+export interface ProjectParametersConfigPageProps {
+  onBack: () => void;
+  /**
+   * Called after the Project is saved AND a new ProjectRelease name is
+   * known (or the existing release if the user made no changes). Receives
+   * the first env's K8s ref and the release to pin.
+   */
+  onContinue: (firstEnvRef: string, releaseName: string) => void;
+}
+
+const POLL_INTERVAL_MS = 1_000;
+const POLL_TIMEOUT_MS = 30_000;
+
+/**
+ * Edits `Project.spec.parameters` against the per-type RJSF schema fetched
+ * from the (Cluster)ProjectType the Project references.
+ *
+ * Saving PUTs the Project and (when parameters changed) polls
+ * `fetchProjectEnvironmentInfo` until the controller-cut release name
+ * differs from the pre-save baseline, then hands the new release + first
+ * env to the parent so the overrides wizard can pin them.
+ */
+export const ProjectParametersConfigPage = ({
+  onBack,
+  onContinue,
+}: ProjectParametersConfigPageProps) => {
+  const classes = useStyles();
+  const { entity } = useEntity();
+  const client = useApi(openChoreoClientApiRef);
+  const notification = useNotification();
+  const {
+    canUpdate,
+    loading: permLoading,
+    updateDeniedTooltip,
+  } = useProjectUpdatePermission();
+  const cancelledRef = useRef(false);
+
+  const [project, setProject] = useState<Record<string, unknown> | null>(null);
+  const [schema, setSchema] = useState<JSONSchema7 | null>(null);
+  const [parameters, setParameters] = useState<Record<string, unknown>>({});
+  const [initialParameters, setInitialParameters] = useState<
+    Record<string, unknown>
+  >({});
+  /**
+   * When the Project has no stored parameters, RJSF auto-fills schema
+   * defaults on its first onChange and we adopt that normalized snapshot
+   * as the baseline (otherwise hasChanges would flip true on mount).
+   * When parameters are already stored, those values ARE the baseline and
+   * we skip the capture so a real user edit isn't mistaken for initial
+   * state.
+   */
+  const formInitializedRef = useRef(true);
+  const [firstEnvRef, setFirstEnvRef] = useState<string | null>(null);
+  const [baselineRelease, setBaselineRelease] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<Error | null>(null);
+  const [phase, setPhase] = useState<'idle' | 'saving' | 'awaiting-release'>(
+    'idle',
+  );
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const namespaceName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE] || '';
+  const projectName = entity.metadata.name;
+  const projectTypeName =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT_TYPE] || '';
+  const projectTypeKind =
+    entity.metadata.annotations?.[CHOREO_ANNOTATIONS.PROJECT_TYPE_KIND] ||
+    'ProjectType';
+  const typeDisplayName = projectTypeName || 'this project';
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+
+    const load = async () => {
+      try {
+        // The project-level parameters schema lives on the referenced
+        // (Cluster)ProjectType at spec.parameters.openAPIV3Schema. Cluster
+        // types are cluster-scoped, so getResourceDefinition ignores the
+        // namespace for them.
+        const ptApiKind =
+          projectTypeKind === 'ClusterProjectType'
+            ? 'clusterprojecttypes'
+            : 'projecttypes';
+
+        const schemaPromise = projectTypeName
+          ? client
+              .getResourceDefinition(ptApiKind, namespaceName, projectTypeName)
+              .then(cr => {
+                const ptSpec = (cr?.spec as Record<string, unknown>) || {};
+                const params =
+                  (ptSpec.parameters as
+                    | { openAPIV3Schema?: Record<string, unknown> }
+                    | undefined) ?? {};
+                return params.openAPIV3Schema ?? {};
+              })
+          : Promise.resolve({} as Record<string, unknown>);
+
+        const [projectData, schemaData, envs] = await Promise.all([
+          client.getResourceDefinition('projects', namespaceName, projectName),
+          schemaPromise,
+          client.fetchProjectEnvironmentInfo(entity),
+        ]);
+
+        if (cancelled) return;
+
+        setProject(projectData);
+        const spec = (projectData?.spec as Record<string, unknown>) || {};
+        const currentParams =
+          (spec.parameters as Record<string, unknown>) || {};
+        // Empty stored params → allow the first RJSF onChange to absorb
+        // schema-default expansion as the baseline. Otherwise the stored
+        // params are the baseline directly.
+        formInitializedRef.current = Object.keys(currentParams).length > 0;
+        setParameters(currentParams);
+        setInitialParameters(JSON.parse(JSON.stringify(currentParams)));
+
+        setSchema((schemaData as JSONSchema7) ?? ({} as JSONSchema7));
+
+        const firstEnv = envs[0];
+        setFirstEnvRef(firstEnv?.resourceName ?? firstEnv?.name ?? null);
+        setBaselineRelease(firstEnv?.latestRelease ?? '');
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    client,
+    entity,
+    namespaceName,
+    projectName,
+    projectTypeName,
+    projectTypeKind,
+  ]);
+
+  const hasChanges = useMemo(
+    () => JSON.stringify(parameters) !== JSON.stringify(initialParameters),
+    [parameters, initialParameters],
+  );
+
+  const hasFields =
+    !!schema?.properties && Object.keys(schema.properties).length > 0;
+
+  /**
+   * Polls fetchProjectEnvironmentInfo until the first env's `latestRelease`
+   * differs from the captured baseline (or a previously unset release
+   * becomes set). Resolves with the new release name or rejects on timeout.
+   */
+  const waitForNewRelease = useCallback(async (): Promise<string> => {
+    const start = Date.now();
+    while (!cancelledRef.current) {
+      if (Date.now() - start > POLL_TIMEOUT_MS) {
+        throw new Error(
+          'Timed out waiting for the new ProjectRelease to be cut by the controller.',
+        );
+      }
+      try {
+        const envs = await client.fetchProjectEnvironmentInfo(entity);
+        const current = envs[0]?.latestRelease ?? '';
+        if (current && current !== baselineRelease) {
+          return current;
+        }
+      } catch {
+        // Transient errors are tolerated within the poll window.
+      }
+      await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+    }
+    throw new Error('cancelled');
+  }, [baselineRelease, client, entity]);
+
+  const handleContinue = useCallback(async () => {
+    if (!firstEnvRef) {
+      setSaveError(
+        'No environments found in the deployment pipeline. Configure environments before deploying.',
+      );
+      return;
+    }
+
+    // Unchanged parameters: skip the PUT + poll and reuse the current
+    // release immediately. Defensive against empty baseline (very fresh
+    // Project that hasn't yet been reconciled).
+    if (!hasChanges) {
+      if (!baselineRelease) {
+        setSaveError(
+          'No release exists yet. Wait a moment for the controller to cut the first release, then try again.',
+        );
+        return;
+      }
+      onContinue(firstEnvRef, baselineRelease);
+      return;
+    }
+
+    if (!project) return;
+
+    setPhase('saving');
+    setSaveError(null);
+    try {
+      const next: Record<string, unknown> = {
+        ...project,
+        spec: {
+          ...((project.spec as Record<string, unknown>) || {}),
+          parameters,
+        },
+      };
+      await client.updateResourceDefinition(
+        'projects',
+        namespaceName,
+        projectName,
+        next,
+      );
+      if (cancelledRef.current) return;
+
+      setPhase('awaiting-release');
+      const newRelease = await waitForNewRelease();
+      if (cancelledRef.current) return;
+
+      notification.showSuccess(
+        `Saved configuration for ${projectName}; release ${newRelease} cut.`,
+      );
+      onContinue(firstEnvRef, newRelease);
+    } catch (err: unknown) {
+      // Skip state writes if the user navigated away while a request was in
+      // flight or the poll loop was still iterating — the component is gone
+      // and React would warn about updating an unmounted component.
+      if (!cancelledRef.current) setSaveError(getErrorMessage(err));
+    } finally {
+      if (!cancelledRef.current) setPhase('idle');
+    }
+  }, [
+    baselineRelease,
+    client,
+    firstEnvRef,
+    hasChanges,
+    namespaceName,
+    notification,
+    onContinue,
+    parameters,
+    project,
+    projectName,
+    waitForNewRelease,
+  ]);
+
+  let primaryLabel: string;
+  if (phase === 'saving') {
+    primaryLabel = 'Saving';
+  } else if (phase === 'awaiting-release') {
+    primaryLabel = 'Cutting release';
+  } else {
+    primaryLabel = 'Next';
+  }
+
+  const actionDenied = !permLoading && !canUpdate;
+  const headerActions = !loading && !loadError && (
+    <Tooltip
+      title={actionDenied ? updateDeniedTooltip : ''}
+      disableHoverListener={!actionDenied}
+    >
+      <span>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleContinue}
+          disabled={
+            phase !== 'idle' ||
+            permLoading ||
+            !canUpdate ||
+            !project ||
+            !firstEnvRef ||
+            (!hasChanges && !baselineRelease)
+          }
+          startIcon={
+            phase !== 'idle' ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : undefined
+          }
+        >
+          {primaryLabel}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+
+  if (isForbiddenError(loadError)) {
+    return (
+      <ForbiddenState
+        message="You do not have permission to configure this project."
+        minHeight="400px"
+      />
+    );
+  }
+
+  return (
+    <DetailPageLayout
+      title="Configure Project"
+      subtitle={`Edit the parameters bound to the ${typeDisplayName} schema. Saving cuts a new release.`}
+      onBack={onBack}
+      actions={headerActions}
+    >
+      <NotificationBanner notification={notification.notification} />
+
+      {loading && (
+        <Box className={classes.loadingContainer}>
+          <Skeleton variant="rect" width="100%" height={64} />
+          <Skeleton variant="rect" width="100%" height={120} />
+          <Skeleton variant="rect" width="100%" height={120} />
+        </Box>
+      )}
+
+      {loadError && !loading && (
+        <Box mb={2}>
+          <Alert severity="error">
+            Failed to load project configuration: {getErrorMessage(loadError)}
+          </Alert>
+        </Box>
+      )}
+
+      {saveError && !loading && (
+        <Box mb={2}>
+          <Alert severity="error" onClose={() => setSaveError(null)}>
+            {saveError}
+          </Alert>
+        </Box>
+      )}
+
+      {!loading && !loadError && !firstEnvRef && (
+        <Box mb={2}>
+          <Alert severity="info">
+            No environments are configured in the project&apos;s deployment
+            pipeline. Configure environments before deploying this project.
+          </Alert>
+        </Box>
+      )}
+
+      {!loading && !loadError && (
+        <Box className={classes.formCard}>
+          {hasFields ? (
+            <>
+              <Typography className={classes.formHint}>
+                Fill in the parameters defined by {typeDisplayName}.
+              </Typography>
+              <RjsfForm
+                schema={schema as any}
+                uiSchema={{}}
+                formData={parameters}
+                onChange={data => {
+                  const next = (data.formData ?? {}) as Record<string, unknown>;
+                  setParameters(next);
+                  if (!formInitializedRef.current) {
+                    setInitialParameters(next);
+                    formInitializedRef.current = true;
+                  }
+                }}
+                tagName="div"
+              />
+            </>
+          ) : (
+            <Typography className={classes.emptyState}>
+              {typeDisplayName} has no configurable parameters.
+            </Typography>
+          )}
+        </Box>
+      )}
+    </DetailPageLayout>
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectParametersConfigWrapper.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectParametersConfigWrapper.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProjectParametersConfigWrapper } from './ProjectParametersConfigWrapper';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+// Stub the page so we can drive its onBack / onContinue callbacks directly.
+jest.mock('./ProjectParametersConfigPage', () => ({
+  ProjectParametersConfigPage: ({ onBack, onContinue }: any) => (
+    <div>
+      <button onClick={onBack}>back</button>
+      <button onClick={() => onContinue('development', 'rel-2')}>
+        continue
+      </button>
+    </div>
+  ),
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('ProjectParametersConfigWrapper', () => {
+  it('navigates back to the deploy view on Back', () => {
+    render(
+      <MemoryRouter>
+        <ProjectParametersConfigWrapper />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByText('back'));
+    expect(mockNavigate).toHaveBeenCalledWith('..', { relative: 'path' });
+  });
+
+  it('hands off to the overrides wizard in deploy mode on Continue', () => {
+    render(
+      <MemoryRouter>
+        <ProjectParametersConfigWrapper />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByText('continue'));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '../overrides/development?action=deploy&release=rel-2',
+      { relative: 'path' },
+    );
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectParametersConfigWrapper.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectParametersConfigWrapper.tsx
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ProjectParametersConfigPage } from './ProjectParametersConfigPage';
+
+/**
+ * Routing wrapper for `ProjectParametersConfigPage`. Mounted at
+ * `/deploy/parameters-config` by the entity tab's router. Back returns to
+ * the deploy view; Continue hands off to the overrides wizard for the
+ * first env in the pipeline, pinned to the freshly-cut release.
+ */
+export const ProjectParametersConfigWrapper = () => {
+  const navigate = useNavigate();
+
+  // Path-relative so `..` strips a URL segment instead of climbing the
+  // parent route hierarchy.
+  const back = useCallback(
+    () => navigate('..', { relative: 'path' }),
+    [navigate],
+  );
+
+  const continueToOverrides = useCallback(
+    (firstEnvRef: string, releaseName: string) => {
+      navigate(
+        `../overrides/${encodeURIComponent(
+          firstEnvRef,
+        )}?action=deploy&release=${encodeURIComponent(releaseName)}`,
+        { relative: 'path' },
+      );
+    },
+    [navigate],
+  );
+
+  return (
+    <ProjectParametersConfigPage
+      onBack={back}
+      onContinue={continueToOverrides}
+    />
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectSetupCard.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectSetupCard.tsx
@@ -1,0 +1,31 @@
+import { Box, Typography } from '@material-ui/core';
+import SettingsOutlinedIcon from '@material-ui/icons/SettingsOutlined';
+import clsx from 'clsx';
+import { useProjectSetupCardCompactStyles } from './styles';
+
+interface ProjectSetupCardProps {
+  selected: boolean;
+}
+
+/**
+ * Compact `Set up` tile rendered as the leftmost node on the Project
+ * deploy DAG. Clicking it selects the tile and opens
+ * `ProjectSetupDetailPane` in the right pane; the tile itself stays
+ * passive so the canvas remains action-free.
+ */
+export const ProjectSetupCard = ({ selected }: ProjectSetupCardProps) => {
+  const classes = useProjectSetupCardCompactStyles();
+  return (
+    <Box
+      className={clsx(classes.setupCard, {
+        [classes.cardSelected]: selected,
+      })}
+    >
+      <Box className={classes.titleRow}>
+        <SettingsOutlinedIcon className={classes.titleIcon} />
+        <Typography className={classes.title}>Set up</Typography>
+      </Box>
+      <Typography className={classes.hint}>Project configuration</Typography>
+    </Box>
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectSetupDetailPane.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectSetupDetailPane.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProjectSetupDetailPane } from './ProjectSetupDetailPane';
+
+const mockUpdatePerm = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useProjectUpdatePermission: () => mockUpdatePerm(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdatePerm.mockReturnValue({
+    canUpdate: true,
+    loading: false,
+    updateDeniedTooltip: '',
+  });
+});
+
+describe('ProjectSetupDetailPane', () => {
+  it('invokes Configure & Deploy and Close', () => {
+    const onConfigureDeploy = jest.fn();
+    const onClose = jest.fn();
+    render(
+      <ProjectSetupDetailPane
+        onConfigureDeploy={onConfigureDeploy}
+        onClose={onClose}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /manage project configuration and deploy a new version/i,
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /configure & deploy/i }),
+    );
+    expect(onConfigureDeploy).toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /close detail panel/i }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables Configure & Deploy without project-update permission', () => {
+    mockUpdatePerm.mockReturnValue({
+      canUpdate: false,
+      loading: false,
+      updateDeniedTooltip: 'nope',
+    });
+    render(
+      <ProjectSetupDetailPane
+        onConfigureDeploy={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /configure & deploy/i }),
+    ).toBeDisabled();
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectSetupDetailPane.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectSetupDetailPane.tsx
@@ -1,0 +1,81 @@
+import {
+  Box,
+  Button,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import SettingsOutlinedIcon from '@material-ui/icons/SettingsOutlined';
+import CloseIcon from '@material-ui/icons/Close';
+import { useProjectUpdatePermission } from '@openchoreo/backstage-plugin-react';
+import { useProjectEnvironmentDetailPanelStyles } from './styles';
+
+export interface ProjectSetupDetailPaneProps {
+  onConfigureDeploy: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Right-pane body shown when the Setup tile on the canvas is selected.
+ * Exposes the Configure & Deploy entry point into the project
+ * configuration wizard. Gated on the project-update permission.
+ */
+export const ProjectSetupDetailPane = ({
+  onConfigureDeploy,
+  onClose,
+}: ProjectSetupDetailPaneProps) => {
+  const classes = useProjectEnvironmentDetailPanelStyles();
+  const { canUpdate, loading, updateDeniedTooltip } =
+    useProjectUpdatePermission();
+  const disabled = loading || !canUpdate;
+
+  return (
+    <Box className={classes.panel}>
+      <Box className={classes.setupHeader}>
+        <Box className={classes.headerTopRow}>
+          <Box className={classes.headerNameRow}>
+            <SettingsOutlinedIcon
+              className={classes.headerKindIcon}
+              fontSize="small"
+              aria-hidden
+            />
+            <Typography className={classes.envName}>Set up</Typography>
+          </Box>
+          <Box>
+            <IconButton
+              size="small"
+              onClick={onClose}
+              aria-label="Close detail panel"
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        </Box>
+      </Box>
+
+      <Box className={classes.setupBody}>
+        <Typography variant="body2" color="textSecondary">
+          Manage project configuration and deploy a new version.
+        </Typography>
+
+        <Box mt="auto" pt={2} display="flex" justifyContent="flex-end">
+          <Tooltip
+            title={!canUpdate && !loading ? updateDeniedTooltip : ''}
+            disableHoverListener={canUpdate || loading}
+          >
+            <span>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={onConfigureDeploy}
+                disabled={disabled}
+              >
+                Configure &amp; Deploy
+              </Button>
+            </span>
+          </Tooltip>
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/plugins/openchoreo/src/components/ProjectEnvironments/badgeStatus.test.ts
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/badgeStatus.test.ts
@@ -1,0 +1,46 @@
+import { deriveProjectEnvBadgeStatus } from './badgeStatus';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+
+const base: ProjectEnvironment = { name: 'dev' };
+
+describe('deriveProjectEnvBadgeStatus', () => {
+  it('returns not-deployed when there is no binding', () => {
+    expect(deriveProjectEnvBadgeStatus(base)).toBe('not-deployed');
+  });
+
+  it('maps a Ready binding to active', () => {
+    expect(
+      deriveProjectEnvBadgeStatus({
+        ...base,
+        bindingName: 'b',
+        status: 'Ready',
+      }),
+    ).toBe('active');
+  });
+
+  it('maps a Failed binding to failed', () => {
+    expect(
+      deriveProjectEnvBadgeStatus({
+        ...base,
+        bindingName: 'b',
+        status: 'Failed',
+      }),
+    ).toBe('failed');
+  });
+
+  it('maps a NotReady binding to pending', () => {
+    expect(
+      deriveProjectEnvBadgeStatus({
+        ...base,
+        bindingName: 'b',
+        status: 'NotReady',
+      }),
+    ).toBe('pending');
+  });
+
+  it('falls back to unknown for a bound env with no status', () => {
+    expect(deriveProjectEnvBadgeStatus({ ...base, bindingName: 'b' })).toBe(
+      'unknown',
+    );
+  });
+});

--- a/plugins/openchoreo/src/components/ProjectEnvironments/badgeStatus.ts
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/badgeStatus.ts
@@ -1,0 +1,17 @@
+import type { StatusType } from '@openchoreo/backstage-design-system';
+import type { ProjectEnvironment } from '../../api/OpenChoreoClientApi';
+
+/**
+ * Maps a ProjectEnvironment's binding state to a StatusBadge variant.
+ * Shared by the canvas tile and the detail panel header so the same
+ * env always renders the same badge in both places.
+ */
+export function deriveProjectEnvBadgeStatus(
+  env: ProjectEnvironment,
+): StatusType {
+  if (!env.bindingName) return 'not-deployed';
+  if (env.status === 'Ready') return 'active';
+  if (env.status === 'Failed') return 'failed';
+  if (env.status === 'NotReady') return 'pending';
+  return 'unknown';
+}

--- a/plugins/openchoreo/src/components/ProjectEnvironments/index.ts
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/index.ts
@@ -1,0 +1,10 @@
+export { ProjectEnvironments } from './ProjectEnvironments';
+export { ProjectDeployFlowCanvas } from './ProjectDeployFlowCanvas';
+export { ProjectMiniEnvironmentNode } from './ProjectMiniEnvironmentNode';
+export { ProjectEnvironmentDetailPanel } from './ProjectEnvironmentDetailPanel';
+export {
+  ProjectEnvironmentsProvider,
+  useProjectEnvironmentsContext,
+  type ProjectEnvironmentsContextValue,
+  type ActionKind,
+} from './ProjectEnvironmentsContext';

--- a/plugins/openchoreo/src/components/ProjectEnvironments/styles.ts
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/styles.ts
@@ -1,0 +1,402 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { alpha } from '@material-ui/core/styles/colorManipulator';
+
+/**
+ * Split-pane container for the Project Deploy tab. Pipeline DAG on the
+ * left, detail panel on the right.
+ */
+export const useProjectDeployFlowCanvasStyles = makeStyles(theme => ({
+  splitContainer: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) 380px',
+    gridTemplateRows: 'minmax(0, 1fr)',
+    gap: theme.spacing(2),
+    width: '100%',
+    height: 'calc(100vh - 200px)',
+    minHeight: 480,
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: '1fr',
+      gridTemplateRows: 'auto',
+      gridAutoRows: 'min-content',
+      height: 'auto',
+    },
+  },
+  canvasFrame: {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    minHeight: 0,
+    backgroundColor: theme.palette.background.default,
+    backgroundImage: 'var(--canvas-dots)',
+    backgroundSize: '16px 16px',
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  canvasContainer: {
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+    position: 'relative',
+    cursor: 'grab',
+    '&:active': { cursor: 'grabbing' },
+  },
+  canvasContent: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    transformOrigin: '0 0',
+  },
+  nodeWrapper: { position: 'absolute' },
+  setupNodeWrapper: {
+    position: 'absolute',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  controlsOverlay: {
+    position: 'absolute',
+    bottom: theme.spacing(2),
+    right: theme.spacing(2),
+    zIndex: 2,
+  },
+  detailPanelFrame: {
+    minHeight: 0,
+    overflow: 'auto',
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: 12,
+    backgroundColor: theme.palette.background.paper,
+  },
+}));
+
+/**
+ * Compact `Set up` tile shown as the leftmost node on the deploy canvas.
+ * Width/height come from MINI_SETUP_NODE_* constants in
+ * @openchoreo/backstage-plugin-react so the dagre layout reserves the
+ * correct space.
+ */
+export const useProjectSetupCardCompactStyles = makeStyles(theme => ({
+  setupCard: {
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+    padding: theme.spacing(2),
+    borderRadius: 12,
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxSizing: 'border-box',
+    border: `1px dashed ${theme.palette.divider}`,
+    gap: theme.spacing(0.75),
+    cursor: 'pointer',
+    transition: 'box-shadow 120ms ease, border-color 120ms ease',
+    '&:hover': {
+      boxShadow: theme.shadows[3],
+    },
+  },
+  cardSelected: {
+    borderColor: theme.palette.primary.main,
+    borderStyle: 'solid',
+    backgroundColor: alpha(
+      theme.palette.primary.main,
+      theme.palette.type === 'dark' ? 0.12 : 0.04,
+    ),
+    boxShadow: `0 0 0 2px ${theme.palette.primary.main}, ${theme.shadows[4]}`,
+    '&:hover': {
+      boxShadow: `0 0 0 2px ${theme.palette.primary.main}, ${theme.shadows[4]}`,
+    },
+  },
+  titleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing(1),
+  },
+  titleIcon: {
+    color: theme.palette.text.primary,
+    fontSize: '1.1rem',
+  },
+  title: {
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+  },
+  hint: {
+    color: theme.palette.text.secondary,
+    fontSize: '0.78rem',
+    textAlign: 'center',
+  },
+}));
+
+/**
+ * Per-env compact node tile shown on the canvas. Layout: a vertical
+ * status stripe on the left whose color reflects the binding status,
+ * a body with icon + name + 3-dot menu (top), STATUS: row, and a
+ * DEPLOYED: relative-time row on bound envs.
+ */
+export const useProjectMiniEnvironmentNodeStyles = makeStyles(theme => ({
+  card: {
+    width: '100%',
+    height: '100%',
+    boxSizing: 'border-box',
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: 8,
+    boxShadow: theme.shadows[1],
+    display: 'flex',
+    flexDirection: 'column',
+    cursor: 'pointer',
+    overflow: 'hidden',
+    transition: 'box-shadow 120ms ease, transform 120ms ease',
+    '&:hover': {
+      boxShadow: theme.shadows[3],
+    },
+  },
+  cardSelected: {
+    borderColor: theme.palette.primary.main,
+    backgroundColor: theme.palette.background.paper,
+    backgroundImage: `linear-gradient(${alpha(
+      theme.palette.primary.main,
+      theme.palette.type === 'dark' ? 0.12 : 0.04,
+    )}, ${alpha(
+      theme.palette.primary.main,
+      theme.palette.type === 'dark' ? 0.12 : 0.04,
+    )})`,
+    boxShadow: `0 0 0 2px ${theme.palette.primary.main}, ${theme.shadows[4]}`,
+    '&:hover': {
+      boxShadow: `0 0 0 2px ${theme.palette.primary.main}, ${theme.shadows[4]}`,
+    },
+  },
+  statusStripe: {
+    width: 4,
+    height: '100%',
+    flexShrink: 0,
+  },
+  statusStripeActive: {
+    backgroundColor: theme.palette.success.main,
+  },
+  statusStripePending: {
+    backgroundColor: theme.palette.warning.main,
+  },
+  statusStripeFailed: {
+    backgroundColor: theme.palette.error.main,
+  },
+  statusStripeIdle: {
+    backgroundColor: theme.palette.action.disabled,
+  },
+  body: {
+    flex: 1,
+    minWidth: 0,
+    padding: theme.spacing(1, 1.25),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  },
+  topRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(0.5),
+    minWidth: 0,
+  },
+  nameWrap: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    minWidth: 0,
+    flex: 1,
+  },
+  kindIcon: {
+    color: theme.palette.text.secondary,
+    fontSize: '1rem',
+    flexShrink: 0,
+  },
+  envName: {
+    fontWeight: 600,
+    fontSize: '0.95rem',
+    lineHeight: 1.2,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  menuButton: {
+    padding: theme.spacing(0.25),
+  },
+  metaRow: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.75),
+    rowGap: theme.spacing(0.5),
+    color: theme.palette.text.secondary,
+    fontSize: '0.8rem',
+    minWidth: 0,
+  },
+  meta: {
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    color: theme.palette.text.secondary,
+    fontSize: '0.65rem',
+    fontWeight: 500,
+    flexShrink: 0,
+  },
+  timeText: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  actionRow: {
+    marginTop: 'auto',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(0.75),
+    flexWrap: 'wrap',
+  },
+  primaryButton: {
+    textTransform: 'none',
+  },
+}));
+
+/**
+ * Right-pane detail view. Internal scroll when content overflows the
+ * fixed split-container height.
+ */
+export const useProjectEnvironmentDetailPanelStyles = makeStyles(theme => ({
+  panel: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  header: {
+    padding: theme.spacing(2, 2.5),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+  headerTopRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+  },
+  headerNameRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    minWidth: 0,
+    flex: 1,
+  },
+  headerKindIcon: {
+    color: theme.palette.text.secondary,
+    flexShrink: 0,
+  },
+  headerStatusRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  envName: {
+    fontWeight: 600,
+    fontSize: '1.05rem',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  body: {
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  setupHeader: {
+    padding: theme.spacing(2, 2.5),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+  setupBody: {
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+    padding: theme.spacing(2, 2.5),
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  section: {
+    padding: theme.spacing(2, 2.5),
+    borderTop: `1px solid ${theme.palette.divider}`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+  sectionHeading: {
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+    fontSize: '0.78rem',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  sectionTitleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+  },
+  statusMessage: {
+    color: theme.palette.text.primary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: 280,
+    flex: 1,
+  },
+  actionsRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+  },
+  emptyState: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: theme.spacing(4),
+    color: theme.palette.text.secondary,
+    gap: theme.spacing(2),
+  },
+  emptyIcon: {
+    fontSize: '3rem',
+    color: theme.palette.action.disabled,
+  },
+  releaseNameRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  },
+  releaseNameLabel: {
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    color: theme.palette.text.secondary,
+    fontSize: '0.65rem',
+    flexShrink: 0,
+  },
+  releaseName: {
+    fontFamily:
+      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+    color: theme.palette.text.primary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: 280,
+  },
+  deployedRow: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: theme.spacing(0.75),
+  },
+}));

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -14,6 +14,7 @@ export type {
   InvestigateScope,
 } from './components/Environments/EnvironmentsContext';
 export { ResourceEnvironments } from './components/ResourceEnvironments';
+export { ProjectEnvironments } from './components/ProjectEnvironments';
 export { CellDiagram } from './components/CellDiagram/CellDiagram';
 export {
   WorkflowsOverviewCard,


### PR DESCRIPTION
## Purpose

The Project release concept was introduced with https://github.com/openchoreo/openchoreo/issues/3564. But the project entities (catalog kind `System`) had no way to drive the OpenChoreo project-release lifecycle from the portal. You could view a project but not configure its parameters, cut a release, or deploy/promote it across environments. This PR adds a **"Deploy" tab** to the Project entity page that renders the project's deployment pipeline as a DAG of environments with live status and lets users configure project-level parameters and deploy/promote a release per environment.

## Approach

**Backend (`@openchoreo/backstage-plugin-backend`)**
- Extend `EnvironmentInfoService` with `fetchProjectEnvironmentInfo` (joins environments × `ProjectReleaseBinding`s × deployment pipeline × `Project.status.latestRelease`), `updateProjectReleaseBinding`, and `fetchProjectReleaseBindings`.
- Add `ProjectReleaseInfoService` for frozen `ProjectRelease` schema reads (`parameters` / `environmentConfigs` sections), mirroring `ResourceReleaseInfoService`.
- New routes: `GET /project-environment-info`, `GET /project-release-bindings`, `PUT /update-project-release-binding`, `GET /project-release-schema`.
- Add `ProjectEnvironment` (backend) and `ProjectReleaseBindingResponse` (`@openchoreo/backstage-plugin-common`) types + `transformProjectReleaseBinding`.

**Frontend (`@openchoreo/backstage-plugin`)**
- `OpenChoreoClient` methods: `fetchProjectEnvironmentInfo`, `fetchProjectReleaseBindings`, `updateProjectReleaseBinding`, `fetchProjectReleaseSchema`.
- New `ProjectEnvironments` feature dir: pipeline DAG canvas (shared dagre helpers), Set up card + detail pane, per-env mini node and detail panel, and a two-step **Configure & Deploy** wizard — step 1 edits `Project.spec.parameters` against the `(Cluster)ProjectType` parameters schema (saving polls until the controller cuts a new `ProjectRelease`), step 2 pins the env binding and edits its `environmentConfigs` overrides.
- **Promote** copies an env's pinned release forward to the next environment.
- All mutating actions (Configure & Deploy / Deploy / Promote / Configure overrides) gate on the project-update permission via `useProjectUpdatePermission`.
- Wire a `/deploy` "Deploy" tab into the Project (`System`) entity page.

## Related Issues

Related openchoreo/openchoreo#3921

## Quick Demo


https://github.com/user-attachments/assets/ebd0d1b7-8be6-428a-937f-8b55dce3c82b



## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Deploy** view for projects with a visual environment pipeline, setup flow, environment details, and override editing.
  * Introduced guided configuration for project parameters and environment-specific overrides, including deploy-time release pinning.
  * Added environment promotion actions and clearer status/last deployed information across the deploy experience.

* **Bug Fixes**
  * Improved handling for missing data, loading errors, and permission restrictions so the UI degrades more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->