### PR TITLE
feat: add component tab navigation to Cell Diagram node menu

### DIFF
--- a/.changeset/cell-diagram-node-navigation.md
+++ b/.changeset/cell-diagram-node-navigation.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin': minor
+---
+
+Cell Diagram: each component node's ⋮ menu now links to that component's key tabs — Overview, Deploy, Logs, Metrics, and (when an environment has Cilium-backed network observability) Wirelogs — in a project's Cell Diagram tab.

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.test.tsx
@@ -9,6 +9,12 @@ jest.mock('@backstage/plugin-catalog-react', () => ({
   catalogApiRef: { id: 'catalog' },
 }));
 
+// The component calls useNavigate() at render (for the node ⋮ menu's tab
+// navigation); the tests render <CellDiagram> without a Router, so stub it.
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+}));
+
 jest.mock('@backstage/core-plugin-api', () => ({
   useApi: jest.fn(),
   createApiRef: (def: { id: string }) => ({ id: def?.id ?? 'mock-api-ref' }),

--- a/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
+++ b/plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx
@@ -2,6 +2,7 @@ import {
   lazy,
   memo,
   Suspense,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -16,12 +17,14 @@ import Switch from '@material-ui/core/Switch';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import RefreshIcon from '@material-ui/icons/Refresh';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { catalogApiRef, useEntity } from '@backstage/plugin-catalog-react';
 import { useApi } from '@backstage/core-plugin-api';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { useNavigate } from 'react-router-dom';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { useTheme } from '@material-ui/core/styles';
 import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
-import { DiagramLayer, Project } from '@wso2/cell-diagram';
+import { DiagramLayer, MoreVertMenuItem, Project } from '@wso2/cell-diagram';
 import { useChoreoTokens } from '@openchoreo/backstage-design-system';
 import {
   EmptyState,
@@ -43,7 +46,13 @@ const CellView = lazy(() =>
 // only renders when project/mode actually change — without this, every
 // loading/refresh state flip in our parent causes a center/zoom race
 // and the diagram lands in a random corner.
-const MemoCellView = memo(CellView);
+const MemoCellView = memo(
+  CellView,
+  (prev, next) =>
+    prev.project === next.project &&
+    prev.mode === next.mode &&
+    prev.defaultDiagramLayer === next.defaultDiagramLayer,
+);
 
 function hasObservations(project: Project | undefined): boolean {
   if (!project?.components) return false;
@@ -68,9 +77,45 @@ export const CellDiagram = () => {
   const [hasFetchedOnce, setHasFetchedOnce] = useState(false);
   const [runtimeEnabled, setRuntimeEnabled] = useState(false);
   const client = useApi(openChoreoClientApiRef);
+  const catalogApi = useApi(catalogApiRef);
+  const navigate = useNavigate();
   const { mode } = useChoreoTokens();
   const theme = useTheme();
   const controlBg = theme.palette.background.paper;
+
+  const navDeps = useRef({ catalogApi, navigate, entity });
+  navDeps.current = { catalogApi, navigate, entity };
+
+  // Resolve a component node and navigate to one of its tabs.
+  // no-op when the component isn't in the catalog. `subPath` selects the tab
+  // (e.g. '/environments'); an empty string lands on the Overview tab.
+  const navigateToComponent = useCallback(
+    async (componentId: string, subPath: string = '') => {
+      if (!componentId) return;
+      const {
+        catalogApi: api,
+        navigate: nav,
+        entity: project,
+      } = navDeps.current;
+      try {
+        const { items } = await api.getEntities({
+          filter: {
+            kind: 'Component',
+            'metadata.name': componentId,
+            'relations.partof': stringifyEntityRef(project),
+          },
+          fields: ['kind', 'metadata.name', 'metadata.namespace'],
+        });
+        const target = items[0];
+        if (!target) return;
+        const ns = target.metadata.namespace ?? 'default';
+        nav(`/catalog/${ns}/component/${target.metadata.name}${subPath}`);
+      } catch {
+        // Swallow — a failed lookup just leaves the user on the diagram.
+      }
+    },
+    [],
+  );
 
   const projectName = entity.metadata.name;
   const namespaceName =
@@ -80,6 +125,9 @@ export const CellDiagram = () => {
     namespaceName,
   );
 
+  const envsLoadedOnce = useRef(false);
+  if (!environmentsLoading) envsLoadedOnce.current = true;
+
   const anyEnvHasRuntimeObservability = useMemo(
     () => environments.some(e => e.hasRuntimeObservability),
     [environments],
@@ -87,6 +135,24 @@ export const CellDiagram = () => {
   const selectedEnvHasRuntimeObservability =
     environments.find(e => e.name === environment?.name)
       ?.hasRuntimeObservability ?? false;
+
+  const componentMenu = useMemo<MoreVertMenuItem[]>(() => {
+    const tabs = [
+      { label: 'Overview', path: '' },
+      { label: 'Deploy', path: '/environments' },
+      { label: 'Logs', path: '/runtime-logs' },
+      { label: 'Metrics', path: '/metrics' },
+      ...(anyEnvHasRuntimeObservability
+        ? [{ label: 'Wirelogs', path: '/wirelogs' }]
+        : []),
+    ];
+    return tabs.map(tab => ({
+      label: tab.label,
+      callback: (componentId: string) => {
+        void navigateToComponent(componentId, tab.path);
+      },
+    }));
+  }, [navigateToComponent, anyEnvHasRuntimeObservability]);
 
   // Auto-select the first environment once the list resolves.
   useEffect(() => {
@@ -338,7 +404,7 @@ export const CellDiagram = () => {
           traffic is not observed.
         </Typography>
       )}
-      {cellDiagramData && !hasNoComponents && (
+      {cellDiagramData && !hasNoComponents && envsLoadedOnce.current && (
         <Suspense fallback={<Progress />}>
           {(() => {
             const targetLayer =
@@ -351,6 +417,7 @@ export const CellDiagram = () => {
                 project={cellDiagramData}
                 mode={mode}
                 defaultDiagramLayer={targetLayer}
+                componentMenu={componentMenu}
               />
             );
           })()}
@@ -372,7 +439,10 @@ export const CellDiagram = () => {
           />
         </Box>
       )}
-      {!cellDiagramData && (loading || !hasFetchedOnce) && <Progress />}
+      {((!cellDiagramData && (loading || !hasFetchedOnce)) ||
+        (cellDiagramData && !hasNoComponents && !envsLoadedOnce.current)) && (
+        <Progress />
+      )}
       {!cellDiagramData && hasFetchedOnce && !loading && (
         <Box
           style={{


### PR DESCRIPTION
## Purpose
A project's **Cell Diagram** tab renders each component as a node, and each node already exposes a `⋮` (more) menu — but the menu had no actions wired to it. To inspect a component (its Overview, Deploy, Logs, Metrics, or Wirelogs), a user had to leave the diagram and manually locate that component in the catalog, which is slow and breaks the "see the topology, drill into a piece" flow.

Related: https://github.com/openchoreo/openchoreo/issues/3978

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

All changes are in `plugins/openchoreo/src/components/CellDiagram/CellDiagram.tsx`:

- **Pass a `componentMenu` to `<CellView>`.** `@wso2/cell-diagram` accepts a `componentMenu: MoreVertMenuItem[]` prop; we build one menu item per tab. Each item's `callback(componentId)` resolves the clicked node back to its catalog `Component` and navigates to the right tab.
- **Node → catalog Component resolution.** `navigateToComponent(componentId, subPath)` queries `catalogApi.getEntities` filtered by `kind: Component`, `metadata.name: <componentId>`, and `relations.partof: <project entity ref>` (via `stringifyEntityRef(entity)`), requesting only `kind`/`metadata.name`/`metadata.namespace`. It then navigates to `/catalog/<namespace>/component/<name><subPath>`. If the lookup returns nothing or throws, it's a no-op — the user simply stays on the diagram.
- **Tab map.** Overview (`''`), Deploy (`/environments`), Logs (`/runtime-logs`), Metrics (`/metrics`), and Wirelogs (`/wirelogs`). **Wirelogs is included only when `anyEnvHasRuntimeObservability` is true** (i.e. at least one environment has Cilium-backed network observability), matching the existing behavior that hides the Wirelogs tab otherwise.
- **Stable callback via `navDeps` ref.** `navigateToComponent` is a `useCallback` with an empty dependency array; it reads `catalogApi` / `navigate` / `entity` through a `useRef` that is refreshed every render. This keeps the callback (and therefore the menu items) referentially stable so the menu doesn't churn.
- **No diagram re-center on menu changes.** `MemoCellView` now uses a custom comparator that re-renders only when `project`, `mode`, or `defaultDiagramLayer` change — so attaching/refreshing `componentMenu` doesn't retrigger the center/zoom logic that previously caused the diagram to jump.
- **`envsLoadedOnce` gate.** The diagram now waits for environments to resolve once before its first paint (`envsLoadedOnce` ref), showing a `<Progress />` until then. This guarantees the Wirelogs menu item is correctly present/absent on the very first render rather than popping in after environments load.

Screen recording:

https://github.com/user-attachments/assets/7f27093b-f80b-42f5-87d0-e6c14d0cf56e


Screenshot - light mode: 
<img width="1512" height="885" alt="Screenshot 2026-06-25 at 16 25 49" src="https://github.com/user-attachments/assets/68a35e1e-4b07-40a3-9f29-b44e13166585" />

Screenshot - when cilium enabled:
<img width="1512" height="888" alt="Screenshot 2026-06-25 at 16 28 08" src="https://github.com/user-attachments/assets/636835bb-ac42-4bb7-8efc-ec536aea17e9" />

 
## User stories

> Summary of user stories addressed by this change>

## Release note

Cell Diagram: each component node's `⋮` menu now links to that component's key tabs — Overview, Deploy, Logs, Metrics, and (when an environment has Cilium-backed network observability) Wirelogs — in a project's Cell Diagram tab.

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Component node menus now provide quick navigation to key tabs: Overview, Deploy, Logs, and Metrics.
  * Wirelogs is shown as an additional option when supported by the environment.

* **Bug Fixes**
  * Improved diagram loading so content waits for environment data before rendering, reducing incomplete or flickering views.
  * Fixed test stability for the component diagram by supporting menu navigation behavior during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->