### PR TITLE
feat(catalog): custom component-creation templates via scaffold-template-url annotation

### DIFF
--- a/.changeset/cct-custom-scaffold-template-url.md
+++ b/.changeset/cct-custom-scaffold-template-url.md
@@ -1,0 +1,13 @@
+---
+'@openchoreo/backstage-plugin-catalog-backend-module': minor
+'@openchoreo/backstage-plugin-common': minor
+---
+
+Add support for custom component-creation templates. A (Cluster)ComponentType
+can now set the `scaffolder.openchoreo.dev/backstage-template-url` annotation to
+point at a hand-authored Backstage scaffolder Template. When present, the catalog
+sync fetches that Template from the URL (via the configured `integrations`) and
+emits it in place of the auto-generated wizard; when absent, behaviour is
+unchanged. Applies to both the periodic and event-driven sync paths. If the URL
+cannot be read or does not yield a valid `kind: Template`, an error is logged and
+no template is emitted for that type.

--- a/plugins/catalog-backend-module-openchoreo/package.json
+++ b/plugins/catalog-backend-module-openchoreo/package.json
@@ -46,7 +46,8 @@
     "@openchoreo/openchoreo-auth": "workspace:^",
     "@openchoreo/openchoreo-client-node": "workspace:^",
     "json-schema": "0.4.0",
-    "knex": "3.1.0"
+    "knex": "3.1.0",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.11.3",

--- a/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.test.ts
@@ -106,8 +106,7 @@ describe('RemoteTemplateFetcher', () => {
       namespace: 'ctx-ns',
     });
 
-    // Authored name/namespace are discarded so the entity ref stays deterministic
-    // (`template-<ctName>` in the CT namespace) for discovery + delete + toggle.
+    // Authored name/namespace are discarded for a deterministic entity ref.
     expect(entity.metadata.name).toBe('template-agent-sandbox');
     expect(entity.metadata.namespace).toBe('ctx-ns');
   });

--- a/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.test.ts
@@ -1,0 +1,186 @@
+import { LoggerService, UrlReaderService } from '@backstage/backend-plugin-api';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { RemoteTemplateFetcher } from './RemoteTemplateFetcher';
+
+const mockLogger: LoggerService = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(function child(this: LoggerService) {
+    return this;
+  }),
+};
+
+/** UrlReader stub whose readUrl resolves the given body or rejects. */
+function readerFor(body: string | Error): UrlReaderService {
+  return {
+    readUrl: jest.fn(async () => {
+      if (body instanceof Error) throw body;
+      return { buffer: async () => Buffer.from(body, 'utf-8') };
+    }),
+    readTree: jest.fn(),
+    search: jest.fn(),
+  } as unknown as UrlReaderService;
+}
+
+const VALID_TEMPLATE = `
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: my-custom-template
+  title: My Custom Template
+spec:
+  owner: guests
+  type: Component
+  steps: []
+`;
+
+const URL = 'https://github.com/acme/templates/blob/main/template.yaml';
+
+describe('RemoteTemplateFetcher', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches, parses and stamps a valid Template', async () => {
+    const fetcher = new RemoteTemplateFetcher(
+      readerFor(VALID_TEMPLATE),
+      mockLogger,
+    );
+
+    const entity = await fetcher.fetch(URL, {
+      ctdName: 'agent-sandbox',
+      namespace: 'my-ns',
+      workloadType: 'deployment',
+      displayName: 'Agent Sandbox',
+    });
+
+    expect(entity.kind).toBe('Template');
+    expect(entity.metadata.name).toBe('my-custom-template');
+    // Defaulted from ctx because the authored template omits a namespace.
+    expect(entity.metadata.namespace).toBe('my-ns');
+
+    const ann = entity.metadata.annotations!;
+    expect(ann[CHOREO_ANNOTATIONS.CTD_NAME]).toBe('agent-sandbox');
+    expect(ann[CHOREO_ANNOTATIONS.CTD_GENERATED]).toBe('false');
+    expect(ann[CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL]).toBe(URL);
+    expect(ann[CHOREO_ANNOTATIONS.WORKLOAD_TYPE]).toBe('deployment');
+    expect(ann[CHOREO_ANNOTATIONS.CTD_DISPLAY_NAME]).toBe('Agent Sandbox');
+    // Anchor relative fetch:* steps at the source URL.
+    expect(ann['backstage.io/managed-by-location']).toBe(`url:${URL}`);
+    expect(ann['backstage.io/managed-by-origin-location']).toBe(`url:${URL}`);
+    // No cluster kind for a namespaced type.
+    expect(ann[CHOREO_ANNOTATIONS.CTD_KIND]).toBeUndefined();
+  });
+
+  it('stamps CTD_KIND for cluster-scoped types', async () => {
+    const fetcher = new RemoteTemplateFetcher(
+      readerFor(VALID_TEMPLATE),
+      mockLogger,
+    );
+
+    const entity = await fetcher.fetch(URL, {
+      ctdName: 'cluster-agent',
+      namespace: 'openchoreo-cluster',
+      ctdKind: 'ClusterComponentType',
+    });
+
+    expect(entity.metadata.annotations![CHOREO_ANNOTATIONS.CTD_KIND]).toBe(
+      'ClusterComponentType',
+    );
+    expect(entity.metadata.namespace).toBe('openchoreo-cluster');
+  });
+
+  it('does not override a namespace declared by the authored template', async () => {
+    const withNamespace = VALID_TEMPLATE.replace(
+      'name: my-custom-template',
+      'name: my-custom-template\n  namespace: authored-ns',
+    );
+    const fetcher = new RemoteTemplateFetcher(
+      readerFor(withNamespace),
+      mockLogger,
+    );
+
+    const entity = await fetcher.fetch(URL, {
+      ctdName: 'agent-sandbox',
+      namespace: 'ctx-ns',
+    });
+
+    expect(entity.metadata.namespace).toBe('authored-ns');
+  });
+
+  it('picks the Template out of a multi-document YAML file', async () => {
+    const multiDoc = `
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: not-a-template
+---
+${VALID_TEMPLATE}
+`;
+    const fetcher = new RemoteTemplateFetcher(readerFor(multiDoc), mockLogger);
+
+    const entity = await fetcher.fetch(URL, {
+      ctdName: 'agent-sandbox',
+      namespace: 'my-ns',
+    });
+
+    expect(entity.kind).toBe('Template');
+    expect(entity.metadata.name).toBe('my-custom-template');
+  });
+
+  it('throws when the URL cannot be read', async () => {
+    const fetcher = new RemoteTemplateFetcher(
+      readerFor(new Error('404 Not Found')),
+      mockLogger,
+    );
+
+    await expect(
+      fetcher.fetch(URL, { ctdName: 'x', namespace: 'my-ns' }),
+    ).rejects.toThrow(/Unable to read scaffolder template/);
+  });
+
+  it('throws when no kind: Template document is present', async () => {
+    const notATemplate = `
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: just-a-component
+`;
+    const fetcher = new RemoteTemplateFetcher(
+      readerFor(notATemplate),
+      mockLogger,
+    );
+
+    await expect(
+      fetcher.fetch(URL, { ctdName: 'x', namespace: 'my-ns' }),
+    ).rejects.toThrow(/No 'kind: Template' entity found/);
+  });
+
+  it('throws when the Template is missing metadata.name', async () => {
+    const noName = `
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  title: Nameless
+spec:
+  owner: guests
+  type: Component
+`;
+    const fetcher = new RemoteTemplateFetcher(readerFor(noName), mockLogger);
+
+    await expect(
+      fetcher.fetch(URL, { ctdName: 'x', namespace: 'my-ns' }),
+    ).rejects.toThrow(/missing metadata.name/);
+  });
+
+  it('throws on invalid YAML', async () => {
+    const fetcher = new RemoteTemplateFetcher(
+      readerFor(': : : not valid : yaml : ['),
+      mockLogger,
+    );
+
+    await expect(
+      fetcher.fetch(URL, { ctdName: 'x', namespace: 'my-ns' }),
+    ).rejects.toThrow();
+  });
+});

--- a/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.test.ts
@@ -188,7 +188,10 @@ spec:
   owner: guests
   type: Component
 `;
-    const fetcher = new RemoteTemplateFetcher(readerFor(noMetadata), mockLogger);
+    const fetcher = new RemoteTemplateFetcher(
+      readerFor(noMetadata),
+      mockLogger,
+    );
 
     await expect(
       fetcher.fetch(URL, { ctdName: 'x', namespace: 'my-ns' }),

--- a/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.test.ts
@@ -55,8 +55,8 @@ describe('RemoteTemplateFetcher', () => {
     });
 
     expect(entity.kind).toBe('Template');
-    expect(entity.metadata.name).toBe('my-custom-template');
-    // Defaulted from ctx because the authored template omits a namespace.
+    // Identity is normalised to the deterministic scheme, not the authored name.
+    expect(entity.metadata.name).toBe('template-agent-sandbox');
     expect(entity.metadata.namespace).toBe('my-ns');
 
     const ann = entity.metadata.annotations!;
@@ -87,16 +87,17 @@ describe('RemoteTemplateFetcher', () => {
     expect(entity.metadata.annotations![CHOREO_ANNOTATIONS.CTD_KIND]).toBe(
       'ClusterComponentType',
     );
+    expect(entity.metadata.name).toBe('template-cluster-agent');
     expect(entity.metadata.namespace).toBe('openchoreo-cluster');
   });
 
-  it('does not override a namespace declared by the authored template', async () => {
-    const withNamespace = VALID_TEMPLATE.replace(
+  it('forces the ComponentType name and namespace over the authored ones', async () => {
+    const withOwnIdentity = VALID_TEMPLATE.replace(
       'name: my-custom-template',
       'name: my-custom-template\n  namespace: authored-ns',
     );
     const fetcher = new RemoteTemplateFetcher(
-      readerFor(withNamespace),
+      readerFor(withOwnIdentity),
       mockLogger,
     );
 
@@ -105,7 +106,10 @@ describe('RemoteTemplateFetcher', () => {
       namespace: 'ctx-ns',
     });
 
-    expect(entity.metadata.namespace).toBe('authored-ns');
+    // Authored name/namespace are discarded so the entity ref stays deterministic
+    // (`template-<ctName>` in the CT namespace) for discovery + delete + toggle.
+    expect(entity.metadata.name).toBe('template-agent-sandbox');
+    expect(entity.metadata.namespace).toBe('ctx-ns');
   });
 
   it('picks the Template out of a multi-document YAML file', async () => {
@@ -125,7 +129,7 @@ ${VALID_TEMPLATE}
     });
 
     expect(entity.kind).toBe('Template');
-    expect(entity.metadata.name).toBe('my-custom-template');
+    expect(entity.metadata.name).toBe('template-agent-sandbox');
   });
 
   it('throws when the URL cannot be read', async () => {
@@ -156,7 +160,7 @@ metadata:
     ).rejects.toThrow(/No 'kind: Template' entity found/);
   });
 
-  it('throws when the Template is missing metadata.name', async () => {
+  it('supplies the normalised name even when the authored template omits one', async () => {
     const noName = `
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
@@ -168,19 +172,37 @@ spec:
 `;
     const fetcher = new RemoteTemplateFetcher(readerFor(noName), mockLogger);
 
-    await expect(
-      fetcher.fetch(URL, { ctdName: 'x', namespace: 'my-ns' }),
-    ).rejects.toThrow(/missing metadata.name/);
+    const entity = await fetcher.fetch(URL, {
+      ctdName: 'agent-sandbox',
+      namespace: 'my-ns',
+    });
+
+    expect(entity.metadata.name).toBe('template-agent-sandbox');
   });
 
-  it('throws on invalid YAML', async () => {
+  it('throws when the Template has no metadata block', async () => {
+    const noMetadata = `
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  owner: guests
+  type: Component
+`;
+    const fetcher = new RemoteTemplateFetcher(readerFor(noMetadata), mockLogger);
+
+    await expect(
+      fetcher.fetch(URL, { ctdName: 'x', namespace: 'my-ns' }),
+    ).rejects.toThrow(/has no metadata block/);
+  });
+
+  it('surfaces a YAML syntax error as a parse failure', async () => {
     const fetcher = new RemoteTemplateFetcher(
-      readerFor(': : : not valid : yaml : ['),
+      readerFor('kind: Template\nmetadata:\n  name: x\n bad: : : ['),
       mockLogger,
     );
 
     await expect(
       fetcher.fetch(URL, { ctdName: 'x', namespace: 'my-ns' }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/Failed to parse YAML/);
   });
 });

--- a/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.ts
@@ -3,39 +3,21 @@ import { LoggerService, UrlReaderService } from '@backstage/backend-plugin-api';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { parseAllDocuments } from 'yaml';
 
-/**
- * Context describing the OpenChoreo (Cluster)ComponentType that a remote
- * scaffolder Template is being fetched for. Used to stamp the linkage
- * annotations the portal's component-creation view relies on for discovery.
- */
+/** The (Cluster)ComponentType a fetched Template is emitted for. */
 export interface RemoteTemplateContext {
-  /** The (Cluster)ComponentType name this template is associated with. */
   ctdName: string;
-  /**
-   * Backstage namespace the emitted Template should live in when the authored
-   * template does not declare one. Namespaced types pass the CT's namespace;
-   * cluster-scoped types pass `openchoreo-cluster`.
-   */
+  /** Namespace to emit into: the CT's namespace, or `openchoreo-cluster`. */
   namespace: string;
-  /** Workload type of the source ComponentType (parity with generated templates). */
   workloadType?: string;
-  /** Display name of the source ComponentType. */
   displayName?: string;
-  /** `ClusterComponentType` for cluster-scoped types; omit for namespaced ones. */
+  /** Set for cluster-scoped types; omit for namespaced ones. */
   ctdKind?: 'ComponentType' | 'ClusterComponentType';
 }
 
 /**
- * Fetches a hand-authored Backstage scaffolder Template from a remote URL and
- * turns it into a catalog Entity that stands in for the auto-generated
- * component-creation wizard.
- *
- * Fetching goes through Backstage's {@link UrlReaderService}, so the set of
- * reachable URLs (public GitHub out of the box, private GitHub / S3 / others)
- * is governed entirely by the `integrations` config. Any failure — unreachable
- * URL, non-YAML body, or a document that isn't a `kind: Template` — throws;
- * callers log the error and emit no template for that type rather than falling
- * back to a possibly-wrong generated wizard.
+ * Fetches a hand-authored scaffolder Template via {@link UrlReaderService} (so
+ * `integrations` config governs reachability) and returns it as a catalog
+ * Entity. Any failure throws; callers emit no template rather than falling back.
  */
 export class RemoteTemplateFetcher {
   constructor(
@@ -43,10 +25,7 @@ export class RemoteTemplateFetcher {
     private readonly logger: LoggerService,
   ) {}
 
-  /**
-   * Read, parse, validate and stamp the remote Template.
-   * @throws if the URL cannot be read or does not yield a valid Template entity.
-   */
+  /** Read, parse, validate and stamp the remote Template. Throws on any failure. */
   async fetch(
     templateUrl: string,
     ctx: RemoteTemplateContext,
@@ -79,9 +58,8 @@ export class RemoteTemplateFetcher {
       );
     }
 
-    // `parseAllDocuments` collects recoverable syntax errors on each document
-    // instead of throwing, so surface them explicitly — otherwise a half-parsed
-    // document silently masquerades as a missing Template.
+    // parseAllDocuments collects recoverable errors instead of throwing; surface
+    // them so a half-parsed doc isn't mistaken for a missing Template.
     for (const doc of docs) {
       if (doc.errors.length > 0) {
         throw new Error(
@@ -120,11 +98,10 @@ export class RemoteTemplateFetcher {
     const annotations: Record<string, string> = {
       ...(entity.metadata.annotations ?? {}),
       [CHOREO_ANNOTATIONS.CTD_NAME]: ctx.ctdName,
-      // Marks this as an associated hand-authored template, not a generated wizard.
+      // Hand-authored, not a generated wizard.
       [CHOREO_ANNOTATIONS.CTD_GENERATED]: 'false',
       [CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL]: templateUrl,
-      // Anchor relative `fetch:*` steps (e.g. `./skeleton`) at the source URL so
-      // the scaffolder resolves skeleton files against the template's origin.
+      // Anchor relative `fetch:*` (e.g. `./skeleton`) at the source URL.
       'backstage.io/managed-by-location': `url:${templateUrl}`,
       'backstage.io/managed-by-origin-location': `url:${templateUrl}`,
     };
@@ -142,14 +119,8 @@ export class RemoteTemplateFetcher {
       ...entity,
       metadata: {
         ...entity.metadata,
-        // Normalise the catalog identity to the same deterministic scheme as
-        // generated templates (`template-<ctName>` in the ComponentType's
-        // namespace). The portal discovery, the periodic full sync, and the
-        // event-driven delete path all key off this identity, so owning it here
-        // keeps custom and generated templates interchangeable and prevents
-        // cross-type name collisions and orphaned/duplicated entities. The
-        // authored title, description, parameters and steps are preserved — only
-        // name and namespace are ours.
+        // Own the identity (like generated templates) so discovery, full sync
+        // and delete stay consistent; the authored spec/title are untouched.
         name: `template-${ctx.ctdName}`,
         namespace: ctx.namespace,
         annotations,

--- a/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.ts
@@ -1,0 +1,137 @@
+import { Entity } from '@backstage/catalog-model';
+import { LoggerService, UrlReaderService } from '@backstage/backend-plugin-api';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { parseAllDocuments } from 'yaml';
+
+/**
+ * Context describing the OpenChoreo (Cluster)ComponentType that a remote
+ * scaffolder Template is being fetched for. Used to stamp the linkage
+ * annotations the portal's component-creation view relies on for discovery.
+ */
+export interface RemoteTemplateContext {
+  /** The (Cluster)ComponentType name this template is associated with. */
+  ctdName: string;
+  /**
+   * Backstage namespace the emitted Template should live in when the authored
+   * template does not declare one. Namespaced types pass the CT's namespace;
+   * cluster-scoped types pass `openchoreo-cluster`.
+   */
+  namespace: string;
+  /** Workload type of the source ComponentType (parity with generated templates). */
+  workloadType?: string;
+  /** Display name of the source ComponentType. */
+  displayName?: string;
+  /** `ClusterComponentType` for cluster-scoped types; omit for namespaced ones. */
+  ctdKind?: 'ComponentType' | 'ClusterComponentType';
+}
+
+/**
+ * Fetches a hand-authored Backstage scaffolder Template from a remote URL and
+ * turns it into a catalog Entity that stands in for the auto-generated
+ * component-creation wizard.
+ *
+ * Fetching goes through Backstage's {@link UrlReaderService}, so the set of
+ * reachable URLs (public GitHub out of the box, private GitHub / S3 / others)
+ * is governed entirely by the `integrations` config. Any failure — unreachable
+ * URL, non-YAML body, or a document that isn't a `kind: Template` — throws;
+ * callers log the error and emit no template for that type rather than falling
+ * back to a possibly-wrong generated wizard.
+ */
+export class RemoteTemplateFetcher {
+  constructor(
+    private readonly urlReader: UrlReaderService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  /**
+   * Read, parse, validate and stamp the remote Template.
+   * @throws if the URL cannot be read or does not yield a valid Template entity.
+   */
+  async fetch(
+    templateUrl: string,
+    ctx: RemoteTemplateContext,
+  ): Promise<Entity> {
+    this.logger.debug(
+      `Fetching custom scaffolder template for ${ctx.ctdName} from ${templateUrl}`,
+    );
+
+    let raw: string;
+    try {
+      const response = await this.urlReader.readUrl(templateUrl);
+      raw = (await response.buffer()).toString('utf-8');
+    } catch (error) {
+      throw new Error(
+        `Unable to read scaffolder template from ${templateUrl}: ${error}`,
+      );
+    }
+
+    const template = this.parseTemplate(raw, templateUrl);
+    return this.stamp(template, templateUrl, ctx);
+  }
+
+  private parseTemplate(raw: string, templateUrl: string): Entity {
+    let entities: unknown[];
+    try {
+      entities = parseAllDocuments(raw).map(doc => doc.toJSON());
+    } catch (error) {
+      throw new Error(
+        `Failed to parse YAML for scaffolder template at ${templateUrl}: ${error}`,
+      );
+    }
+
+    const template = entities.find(
+      (doc): doc is Entity =>
+        Boolean(doc) &&
+        typeof doc === 'object' &&
+        (doc as Entity).kind === 'Template',
+    );
+
+    if (!template) {
+      throw new Error(
+        `No 'kind: Template' entity found in scaffolder template at ${templateUrl}`,
+      );
+    }
+    if (!template.metadata?.name) {
+      throw new Error(
+        `Scaffolder template at ${templateUrl} is missing metadata.name`,
+      );
+    }
+    return template;
+  }
+
+  private stamp(
+    entity: Entity,
+    templateUrl: string,
+    ctx: RemoteTemplateContext,
+  ): Entity {
+    const annotations: Record<string, string> = {
+      ...(entity.metadata.annotations ?? {}),
+      [CHOREO_ANNOTATIONS.CTD_NAME]: ctx.ctdName,
+      // Marks this as an associated hand-authored template, not a generated wizard.
+      [CHOREO_ANNOTATIONS.CTD_GENERATED]: 'false',
+      [CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL]: templateUrl,
+      // Anchor relative `fetch:*` steps (e.g. `./skeleton`) at the source URL so
+      // the scaffolder resolves skeleton files against the template's origin.
+      'backstage.io/managed-by-location': `url:${templateUrl}`,
+      'backstage.io/managed-by-origin-location': `url:${templateUrl}`,
+    };
+    if (ctx.workloadType) {
+      annotations[CHOREO_ANNOTATIONS.WORKLOAD_TYPE] = ctx.workloadType;
+    }
+    if (ctx.ctdKind === 'ClusterComponentType') {
+      annotations[CHOREO_ANNOTATIONS.CTD_KIND] = ctx.ctdKind;
+    }
+    if (ctx.displayName) {
+      annotations[CHOREO_ANNOTATIONS.CTD_DISPLAY_NAME] = ctx.displayName;
+    }
+
+    return {
+      ...entity,
+      metadata: {
+        ...entity.metadata,
+        namespace: entity.metadata.namespace || ctx.namespace,
+        annotations,
+      },
+    };
+  }
+}

--- a/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/RemoteTemplateFetcher.ts
@@ -70,30 +70,43 @@ export class RemoteTemplateFetcher {
   }
 
   private parseTemplate(raw: string, templateUrl: string): Entity {
-    let entities: unknown[];
+    let docs;
     try {
-      entities = parseAllDocuments(raw).map(doc => doc.toJSON());
+      docs = parseAllDocuments(raw);
     } catch (error) {
       throw new Error(
         `Failed to parse YAML for scaffolder template at ${templateUrl}: ${error}`,
       );
     }
 
-    const template = entities.find(
-      (doc): doc is Entity =>
-        Boolean(doc) &&
-        typeof doc === 'object' &&
-        (doc as Entity).kind === 'Template',
-    );
+    // `parseAllDocuments` collects recoverable syntax errors on each document
+    // instead of throwing, so surface them explicitly — otherwise a half-parsed
+    // document silently masquerades as a missing Template.
+    for (const doc of docs) {
+      if (doc.errors.length > 0) {
+        throw new Error(
+          `Failed to parse YAML for scaffolder template at ${templateUrl}: ${doc.errors[0]}`,
+        );
+      }
+    }
+
+    const template = docs
+      .map(doc => doc.toJSON())
+      .find(
+        (doc): doc is Entity =>
+          Boolean(doc) &&
+          typeof doc === 'object' &&
+          (doc as Entity).kind === 'Template',
+      );
 
     if (!template) {
       throw new Error(
         `No 'kind: Template' entity found in scaffolder template at ${templateUrl}`,
       );
     }
-    if (!template.metadata?.name) {
+    if (!template.metadata || typeof template.metadata !== 'object') {
       throw new Error(
-        `Scaffolder template at ${templateUrl} is missing metadata.name`,
+        `Scaffolder template at ${templateUrl} has no metadata block`,
       );
     }
     return template;
@@ -129,7 +142,16 @@ export class RemoteTemplateFetcher {
       ...entity,
       metadata: {
         ...entity.metadata,
-        namespace: entity.metadata.namespace || ctx.namespace,
+        // Normalise the catalog identity to the same deterministic scheme as
+        // generated templates (`template-<ctName>` in the ComponentType's
+        // namespace). The portal discovery, the periodic full sync, and the
+        // event-driven delete path all key off this identity, so owning it here
+        // keeps custom and generated templates interchangeable and prevents
+        // cross-type name collisions and orphaned/duplicated entities. The
+        // authored title, description, parameters and steps are preserved — only
+        // name and namespace are ours.
+        name: `template-${ctx.ctdName}`,
+        namespace: ctx.namespace,
         annotations,
       },
     };

--- a/plugins/catalog-backend-module-openchoreo/src/module.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/module.ts
@@ -79,6 +79,7 @@ export const catalogModuleOpenchoreo = createBackendModule({
         tokenService: openChoreoTokenServiceRef,
         annotationStore: annotationStoreRef,
         events: eventsServiceRef,
+        urlReader: coreServices.urlReader,
       },
       async init({
         catalog,
@@ -91,6 +92,7 @@ export const catalogModuleOpenchoreo = createBackendModule({
         tokenService,
         annotationStore,
         events,
+        urlReader,
       }) {
         const openchoreoConfig = config.getOptionalConfig('openchoreo');
         const frequency =
@@ -206,6 +208,7 @@ export const catalogModuleOpenchoreo = createBackendModule({
             eventsEnabled ? events : undefined,
             catalogService,
             auth,
+            urlReader,
           ),
         );
 

--- a/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.test.ts
@@ -38,7 +38,10 @@ function mkLogger() {
   } as any;
 }
 
-function newApplier(connection: EntityProviderConnection) {
+function newApplier(
+  connection: EntityProviderConnection,
+  remoteTemplateFetcher?: any,
+) {
   return new EventDeltaApplier({
     logger: mkLogger(),
     baseUrl: 'http://test:8080',
@@ -54,6 +57,7 @@ function newApplier(connection: EntityProviderConnection) {
     ctdConverter: new CtdToTemplateConverter(mkLogger()),
     rtdConverter: new RtdToTemplateConverter(mkLogger()),
     ptdConverter: new PtdToTemplateConverter(mkLogger()),
+    remoteTemplateFetcher,
   });
 }
 
@@ -835,5 +839,93 @@ describe('EventDeltaApplier.handleEvent', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('no CatalogService is wired'),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom scaffolder template resolution: a ComponentType carrying the
+// SCAFFOLD_TEMPLATE_URL annotation is served by the RemoteTemplateFetcher
+// instead of the auto-generated wizard.
+// ---------------------------------------------------------------------------
+
+describe('EventDeltaApplier custom scaffolder templates', () => {
+  const URL = 'https://github.com/acme/templates/blob/main/agent.yaml';
+  let applyMutation: jest.Mock;
+  let connection: EntityProviderConnection;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    applyMutation = jest.fn();
+    connection = { applyMutation, refresh: jest.fn() } as any;
+  });
+
+  // A ComponentType API response carrying the custom-template annotation.
+  function ctWithTemplateUrl() {
+    return {
+      data: {
+        metadata: {
+          name: 'agent-sandbox',
+          annotations: {
+            'scaffolder.openchoreo.dev/backstage-template-url': URL,
+          },
+        },
+        spec: { workloadType: 'deployment' },
+      },
+      response: { status: 200 },
+    };
+  }
+
+  it('fetches the custom template and upserts it instead of generating one', async () => {
+    const fetched = {
+      apiVersion: 'scaffolder.backstage.io/v1beta3',
+      kind: 'Template',
+      metadata: { name: 'agent-sandbox-template', namespace: 'test-ns' },
+      spec: { owner: 'guests', type: 'Component', steps: [] },
+    };
+    const fetcher = { fetch: jest.fn().mockResolvedValue(fetched) };
+    mockGET.mockResolvedValue(ctWithTemplateUrl());
+    const applier = newApplier(connection, fetcher);
+
+    await applier.handleEvent(
+      'ComponentType',
+      'agent-sandbox',
+      'test-ns',
+      'created',
+    );
+
+    expect(fetcher.fetch).toHaveBeenCalledWith(
+      URL,
+      expect.objectContaining({
+        ctdName: 'agent-sandbox',
+        namespace: 'test-ns',
+        workloadType: 'deployment',
+      }),
+    );
+    // Only the ComponentType is fetched; no schema GET for wizard generation.
+    expect(mockGET).toHaveBeenCalledTimes(1);
+    const added = applyMutation.mock.calls[0][0].added.map(
+      (d: any) => d.entity.metadata.name,
+    );
+    expect(added).toEqual(
+      expect.arrayContaining(['agent-sandbox', 'agent-sandbox-template']),
+    );
+  });
+
+  it('emits no template (only the ComponentType) when the custom fetch fails', async () => {
+    const fetcher = { fetch: jest.fn().mockRejectedValue(new Error('boom')) };
+    mockGET.mockResolvedValue(ctWithTemplateUrl());
+    const applier = newApplier(connection, fetcher);
+
+    await applier.handleEvent(
+      'ComponentType',
+      'agent-sandbox',
+      'test-ns',
+      'created',
+    );
+
+    const addedKinds = applyMutation.mock.calls[0][0].added.map(
+      (d: any) => d.entity.kind,
+    );
+    expect(addedKinds).toEqual(['ComponentType']);
   });
 });

--- a/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.test.ts
@@ -842,12 +842,6 @@ describe('EventDeltaApplier.handleEvent', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Custom scaffolder template resolution: a ComponentType carrying the
-// SCAFFOLD_TEMPLATE_URL annotation is served by the RemoteTemplateFetcher
-// instead of the auto-generated wizard.
-// ---------------------------------------------------------------------------
-
 describe('EventDeltaApplier custom scaffolder templates', () => {
   const URL = 'https://github.com/acme/templates/blob/main/agent.yaml';
   let applyMutation: jest.Mock;

--- a/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.test.ts
@@ -922,4 +922,82 @@ describe('EventDeltaApplier custom scaffolder templates', () => {
     );
     expect(addedKinds).toEqual(['ComponentType']);
   });
+
+  // A ClusterComponentType API response carrying the custom-template annotation.
+  function cctWithTemplateUrl() {
+    return {
+      data: {
+        metadata: {
+          name: 'cluster-agent-sandbox',
+          annotations: {
+            'scaffolder.openchoreo.dev/backstage-template-url': URL,
+          },
+        },
+        spec: { workloadType: 'deployment' },
+      },
+      response: { status: 200 },
+    };
+  }
+
+  it('fetches the custom template for a ClusterComponentType and upserts it under openchoreo-cluster', async () => {
+    const fetched = {
+      apiVersion: 'scaffolder.backstage.io/v1beta3',
+      kind: 'Template',
+      metadata: {
+        name: 'cluster-agent-sandbox-template',
+        namespace: 'openchoreo-cluster',
+      },
+      spec: { owner: 'guests', type: 'Component', steps: [] },
+    };
+    const fetcher = { fetch: jest.fn().mockResolvedValue(fetched) };
+    mockGET.mockResolvedValue(cctWithTemplateUrl());
+    const applier = newApplier(connection, fetcher);
+
+    await applier.handleEvent(
+      'ClusterComponentType',
+      'cluster-agent-sandbox',
+      '',
+      'created',
+    );
+
+    // Cluster-scoped fetch: emitted into openchoreo-cluster with ctdKind set.
+    expect(fetcher.fetch).toHaveBeenCalledWith(
+      URL,
+      expect.objectContaining({
+        ctdName: 'cluster-agent-sandbox',
+        namespace: 'openchoreo-cluster',
+        workloadType: 'deployment',
+        ctdKind: 'ClusterComponentType',
+      }),
+    );
+    // Only the ClusterComponentType is fetched; no schema GET for generation.
+    expect(mockGET).toHaveBeenCalledTimes(1);
+    const added = applyMutation.mock.calls[0][0].added.map(
+      (d: any) => d.entity.metadata.name,
+    );
+    expect(added).toEqual(
+      expect.arrayContaining([
+        'cluster-agent-sandbox',
+        'cluster-agent-sandbox-template',
+      ]),
+    );
+  });
+
+  it('emits no template (only the ClusterComponentType) when the custom fetch fails', async () => {
+    const fetcher = { fetch: jest.fn().mockRejectedValue(new Error('boom')) };
+    mockGET.mockResolvedValue(cctWithTemplateUrl());
+    const applier = newApplier(connection, fetcher);
+
+    await applier.handleEvent(
+      'ClusterComponentType',
+      'cluster-agent-sandbox',
+      '',
+      'created',
+    );
+
+    const addedKinds = applyMutation.mock.calls[0][0].added.map(
+      (d: any) => d.entity.kind,
+    );
+    expect(addedKinds).toEqual(['ClusterComponentType']);
+  });
 });

--- a/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.ts
@@ -49,11 +49,16 @@ import {
   translateNewWorkflowToEntity,
 } from '../utils/entityTranslation';
 import {
+  getAnnotation,
   getCreatedAt,
   getDescription,
   getDisplayName,
   getName,
 } from '@openchoreo/openchoreo-client-node';
+import {
+  RemoteTemplateContext,
+  RemoteTemplateFetcher,
+} from '../converters/RemoteTemplateFetcher';
 import { CtdToTemplateConverter } from '../converters/CtdToTemplateConverter';
 import { RtdToTemplateConverter } from '../converters/RtdToTemplateConverter';
 import {
@@ -119,6 +124,7 @@ export class EventDeltaApplier {
   private readonly ctdConverter: CtdToTemplateConverter;
   private readonly rtdConverter: RtdToTemplateConverter;
   private readonly ptdConverter: PtdToTemplateConverter;
+  private readonly remoteTemplateFetcher?: RemoteTemplateFetcher;
   private readonly catalogService?: CatalogService;
   private readonly auth?: AuthService;
 
@@ -132,6 +138,12 @@ export class EventDeltaApplier {
     ctdConverter: CtdToTemplateConverter;
     rtdConverter: RtdToTemplateConverter;
     ptdConverter: PtdToTemplateConverter;
+    /**
+     * Resolves custom scaffolder Templates referenced by the
+     * SCAFFOLD_TEMPLATE_URL annotation. Shared with the periodic provider so
+     * both sync paths behave identically. Undefined disables the feature.
+     */
+    remoteTemplateFetcher?: RemoteTemplateFetcher;
     /**
      * Optional catalog read-side. Used by the workload-deletion handler
      * to find entities annotated with the deleted workload's name and
@@ -153,6 +165,7 @@ export class EventDeltaApplier {
     this.ctdConverter = opts.ctdConverter;
     this.rtdConverter = opts.rtdConverter;
     this.ptdConverter = opts.ptdConverter;
+    this.remoteTemplateFetcher = opts.remoteTemplateFetcher;
     this.getConnection = opts.getConnection;
     this.catalogService = opts.catalogService;
     this.auth = opts.auth;
@@ -162,6 +175,32 @@ export class EventDeltaApplier {
 
   private locationKey(): string {
     return `provider:${this.translatorContext.providerName}`;
+  }
+
+  /**
+   * Resolve a custom scaffolder Template referenced by a ComponentType's
+   * SCAFFOLD_TEMPLATE_URL annotation. Returns the fetched Template, or
+   * `undefined` (with an error logged) when no UrlReader is configured or the
+   * fetch fails — no template is emitted for that type in that case.
+   */
+  private async resolveCustomTemplate(
+    templateUrl: string,
+    ctx: RemoteTemplateContext,
+  ): Promise<Entity | undefined> {
+    if (!this.remoteTemplateFetcher) {
+      this.logger.error(
+        `ComponentType ${ctx.ctdName} sets ${CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL} but no UrlReader is configured; skipping its template`,
+      );
+      return undefined;
+    }
+    try {
+      return await this.remoteTemplateFetcher.fetch(templateUrl, ctx);
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch custom template for ComponentType ${ctx.ctdName} from ${templateUrl}: ${error}`,
+      );
+      return undefined;
+    }
   }
 
   private toDeferred(entities: Entity[]): {
@@ -850,6 +889,20 @@ export class EventDeltaApplier {
     const ctName = getName(ct);
     if (!ctName) return undefined;
 
+    // A custom template URL short-circuits schema fetch + generation.
+    const templateUrl = getAnnotation(
+      ct,
+      CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
+    );
+    if (templateUrl) {
+      return this.resolveCustomTemplate(templateUrl, {
+        ctdName: ctName,
+        namespace: ns,
+        workloadType: ct.spec?.workloadType ?? 'deployment',
+        displayName: getDisplayName(ct),
+      });
+    }
+
     try {
       const { data: schemaData, error: schemaError } = await client.GET(
         '/api/v1/namespaces/{namespaceName}/componenttypes/{ctName}/schema',
@@ -909,6 +962,21 @@ export class EventDeltaApplier {
   ): Promise<Entity | undefined> {
     const cctName = getName(cct);
     if (!cctName) return undefined;
+
+    // A custom template URL short-circuits schema fetch + generation.
+    const templateUrl = getAnnotation(
+      cct,
+      CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
+    );
+    if (templateUrl) {
+      return this.resolveCustomTemplate(templateUrl, {
+        ctdName: cctName,
+        namespace: 'openchoreo-cluster',
+        workloadType: cct.spec?.workloadType ?? 'deployment',
+        displayName: getDisplayName(cct),
+        ctdKind: 'ClusterComponentType',
+      });
+    }
 
     try {
       const { data: schemaData, error: schemaError } = await client.GET(

--- a/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.ts
@@ -138,11 +138,7 @@ export class EventDeltaApplier {
     ctdConverter: CtdToTemplateConverter;
     rtdConverter: RtdToTemplateConverter;
     ptdConverter: PtdToTemplateConverter;
-    /**
-     * Resolves custom scaffolder Templates referenced by the
-     * SCAFFOLD_TEMPLATE_URL annotation. Shared with the periodic provider so
-     * both sync paths behave identically. Undefined disables the feature.
-     */
+    /** Resolves custom templates; shared with the provider. Undefined disables it. */
     remoteTemplateFetcher?: RemoteTemplateFetcher;
     /**
      * Optional catalog read-side. Used by the workload-deletion handler
@@ -177,12 +173,7 @@ export class EventDeltaApplier {
     return `provider:${this.translatorContext.providerName}`;
   }
 
-  /**
-   * Resolve a custom scaffolder Template referenced by a ComponentType's
-   * SCAFFOLD_TEMPLATE_URL annotation. Returns the fetched Template, or
-   * `undefined` (with an error logged) when no UrlReader is configured or the
-   * fetch fails — no template is emitted for that type in that case.
-   */
+  /** Fetch the custom Template, or undefined (error logged) if unavailable/failed. */
   private async resolveCustomTemplate(
     templateUrl: string,
     ctx: RemoteTemplateContext,

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -128,11 +128,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
   private readonly translatorContext: NewApiTranslatorContext;
   /** Subsystem that handles per-event delta updates. Built once. */
   private readonly eventApplier: EventDeltaApplier;
-  /**
-   * Fetches hand-authored scaffolder Templates referenced via the
-   * {@link CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL} annotation. Undefined when
-   * no UrlReader was provided (feature effectively disabled).
-   */
+  /** Resolves custom templates; undefined disables the feature (no UrlReader). */
   private readonly remoteTemplateFetcher?: RemoteTemplateFetcher;
 
   constructor(
@@ -173,10 +169,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     // Initialize component type utilities from config
     this.componentTypeUtils = ComponentTypeUtils.fromConfig(config);
 
-    // Build the remote-template fetcher when a UrlReader is available. Used to
-    // resolve custom scaffolder templates referenced by ComponentTypes via the
-    // SCAFFOLD_TEMPLATE_URL annotation. Shared with the event-driven applier so
-    // both sync paths behave identically.
+    // Shared with the event applier so both sync paths behave identically.
     this.remoteTemplateFetcher = urlReader
       ? new RemoteTemplateFetcher(urlReader, this.logger)
       : undefined;
@@ -207,13 +200,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     return 'OpenChoreoEntityProvider';
   }
 
-  /**
-   * Resolve a custom scaffolder Template referenced by a ComponentType's
-   * SCAFFOLD_TEMPLATE_URL annotation. Returns the fetched Template entity, or
-   * `null` (with an error logged) when no UrlReader is configured or the fetch
-   * fails — in which case no template is emitted for that type rather than
-   * falling back to a generated wizard.
-   */
+  /** Fetch the custom Template, or null (error logged) if unavailable/failed. */
   private async resolveCustomTemplate(
     templateUrl: string,
     ctx: RemoteTemplateContext,
@@ -892,18 +879,14 @@ export class OpenChoreoEntityProvider implements EntityProvider {
             componentTypes.map(async ct => {
               const ctName = getName(ct);
               if (!ctName) return null;
-              // `templateUrl` carries the custom-template annotation from the
-              // raw CR (dropped by the trimmed metadata below) to the emission
-              // step, which decides fetch-vs-generate.
+              // Carried to the emission step, which decides fetch-vs-generate.
               const templateUrl = getAnnotation(
                 ct,
                 CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
               );
               try {
-                // A custom template replaces the generated wizard, so its input
-                // schema is irrelevant. Skip the schema fetch (and don't drop the
-                // type when it has no schema) — mirrors the event-driven path so
-                // both syncs emit the custom template identically.
+                // Custom templates need no schema — skip the fetch (mirrors the
+                // event path; also avoids dropping schema-less types).
                 let schemaData: any;
                 if (!templateUrl) {
                   const { data, error: schemaError } = await client.GET(
@@ -956,9 +939,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
             (ctd): ctd is NonNullable<typeof ctd> => ctd !== null,
           );
 
-          // Convert CTDs to template entities. When a CTD declares a custom
-          // template URL we fetch that Template instead of generating one;
-          // otherwise we generate the wizard as before.
+          // Fetch a custom Template when the CTD declares one, else generate.
           const templateEntities: Entity[] = (
             await Promise.all(
               validCTDs.map(async ctd => {

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -892,9 +892,21 @@ export class OpenChoreoEntityProvider implements EntityProvider {
             componentTypes.map(async ct => {
               const ctName = getName(ct);
               if (!ctName) return null;
+              // `templateUrl` carries the custom-template annotation from the
+              // raw CR (dropped by the trimmed metadata below) to the emission
+              // step, which decides fetch-vs-generate.
+              const templateUrl = getAnnotation(
+                ct,
+                CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
+              );
               try {
-                const { data: schemaData, error: schemaError } =
-                  await client.GET(
+                // A custom template replaces the generated wizard, so its input
+                // schema is irrelevant. Skip the schema fetch (and don't drop the
+                // type when it has no schema) — mirrors the event-driven path so
+                // both syncs emit the custom template identically.
+                let schemaData: any;
+                if (!templateUrl) {
+                  const { data, error: schemaError } = await client.GET(
                     '/api/v1/namespaces/{namespaceName}/componenttypes/{ctName}/schema',
                     {
                       params: {
@@ -903,17 +915,16 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                     },
                   );
 
-                if (schemaError || !schemaData) {
-                  this.logger.warn(
-                    `Failed to fetch schema for CTD ${ctName} in namespace ${nsName}`,
-                  );
-                  return null;
+                  if (schemaError || !data) {
+                    this.logger.warn(
+                      `Failed to fetch schema for CTD ${ctName} in namespace ${nsName}`,
+                    );
+                    return null;
+                  }
+                  schemaData = data;
                 }
 
                 // Combine metadata from list item + schema into full object.
-                // `templateUrl` carries the custom-template annotation from the
-                // raw CR (dropped by the trimmed metadata below) to the
-                // emission step, which decides fetch-vs-generate.
                 const fullComponentType = {
                   metadata: {
                     name: ctName,
@@ -925,12 +936,9 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                     createdAt: getCreatedAt(ct) || '',
                   },
                   spec: {
-                    inputParametersSchema: schemaData as any,
+                    inputParametersSchema: schemaData,
                   },
-                  templateUrl: getAnnotation(
-                    ct,
-                    CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
-                  ),
+                  templateUrl,
                 };
 
                 return fullComponentType;
@@ -1384,21 +1392,30 @@ export class OpenChoreoEntityProvider implements EntityProvider {
           clusterComponentTypes.map(async cct => {
             const cctName = getName(cct);
             if (!cctName) return null;
+            const templateUrl = getAnnotation(
+              cct,
+              CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
+            );
             try {
-              const { data: schemaData, error: schemaError } = await client.GET(
-                '/api/v1/clustercomponenttypes/{cctName}/schema',
-                {
-                  params: {
-                    path: { cctName },
+              // Custom template: skip the schema fetch (see the namespaced path).
+              let schemaData: any;
+              if (!templateUrl) {
+                const { data, error: schemaError } = await client.GET(
+                  '/api/v1/clustercomponenttypes/{cctName}/schema',
+                  {
+                    params: {
+                      path: { cctName },
+                    },
                   },
-                },
-              );
-
-              if (schemaError || !schemaData) {
-                this.logger.warn(
-                  `Failed to fetch schema for ClusterComponentType ${cctName}`,
                 );
-                return null;
+
+                if (schemaError || !data) {
+                  this.logger.warn(
+                    `Failed to fetch schema for ClusterComponentType ${cctName}`,
+                  );
+                  return null;
+                }
+                schemaData = data;
               }
 
               return {
@@ -1417,12 +1434,9 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                   createdAt: getCreatedAt(cct) || '',
                 },
                 spec: {
-                  inputParametersSchema: schemaData as any,
+                  inputParametersSchema: schemaData,
                 },
-                templateUrl: getAnnotation(
-                  cct,
-                  CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
-                ),
+                templateUrl,
               };
             } catch (error) {
               this.logger.warn(

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -8,11 +8,13 @@ import {
   AuthService,
   LoggerService,
   SchedulerServiceTaskRunner,
+  UrlReaderService,
 } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import type { EventsService, EventParams } from '@backstage/plugin-events-node';
 import {
   fetchAllPages,
+  getAnnotation,
   getCreatedAt,
   getDescription,
   getDisplayName,
@@ -20,9 +22,16 @@ import {
   type OpenChoreoComponents,
 } from '@openchoreo/openchoreo-client-node';
 import { OpenChoreoTokenService } from '@openchoreo/openchoreo-auth';
-import { ComponentTypeUtils } from '@openchoreo/backstage-plugin-common';
+import {
+  CHOREO_ANNOTATIONS,
+  ComponentTypeUtils,
+} from '@openchoreo/backstage-plugin-common';
 import { DeploymentPipelineEntityV1alpha1 } from '../kinds';
 import { CtdToTemplateConverter } from '../converters/CtdToTemplateConverter';
+import {
+  RemoteTemplateContext,
+  RemoteTemplateFetcher,
+} from '../converters/RemoteTemplateFetcher';
 import { RtdToTemplateConverter } from '../converters/RtdToTemplateConverter';
 import {
   PtdToTemplateConverter,
@@ -119,6 +128,12 @@ export class OpenChoreoEntityProvider implements EntityProvider {
   private readonly translatorContext: NewApiTranslatorContext;
   /** Subsystem that handles per-event delta updates. Built once. */
   private readonly eventApplier: EventDeltaApplier;
+  /**
+   * Fetches hand-authored scaffolder Templates referenced via the
+   * {@link CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL} annotation. Undefined when
+   * no UrlReader was provided (feature effectively disabled).
+   */
+  private readonly remoteTemplateFetcher?: RemoteTemplateFetcher;
 
   constructor(
     taskRunner: SchedulerServiceTaskRunner,
@@ -128,6 +143,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     events?: EventsService,
     catalogService?: CatalogService,
     auth?: AuthService,
+    urlReader?: UrlReaderService,
   ) {
     this.taskRunner = taskRunner;
     this.logger = logger;
@@ -157,6 +173,14 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     // Initialize component type utilities from config
     this.componentTypeUtils = ComponentTypeUtils.fromConfig(config);
 
+    // Build the remote-template fetcher when a UrlReader is available. Used to
+    // resolve custom scaffolder templates referenced by ComponentTypes via the
+    // SCAFFOLD_TEMPLATE_URL annotation. Shared with the event-driven applier so
+    // both sync paths behave identically.
+    this.remoteTemplateFetcher = urlReader
+      ? new RemoteTemplateFetcher(urlReader, this.logger)
+      : undefined;
+
     this.translatorContext = {
       providerName: this.getProviderName(),
       defaultOwner: this.defaultOwner,
@@ -173,6 +197,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       ctdConverter: this.ctdConverter,
       rtdConverter: this.rtdConverter,
       ptdConverter: this.ptdConverter,
+      remoteTemplateFetcher: this.remoteTemplateFetcher,
       catalogService,
       auth,
     });
@@ -180,6 +205,33 @@ export class OpenChoreoEntityProvider implements EntityProvider {
 
   getProviderName(): string {
     return 'OpenChoreoEntityProvider';
+  }
+
+  /**
+   * Resolve a custom scaffolder Template referenced by a ComponentType's
+   * SCAFFOLD_TEMPLATE_URL annotation. Returns the fetched Template entity, or
+   * `null` (with an error logged) when no UrlReader is configured or the fetch
+   * fails — in which case no template is emitted for that type rather than
+   * falling back to a generated wizard.
+   */
+  private async resolveCustomTemplate(
+    templateUrl: string,
+    ctx: RemoteTemplateContext,
+  ): Promise<Entity | null> {
+    if (!this.remoteTemplateFetcher) {
+      this.logger.error(
+        `ComponentType ${ctx.ctdName} sets ${CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL} but no UrlReader is configured; skipping its template`,
+      );
+      return null;
+    }
+    try {
+      return await this.remoteTemplateFetcher.fetch(templateUrl, ctx);
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch custom template for ComponentType ${ctx.ctdName} from ${templateUrl}: ${error}`,
+      );
+      return null;
+    }
   }
 
   /**
@@ -858,7 +910,10 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                   return null;
                 }
 
-                // Combine metadata from list item + schema into full object
+                // Combine metadata from list item + schema into full object.
+                // `templateUrl` carries the custom-template annotation from the
+                // raw CR (dropped by the trimmed metadata below) to the
+                // emission step, which decides fetch-vs-generate.
                 const fullComponentType = {
                   metadata: {
                     name: ctName,
@@ -872,6 +927,10 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                   spec: {
                     inputParametersSchema: schemaData as any,
                   },
+                  templateUrl: getAnnotation(
+                    ct,
+                    CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
+                  ),
                 };
 
                 return fullComponentType;
@@ -889,30 +948,42 @@ export class OpenChoreoEntityProvider implements EntityProvider {
             (ctd): ctd is NonNullable<typeof ctd> => ctd !== null,
           );
 
-          // Convert CTDs to template entities
-          const templateEntities: Entity[] = validCTDs
-            .map(ctd => {
-              try {
-                const templateEntity =
-                  this.ctdConverter.convertCtdToTemplateEntity(ctd, nsName);
-                if (!templateEntity.metadata.annotations) {
-                  templateEntity.metadata.annotations = {};
+          // Convert CTDs to template entities. When a CTD declares a custom
+          // template URL we fetch that Template instead of generating one;
+          // otherwise we generate the wizard as before.
+          const templateEntities: Entity[] = (
+            await Promise.all(
+              validCTDs.map(async ctd => {
+                if (ctd.templateUrl) {
+                  return this.resolveCustomTemplate(ctd.templateUrl, {
+                    ctdName: ctd.metadata.name,
+                    namespace: nsName,
+                    workloadType: ctd.metadata.workloadType,
+                    displayName: ctd.metadata.displayName,
+                  });
                 }
-                templateEntity.metadata.annotations[
-                  'backstage.io/managed-by-location'
-                ] = `provider:${this.getProviderName()}`;
-                templateEntity.metadata.annotations[
-                  'backstage.io/managed-by-origin-location'
-                ] = `provider:${this.getProviderName()}`;
-                return templateEntity;
-              } catch (error) {
-                this.logger.warn(
-                  `Failed to convert CTD ${ctd.metadata.name} to template: ${error}`,
-                );
-                return null;
-              }
-            })
-            .filter((entity): entity is Entity => entity !== null);
+                try {
+                  const templateEntity =
+                    this.ctdConverter.convertCtdToTemplateEntity(ctd, nsName);
+                  if (!templateEntity.metadata.annotations) {
+                    templateEntity.metadata.annotations = {};
+                  }
+                  templateEntity.metadata.annotations[
+                    'backstage.io/managed-by-location'
+                  ] = `provider:${this.getProviderName()}`;
+                  templateEntity.metadata.annotations[
+                    'backstage.io/managed-by-origin-location'
+                  ] = `provider:${this.getProviderName()}`;
+                  return templateEntity;
+                } catch (error) {
+                  this.logger.warn(
+                    `Failed to convert CTD ${ctd.metadata.name} to template: ${error}`,
+                  );
+                  return null;
+                }
+              }),
+            )
+          ).filter((entity): entity is Entity => entity !== null);
 
           allEntities.push(...templateEntities);
           this.logger.info(
@@ -1348,6 +1419,10 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                 spec: {
                   inputParametersSchema: schemaData as any,
                 },
+                templateUrl: getAnnotation(
+                  cct,
+                  CHOREO_ANNOTATIONS.SCAFFOLD_TEMPLATE_URL,
+                ),
               };
             } catch (error) {
               this.logger.warn(
@@ -1362,29 +1437,41 @@ export class OpenChoreoEntityProvider implements EntityProvider {
           (cct): cct is NonNullable<typeof cct> => cct !== null,
         );
 
-        const cctTemplateEntities: Entity[] = validCCTs
-          .map(cct => {
-            try {
-              const templateEntity =
-                this.ctdConverter.convertClusterCtdToTemplateEntity(cct);
-              if (!templateEntity.metadata.annotations) {
-                templateEntity.metadata.annotations = {};
+        const cctTemplateEntities: Entity[] = (
+          await Promise.all(
+            validCCTs.map(async cct => {
+              if (cct.templateUrl) {
+                return this.resolveCustomTemplate(cct.templateUrl, {
+                  ctdName: cct.metadata.name,
+                  // Cluster-scoped Templates live in the shared cluster namespace.
+                  namespace: 'openchoreo-cluster',
+                  workloadType: cct.metadata.workloadType,
+                  displayName: cct.metadata.displayName,
+                  ctdKind: 'ClusterComponentType',
+                });
               }
-              templateEntity.metadata.annotations[
-                'backstage.io/managed-by-location'
-              ] = `provider:${this.getProviderName()}`;
-              templateEntity.metadata.annotations[
-                'backstage.io/managed-by-origin-location'
-              ] = `provider:${this.getProviderName()}`;
-              return templateEntity;
-            } catch (error) {
-              this.logger.warn(
-                `Failed to convert ClusterComponentType ${cct.metadata.name} to template: ${error}`,
-              );
-              return null;
-            }
-          })
-          .filter((entity): entity is Entity => entity !== null);
+              try {
+                const templateEntity =
+                  this.ctdConverter.convertClusterCtdToTemplateEntity(cct);
+                if (!templateEntity.metadata.annotations) {
+                  templateEntity.metadata.annotations = {};
+                }
+                templateEntity.metadata.annotations[
+                  'backstage.io/managed-by-location'
+                ] = `provider:${this.getProviderName()}`;
+                templateEntity.metadata.annotations[
+                  'backstage.io/managed-by-origin-location'
+                ] = `provider:${this.getProviderName()}`;
+                return templateEntity;
+              } catch (error) {
+                this.logger.warn(
+                  `Failed to convert ClusterComponentType ${cct.metadata.name} to template: ${error}`,
+                );
+                return null;
+              }
+            }),
+          )
+        ).filter((entity): entity is Entity => entity !== null);
 
         allEntities.push(...cctTemplateEntities);
         this.logger.info(

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -954,15 +954,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
                 try {
                   const templateEntity =
                     this.ctdConverter.convertCtdToTemplateEntity(ctd, nsName);
-                  if (!templateEntity.metadata.annotations) {
-                    templateEntity.metadata.annotations = {};
-                  }
-                  templateEntity.metadata.annotations[
-                    'backstage.io/managed-by-location'
-                  ] = `provider:${this.getProviderName()}`;
-                  templateEntity.metadata.annotations[
-                    'backstage.io/managed-by-origin-location'
-                  ] = `provider:${this.getProviderName()}`;
+                  this.stampManagedByLocation(templateEntity);
                   return templateEntity;
                 } catch (error) {
                   this.logger.warn(
@@ -1448,15 +1440,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
               try {
                 const templateEntity =
                   this.ctdConverter.convertClusterCtdToTemplateEntity(cct);
-                if (!templateEntity.metadata.annotations) {
-                  templateEntity.metadata.annotations = {};
-                }
-                templateEntity.metadata.annotations[
-                  'backstage.io/managed-by-location'
-                ] = `provider:${this.getProviderName()}`;
-                templateEntity.metadata.annotations[
-                  'backstage.io/managed-by-origin-location'
-                ] = `provider:${this.getProviderName()}`;
+                this.stampManagedByLocation(templateEntity);
                 return templateEntity;
               } catch (error) {
                 this.logger.warn(

--- a/plugins/openchoreo-common/src/constants.ts
+++ b/plugins/openchoreo-common/src/constants.ts
@@ -31,6 +31,11 @@ export const CHOREO_ANNOTATIONS = {
   CTD_DISPLAY_NAME: 'openchoreo.io/ctd-display-name',
   CTD_GENERATED: 'openchoreo.io/ctd-generated',
   CTD_KIND: 'openchoreo.io/ctd-kind',
+  // Set on an OpenChoreo (Cluster)ComponentType to point the catalog sync at a
+  // hand-authored Backstage scaffolder Template. When present, the sync fetches
+  // that Template from the URL (via Backstage `integrations`) and emits it in
+  // place of the auto-generated component-creation wizard for this type.
+  SCAFFOLD_TEMPLATE_URL: 'scaffolder.openchoreo.dev/backstage-template-url',
   // (Cluster)ResourceType Definition (RTD) annotations
   // Umbrella prefix `RTD` mirrors `CTD` on the Component side: a third
   // letter (`D` for Definition) keeps it distinct from `RT` (ResourceType)

--- a/plugins/openchoreo-common/src/constants.ts
+++ b/plugins/openchoreo-common/src/constants.ts
@@ -31,10 +31,8 @@ export const CHOREO_ANNOTATIONS = {
   CTD_DISPLAY_NAME: 'openchoreo.io/ctd-display-name',
   CTD_GENERATED: 'openchoreo.io/ctd-generated',
   CTD_KIND: 'openchoreo.io/ctd-kind',
-  // Set on an OpenChoreo (Cluster)ComponentType to point the catalog sync at a
-  // hand-authored Backstage scaffolder Template. When present, the sync fetches
-  // that Template from the URL (via Backstage `integrations`) and emits it in
-  // place of the auto-generated component-creation wizard for this type.
+  // Points the sync at a hand-authored scaffolder Template to serve instead of
+  // the generated wizard for this (Cluster)ComponentType.
   SCAFFOLD_TEMPLATE_URL: 'scaffolder.openchoreo.dev/backstage-template-url',
   // (Cluster)ResourceType Definition (RTD) annotations
   // Umbrella prefix `RTD` mirrors `CTD` on the Component side: a third

--- a/yarn.lock
+++ b/yarn.lock
@@ -9837,6 +9837,7 @@ __metadata:
     "@openchoreo/openchoreo-client-node": "workspace:^"
     json-schema: "npm:0.4.0"
     knex: "npm:3.1.0"
+    yaml: "npm:^2.8.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Purpose

The Backstage portal auto-generates a fixed 3-section component-creation wizard
(Component Metadata → Build & Deploy → Workload Details) for every ComponentType (CCT).
Fixed-image components — e.g. the agent sandbox — shouldn't show a Build & Deploy step,
and CCT authors currently have no way to customise the wizard.

Per the design agreed for dynamic wizard steps (openchoreo/openchoreo discussion #3678), this
lets a CCT point at a hand-authored Backstage scaffolder Template that replaces the generated
wizard, without any portal UI changes.

## Goals

- Let a `(Cluster)ComponentType` declare a single annotation,
  `scaffolder.openchoreo.dev/backstage-template-url`, pointing at a hand-authored Template.
- When present, the catalog sync fetches that Template and emits it **instead of** the
  generated wizard; its presence both suppresses generation and associates the type with the
  custom template.
- Behave identically on the periodic full sync and the event-driven delta sync.

## Approach

- **Annotation:** add `SCAFFOLD_TEMPLATE_URL` (`scaffolder.openchoreo.dev/backstage-template-url`)
  to `CHOREO_ANNOTATIONS`.
- **`RemoteTemplateFetcher`:** reads the URL via Backstage `UrlReaderService` (so reachability
  is governed by the `integrations` config — public GitHub out of the box, private GitHub / S3 /
  others via standard integration creds), validates a `kind: Template`, and stamps the CCT
  linkage annotations plus `backstage.io/managed-by-location: url:<url>` so relative `fetch:*`
  skeleton paths resolve against the source. The emitted Template's identity is normalised to
  the deterministic `template-<ctName>` in the CT's namespace so custom and generated templates
  are interchangeable for discovery, the periodic full sync, and the event-driven delete path.
- **Wiring:** `coreServices.urlReader` is injected through the module into the provider and the
  event applier; the namespaced and cluster ComponentType paths branch fetch-vs-generate in both.
- **Failure handling:** unreadable URL / non-`Template` / YAML parse error → log an error and
  emit no template for that type (no fallback to a generated wizard).

Scope: ComponentType only (ResourceType/ProjectType generators unchanged). Remote URL only
(local file-mount sourcing is out of scope).

## User stories

- As a platform engineer, I can attach a hand-authored scaffolder template to a ComponentType so
  its component-creation UI matches the type (e.g. a fixed-image agent sandbox with no Build &
  Deploy step) without patching the portal.

## Release note

Added support for custom component-creation templates: a `(Cluster)ComponentType` can set the
`scaffolder.openchoreo.dev/backstage-template-url` annotation to serve a hand-authored Backstage
scaffolder Template in place of the auto-generated wizard.

## Documentation

N/A in this PR — GitOps/CCT authoring docs to follow as a separate docs change once the annotation
name is finalised.

## Automation tests

- Unit tests
  > New `RemoteTemplateFetcher` suite (fetch/parse/validate/stamp, identity normalisation, and
  > every error path — unreadable URL, non-Template, malformed YAML, no metadata). Added
  > `EventDeltaApplier` cases: annotation present → fetcher used & generation skipped; fetch
  > failure → no template emitted. Full module suite: **293 passing**.
- Integration tests
  > Manual end-to-end verification performed against a live control plane — see **Manual testing** below.

## Manual testing

Verified end-to-end on a live k3d control plane (Backstage 1.51, event-forwarder + periodic sync
both enabled) against a `ClusterComponentType` carrying `scaffolder.openchoreo.dev/backstage-template-url`:

- **Fetch & render (full-sync path)** — the annotated CCT surfaces the fetched remote template
  (title / parameters / steps come from the file) instead of the auto-generated wizard, and
  `backstage.io/managed-by-location` is stamped with the template URL. Editing the remote file and
  re-syncing re-fetches the new version (no stale cache).
- **Event / delta path** — via the OpenChoreo event webhook, a `deleted` event removes the template
  and an `updated` / `created` event re-fetches and re-inserts it within ~3 s (well before the
  periodic full sync), confirming the delta path drives the same `RemoteTemplateFetcher`.
- **Fail-closed** — fetch failures (DNS error, `raw.githubusercontent.com` `429`, host not in
  `backend.reading.allow`, private repo without a token) drop the entity rather than falling back to
  the generated wizard; the backend logs the error.
- **Public & private repos** — a public `github.com` blob URL resolves anonymously; a private repo
  fail-closes without credentials and succeeds once `integrations.github[].token` (repo scope) is
  configured, with `managed-by-location` confirmed as the private URL.
- **`spec.type` categorisation** — `Component` lands under the Component view; other / lower-cased
  types fall into "Other Templates".
- **End-to-end create** — ran a fetched template through `openchoreo:component:create` and created a
  component successfully.

> Notes for template authors surfaced during testing (not feature behaviour): use a **blob** URL
> (raw URLs need the host allow-listed / are rate-limited); a private repo needs
> `integrations.github[].token`; and to actually create, the remote template should declare
> `spec.EXPERIMENTAL_formDecorators: [{ id: openchoreo:inject-user-token }]`, use the registered
> `ProjectNamespaceField` / `Secret` field extensions, and pass env vars under `workloadDetails.envVars`.

## Security checks

- Followed secure coding standards? yes
- Ran FindSecurityBugs plugin and verified report? N/A (no Java; TS lint clean)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs

- Design discussion: openchoreo/openchoreo#3678

## Migrations (if applicable)

N/A — additive annotation; existing ComponentTypes without it keep the generated wizard unchanged.

## Test environment

- Node 20/22, Yarn 4.4.1, Backstage 1.51. `yarn workspace @openchoreo/backstage-plugin-catalog-backend-module test`, repo `tsc`, and package lint run locally.

## Learning

Backstage `UrlReaderService` / `integrations` for credentialed remote reads, and the scaffolder's
`backstage.io/managed-by-location` mechanism for resolving relative skeleton fetches against a
template's origin URL.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenChoreo now supports hand-authored Backstage scaffolder Templates for component types when `scaffolder.openchoreo.dev/backstage-template-url` is set, using the referenced remote Template instead of the default wizard.
  * Works for both standard and cluster-scoped component types, including consistent behavior across full sync and event-driven updates.

* **Bug Fixes**
  * If the URL can’t be read, the YAML can’t be parsed, or no valid `kind: Template` is found, the system logs an error and skips emitting the custom template.

* **Tests**
  * Added coverage for remote template fetching, validation, stamping, and event-delta custom-template handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->