### PR TITLE
feat(openchoreo): show Summary and Definition tabs for rendered releases

### DIFF
--- a/.changeset/rendered-release-events-spec-tabs.md
+++ b/.changeset/rendered-release-events-spec-tabs.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin': minor
+---
+
+Show **Events** and **Spec** tabs on the release details page when a rendered release is selected in the resource tree. The Events tab surfaces release-level Kubernetes events (reusing the existing events table and API endpoint), and the Spec tab renders the full rendered release spec as YAML.

--- a/.changeset/rendered-release-events-spec-tabs.md
+++ b/.changeset/rendered-release-events-spec-tabs.md
@@ -1,5 +1,0 @@
----
-'@openchoreo/backstage-plugin': minor
----
-
-Show **Events** and **Spec** tabs on the release details page when a rendered release is selected in the resource tree. The Events tab surfaces release-level Kubernetes events (reusing the existing events table and API endpoint), and the Spec tab renders the full rendered release spec as YAML.

--- a/.changeset/rendered-release-summary-tabs.md
+++ b/.changeset/rendered-release-summary-tabs.md
@@ -1,0 +1,7 @@
+---
+'@openchoreo/backstage-plugin': minor
+---
+
+Show **Summary** and **Definition** tabs on the release details page when a rendered release is selected in the resource tree. The Summary tab lists the release's status conditions alongside its owning project, component, environment and target plane, so a failed apply to the data plane surfaces directly in the drawer as `ResourcesApplied=False` with the apply error as the condition message. The Definition tab renders the full rendered release as YAML.
+
+Rendered releases are not given an Events tab: the release controllers report state through status conditions rather than Kubernetes events, so it would always be empty. Events remain available on the individual resources under a release.

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.test.tsx
@@ -34,7 +34,10 @@ function makeReleaseNode(overrides: Partial<LayoutNode> = {}): LayoutNode {
     version: 'v1alpha1',
     targetPlane: 'dataplane',
     parentIds: ['__release_binding__'],
-    specObject: { apiVersion: 'openchoreo.dev/v1alpha1', kind: 'RenderedRelease' },
+    specObject: {
+      apiVersion: 'openchoreo.dev/v1alpha1',
+      kind: 'RenderedRelease',
+    },
     x: 0,
     y: 0,
     width: 200,
@@ -65,7 +68,9 @@ describe('ReleaseDetailTabs', () => {
 
     const viewer = screen.getByTestId('yaml-viewer');
     expect(viewer).toHaveTextContent('kind: RenderedRelease');
-    expect(screen.queryByTestId('resource-events-table')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('resource-events-table'),
+    ).not.toBeInTheDocument();
   });
 
   it('shows an empty state on the Spec tab when no spec is available', async () => {
@@ -80,6 +85,23 @@ describe('ReleaseDetailTabs', () => {
 
     expect(screen.getByText('No release spec available')).toBeInTheDocument();
     expect(screen.queryByTestId('yaml-viewer')).not.toBeInTheDocument();
+  });
+
+  it('surfaces the target plane as a chip when present', () => {
+    render(<ReleaseDetailTabs {...defaultProps} node={makeReleaseNode()} />);
+
+    expect(screen.getByText('Target: dataplane')).toBeInTheDocument();
+  });
+
+  it('omits the target plane chip when the node has none', () => {
+    render(
+      <ReleaseDetailTabs
+        {...defaultProps}
+        node={makeReleaseNode({ targetPlane: undefined })}
+      />,
+    );
+
+    expect(screen.queryByText(/^Target:/)).not.toBeInTheDocument();
   });
 
   it('bumps the events refresh key when the refresh button is clicked', async () => {

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReleaseDetailTabs } from './ReleaseDetailTabs';
+import type { LayoutNode } from './treeTypes';
+
+// Mock design-system YamlViewer
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  YamlViewer: ({ value }: { value: string }) => (
+    <pre data-testid="yaml-viewer">{value}</pre>
+  ),
+}));
+
+// Mock the events table to isolate the tab container logic
+jest.mock('./ResourceEventsTable', () => ({
+  ResourceEventsTable: ({
+    node,
+    refreshKey,
+  }: {
+    node: { name: string };
+    refreshKey?: number;
+  }) => (
+    <div data-testid="resource-events-table">
+      {node.name}:{refreshKey ?? 0}
+    </div>
+  ),
+}));
+
+function makeReleaseNode(overrides: Partial<LayoutNode> = {}): LayoutNode {
+  return {
+    id: '__release__my-release',
+    kind: 'RenderedRelease',
+    name: 'my-release',
+    group: 'openchoreo.dev',
+    version: 'v1alpha1',
+    targetPlane: 'dataplane',
+    parentIds: ['__release_binding__'],
+    specObject: { apiVersion: 'openchoreo.dev/v1alpha1', kind: 'RenderedRelease' },
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 50,
+    ...overrides,
+  };
+}
+
+describe('ReleaseDetailTabs', () => {
+  const defaultProps = {
+    namespaceName: 'default-ns',
+    releaseBindingName: 'rb-name',
+  };
+
+  it('shows the events table on the default (Events) tab', () => {
+    render(<ReleaseDetailTabs {...defaultProps} node={makeReleaseNode()} />);
+
+    expect(screen.getByTestId('resource-events-table')).toHaveTextContent(
+      'my-release:0',
+    );
+    expect(screen.queryByTestId('yaml-viewer')).not.toBeInTheDocument();
+  });
+
+  it('renders the release spec as YAML on the Spec tab', async () => {
+    render(<ReleaseDetailTabs {...defaultProps} node={makeReleaseNode()} />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Spec' }));
+
+    const viewer = screen.getByTestId('yaml-viewer');
+    expect(viewer).toHaveTextContent('kind: RenderedRelease');
+    expect(screen.queryByTestId('resource-events-table')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state on the Spec tab when no spec is available', async () => {
+    render(
+      <ReleaseDetailTabs
+        {...defaultProps}
+        node={makeReleaseNode({ specObject: undefined })}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Spec' }));
+
+    expect(screen.getByText('No release spec available')).toBeInTheDocument();
+    expect(screen.queryByTestId('yaml-viewer')).not.toBeInTheDocument();
+  });
+
+  it('bumps the events refresh key when the refresh button is clicked', async () => {
+    render(<ReleaseDetailTabs {...defaultProps} node={makeReleaseNode()} />);
+
+    expect(screen.getByTestId('resource-events-table')).toHaveTextContent(
+      'my-release:0',
+    );
+
+    // The only role="button" in the Events tab is the refresh icon button
+    // (tabs use role="tab").
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByTestId('resource-events-table')).toHaveTextContent(
+      'my-release:1',
+    );
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.test.tsx
@@ -84,6 +84,35 @@ describe('ReleaseDetailTabs', () => {
     expect(screen.getByText(/admission webhook denied/)).toBeInTheDocument();
   });
 
+  it('does not style an Unknown condition as a failure', () => {
+    const { container } = render(
+      <ReleaseDetailTabs
+        node={makeReleaseNode({
+          specObject: {
+            status: {
+              conditions: [
+                {
+                  type: 'ResourcesApplied',
+                  status: 'Unknown',
+                  reason: 'Progressing',
+                },
+              ],
+            },
+          },
+        })}
+      />,
+    );
+
+    // An indeterminate condition reads as progressing, not as a failure.
+    expect(
+      container.querySelector('[class*="degraded"]'),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[class*="progressing"]'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
   it('shows the owning project, component and environment on the Summary tab', () => {
     render(<ReleaseDetailTabs node={makeReleaseNode()} />);
 

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.test.tsx
@@ -10,21 +10,6 @@ jest.mock('@openchoreo/backstage-design-system', () => ({
   ),
 }));
 
-// Mock the events table to isolate the tab container logic
-jest.mock('./ResourceEventsTable', () => ({
-  ResourceEventsTable: ({
-    node,
-    refreshKey,
-  }: {
-    node: { name: string };
-    refreshKey?: number;
-  }) => (
-    <div data-testid="resource-events-table">
-      {node.name}:{refreshKey ?? 0}
-    </div>
-  ),
-}));
-
 function makeReleaseNode(overrides: Partial<LayoutNode> = {}): LayoutNode {
   return {
     id: '__release__my-release',
@@ -37,6 +22,21 @@ function makeReleaseNode(overrides: Partial<LayoutNode> = {}): LayoutNode {
     specObject: {
       apiVersion: 'openchoreo.dev/v1alpha1',
       kind: 'RenderedRelease',
+      spec: {
+        environmentName: 'development',
+        owner: { projectName: 'my-project', componentName: 'my-component' },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'ResourcesApplied',
+            status: 'True',
+            reason: 'ApplySucceeded',
+            message: 'All resources applied successfully',
+            lastTransitionTime: '2025-01-01T00:00:00Z',
+          },
+        ],
+      },
     },
     x: 0,
     y: 0,
@@ -47,76 +47,94 @@ function makeReleaseNode(overrides: Partial<LayoutNode> = {}): LayoutNode {
 }
 
 describe('ReleaseDetailTabs', () => {
-  const defaultProps = {
-    namespaceName: 'default-ns',
-    releaseBindingName: 'rb-name',
-  };
+  it('shows the release conditions on the default (Summary) tab', () => {
+    render(<ReleaseDetailTabs node={makeReleaseNode()} />);
 
-  it('shows the events table on the default (Events) tab', () => {
-    render(<ReleaseDetailTabs {...defaultProps} node={makeReleaseNode()} />);
-
-    expect(screen.getByTestId('resource-events-table')).toHaveTextContent(
-      'my-release:0',
-    );
+    expect(screen.getByText('Conditions')).toBeInTheDocument();
+    expect(screen.getByText('ResourcesApplied')).toBeInTheDocument();
+    expect(screen.getByText('ApplySucceeded')).toBeInTheDocument();
+    expect(
+      screen.getByText('All resources applied successfully'),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('yaml-viewer')).not.toBeInTheDocument();
   });
 
-  it('renders the release spec as YAML on the Spec tab', async () => {
-    render(<ReleaseDetailTabs {...defaultProps} node={makeReleaseNode()} />);
-
-    await userEvent.click(screen.getByRole('tab', { name: 'Spec' }));
-
-    const viewer = screen.getByTestId('yaml-viewer');
-    expect(viewer).toHaveTextContent('kind: RenderedRelease');
-    expect(
-      screen.queryByTestId('resource-events-table'),
-    ).not.toBeInTheDocument();
-  });
-
-  it('shows an empty state on the Spec tab when no spec is available', async () => {
+  it('surfaces a failed apply to the target plane in the conditions table', () => {
     render(
       <ReleaseDetailTabs
-        {...defaultProps}
-        node={makeReleaseNode({ specObject: undefined })}
+        node={makeReleaseNode({
+          specObject: {
+            status: {
+              conditions: [
+                {
+                  type: 'ResourcesApplied',
+                  status: 'False',
+                  reason: 'ApplyFailed',
+                  message:
+                    'Failed to apply resources to target plane: admission webhook denied the request',
+                },
+              ],
+            },
+          },
+        })}
       />,
     );
 
-    await userEvent.click(screen.getByRole('tab', { name: 'Spec' }));
+    expect(screen.getByText('ApplyFailed')).toBeInTheDocument();
+    expect(screen.getByText(/admission webhook denied/)).toBeInTheDocument();
+  });
 
-    expect(screen.getByText('No release spec available')).toBeInTheDocument();
+  it('shows the owning project, component and environment on the Summary tab', () => {
+    render(<ReleaseDetailTabs node={makeReleaseNode()} />);
+
+    expect(screen.getByText('my-project')).toBeInTheDocument();
+    expect(screen.getByText('my-component')).toBeInTheDocument();
+    expect(screen.getByText('development')).toBeInTheDocument();
+  });
+
+  it('omits the conditions table when the release reports no conditions', () => {
+    render(
+      <ReleaseDetailTabs node={makeReleaseNode({ specObject: undefined })} />,
+    );
+
+    expect(screen.queryByText('Conditions')).not.toBeInTheDocument();
+  });
+
+  it('renders the release definition as YAML on the Definition tab', async () => {
+    render(<ReleaseDetailTabs node={makeReleaseNode()} />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Definition' }));
+
+    expect(screen.getByTestId('yaml-viewer')).toHaveTextContent(
+      'kind: RenderedRelease',
+    );
+    expect(screen.queryByText('Conditions')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state on the Definition tab when no definition is available', async () => {
+    render(
+      <ReleaseDetailTabs node={makeReleaseNode({ specObject: undefined })} />,
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Definition' }));
+
+    expect(
+      screen.getByText('No release definition available'),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('yaml-viewer')).not.toBeInTheDocument();
   });
 
   it('surfaces the target plane as a chip when present', () => {
-    render(<ReleaseDetailTabs {...defaultProps} node={makeReleaseNode()} />);
+    render(<ReleaseDetailTabs node={makeReleaseNode()} />);
 
     expect(screen.getByText('Target: dataplane')).toBeInTheDocument();
   });
 
   it('omits the target plane chip when the node has none', () => {
     render(
-      <ReleaseDetailTabs
-        {...defaultProps}
-        node={makeReleaseNode({ targetPlane: undefined })}
-      />,
+      <ReleaseDetailTabs node={makeReleaseNode({ targetPlane: undefined })} />,
     );
 
     expect(screen.queryByText(/^Target:/)).not.toBeInTheDocument();
-  });
-
-  it('bumps the events refresh key when the refresh button is clicked', async () => {
-    render(<ReleaseDetailTabs {...defaultProps} node={makeReleaseNode()} />);
-
-    expect(screen.getByTestId('resource-events-table')).toHaveTextContent(
-      'my-release:0',
-    );
-
-    // The only role="button" in the Events tab is the refresh icon button
-    // (tabs use role="tab").
-    await userEvent.click(screen.getByRole('button'));
-
-    expect(screen.getByTestId('resource-events-table')).toHaveTextContent(
-      'my-release:1',
-    );
   });
 });

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.tsx
@@ -1,5 +1,13 @@
 import { useState, useEffect, useCallback, type FC } from 'react';
-import { Box, Tabs, Tab, Typography, IconButton, Tooltip } from '@material-ui/core';
+import {
+  Box,
+  Tabs,
+  Tab,
+  Typography,
+  IconButton,
+  Tooltip,
+  Chip,
+} from '@material-ui/core';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import YAML from 'yaml';
 import { YamlViewer } from '@openchoreo/backstage-design-system';
@@ -58,6 +66,14 @@ export const ReleaseDetailTabs: FC<ReleaseDetailTabsProps> = ({
             <Tab key={tab.id} label={tab.label} />
           ))}
         </Tabs>
+        {node.targetPlane && (
+          <Chip
+            label={`Target: ${node.targetPlane}`}
+            size="small"
+            variant="outlined"
+            style={{ marginRight: 8 }}
+          />
+        )}
         {currentTab === 'events' && (
           <Tooltip title="Refresh">
             <IconButton size="small" onClick={handleRefresh}>

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.tsx
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback, type FC } from 'react';
+import { Box, Tabs, Tab, Typography, IconButton, Tooltip } from '@material-ui/core';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import YAML from 'yaml';
+import { YamlViewer } from '@openchoreo/backstage-design-system';
+import { useTreeStyles } from './treeStyles';
+import { ResourceEventsTable } from './ResourceEventsTable';
+import type { LayoutNode } from './treeTypes';
+
+const TABS = [
+  { id: 'events', label: 'Events' },
+  { id: 'spec', label: 'Spec' },
+] as const;
+
+interface ReleaseDetailTabsProps {
+  node: LayoutNode;
+  namespaceName: string;
+  releaseBindingName: string;
+}
+
+/**
+ * Detail tabs shown when a rendered release node is selected in the resource
+ * tree. Surfaces the release's own Kubernetes events and full spec (YAML),
+ * reusing the same components used for individual resources.
+ */
+export const ReleaseDetailTabs: FC<ReleaseDetailTabsProps> = ({
+  node,
+  namespaceName,
+  releaseBindingName,
+}) => {
+  const classes = useTreeStyles();
+  const [activeTab, setActiveTab] = useState(0);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Reset tab when switching to a different node
+  useEffect(() => {
+    setActiveTab(0);
+  }, [node.id]);
+
+  const currentTab = TABS[activeTab]?.id;
+
+  const handleRefresh = useCallback(() => {
+    setRefreshKey(prev => prev + 1);
+  }, []);
+
+  return (
+    <>
+      <Box display="flex" alignItems="center">
+        <Tabs
+          value={activeTab}
+          onChange={(_, newValue) => setActiveTab(newValue)}
+          indicatorColor="primary"
+          textColor="primary"
+          className={classes.drawerTabs}
+          style={{ flex: 1 }}
+        >
+          {TABS.map(tab => (
+            <Tab key={tab.id} label={tab.label} />
+          ))}
+        </Tabs>
+        {currentTab === 'events' && (
+          <Tooltip title="Refresh">
+            <IconButton size="small" onClick={handleRefresh}>
+              <RefreshIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
+
+      <Box className={classes.drawerTabContent}>
+        {currentTab === 'events' && (
+          <ResourceEventsTable
+            node={node}
+            namespaceName={namespaceName}
+            releaseBindingName={releaseBindingName}
+            refreshKey={refreshKey}
+          />
+        )}
+
+        {currentTab === 'spec' && (
+          <>
+            {node.specObject ? (
+              <YamlViewer
+                value={YAML.stringify(node.specObject)}
+                maxHeight="auto"
+              />
+            ) : (
+              <Box className={classes.drawerEmptyState}>
+                <Typography variant="body2" color="textSecondary">
+                  No release spec available
+                </Typography>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+    </>
+  );
+};

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.tsx
@@ -40,6 +40,17 @@ function getReleaseConditions(
   return [];
 }
 
+/**
+ * A condition status is True, False or Unknown. Unknown means the controller has
+ * not determined the state yet, so it reads as progressing rather than a failure
+ * — the same mapping the release binding uses for its Ready condition.
+ */
+function conditionHealth(status: string | undefined): string {
+  if (status === 'True') return 'Healthy';
+  if (status === 'False') return 'Degraded';
+  return 'Progressing';
+}
+
 interface ReleaseDetailTabsProps {
   node: LayoutNode;
 }
@@ -182,9 +193,7 @@ export const ReleaseDetailTabs: FC<ReleaseDetailTabsProps> = ({ node }) => {
                                 label={condition.status}
                                 size="small"
                                 className={getHealthChipClass(
-                                  condition.status === 'True'
-                                    ? 'Healthy'
-                                    : 'Degraded',
+                                  conditionHealth(condition.status),
                                   releaseClasses,
                                 )}
                               />

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ReleaseDetailTabs.tsx
@@ -1,44 +1,59 @@
-import { useState, useEffect, useCallback, type FC } from 'react';
+import { useState, useEffect, type FC } from 'react';
 import {
   Box,
   Tabs,
   Tab,
   Typography,
-  IconButton,
-  Tooltip,
   Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
 } from '@material-ui/core';
-import RefreshIcon from '@material-ui/icons/Refresh';
 import YAML from 'yaml';
 import { YamlViewer } from '@openchoreo/backstage-design-system';
 import { useTreeStyles } from './treeStyles';
-import { ResourceEventsTable } from './ResourceEventsTable';
+import { useReleaseInfoStyles } from '../styles';
+import { formatTimestamp, getHealthChipClass } from '../utils';
 import type { LayoutNode } from './treeTypes';
 
 const TABS = [
-  { id: 'events', label: 'Events' },
-  { id: 'spec', label: 'Spec' },
+  { id: 'summary', label: 'Summary' },
+  { id: 'definition', label: 'Definition' },
 ] as const;
+
+function getReleaseField(
+  release: Record<string, unknown> | undefined,
+  field: string,
+): unknown {
+  const spec = release?.spec as Record<string, unknown> | undefined;
+  return spec?.[field];
+}
+
+function getReleaseConditions(
+  release: Record<string, unknown> | undefined,
+): any[] {
+  const status = release?.status as Record<string, unknown> | undefined;
+  if (status && Array.isArray(status.conditions)) return status.conditions;
+  return [];
+}
 
 interface ReleaseDetailTabsProps {
   node: LayoutNode;
-  namespaceName: string;
-  releaseBindingName: string;
 }
 
 /**
  * Detail tabs shown when a rendered release node is selected in the resource
- * tree. Surfaces the release's own Kubernetes events and full spec (YAML),
- * reusing the same components used for individual resources.
+ * tree. The release controllers report state through status.conditions rather
+ * than Kubernetes events, so the Summary tab is where a failed apply to the
+ * data plane shows up (ResourcesApplied=False with the apply error as message).
  */
-export const ReleaseDetailTabs: FC<ReleaseDetailTabsProps> = ({
-  node,
-  namespaceName,
-  releaseBindingName,
-}) => {
+export const ReleaseDetailTabs: FC<ReleaseDetailTabsProps> = ({ node }) => {
   const classes = useTreeStyles();
+  const releaseClasses = useReleaseInfoStyles();
   const [activeTab, setActiveTab] = useState(0);
-  const [refreshKey, setRefreshKey] = useState(0);
 
   // Reset tab when switching to a different node
   useEffect(() => {
@@ -46,10 +61,15 @@ export const ReleaseDetailTabs: FC<ReleaseDetailTabsProps> = ({
   }, [node.id]);
 
   const currentTab = TABS[activeTab]?.id;
+  const release = node.specObject as Record<string, unknown> | undefined;
 
-  const handleRefresh = useCallback(() => {
-    setRefreshKey(prev => prev + 1);
-  }, []);
+  const displayConditions = getReleaseConditions(release);
+  const environment = getReleaseField(release, 'environmentName') as
+    | string
+    | undefined;
+  const owner = getReleaseField(release, 'owner') as
+    | Record<string, string>
+    | undefined;
 
   return (
     <>
@@ -74,26 +94,138 @@ export const ReleaseDetailTabs: FC<ReleaseDetailTabsProps> = ({
             style={{ marginRight: 8 }}
           />
         )}
-        {currentTab === 'events' && (
-          <Tooltip title="Refresh">
-            <IconButton size="small" onClick={handleRefresh}>
-              <RefreshIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        )}
       </Box>
 
       <Box className={classes.drawerTabContent}>
-        {currentTab === 'events' && (
-          <ResourceEventsTable
-            node={node}
-            namespaceName={namespaceName}
-            releaseBindingName={releaseBindingName}
-            refreshKey={refreshKey}
-          />
+        {currentTab === 'summary' && (
+          <Box>
+            {/* Key-value properties */}
+            {owner?.projectName && (
+              <Box className={classes.drawerProperty}>
+                <Typography className={classes.drawerPropertyKey}>
+                  Project
+                </Typography>
+                <Typography className={classes.drawerPropertyValue}>
+                  {owner.projectName}
+                </Typography>
+              </Box>
+            )}
+
+            {owner?.componentName && (
+              <Box className={classes.drawerProperty}>
+                <Typography className={classes.drawerPropertyKey}>
+                  Component
+                </Typography>
+                <Typography className={classes.drawerPropertyValue}>
+                  {owner.componentName}
+                </Typography>
+              </Box>
+            )}
+
+            {environment && (
+              <Box className={classes.drawerProperty}>
+                <Typography className={classes.drawerPropertyKey}>
+                  Environment
+                </Typography>
+                <Typography className={classes.drawerPropertyValue}>
+                  {environment}
+                </Typography>
+              </Box>
+            )}
+
+            {node.targetPlane && (
+              <Box className={classes.drawerProperty}>
+                <Typography className={classes.drawerPropertyKey}>
+                  Target Plane
+                </Typography>
+                <Typography className={classes.drawerPropertyValue}>
+                  {node.targetPlane}
+                </Typography>
+              </Box>
+            )}
+
+            {/* Conditions table */}
+            {displayConditions.length > 0 && (
+              <Box mt={3}>
+                <Typography
+                  variant="subtitle2"
+                  gutterBottom
+                  style={{ fontWeight: 600 }}
+                >
+                  Conditions
+                </Typography>
+                <TableContainer>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell scope="col">Type</TableCell>
+                        <TableCell scope="col">Status</TableCell>
+                        <TableCell scope="col">Reason</TableCell>
+                        <TableCell scope="col">Message</TableCell>
+                        <TableCell scope="col">Last Transition</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {displayConditions.map(
+                        (condition: any, index: number) => (
+                          <TableRow key={`${condition.type}-${index}`}>
+                            <TableCell>
+                              <Typography
+                                variant="body2"
+                                style={{ fontWeight: 500 }}
+                              >
+                                {condition.type}
+                              </Typography>
+                            </TableCell>
+                            <TableCell>
+                              <Chip
+                                label={condition.status}
+                                size="small"
+                                className={getHealthChipClass(
+                                  condition.status === 'True'
+                                    ? 'Healthy'
+                                    : 'Degraded',
+                                  releaseClasses,
+                                )}
+                              />
+                            </TableCell>
+                            <TableCell>
+                              <Typography variant="body2">
+                                {condition.reason ?? '-'}
+                              </Typography>
+                            </TableCell>
+                            <TableCell>
+                              <Typography
+                                variant="body2"
+                                style={{
+                                  maxWidth: 400,
+                                  wordBreak: 'break-word',
+                                }}
+                              >
+                                {condition.message ?? '-'}
+                              </Typography>
+                            </TableCell>
+                            <TableCell>
+                              <Typography variant="body2">
+                                {condition.lastTransitionTime
+                                  ? formatTimestamp(
+                                      condition.lastTransitionTime,
+                                    )
+                                  : '-'}
+                              </Typography>
+                            </TableCell>
+                          </TableRow>
+                        ),
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Box>
+            )}
+          </Box>
         )}
 
-        {currentTab === 'spec' && (
+        {currentTab === 'definition' && (
           <>
             {node.specObject ? (
               <YamlViewer
@@ -103,7 +235,7 @@ export const ReleaseDetailTabs: FC<ReleaseDetailTabsProps> = ({
             ) : (
               <Box className={classes.drawerEmptyState}>
                 <Typography variant="body2" color="textSecondary">
-                  No release spec available
+                  No release definition available
                 </Typography>
               </Box>
             )}

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.test.tsx
@@ -23,6 +23,14 @@ jest.mock('./ResourceDetailTabs', () => ({
   ),
 }));
 
+jest.mock('./ReleaseDetailTabs', () => ({
+  ReleaseDetailTabs: ({ node }: { node: { kind: string; name: string } }) => (
+    <div data-testid="release-detail-tabs">
+      {node.kind}/{node.name}
+    </div>
+  ),
+}));
+
 jest.mock('./ResourceKindIcon', () => ({
   ResourceKindIcon: ({ kind }: { kind: string }) => (
     <span data-testid="kind-icon">{kind}</span>
@@ -145,24 +153,24 @@ describe('ResourceDetailPanel', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('renders release name and target plane for RenderedRelease node', () => {
+    it('renders ReleaseDetailTabs for RenderedRelease node', () => {
       const node = makeLayoutNode({
         kind: 'RenderedRelease',
         name: 'my-release',
-        version: 'dataplane-1',
+        group: 'openchoreo.dev',
+        version: 'v1alpha1',
+        targetPlane: 'dataplane-1',
         isRoot: false,
       });
 
       render(<ResourceDetailPanel {...defaultProps} node={node} />);
 
-      expect(screen.getByText('Release Name')).toBeInTheDocument();
-      // "my-release" appears in header and body
-      expect(screen.getAllByText('my-release')).toHaveLength(2);
-      expect(screen.getByText('Target Plane')).toBeInTheDocument();
-      // "dataplane-1" appears in metadata chip (version) and in body text
-      expect(screen.getAllByText('dataplane-1').length).toBeGreaterThanOrEqual(
-        1,
+      expect(screen.getByTestId('release-detail-tabs')).toHaveTextContent(
+        'RenderedRelease/my-release',
       );
+      expect(
+        screen.queryByTestId('resource-detail-tabs'),
+      ).not.toBeInTheDocument();
     });
 
     it('renders ResourceDetailTabs for regular resource nodes', () => {
@@ -202,8 +210,9 @@ describe('ResourceDetailPanel', () => {
 
       render(<ResourceDetailPanel {...defaultProps} node={node} />);
 
-      expect(screen.queryByText('Release Name')).not.toBeInTheDocument();
-      expect(screen.queryByText('Target Plane')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('release-detail-tabs'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.tsx
@@ -10,6 +10,7 @@ import {
 import CloseIcon from '@material-ui/icons/Close';
 import { ResourceKindIcon } from './ResourceKindIcon';
 import { ResourceDetailTabs } from './ResourceDetailTabs';
+import { ReleaseDetailTabs } from './ReleaseDetailTabs';
 import { ReleaseBindingDetailTabs } from './ReleaseBindingDetailTabs';
 import { useTreeStyles } from './treeStyles';
 import type { LayoutNode } from './treeTypes';
@@ -86,22 +87,11 @@ export const ResourceDetailPanel: FC<ResourceDetailPanelProps> = ({
             <ReleaseBindingDetailTabs releaseBindingData={releaseBindingData} />
           )}
           {!node.isRoot && node.kind === 'RenderedRelease' && (
-            <Box padding={2}>
-              <Typography variant="subtitle2" gutterBottom>
-                Release Name
-              </Typography>
-              <Typography variant="body2" gutterBottom>
-                {node.name}
-              </Typography>
-              <Typography
-                variant="subtitle2"
-                gutterBottom
-                style={{ marginTop: 16 }}
-              >
-                Target Plane
-              </Typography>
-              <Typography variant="body2">{node.version}</Typography>
-            </Box>
+            <ReleaseDetailTabs
+              node={node}
+              namespaceName={namespaceName}
+              releaseBindingName={releaseBindingName}
+            />
           )}
           {!node.isRoot && node.kind !== 'RenderedRelease' && (
             <ResourceDetailTabs

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceDetailPanel.tsx
@@ -87,11 +87,7 @@ export const ResourceDetailPanel: FC<ResourceDetailPanelProps> = ({
             <ReleaseBindingDetailTabs releaseBindingData={releaseBindingData} />
           )}
           {!node.isRoot && node.kind === 'RenderedRelease' && (
-            <ReleaseDetailTabs
-              node={node}
-              namespaceName={namespaceName}
-              releaseBindingName={releaseBindingName}
-            />
+            <ReleaseDetailTabs node={node} />
           )}
           {!node.isRoot && node.kind !== 'RenderedRelease' && (
             <ResourceDetailTabs

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceTreeNode.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceTreeNode.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { ResourceTreeNode } from './ResourceTreeNode';
+import type { LayoutNode } from './treeTypes';
+
+function makeNode(overrides: Partial<LayoutNode> = {}): LayoutNode {
+  return {
+    id: 'node-1',
+    kind: 'RenderedRelease',
+    name: 'my-release',
+    targetPlane: 'dataplane',
+    parentIds: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 50,
+    ...overrides,
+  };
+}
+
+describe('ResourceTreeNode', () => {
+  const defaultProps = {
+    isSelected: false,
+    onClick: jest.fn(),
+  };
+
+  it('shows the target plane subtitle for a RenderedRelease node', () => {
+    render(<ResourceTreeNode {...defaultProps} node={makeNode()} />);
+
+    expect(screen.getByText('Target plane: dataplane')).toBeInTheDocument();
+  });
+
+  it('omits the target plane subtitle when targetPlane is absent', () => {
+    render(
+      <ResourceTreeNode
+        {...defaultProps}
+        node={makeNode({ targetPlane: undefined })}
+      />,
+    );
+
+    expect(screen.queryByText(/^Target plane:/)).not.toBeInTheDocument();
+  });
+
+  it('does not show the target plane subtitle for non-release kinds', () => {
+    render(
+      <ResourceTreeNode
+        {...defaultProps}
+        node={makeNode({ kind: 'Deployment' })}
+      />,
+    );
+
+    expect(screen.queryByText(/^Target plane:/)).not.toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceTreeNode.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceTreeNode.tsx
@@ -67,9 +67,9 @@ export const ResourceTreeNode: FC<ResourceTreeNodeProps> = ({
       <div className={classes.nodeContent}>
         <span className={classes.nodeKind}>{node.kind}</span>
         <span className={classes.nodeName}>{node.name}</span>
-        {node.kind === 'RenderedRelease' && node.version && (
+        {node.kind === 'RenderedRelease' && node.targetPlane && (
           <span className={classes.nodeSubtitle}>
-            Target plane: {node.version}
+            Target plane: {node.targetPlane}
           </span>
         )}
       </div>

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.test.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.test.ts
@@ -112,7 +112,10 @@ describe('buildTreeNodes', () => {
 
     expect(releaseNodes).toHaveLength(1);
     expect(releaseNodes[0].name).toBe('my-release');
-    expect(releaseNodes[0].version).toBe('dataplane');
+    expect(releaseNodes[0].targetPlane).toBe('dataplane');
+    // Real GVK is set so the release's own events/spec can be fetched.
+    expect(releaseNodes[0].group).toBe('openchoreo.dev');
+    expect(releaseNodes[0].version).toBe('v1alpha1');
   });
 
   it('links RenderedRelease nodes to root', () => {

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.test.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.test.ts
@@ -71,11 +71,18 @@ describe('getResourceTreeNodes', () => {
 });
 
 describe('buildTreeNodes', () => {
+  const renderedRelease = {
+    apiVersion: 'openchoreo.dev/v1alpha1',
+    kind: 'RenderedRelease',
+    status: { conditions: [{ type: 'ResourcesApplied', status: 'True' }] },
+  };
+
   const singleReleaseData: ResourceTreeData = {
     renderedReleases: [
       {
         name: 'my-release',
         targetPlane: 'dataplane',
+        renderedRelease,
         nodes: [
           makeNode({ uid: 'dep-1', kind: 'Deployment', name: 'nginx' }),
           makeNode({
@@ -112,10 +119,12 @@ describe('buildTreeNodes', () => {
 
     expect(releaseNodes).toHaveLength(1);
     expect(releaseNodes[0].name).toBe('my-release');
+    // The target plane has its own field, and version holds the real CR version.
     expect(releaseNodes[0].targetPlane).toBe('dataplane');
-    // Real GVK is set so the release's own events/spec can be fetched.
     expect(releaseNodes[0].group).toBe('openchoreo.dev');
     expect(releaseNodes[0].version).toBe('v1alpha1');
+    // The detail panel reads its conditions and YAML off the full CR.
+    expect(releaseNodes[0].specObject).toBe(renderedRelease);
   });
 
   it('links RenderedRelease nodes to root', () => {

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.ts
@@ -110,10 +110,14 @@ export function buildTreeNodes(
 
     nodes.push({
       id: releaseNodeId,
+      // Real GVK of the RenderedRelease CR so its events/spec can be fetched.
       kind: 'RenderedRelease',
+      group: 'openchoreo.dev',
+      version: 'v1alpha1',
       name: release.name,
-      version: release.targetPlane,
+      targetPlane: release.targetPlane,
       healthStatus: aggregateHealth(release.nodes),
+      specObject: release.renderedRelease,
       parentIds: [ROOT_NODE_ID],
     });
 

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.ts
@@ -110,7 +110,8 @@ export function buildTreeNodes(
 
     nodes.push({
       id: releaseNodeId,
-      // Real GVK of the RenderedRelease CR so its events/spec can be fetched.
+      // Real GVK of the RenderedRelease CR. The target plane has its own field:
+      // it is not a version, and the detail panel renders group/version as the GVK.
       kind: 'RenderedRelease',
       group: 'openchoreo.dev',
       version: 'v1alpha1',

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeTypes.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeTypes.ts
@@ -20,6 +20,8 @@ export interface TreeNode {
   healthStatus?: HealthStatus;
   /** Whether this is the root node */
   isRoot?: boolean;
+  /** Target plane of a RenderedRelease node (e.g. "dataplane") */
+  targetPlane?: string;
   /** Last observed timestamp */
   lastObservedTime?: string;
   /** Raw status object for detail drawer */


### PR DESCRIPTION
## Purpose

  Selecting a rendered release node in the resource tree now opens a detail panel with **Summary** and **Definition** tabs (previously just a static name/target-plane summary).

  - **Summary** tab: the release's `status.conditions`, alongside its owning project, component, environment and target plane.
  - **Definition** tab: the full RenderedRelease CR rendered as YAML. 
  
  Rendered releases deliberately have no Events tab. The release controllers register no `EventRecorder` — they report state exclusively through `status.conditions` — so a release-level
  Events tab is always empty. Conditions are the real troubleshooting signal: on a failed apply to the data plane, `renderedrelease` sets `ResourcesApplied=False` with reason `ApplyFailed`
  and the apply error as the condition message, which now surfaces directly in the drawer. Events remain available on the individual resources under a release, which do emit them.

  The RenderedRelease tree node carries its real GVK (`openchoreo.dev/v1alpha1`), keeps the target plane in a dedicated field, and exposes the RenderedRelease CR as the node's spec object —
  so the conditions already ride along on the resource tree response and no new backend call is needed.

  Refs openchoreo/openchoreo#3443

 ## Screenshots
<img width="1920" height="1080" alt="Screenshot from 2026-07-13 14-54-10" src="https://github.com/user-attachments/assets/1e04f8b1-53ce-4cba-8dca-6da577583ee6" />


  ## Related PRs

  None. The backend companion PR openchoreo/openchoreo#4063 is closed — with the events endpoint no longer called for rendered releases, that branch nets out to no change against `main`.

  ## Migrations (if applicable)

  N/A

  ## Test environment

  Unit tests (`yarn test`), typecheck and lint pass. Verified manually against a local k3d OpenChoreo cluster.

  ## Learning

  N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Summary and Definition tabs for rendered release details.
  * Summary displays project, component, environment, target plane, and status conditions.
  * Definition displays the complete rendered release as YAML.
  * Added an empty state when no release definition is available.
  * Rendered release tree entries now show their target plane.

* **Changes**
  * Removed the Events tab from rendered release details; event information remains available on individual resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->