### PR TITLE
docs(exec): fix stale exec WS-proxy location in code comments

### DIFF
--- a/.changeset/exec-ws-proxy-doc-refs.md
+++ b/.changeset/exec-ws-proxy-doc-refs.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-backend': patch
+---
+
+Update stale code comments that referenced the exec WebSocket proxy's old location (`packages/backend/src/index.ts`); it now lives in and is registered from the `@openchoreo/backstage-plugin-backend` plugin.

--- a/plugins/openchoreo-backend/src/ExecSessionStore.ts
+++ b/plugins/openchoreo-backend/src/ExecSessionStore.ts
@@ -65,7 +65,8 @@ class ExecSessionStore {
 
 /**
  * Module-level singleton shared between the router (HTTP /exec/init) and the
- * WebSocket upgrade handler in packages/backend/src/index.ts.
+ * WebSocket upgrade proxy (execWebSocketProxy.ts), which this plugin registers
+ * via its httpRouter middleware in plugin.ts.
  *
  * Node.js module caching guarantees both import sites receive the same
  * instance as long as they run in the same process.

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -2352,8 +2352,9 @@ export async function createRouter({
   //      cannot bypass the UI permission gate.
   //   3. Backend stores session → returns { sessionId, ttlSeconds }
   //   4. Frontend opens ws://…/exec/ws?sessionId=<id>
-  //   5. WebSocket upgrade handler (packages/backend/src/index.ts) looks up
-  //      the session and proxies to the OpenChoreo API using the stored token.
+  //   5. WebSocket upgrade proxy (execWebSocketProxy.ts, registered from this
+  //      plugin) looks up the session and proxies to the OpenChoreo API using
+  //      the stored token.
   //
   // podName/containerName are optional: present when launched from a specific
   // Pod node in the K8s resource tree, omitted for the component/environment


### PR DESCRIPTION
## Summary
Addresses @kaviththiranga's review comments on #634: two code comments still referenced the exec WebSocket proxy's old location (`packages/backend/src/index.ts`). Since the proxy was moved into `@openchoreo/backstage-plugin-backend` (registered from the plugin's `httpRouter` middleware), update the references in `ExecSessionStore.ts` and `router.ts`.

Comment-only change. #634 is already merged, so this is a follow-up PR.
