### PR TITLE
feat(openchoreo): show suspended state in the deployment pipeline

### DIFF
--- a/.changeset/suspended-pipeline-status.md
+++ b/.changeset/suspended-pipeline-status.md
@@ -1,0 +1,7 @@
+---
+'@openchoreo/backstage-design-system': minor
+'@openchoreo/backstage-plugin': minor
+'@openchoreo/backstage-plugin-backend': minor
+---
+
+Show a "Suspended" status in the deployment pipeline when a component's workload is scaled to zero. The backend reads the suspended state that core already reports on the ReleaseBinding's ResourcesReady condition, and the pipeline badge now shows "Suspended" instead of "Active" for a scaled-to-zero workload.

--- a/packages/design-system/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/packages/design-system/src/components/StatusBadge/StatusBadge.test.tsx
@@ -8,6 +8,7 @@ describe('StatusBadge', () => {
     ['pending', 'Pending'],
     ['active', 'Active'],
     ['not-deployed', 'Not Deployed'],
+    ['suspended', 'Suspended'],
   ] as const)('renders default label "%s" → "%s"', (status, expectedLabel) => {
     render(<StatusBadge status={status} />);
     expect(screen.getByText(expectedLabel)).toBeInTheDocument();

--- a/packages/design-system/src/components/StatusBadge/StatusBadge.tsx
+++ b/packages/design-system/src/components/StatusBadge/StatusBadge.tsx
@@ -75,6 +75,7 @@ export type StatusType =
   | 'failed'
   | 'not-deployed'
   | 'undeployed'
+  | 'suspended'
   | 'unknown';
 
 interface StatusBadgeProps {
@@ -119,6 +120,7 @@ const STATUS_CONFIG: Record<
   default: { variant: 'default', defaultLabel: 'Default' },
   'not-deployed': { variant: 'default', defaultLabel: 'Not Deployed' },
   undeployed: { variant: 'default', defaultLabel: 'Undeployed' },
+  suspended: { variant: 'warning', defaultLabel: 'Suspended' },
 };
 
 export const StatusBadge: React.FC<StatusBadgeProps> = ({

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
@@ -218,6 +218,24 @@ describe('deriveBindingStatusDetailed', () => {
     });
   });
 
+  it('surfaces the suspended reason from ResourcesReady on a Ready binding', () => {
+    const binding = makeBinding([
+      { type: 'Ready', status: 'True', reason: 'Ready' },
+      {
+        type: 'ResourcesReady',
+        status: 'True',
+        reason: 'ReadyWithSuspendedResources',
+        message: 'Primary workload Deployment is suspended (scaled to 0)',
+      },
+    ]);
+    const result = deriveBindingStatusDetailed(binding);
+    expect(result).toEqual({
+      status: 'Ready',
+      reason: 'ReadyWithSuspendedResources',
+      message: 'Primary workload Deployment is suspended (scaled to 0)',
+    });
+  });
+
   it('returns reason and message for NotReady progressing status', () => {
     const binding = makeBinding([
       {

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -19,6 +19,13 @@ const PROGRESSING_REASONS = [
 /** Reasons that represent an intentional non-deployed state, not an error. */
 const NON_ERROR_REASONS = ['ResourcesUndeployed'] as const;
 
+/**
+ * Reason core sets on the ResourcesReady condition when the primary workload is
+ * intentionally suspended (e.g. a Deployment scaled to zero). The binding is
+ * still Ready, so this is read from ResourcesReady, not the Ready condition.
+ */
+const SUSPENDED_REASON = 'ReadyWithSuspendedResources';
+
 export interface DerivedBindingStatus {
   status: 'Ready' | 'NotReady' | 'Failed';
   reason?: string;
@@ -75,6 +82,20 @@ export function deriveBindingStatusDetailed(
   if (!readyCond) return { status: 'NotReady' }; // Not yet reconciled
 
   if (readyCond.status === 'True') {
+    // A Ready binding may still be intentionally scaled to zero. Core reports
+    // that on the ResourcesReady condition, not on Ready, so surface its reason
+    // and message here so the pipeline can distinguish a suspended workload from
+    // a running one.
+    const resourcesReady = conditionsForGeneration.find(
+      c => c.type === 'ResourcesReady',
+    );
+    if (resourcesReady?.reason === SUSPENDED_REASON) {
+      return {
+        status: 'Ready',
+        reason: resourcesReady.reason,
+        message: resourcesReady.message,
+      };
+    }
     return {
       status: 'Ready',
       reason: readyCond.reason,

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentStatusVariant.test.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentStatusVariant.test.ts
@@ -12,6 +12,16 @@ describe('useEnvironmentStatusVariant', () => {
     });
   });
 
+  it('maps a Ready binding with ReadyWithSuspendedResources to suspended', () => {
+    const { result } = renderHook(() =>
+      useEnvironmentStatusVariant('Ready', 'ReadyWithSuspendedResources'),
+    );
+    expect(result.current).toEqual({
+      variant: 'suspended',
+      label: 'Suspended',
+    });
+  });
+
   it('maps Ready (without undeployed reason) to active', () => {
     const { result } = renderHook(() =>
       useEnvironmentStatusVariant('Ready', undefined),

--- a/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentStatusVariant.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useEnvironmentStatusVariant.ts
@@ -15,6 +15,12 @@ export function getEnvironmentStatusVariant(
   if (statusReason === 'ResourcesUndeployed') {
     return { variant: 'undeployed', label: 'Undeployed' };
   }
+  // A Ready binding whose primary workload is scaled to zero. Core reports this
+  // on the ResourcesReady condition; the backend surfaces its reason here so the
+  // pipeline shows "Suspended" rather than "Active".
+  if (statusReason === 'ReadyWithSuspendedResources') {
+    return { variant: 'suspended', label: 'Suspended' };
+  }
   if (status === 'Ready') {
     return { variant: 'active', label: 'Active' };
   }


### PR DESCRIPTION
## What

A component whose workload is scaled to zero showed as "Active" in the deployment pipeline, which is misleading. This adds a distinct "Suspended" state so it reads correctly.

## How

Core already reports the suspended state on the ReleaseBinding's ResourcesReady condition (reason `ReadyWithSuspendedResources`), but the backend transformer only looked at the Ready condition, which stays Ready for a scaled-to-zero workload. The transformer now also checks ResourcesReady on a Ready binding and surfaces that reason, and the frontend maps it to a new `suspended` badge variant labelled "Suspended".

- `release-binding.ts` reads the ResourcesReady reason on a Ready binding.
- `useEnvironmentStatusVariant.ts` maps `ReadyWithSuspendedResources` to a `suspended` variant.
- `StatusBadge.tsx` adds the `suspended` variant (amber, matching the existing suspended styling in the resource tree).

No core change is needed. The state is already aggregated onto the ReleaseBinding.

## Testing

Unit tests added for the transformer, the status hook, and the badge. The data path was checked against a live cluster: a scaled-to-zero component's ReleaseBinding carries `ResourcesReady=ReadyWithSuspendedResources`, which is what the backend now reads. Affected tests, lint, and prettier pass, and the touched files are type-clean.

Part of https://github.com/openchoreo/openchoreo/issues/3104
