### PR TITLE
feat: add Auto Deploy option to the project creation wizard

### DIFF
--- a/.changeset/project-auto-deploy-on-create.md
+++ b/.changeset/project-auto-deploy-on-create.md
@@ -1,0 +1,7 @@
+---
+'@openchoreo/backstage-plugin-catalog-backend-module': minor
+'@openchoreo/backstage-plugin-scaffolder-backend-module': minor
+'@openchoreo/backstage-plugin-backend': patch
+---
+
+Add a default-on Auto Deploy toggle to the project creation wizard. When on, `openchoreo:project:create` creates one unpinned ProjectReleaseBinding per deployment-pipeline environment after the project is created, and the control plane seeds the release pin once the first release is cut. Toggling it off shows a warning that the project must be deployed manually from its Deploy tab before components can be deployed. The Deploy tab now shows just-created unpinned bindings (`ProjectReleaseNotSet`) as pending instead of failed.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,6 +47,7 @@
     "@backstage/plugin-permission-common": "^0.9.9",
     "@backstage/plugin-permission-react": "^0.5.1",
     "@backstage/plugin-scaffolder": "^1.37.0",
+    "@backstage/plugin-scaffolder-common": "^2.2.0",
     "@backstage/plugin-scaffolder-react": "^2.0.0",
     "@backstage/plugin-search": "^1.7.4",
     "@backstage/plugin-search-react": "^1.11.4",

--- a/packages/app/src/components/scaffolder/OpenChoreoScaffolderPage.tsx
+++ b/packages/app/src/components/scaffolder/OpenChoreoScaffolderPage.tsx
@@ -34,6 +34,7 @@ import { NotificationChannelFormWithYamlFieldExtension } from '../../scaffolder/
 import { DeploymentPipelineFormWithYamlFieldExtension } from '../../scaffolder/DeploymentPipelineFormWithYaml';
 import { WorkloadDetailsFieldExtension } from '../../scaffolder/WorkloadDetailsField';
 import { CustomTemplateListPage } from './CustomTemplateListPage';
+import { OpenChoreoTemplateOutputs } from './OpenChoreoTemplateOutputs';
 import { CustomReviewStep } from '../../scaffolder/CustomReviewState';
 
 /**
@@ -55,6 +56,7 @@ export function OpenChoreoScaffolderPage() {
         }}
         components={{
           EXPERIMENTAL_TemplateListPageComponent: CustomTemplateListPage,
+          EXPERIMENTAL_TemplateOutputsComponent: OpenChoreoTemplateOutputs,
           ReviewStepComponent: CustomReviewStep,
         }}
       >

--- a/packages/app/src/components/scaffolder/OpenChoreoTemplateOutputs.tsx
+++ b/packages/app/src/components/scaffolder/OpenChoreoTemplateOutputs.tsx
@@ -1,0 +1,139 @@
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Paper from '@material-ui/core/Paper';
+import { makeStyles } from '@material-ui/core/styles';
+import Alert, { Color as AlertSeverity } from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
+import LinkIcon from '@material-ui/icons/Link';
+import { parseEntityRef } from '@backstage/catalog-model';
+import { Link, MarkdownContent } from '@backstage/core-components';
+import { useApp, useRouteRef } from '@backstage/core-plugin-api';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import type { ScaffolderTaskOutput } from '@backstage/plugin-scaffolder-common';
+
+const useStyles = makeStyles({
+  section: {
+    padding: 16,
+    display: 'flex',
+    justifyContent: 'center',
+    gap: 16,
+    flexWrap: 'wrap',
+  },
+  link: {
+    '&:hover': {
+      textDecoration: 'none',
+    },
+  },
+  alert: {
+    // MarkdownContent renders its text in a <p>; drop the default block margins
+    // so the note reads as a single alert-bar line.
+    '& p': {
+      margin: 0,
+    },
+  },
+});
+
+const ALERT_SEVERITIES: readonly AlertSeverity[] = [
+  'error',
+  'warning',
+  'info',
+  'success',
+];
+
+/**
+ * Maps a scaffolder `output.text` entry's `icon` field to an Alert severity.
+ * `output.text` has no dedicated severity field, so templates signal intent via
+ * `icon` (e.g. `icon: 'warning'`). Anything unset/unrecognised renders as a
+ * neutral info bar.
+ */
+const toSeverity = (icon?: string): AlertSeverity =>
+  ALERT_SEVERITIES.includes(icon as AlertSeverity)
+    ? (icon as AlertSeverity)
+    : 'info';
+
+/** A single `output.text` entry rendered as a severity-coloured alert bar. */
+function TemplateTextOutput(props: {
+  severity: AlertSeverity;
+  title?: string;
+  content: string;
+}) {
+  const classes = useStyles();
+  return (
+    <Box paddingBottom={2}>
+      <Alert severity={props.severity} className={classes.alert}>
+        {props.title && <AlertTitle>{props.title}</AlertTitle>}
+        <MarkdownContent content={props.content} />
+      </Alert>
+    </Box>
+  );
+}
+
+/**
+ * Scaffolder task-page outputs renderer used across all OpenChoreo templates
+ * (wired as `EXPERIMENTAL_TemplateOutputsComponent` in OpenChoreoScaffolderPage).
+ *
+ * Renders the standard "links in a centered box" (e.g. the "View Project"
+ * link), then each `output.text` entry as an alert bar below it instead of the
+ * default plain card. Each bar's variant is data-driven: `text.icon` selects
+ * the severity ('error' | 'warning' | 'info' | 'success', default 'info') and
+ * `text.title` renders as an optional heading. The project wizard's manual-
+ * deploy note, for example, sets `icon: 'warning'` and no title.
+ */
+export function OpenChoreoTemplateOutputs(props: {
+  output?: ScaffolderTaskOutput;
+}) {
+  const classes = useStyles();
+  const app = useApp();
+  const entityRoute = useRouteRef(entityRouteRef);
+
+  const output = props.output;
+  const links = (output?.links ?? []).filter(({ url, entityRef }) =>
+    Boolean(url || entityRef),
+  );
+  const texts = (output?.text ?? []).filter(text => Boolean(text.content));
+
+  if (links.length === 0 && texts.length === 0) {
+    return null;
+  }
+
+  const resolveIcon = (key?: string) =>
+    (key && app.getSystemIcon(key)) || LinkIcon;
+
+  return (
+    <>
+      {links.length > 0 && (
+        <Box paddingBottom={2}>
+          <Paper>
+            <Box className={classes.section}>
+              {links.map(({ url, entityRef, title, icon }, index) => {
+                const Icon = resolveIcon(icon);
+                const to = entityRef
+                  ? entityRoute(parseEntityRef(entityRef))
+                  : url!;
+                return (
+                  <Link key={index} to={to} classes={{ root: classes.link }}>
+                    <Button
+                      startIcon={<Icon />}
+                      component="div"
+                      color="primary"
+                    >
+                      {title}
+                    </Button>
+                  </Link>
+                );
+              })}
+            </Box>
+          </Paper>
+        </Box>
+      )}
+      {texts.map((text, index) => (
+        <TemplateTextOutput
+          key={index}
+          severity={toSeverity(text.icon)}
+          title={text.title}
+          content={text.content ?? ''}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/app/src/scaffolder/CustomReviewState/CustomReviewStep.test.tsx
+++ b/packages/app/src/scaffolder/CustomReviewState/CustomReviewStep.test.tsx
@@ -81,6 +81,21 @@ describe('CustomReviewStep — Project (per-ProjectType) templates', () => {
     expect(screen.queryByText('Parameters')).not.toBeInTheDocument();
     expect(tables()).toHaveLength(1);
   });
+
+  it('renders the Auto Deploy toggle value as Yes/No', () => {
+    render(
+      <CustomReviewStep
+        {...makeProps({
+          namespace_name: 'domain:default/default',
+          project_name: 'minimal-demo',
+          deployment_pipeline: 'default',
+          auto_deploy: false,
+        })}
+      />,
+    );
+
+    expect(tables()[0]['Auto Deploy']).toBe('No');
+  });
 });
 
 describe('CustomReviewStep — Notification Channel templates', () => {

--- a/packages/app/src/scaffolder/CustomReviewState/CustomReviewStep.tsx
+++ b/packages/app/src/scaffolder/CustomReviewState/CustomReviewStep.tsx
@@ -636,6 +636,9 @@ function ProjectReview({ data }: { data: Record<string, unknown> }) {
       String(data.deployment_pipeline),
     );
   }
+  if (data.auto_deploy !== undefined) {
+    setMeta(projectMeta, 'Auto Deploy', data.auto_deploy ? 'Yes' : 'No');
+  }
 
   // Section: Parameters — the per-type schema-driven form values flattened
   // to label/value rows. Empty/missing fields are dropped by flattenToMetadata.

--- a/packages/app/src/scaffolder/SwitchField/SwitchFieldExtension.test.tsx
+++ b/packages/app/src/scaffolder/SwitchField/SwitchFieldExtension.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { SwitchField } from './SwitchFieldExtension';
+
+const makeProps = (overrides: Record<string, unknown> = {}) =>
+  ({
+    onChange: jest.fn(),
+    rawErrors: [],
+    formData: false,
+    schema: { title: 'Auto Deploy', description: 'Deploys the project' },
+    uiSchema: {},
+    ...overrides,
+  } as any);
+
+describe('SwitchField', () => {
+  it('renders the title and description', () => {
+    render(<SwitchField {...makeProps()} />);
+
+    expect(screen.getByText('Auto Deploy')).toBeInTheDocument();
+    expect(screen.getByText('Deploys the project')).toBeInTheDocument();
+  });
+
+  it('shows the ui:options.offWarning while the switch is off', () => {
+    render(
+      <SwitchField
+        {...makeProps({
+          formData: false,
+          uiSchema: {
+            'ui:options': { offWarning: 'You will need to deploy manually.' },
+          },
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText('You will need to deploy manually.'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the warning while the switch is on', () => {
+    render(
+      <SwitchField
+        {...makeProps({
+          formData: true,
+          uiSchema: {
+            'ui:options': { offWarning: 'You will need to deploy manually.' },
+          },
+        })}
+      />,
+    );
+
+    expect(
+      screen.queryByText('You will need to deploy manually.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders no warning when offWarning is not configured', () => {
+    const { container } = render(
+      <SwitchField {...makeProps({ formData: false })} />,
+    );
+
+    expect(container.querySelector('.MuiAlert-root')).toBeNull();
+  });
+});

--- a/packages/app/src/scaffolder/SwitchField/SwitchFieldExtension.tsx
+++ b/packages/app/src/scaffolder/SwitchField/SwitchFieldExtension.tsx
@@ -1,10 +1,15 @@
 import { ChangeEvent } from 'react';
 import { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
 import { Box, Typography, Switch } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
 
 /**
  * SwitchField component
- * Renders a switch toggle for boolean fields
+ * Renders a switch toggle for boolean fields.
+ *
+ * ui:options:
+ * - `offWarning`: warning text shown below the field while the switch is
+ *   off, for toggles whose opt-out has consequences worth calling out.
  */
 export const SwitchField = ({
   onChange,
@@ -14,6 +19,7 @@ export const SwitchField = ({
   uiSchema,
 }: FieldExtensionComponentProps<boolean>) => {
   const disabled = uiSchema?.['ui:disabled'] === true;
+  const offWarning = uiSchema?.['ui:options']?.offWarning;
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!disabled) {
@@ -47,6 +53,11 @@ export const SwitchField = ({
         >
           {description}
         </Typography>
+      )}
+      {!formData && typeof offWarning === 'string' && offWarning && (
+        <Box mt={1}>
+          <Alert severity="warning">{offWarning}</Alert>
+        </Box>
       )}
       {rawErrors?.length ? (
         <Typography variant="body2" color="error" style={{ marginTop: 8 }}>

--- a/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.cluster.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.cluster.test.ts
@@ -104,6 +104,18 @@ describe('PtdToTemplateConverter – convertClusterPtdToTemplateEntity', () => {
     expect(steps[0].input.typeName).toBe('default');
   });
 
+  it('emits a default-on Auto Deploy toggle and threads it into the step input', () => {
+    const result = converter.convertClusterPtdToTemplateEntity(baseCpt);
+    const autoDeploy = (result.spec as any).parameters[0].properties
+      .auto_deploy;
+    const steps = (result.spec as any).steps as any[];
+
+    expect(autoDeploy.type).toBe('boolean');
+    expect(autoDeploy.default).toBe(true);
+    expect(autoDeploy['ui:field']).toBe('SwitchField');
+    expect(steps[0].input.autoDeploy).toBe('${{ parameters.auto_deploy }}');
+  });
+
   it('passes PTD schema in parameters ui:options', () => {
     const result = converter.convertClusterPtdToTemplateEntity(baseCpt);
     const options = (result.spec as any).parameters[1].properties.parameters[

--- a/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.test.ts
@@ -146,6 +146,9 @@ describe('PtdToTemplateConverter', () => {
       expect(autoDeploy.title).toBe('Auto Deploy');
       expect(autoDeploy.default).toBe(true);
       expect(autoDeploy['ui:field']).toBe('SwitchField');
+      // Opting out has consequences (manual deploy before any component
+      // deploys); SwitchField surfaces this while the toggle is off.
+      expect(autoDeploy['ui:options'].offWarning).toMatch(/deploy it manually/);
       // Not in the section's required list: a toggle always carries a value.
       expect((result.spec as any).parameters[0].required).not.toContain(
         'auto_deploy',

--- a/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.test.ts
@@ -243,6 +243,27 @@ describe('PtdToTemplateConverter', () => {
       ]);
     });
 
+    it('emits a conditional manual-deploy warning text output', () => {
+      const pt: ProjectTypeCRD = { metadata: { name: 'web-app' }, spec: {} };
+
+      const result = converter.convertPtdToTemplateEntity(pt, 'finance');
+      const output = (result.spec as any).output;
+
+      // A static, schema-valid array (output.text must be an array) whose single
+      // entry is dropped by the scaffolder when the `if` condition is falsy.
+      // `icon: 'warning'` selects the alert severity in the app's custom
+      // outputs renderer; no title so the note renders as a plain warning bar.
+      expect(output.text).toHaveLength(1);
+      expect(output.text[0].if).toBe(
+        "${{ steps['create-project'].output.autoDeployFailed }}",
+      );
+      expect(output.text[0].icon).toBe('warning');
+      expect(output.text[0].title).toBeUndefined();
+      expect(output.text[0].content).toContain(
+        "${{ steps['create-project'].output.failedEnvironments }}",
+      );
+    });
+
     it('formats hyphenated ProjectType names as title case', () => {
       expect(
         converter.convertPtdToTemplateEntity(

--- a/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.test.ts
@@ -132,6 +132,26 @@ describe('PtdToTemplateConverter', () => {
       );
     });
 
+    it('emits a default-on Auto Deploy toggle in the Project Metadata section', () => {
+      const pt: ProjectTypeCRD = {
+        metadata: { name: 'web-app' },
+        spec: {},
+      };
+
+      const result = converter.convertPtdToTemplateEntity(pt, 'finance');
+      const autoDeploy = (result.spec as any).parameters[0].properties
+        .auto_deploy;
+
+      expect(autoDeploy.type).toBe('boolean');
+      expect(autoDeploy.title).toBe('Auto Deploy');
+      expect(autoDeploy.default).toBe(true);
+      expect(autoDeploy['ui:field']).toBe('SwitchField');
+      // Not in the section's required list: a toggle always carries a value.
+      expect((result.spec as any).parameters[0].required).not.toContain(
+        'auto_deploy',
+      );
+    });
+
     it('pre-fills the namespace dropdown with the type own namespace (namespaced scope)', () => {
       const pt: ProjectTypeCRD = { metadata: { name: 'web-app' }, spec: {} };
 
@@ -197,6 +217,7 @@ describe('PtdToTemplateConverter', () => {
         displayName: '${{ parameters.displayName }}',
         description: '${{ parameters.description }}',
         deploymentPipeline: '${{ parameters.deployment_pipeline }}',
+        autoDeploy: '${{ parameters.auto_deploy }}',
         typeKind: 'ProjectType',
         typeName: 'web-app',
         parameters: '${{ parameters.parameters }}',

--- a/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.ts
@@ -139,6 +139,24 @@ export class PtdToTemplateConverter {
                 "system:${{ steps['create-project'].output.namespaceName }}/${{ steps['create-project'].output.projectName }}",
             },
           ],
+          // Rendered as a warning bar below the "View Project" link, but only
+          // when auto deploy could not create some release bindings. The `if`
+          // condition is evaluated by the scaffolder after the step runs
+          // (falsy items are dropped), so on success no bar is shown. `icon`
+          // drives the alert severity in OpenChoreoTemplateOutputs (the app's
+          // custom outputs renderer); a title is intentionally omitted.
+          text: [
+            {
+              if: "${{ steps['create-project'].output.autoDeployFailed }}",
+              icon: 'warning',
+              content:
+                'Auto Deploy could not create release binding(s) for ' +
+                "**${{ steps['create-project'].output.failedEnvironments }}**. " +
+                'The project was created successfully, but it will not be ' +
+                'deployed automatically — deploy it manually from the ' +
+                "project's **Deploy** tab.",
+            },
+          ],
         },
       } as any,
     };

--- a/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.ts
@@ -233,6 +233,12 @@ export class PtdToTemplateConverter {
             'Automatically deploys the project to all environments in the deployment pipeline once created',
           default: true,
           'ui:field': 'SwitchField',
+          'ui:options': {
+            offWarning:
+              'The project will not be deployed to any environment. You will ' +
+              'need to deploy it manually from the project’s Deploy tab ' +
+              'before you can deploy components.',
+          },
         },
       },
     };

--- a/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/PtdToTemplateConverter.ts
@@ -167,7 +167,7 @@ export class PtdToTemplateConverter {
 
   /**
    * Two parameter sections:
-   *   1. Project Metadata — namespace + project_name (+ display name / description / deployment pipeline)
+   *   1. Project Metadata — namespace + project_name (+ display name / description / deployment pipeline / auto deploy)
    *   2. <Display Name> Details — single `parameters` field rendered by `ProjectParametersField`
    *                               which reads the schema from ui:options.ptdSchema
    *
@@ -226,6 +226,14 @@ export class PtdToTemplateConverter {
           description: 'Deployment pipeline to associate with this project',
           'ui:field': 'DeploymentPipelinePicker',
         },
+        auto_deploy: {
+          title: 'Auto Deploy',
+          type: 'boolean',
+          description:
+            'Automatically deploys the project to all environments in the deployment pipeline once created',
+          default: true,
+          'ui:field': 'SwitchField',
+        },
       },
     };
 
@@ -265,6 +273,7 @@ export class PtdToTemplateConverter {
           displayName: '${{ parameters.displayName }}',
           description: '${{ parameters.description }}',
           deploymentPipeline: '${{ parameters.deployment_pipeline }}',
+          autoDeploy: '${{ parameters.auto_deploy }}',
           typeKind: ptdKind,
           typeName: pt.metadata.name,
           parameters: '${{ parameters.parameters }}',

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
@@ -83,6 +83,19 @@ describe('deriveBindingStatus', () => {
     expect(deriveBindingStatus(binding)).toBe('NotReady');
   });
 
+  it('returns NotReady for ProjectReleaseNotSet reason (awaiting pin seeding)', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'ProjectReleaseNotSet',
+        message:
+          'spec.projectRelease is unset; pin a ProjectRelease to deploy this binding',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
   it('returns Failed for ResourcesDegraded reason', () => {
     const binding = makeBinding([
       {

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -14,6 +14,10 @@ const PROGRESSING_REASONS = [
   'JobRunning',
   'ConnectionsPending',
   'ResourcesUnknown',
+  // ProjectReleaseBinding with an empty spec.projectRelease pin: the control
+  // plane seeds it with the project's latest release once one exists, so a
+  // just-created binding sits here briefly. Pending, not an error.
+  'ProjectReleaseNotSet',
 ] as const;
 
 /** Reasons that represent an intentional non-deployed state, not an error. */

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/project.test.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/project.test.ts
@@ -356,6 +356,9 @@ describe('createProjectAction', () => {
         'my-project-staging',
         'my-project-prod',
       ]);
+      // No failures, so the manual-deploy warning is suppressed.
+      expect(ctx.output).toHaveBeenCalledWith('autoDeployFailed', false);
+      expect(ctx.output).toHaveBeenCalledWith('failedEnvironments', '');
     });
 
     it('creates no bindings when autoDeploy is false', async () => {
@@ -419,9 +422,12 @@ describe('createProjectAction', () => {
         'my-project-dev',
         'my-project-prod',
       ]);
+      // The failed environment is surfaced for the manual-deploy warning.
+      expect(ctx.output).toHaveBeenCalledWith('autoDeployFailed', true);
+      expect(ctx.output).toHaveBeenCalledWith('failedEnvironments', 'staging');
     });
 
-    it('fails the step when every binding create fails', async () => {
+    it('warns without failing the task when every binding create fails', async () => {
       mockPOST.mockResolvedValueOnce(successResponse());
       mockGET.mockResolvedValue(pipelineResponse());
       mockPOST.mockResolvedValue(bindingErrorResponse(403));
@@ -430,8 +436,23 @@ describe('createProjectAction', () => {
         buildConfig(),
         mockImmediateCatalog as any,
       );
-      await expect(action.handler(buildCtx() as any)).rejects.toThrow(
-        /failed to create release bindings for all 3/i,
+      const ctx = buildCtx();
+      await action.handler(ctx as any);
+
+      // The project was already created, so the step succeeds and still emits
+      // its outputs (letting the "View Project" link render); the binding
+      // failures only surface as warnings.
+      expect(bindingCalls()).toHaveLength(3);
+      expect(ctx.output).toHaveBeenCalledWith('projectName', 'my-project');
+      expect(ctx.output).toHaveBeenCalledWith('createdBindings', []);
+      expect(ctx.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('created 0 of 3'),
+      );
+      // All environments failed, so the warning lists them all.
+      expect(ctx.output).toHaveBeenCalledWith('autoDeployFailed', true);
+      expect(ctx.output).toHaveBeenCalledWith(
+        'failedEnvironments',
+        'dev, staging, prod',
       );
     });
 

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/project.test.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/project.test.ts
@@ -2,12 +2,13 @@ import { translateProjectToEntity } from '@openchoreo/backstage-plugin-catalog-b
 import { createProjectAction } from './project';
 
 const mockPOST = jest.fn();
+const mockGET = jest.fn();
 
 jest.mock('@openchoreo/openchoreo-client-node', () => ({
   ...jest.requireActual('@openchoreo/openchoreo-client-node'),
   createOpenChoreoApiClient: jest.fn(() => ({
     POST: mockPOST,
-    GET: jest.fn(),
+    GET: mockGET,
     PUT: jest.fn(),
     DELETE: jest.fn(),
   })),
@@ -68,11 +69,58 @@ const successResponse = (name = 'my-project') => ({
   response: { ok: true, status: 200 } as any,
 });
 
+// dev -> staging -> prod; staging appears as both target and source to
+// exercise deduplication in the auto-deploy environment expansion.
+const pipelineResponse = () => ({
+  data: {
+    metadata: { name: 'default-pipeline' },
+    spec: {
+      promotionPaths: [
+        {
+          sourceEnvironmentRef: { kind: 'Environment', name: 'dev' },
+          targetEnvironmentRefs: [{ kind: 'Environment', name: 'staging' }],
+        },
+        {
+          sourceEnvironmentRef: { kind: 'Environment', name: 'staging' },
+          targetEnvironmentRefs: [{ kind: 'Environment', name: 'prod' }],
+        },
+      ],
+    },
+  },
+  error: undefined,
+  response: { ok: true, status: 200 } as any,
+});
+
+const bindingCreatedResponse = (status = 201) => ({
+  data: {},
+  error: undefined,
+  response: { ok: true, status } as any,
+});
+
+const bindingErrorResponse = (status: number) => ({
+  data: undefined,
+  error: { message: `error ${status}` },
+  response: { ok: false, status } as any,
+});
+
+const bindingCalls = () =>
+  mockPOST.mock.calls.filter(
+    ([path]) =>
+      path === '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
+  );
+
 describe('createProjectAction', () => {
   let mockImmediateCatalog: { insertEntity: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: pipeline fetch fails; auto deploy warns and skips the fan-out,
+    // so tests not about auto deploy are unaffected.
+    mockGET.mockResolvedValue({
+      data: undefined,
+      error: { message: 'not found' },
+      response: { ok: false, status: 404 } as any,
+    });
     mockImmediateCatalog = {
       insertEntity: jest.fn().mockResolvedValue(undefined),
     };
@@ -259,5 +307,191 @@ describe('createProjectAction', () => {
       buildCtx({ secrets: { OPENCHOREO_USER_TOKEN: 'tkn' } }) as any,
     );
     expect(mockPOST).toHaveBeenCalled();
+  });
+
+  describe('auto deploy release binding fan-out', () => {
+    it('creates one unpinned binding per pipeline environment, deduplicated in pipeline order', async () => {
+      mockPOST.mockResolvedValueOnce(successResponse());
+      mockGET.mockResolvedValue(pipelineResponse());
+      mockPOST.mockResolvedValue(bindingCreatedResponse());
+
+      const action = createProjectAction(
+        buildConfig(),
+        mockImmediateCatalog as any,
+      );
+      const ctx = buildCtx();
+      await action.handler(ctx as any);
+
+      expect(mockGET).toHaveBeenCalledWith(
+        '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
+        {
+          params: {
+            path: {
+              namespaceName: 'my-ns',
+              deploymentPipelineName: 'default-pipeline',
+            },
+          },
+        },
+      );
+
+      const calls = bindingCalls();
+      expect(calls).toHaveLength(3);
+      expect(calls.map(([, opts]) => opts.body.metadata.name)).toEqual([
+        'my-project-dev',
+        'my-project-staging',
+        'my-project-prod',
+      ]);
+      for (const [, opts] of calls) {
+        expect(opts.params.path.namespaceName).toBe('my-ns');
+        expect(opts.body.spec.owner).toEqual({ projectName: 'my-project' });
+        expect(opts.body.spec.projectRelease).toBeUndefined();
+      }
+      expect(calls.map(([, opts]) => opts.body.spec.environment)).toEqual([
+        'dev',
+        'staging',
+        'prod',
+      ]);
+      expect(ctx.output).toHaveBeenCalledWith('createdBindings', [
+        'my-project-dev',
+        'my-project-staging',
+        'my-project-prod',
+      ]);
+    });
+
+    it('creates no bindings when autoDeploy is false', async () => {
+      mockPOST.mockResolvedValueOnce(successResponse());
+      mockGET.mockResolvedValue(pipelineResponse());
+
+      const action = createProjectAction(
+        buildConfig(),
+        mockImmediateCatalog as any,
+      );
+      const ctx = buildCtx({ input: { autoDeploy: false } });
+      await action.handler(ctx as any);
+
+      expect(mockGET).not.toHaveBeenCalled();
+      expect(bindingCalls()).toHaveLength(0);
+      expect(ctx.output).toHaveBeenCalledWith('createdBindings', []);
+    });
+
+    it('treats 409 (binding already exists) as success', async () => {
+      mockPOST.mockResolvedValueOnce(successResponse());
+      mockGET.mockResolvedValue(pipelineResponse());
+      mockPOST
+        .mockResolvedValueOnce(bindingCreatedResponse())
+        .mockResolvedValueOnce(bindingErrorResponse(409))
+        .mockResolvedValueOnce(bindingCreatedResponse());
+
+      const action = createProjectAction(
+        buildConfig(),
+        mockImmediateCatalog as any,
+      );
+      const ctx = buildCtx();
+      await action.handler(ctx as any);
+
+      expect(ctx.output).toHaveBeenCalledWith('createdBindings', [
+        'my-project-dev',
+        'my-project-staging',
+        'my-project-prod',
+      ]);
+    });
+
+    it('continues past per-environment failures and reports the rest', async () => {
+      mockPOST.mockResolvedValueOnce(successResponse());
+      mockGET.mockResolvedValue(pipelineResponse());
+      mockPOST
+        .mockResolvedValueOnce(bindingCreatedResponse())
+        .mockResolvedValueOnce(bindingErrorResponse(500))
+        .mockResolvedValueOnce(bindingCreatedResponse());
+
+      const action = createProjectAction(
+        buildConfig(),
+        mockImmediateCatalog as any,
+      );
+      const ctx = buildCtx();
+      await action.handler(ctx as any);
+
+      expect(bindingCalls()).toHaveLength(3);
+      expect(ctx.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('my-project-staging'),
+      );
+      expect(ctx.output).toHaveBeenCalledWith('createdBindings', [
+        'my-project-dev',
+        'my-project-prod',
+      ]);
+    });
+
+    it('fails the step when every binding create fails', async () => {
+      mockPOST.mockResolvedValueOnce(successResponse());
+      mockGET.mockResolvedValue(pipelineResponse());
+      mockPOST.mockResolvedValue(bindingErrorResponse(403));
+
+      const action = createProjectAction(
+        buildConfig(),
+        mockImmediateCatalog as any,
+      );
+      await expect(action.handler(buildCtx() as any)).rejects.toThrow(
+        /failed to create release bindings for all 3/i,
+      );
+    });
+
+    it('warns without failing the task when the pipeline fetch fails', async () => {
+      mockPOST.mockResolvedValueOnce(successResponse());
+      // beforeEach default: GET resolves 404
+
+      const action = createProjectAction(
+        buildConfig(),
+        mockImmediateCatalog as any,
+      );
+      const ctx = buildCtx();
+      await action.handler(ctx as any);
+
+      expect(bindingCalls()).toHaveLength(0);
+      expect(ctx.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Deploy tab'),
+      );
+      expect(ctx.output).toHaveBeenCalledWith('projectName', 'my-project');
+      expect(ctx.output).toHaveBeenCalledWith('createdBindings', []);
+    });
+
+    it('warns without failing when the pipeline has no environments', async () => {
+      mockPOST.mockResolvedValueOnce(successResponse());
+      mockGET.mockResolvedValue({
+        data: { metadata: { name: 'default-pipeline' }, spec: {} },
+        error: undefined,
+        response: { ok: true, status: 200 } as any,
+      });
+
+      const action = createProjectAction(
+        buildConfig(),
+        mockImmediateCatalog as any,
+      );
+      const ctx = buildCtx();
+      await action.handler(ctx as any);
+
+      expect(bindingCalls()).toHaveLength(0);
+      expect(ctx.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('no environments'),
+      );
+      expect(ctx.output).toHaveBeenCalledWith('createdBindings', []);
+    });
+
+    it('falls back to the default pipeline name when the input is empty', async () => {
+      mockPOST.mockResolvedValueOnce(successResponse());
+      mockGET.mockResolvedValue(pipelineResponse());
+      mockPOST.mockResolvedValue(bindingCreatedResponse());
+
+      const action = createProjectAction(
+        buildConfig(),
+        mockImmediateCatalog as any,
+      );
+      await action.handler(
+        buildCtx({ input: { deploymentPipeline: '' } }) as any,
+      );
+
+      expect(mockGET.mock.calls[0][1].params.path.deploymentPipelineName).toBe(
+        'default',
+      );
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/project.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/project.ts
@@ -58,10 +58,18 @@ const expandPipelineEnvironments = (pipeline: {
  * the first ProjectRelease does not exist yet at project-creation time; the
  * control plane seeds empty pins with the latest release once it is cut.
  *
- * Failure semantics: a pipeline fetch failure only warns (the project is
- * already created at this point); per-environment failures are logged and
- * the fan-out continues; 409 means the binding already exists (safe re-run)
- * and counts as success. Throws only when every create failed.
+ * Bindings are created concurrently (Promise.allSettled) to keep the
+ * scaffolder step fast, then aggregated into created/failed sets in pipeline
+ * order.
+ *
+ * Failure semantics: binding creation is best-effort and never fails the
+ * scaffolder task, because the project is already created at this point and
+ * the user must still be able to navigate to it (via the template's "View
+ * Project" link). A pipeline fetch failure only warns; per-environment
+ * failures are logged and the other environments still proceed; 409 means the
+ * binding already exists (safe re-run) and counts as success. Even when every
+ * create fails the step succeeds with an empty result and a warning; the user
+ * can deploy per environment from the Deploy tab.
  */
 const createInitialReleaseBindings = async (options: {
   client: OpenChoreoClient;
@@ -69,7 +77,7 @@ const createInitialReleaseBindings = async (options: {
   namespaceName: string;
   projectName: string;
   pipelineName: string;
-}): Promise<string[]> => {
+}): Promise<{ created: string[]; failed: string[] }> => {
   const { client, logger, namespaceName, projectName, pipelineName } = options;
 
   let environments: string[];
@@ -88,7 +96,7 @@ const createInitialReleaseBindings = async (options: {
           `(status ${response?.status}). No release bindings were created; ` +
           `use the Deploy tab to deploy the project per environment.`,
       );
-      return [];
+      return { created: [], failed: [] };
     }
     environments = expandPipelineEnvironments(data);
   } catch (error) {
@@ -96,77 +104,88 @@ const createInitialReleaseBindings = async (options: {
       `Auto deploy: failed to fetch deployment pipeline '${pipelineName}': ${error}. ` +
         `No release bindings were created; use the Deploy tab to deploy the project per environment.`,
     );
-    return [];
+    return { created: [], failed: [] };
   }
 
   if (environments.length === 0) {
     logger.warn(
       `Auto deploy: deployment pipeline '${pipelineName}' has no environments; no release bindings created.`,
     );
-    return [];
+    return { created: [], failed: [] };
   }
+
+  // Fan out over all environments concurrently. Each task resolves to the
+  // created binding name or rejects with a contextual message; allSettled
+  // preserves input order so results map back to `environments` by index.
+  const results = await Promise.allSettled(
+    environments.map(async environment => {
+      const bindingName = `${projectName}-${environment}`;
+      try {
+        const { error, response } = await client.POST(
+          '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
+          {
+            params: {
+              path: { namespaceName },
+            },
+            body: {
+              metadata: {
+                name: bindingName,
+                namespace: namespaceName,
+              },
+              spec: {
+                owner: {
+                  projectName,
+                },
+                environment,
+              },
+            },
+          },
+        );
+        if (response.ok) {
+          logger.info(`Auto deploy: created release binding '${bindingName}'`);
+        } else if (response.status === 409) {
+          logger.info(
+            `Auto deploy: release binding '${bindingName}' already exists`,
+          );
+        } else {
+          throw new Error(
+            `(status ${response.status})${
+              error ? `: ${JSON.stringify(error)}` : ''
+            }`,
+          );
+        }
+        return bindingName;
+      } catch (error) {
+        throw new Error(
+          `failed to create release binding '${bindingName}': ${
+            error instanceof Error ? error.message : error
+          }`,
+        );
+      }
+    }),
+  );
 
   const created: string[] = [];
   const failures: string[] = [];
-  for (const environment of environments) {
-    const bindingName = `${projectName}-${environment}`;
-    try {
-      const { error, response } = await client.POST(
-        '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
-        {
-          params: {
-            path: { namespaceName },
-          },
-          body: {
-            metadata: {
-              name: bindingName,
-              namespace: namespaceName,
-            },
-            spec: {
-              owner: {
-                projectName,
-              },
-              environment,
-            },
-          },
-        },
-      );
-      if (response.ok) {
-        logger.info(`Auto deploy: created release binding '${bindingName}'`);
-        created.push(bindingName);
-      } else if (response.status === 409) {
-        logger.info(
-          `Auto deploy: release binding '${bindingName}' already exists`,
-        );
-        created.push(bindingName);
-      } else {
-        failures.push(environment);
-        logger.warn(
-          `Auto deploy: failed to create release binding '${bindingName}' ` +
-            `(status ${response.status}): ${
-              error ? JSON.stringify(error) : ''
-            }`,
-        );
-      }
-    } catch (error) {
-      failures.push(environment);
-      logger.warn(
-        `Auto deploy: failed to create release binding '${bindingName}': ${error}`,
-      );
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      created.push(result.value);
+    } else {
+      failures.push(environments[index]);
+      logger.warn(`Auto deploy: ${result.reason.message}`);
     }
-  }
+  });
 
-  if (created.length === 0) {
-    throw new Error(
-      `Auto deploy: failed to create release bindings for all ${failures.length} ` +
-        `pipeline environments (${failures.join(
-          ', ',
-        )}). The project was created; ` +
-        `use the Deploy tab to deploy it per environment.`,
+  if (failures.length > 0) {
+    logger.warn(
+      `Auto deploy: created ${created.length} of ${environments.length} release ` +
+        `binding(s); ${failures.length} failed (${failures.join(', ')}). The ` +
+        `project was created; use the Deploy tab to deploy the remaining ` +
+        `environments.`,
     );
   }
 
-  return created;
+  return { created, failed: failures };
 };
 
 export const createProjectAction = (
@@ -242,6 +261,23 @@ export const createProjectAction = (
             .array(z.string(), {
               description:
                 'Names of the ProjectReleaseBindings created for auto deploy',
+            })
+            .optional(),
+        autoDeployFailed: z =>
+          z
+            .boolean({
+              description:
+                'True when auto deploy could not create one or more release ' +
+                'bindings. Drives the conditional manual-deploy warning on the ' +
+                'task page.',
+            })
+            .optional(),
+        failedEnvironments: z =>
+          z
+            .string({
+              description:
+                'Comma-separated list of environments whose release binding ' +
+                'could not be created (empty when auto deploy succeeded).',
             })
             .optional(),
       },
@@ -397,25 +433,32 @@ export const createProjectAction = (
 
         const autoDeploy = ctx.input.autoDeploy ?? true;
         let createdBindings: string[] = [];
+        let failedBindings: string[] = [];
         if (autoDeploy) {
-          createdBindings = await createInitialReleaseBindings({
-            client,
-            logger: ctx.logger,
-            namespaceName,
-            projectName,
-            // Mirror the openchoreo-api service default so both sides agree
-            // when no pipeline is picked.
-            pipelineName: ctx.input.deploymentPipeline || 'default',
-          });
+          ({ created: createdBindings, failed: failedBindings } =
+            await createInitialReleaseBindings({
+              client,
+              logger: ctx.logger,
+              namespaceName,
+              projectName,
+              // Mirror the openchoreo-api service default so both sides agree
+              // when no pipeline is picked.
+              pipelineName: ctx.input.deploymentPipeline || 'default',
+            }));
         } else {
           ctx.logger.info('Auto deploy disabled - no release bindings created');
         }
 
-        // Set outputs for the scaffolder
+        // Drive the conditional manual-deploy warning on the task page
+        // (rendered below the "View Project" link) when auto deploy could not
+        // create some bindings. The template's output.text entry has an `if`
+        // condition bound to autoDeployFailed, so no card shows on success.
         ctx.output('projectName', projectName);
         ctx.output('namespaceName', namespaceName);
         ctx.output('entityRef', `system:${namespaceName}/${projectName}`);
         ctx.output('createdBindings', createdBindings);
+        ctx.output('autoDeployFailed', failedBindings.length > 0);
+        ctx.output('failedEnvironments', failedBindings.join(', '));
       } catch (error) {
         ctx.logger.error(`Error creating project: ${error}`);
         throw error instanceof Error

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/project.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/project.ts
@@ -9,6 +9,166 @@ import {
   translateProjectToEntity,
 } from '@openchoreo/backstage-plugin-catalog-backend-module';
 
+type OpenChoreoClient = ReturnType<typeof createOpenChoreoApiClient>;
+
+type ActionLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+const environmentRefName = (
+  ref: { name?: string } | string | undefined,
+): string | undefined => (typeof ref === 'string' ? ref : ref?.name);
+
+/**
+ * Expands the environment names a DeploymentPipeline promotes through:
+ * source + target refs of every promotion path, deduplicated, in pipeline
+ * order. Mirrors the expansion the Deploy tab performs in
+ * EnvironmentInfoService.
+ */
+const expandPipelineEnvironments = (pipeline: {
+  spec?: {
+    promotionPaths?: Array<{
+      sourceEnvironmentRef?: { name?: string } | string;
+      targetEnvironmentRefs?: Array<{ name?: string } | string>;
+    }>;
+  };
+}): string[] => {
+  const environments: string[] = [];
+  const seen = new Set<string>();
+  const add = (name: string | undefined) => {
+    if (name && !seen.has(name)) {
+      seen.add(name);
+      environments.push(name);
+    }
+  };
+  for (const path of pipeline.spec?.promotionPaths ?? []) {
+    add(environmentRefName(path.sourceEnvironmentRef));
+    for (const target of path.targetEnvironmentRefs ?? []) {
+      add(environmentRefName(target));
+    }
+  }
+  return environments;
+};
+
+/**
+ * Creates one unpinned ProjectReleaseBinding per environment of the
+ * project's DeploymentPipeline (name `{project}-{env}`, spec.owner +
+ * spec.environment only). `spec.projectRelease` is deliberately left unset:
+ * the first ProjectRelease does not exist yet at project-creation time; the
+ * control plane seeds empty pins with the latest release once it is cut.
+ *
+ * Failure semantics: a pipeline fetch failure only warns (the project is
+ * already created at this point); per-environment failures are logged and
+ * the fan-out continues; 409 means the binding already exists (safe re-run)
+ * and counts as success. Throws only when every create failed.
+ */
+const createInitialReleaseBindings = async (options: {
+  client: OpenChoreoClient;
+  logger: ActionLogger;
+  namespaceName: string;
+  projectName: string;
+  pipelineName: string;
+}): Promise<string[]> => {
+  const { client, logger, namespaceName, projectName, pipelineName } = options;
+
+  let environments: string[];
+  try {
+    const { data, error, response } = await client.GET(
+      '/api/v1/namespaces/{namespaceName}/deploymentpipelines/{deploymentPipelineName}',
+      {
+        params: {
+          path: { namespaceName, deploymentPipelineName: pipelineName },
+        },
+      },
+    );
+    if (error || !response.ok || !data) {
+      logger.warn(
+        `Auto deploy: failed to fetch deployment pipeline '${pipelineName}' ` +
+          `(status ${response?.status}). No release bindings were created; ` +
+          `use the Deploy tab to deploy the project per environment.`,
+      );
+      return [];
+    }
+    environments = expandPipelineEnvironments(data);
+  } catch (error) {
+    logger.warn(
+      `Auto deploy: failed to fetch deployment pipeline '${pipelineName}': ${error}. ` +
+        `No release bindings were created; use the Deploy tab to deploy the project per environment.`,
+    );
+    return [];
+  }
+
+  if (environments.length === 0) {
+    logger.warn(
+      `Auto deploy: deployment pipeline '${pipelineName}' has no environments; no release bindings created.`,
+    );
+    return [];
+  }
+
+  const created: string[] = [];
+  const failures: string[] = [];
+  for (const environment of environments) {
+    const bindingName = `${projectName}-${environment}`;
+    try {
+      const { error, response } = await client.POST(
+        '/api/v1/namespaces/{namespaceName}/projectreleasebindings',
+        {
+          params: {
+            path: { namespaceName },
+          },
+          body: {
+            metadata: {
+              name: bindingName,
+              namespace: namespaceName,
+            },
+            spec: {
+              owner: {
+                projectName,
+              },
+              environment,
+            },
+          },
+        },
+      );
+      if (response.ok) {
+        logger.info(`Auto deploy: created release binding '${bindingName}'`);
+        created.push(bindingName);
+      } else if (response.status === 409) {
+        logger.info(
+          `Auto deploy: release binding '${bindingName}' already exists`,
+        );
+        created.push(bindingName);
+      } else {
+        failures.push(environment);
+        logger.warn(
+          `Auto deploy: failed to create release binding '${bindingName}' ` +
+            `(status ${response.status}): ${
+              error ? JSON.stringify(error) : ''
+            }`,
+        );
+      }
+    } catch (error) {
+      failures.push(environment);
+      logger.warn(
+        `Auto deploy: failed to create release binding '${bindingName}': ${error}`,
+      );
+    }
+  }
+
+  if (created.length === 0) {
+    throw new Error(
+      `Auto deploy: failed to create release bindings for all ${failures.length} ` +
+        `pipeline environments (${failures.join(
+          ', ',
+        )}). The project was created; ` +
+        `use the Deploy tab to deploy it per environment.`,
+    );
+  }
+
+  return created;
+};
+
 export const createProjectAction = (
   config: Config,
   immediateCatalog: ImmediateCatalogService,
@@ -36,6 +196,14 @@ export const createProjectAction = (
           z.string({
             description: 'The deployment pipeline for the project',
           }),
+        autoDeploy: z =>
+          z
+            .boolean({
+              description:
+                'Create one unpinned ProjectReleaseBinding per environment of ' +
+                'the deployment pipeline after the project is created (default true)',
+            })
+            .optional(),
         typeKind: z =>
           z
             .enum(['ProjectType', 'ClusterProjectType'], {
@@ -69,6 +237,13 @@ export const createProjectAction = (
           z.string({
             description: 'Entity reference for the created project',
           }),
+        createdBindings: z =>
+          z
+            .array(z.string(), {
+              description:
+                'Names of the ProjectReleaseBindings created for auto deploy',
+            })
+            .optional(),
       },
     },
     async handler(ctx) {
@@ -220,10 +395,27 @@ export const createProjectAction = (
           );
         }
 
+        const autoDeploy = ctx.input.autoDeploy ?? true;
+        let createdBindings: string[] = [];
+        if (autoDeploy) {
+          createdBindings = await createInitialReleaseBindings({
+            client,
+            logger: ctx.logger,
+            namespaceName,
+            projectName,
+            // Mirror the openchoreo-api service default so both sides agree
+            // when no pipeline is picked.
+            pipelineName: ctx.input.deploymentPipeline || 'default',
+          });
+        } else {
+          ctx.logger.info('Auto deploy disabled - no release bindings created');
+        }
+
         // Set outputs for the scaffolder
         ctx.output('projectName', projectName);
         ctx.output('namespaceName', namespaceName);
         ctx.output('entityRef', `system:${namespaceName}/${projectName}`);
+        ctx.output('createdBindings', createdBindings);
       } catch (error) {
         ctx.logger.error(`Error creating project: ${error}`);
         throw error instanceof Error

--- a/yarn.lock
+++ b/yarn.lock
@@ -16929,6 +16929,7 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:^0.9.9"
     "@backstage/plugin-permission-react": "npm:^0.5.1"
     "@backstage/plugin-scaffolder": "npm:^1.37.0"
+    "@backstage/plugin-scaffolder-common": "npm:^2.2.0"
     "@backstage/plugin-scaffolder-react": "npm:^2.0.0"
     "@backstage/plugin-search": "npm:^1.7.4"
     "@backstage/plugin-search-react": "npm:^1.11.4"


### PR DESCRIPTION
## Purpose

The OpenChoreo controller's automatic ProjectReleaseBinding creation is being removed (client-driven binding creation, openchoreo/openchoreo `feat/client-driven-project-release-bindings`). Initial binding creation moves to the clients, so the project creation wizard needs to take over: a default-on **Auto Deploy** option that provisions one release binding per pipeline environment on create, with an explicit opt-out.

## Approach

- Generated (Cluster)ProjectType templates gain a default-on `auto_deploy` toggle (`SwitchField`) in the Project Metadata step.
- `openchoreo:project:create` fans out one unpinned ProjectReleaseBinding per deployment-pipeline environment (`{project}-{env}`, `spec.owner` + `spec.environment` only) after the project POST; the control plane seeds `spec.projectRelease` once the first release is cut. 409 counts as success, per-environment failures are logged and skipped, the step fails only when every create fails, and a pipeline-fetch failure warns and defers to the Deploy tab.
- `SwitchField` supports `ui:options.offWarning`; project templates use it to warn that opting out means manually deploying the project (Deploy tab) before deploying components.
- Wizard review step shows the Auto Deploy value as Yes/No.
- Deploy tab: `Ready=False / ProjectReleaseNotSet` (a just-created unpinned binding awaiting seeding) is now classified as pending instead of failed; the existing NotReady polling picks up the seeded pin automatically.

## Quick demo


https://github.com/user-attachments/assets/415ef69a-901e-40b7-8a42-581eb07d41a5



## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks

Ships strictly after the control-plane change (pin seeding + removal of controller auto-creation). Against an older control plane, wizard-created bindings are never seeded and park at `ProjectReleaseNotSet` until promoted manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an **Auto Deploy** toggle to project creation (default enabled).
  * When enabled, initial per-environment release bindings are created automatically after project creation.
  * When disabled, the wizard and template UI show a manual-deploy warning.
  * Introduced an experimental template outputs renderer for displaying template links and text outputs.

* **Bug Fixes**
  * Project review now displays **Auto Deploy** as **Yes/No**.
  * Improved release status handling so `ProjectReleaseNotSet` is treated as **Not Ready** (not a failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->