### PR TITLE
feat(loading): unify portal loading with shared skeleton system

### DIFF
--- a/.changeset/unify-loading-components.md
+++ b/.changeset/unify-loading-components.md
@@ -1,0 +1,14 @@
+---
+'@openchoreo/backstage-design-system': patch
+'@openchoreo/backstage-plugin-react': patch
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+---
+
+Add a unified loading system to standardize portal loading states. New
+`Skeleton` primitive (token-driven shimmer) in the design system, plus
+`ContentLoader` and `SkeletonRows` in the React plugin. `ContentLoader`
+keeps content on screen during a background refetch (overlay spinner
+instead of a full swap), fixing cards that "pop in and out" on slow
+networks. Applied to the observability Alerts and Incidents views: the
+alerts list no longer blanks on refresh, and the permission gate shows a
+stable page skeleton instead of a top progress bar.

--- a/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import { Skeleton } from './Skeleton';
+
+describe('Skeleton', () => {
+  it('renders a single placeholder by default', () => {
+    const { container } = render(<Skeleton />);
+    // One shimmer element, marked decorative for screen readers.
+    const items = container.querySelectorAll('[aria-hidden="true"]');
+    expect(items).toHaveLength(1);
+  });
+
+  it('renders N stacked lines when count > 1', () => {
+    const { container } = render(<Skeleton count={3} />);
+    // A stack wrapper plus three child lines — four aria-hidden nodes total.
+    const items = container.querySelectorAll('[aria-hidden="true"]');
+    expect(items.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('applies an infinite shimmer animation and a token-driven duration', () => {
+    const { container } = render(<Skeleton variant="rect" height={120} />);
+    const el = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(el).toBeInTheDocument();
+    // Duration comes from motion.shimmerDuration (1.5s) via inline style.
+    expect(el.style.animationDuration).toBe('1.5s');
+    // Explicit height is forwarded.
+    expect(el.style.height).toBe('120px');
+  });
+
+  it('forwards width and defaults to full width for text/rect', () => {
+    const { container } = render(<Skeleton variant="text" />);
+    const el = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(el.style.width).toBe('100%');
+  });
+
+  it('is decorative (no accessible role) so aria-busy lives on the container', () => {
+    const { queryByRole } = render(<Skeleton />);
+    expect(queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/Skeleton/Skeleton.tsx
+++ b/packages/design-system/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,123 @@
+import { CSSProperties } from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import { Box } from '@material-ui/core';
+import { useChoreoTokens } from '../../theme/useChoreoTokens';
+
+/**
+ * A single moving-shimmer keyframe, defined once here so every loading
+ * placeholder in the app animates identically. The gradient background is
+ * 200% wide and slides left→right; colours come from the theme's
+ * `graph.skeletonStops` and timing from `motion.shimmerDuration`.
+ */
+const useStyles = makeStyles((theme: Theme) => ({
+  '@keyframes ocShimmer': {
+    '0%': { backgroundPosition: '200% 0' },
+    '100%': { backgroundPosition: '-200% 0' },
+  },
+  skeleton: {
+    display: 'block',
+    backgroundSize: '200% 100%',
+    animationName: '$ocShimmer',
+    animationTimingFunction: 'linear',
+    animationIterationCount: 'infinite',
+  },
+  text: {
+    height: '1em',
+    marginTop: 0,
+    marginBottom: 0,
+    borderRadius: theme.shape.borderRadius,
+    transform: 'scale(1, 0.7)',
+    transformOrigin: '0 60%',
+  },
+  rect: {
+    borderRadius: theme.shape.borderRadius,
+  },
+  circle: {
+    borderRadius: '50%',
+  },
+  stack: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+}));
+
+export interface SkeletonProps {
+  /**
+   * Shape of the placeholder.
+   * @default 'text'
+   */
+  variant?: 'text' | 'rect' | 'circle';
+  /** Width (number = px). Defaults to 100% for text/rect. */
+  width?: number | string;
+  /** Height (number = px). Defaults to a line height for text. */
+  height?: number | string;
+  /**
+   * Render N stacked placeholder lines. Replaces the ad-hoc
+   * `Array.from({ length: n }).map(...)` loops scattered across the app.
+   * @default 1
+   */
+  count?: number;
+  className?: string;
+}
+
+/**
+ * The single, token-driven loading placeholder for the OpenChoreo portal.
+ *
+ * Prefer this over raw MUI `Skeleton` / `CircularProgress` for first-load
+ * placeholders so shimmer colour and timing stay consistent everywhere. For
+ * combined loading/error/empty/content handling that keeps content on screen
+ * during refetch, wrap views in `ContentLoader` (from
+ * `@openchoreo/backstage-plugin-react`), which uses this primitive.
+ *
+ * @example
+ * ```tsx
+ * <Skeleton variant="rect" height={120} />
+ * <Skeleton count={3} />           // three stacked text lines
+ * ```
+ */
+export const Skeleton = ({
+  variant = 'text',
+  width,
+  height,
+  count = 1,
+  className,
+}: SkeletonProps) => {
+  const classes = useStyles();
+  const tokens = useChoreoTokens();
+  const [base, mid, highlight] = tokens.graph.skeletonStops;
+
+  const shimmerStyle: CSSProperties = {
+    backgroundImage: `linear-gradient(90deg, ${base} 25%, ${mid} 37%, ${highlight} 50%, ${mid} 63%, ${base} 75%)`,
+    animationDuration: tokens.motion.shimmerDuration,
+    width: width ?? (variant === 'circle' ? height : '100%'),
+    height,
+  };
+
+  const variantClass = {
+    text: classes.text,
+    rect: classes.rect,
+    circle: classes.circle,
+  }[variant];
+
+  const item = (key?: number) => (
+    <Box
+      key={key}
+      className={[classes.skeleton, variantClass, className]
+        .filter(Boolean)
+        .join(' ')}
+      style={shimmerStyle}
+      aria-hidden="true"
+    />
+  );
+
+  if (count > 1) {
+    return (
+      <Box className={classes.stack} aria-hidden="true">
+        {Array.from({ length: count }).map((_, i) => item(i))}
+      </Box>
+    );
+  }
+
+  return item();
+};

--- a/packages/design-system/src/components/Skeleton/index.ts
+++ b/packages/design-system/src/components/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps } from './Skeleton';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -13,6 +13,8 @@ export { StatusBadge } from './components/StatusBadge';
 export type { StatusType } from './components/StatusBadge';
 export { Card } from './components/Card';
 export type { CardProps } from './components/Card';
+export { Skeleton } from './components/Skeleton';
+export type { SkeletonProps } from './components/Skeleton';
 export { VerticalTabNav, VerticalTabItem } from './components/VerticalTabNav';
 export type {
   VerticalTabNavProps,

--- a/packages/design-system/src/theme/tokens.ts
+++ b/packages/design-system/src/theme/tokens.ts
@@ -211,6 +211,21 @@ export type ThemeTokens = {
 
   // ---- Deletion warning (graph nodes marked for deletion) -------------------
   deletionWarning: string;
+
+  // ---- Motion / animation timing --------------------------------------------
+  // Single source of truth for loading/animation timing so shimmer, pulse,
+  // spin and fade-in read consistently everywhere. Colors for shimmer live in
+  // `graph.skeletonStops`; only timing/easing belong here.
+  motion: {
+    /** Shimmer/pulse cycle used by the Skeleton primitive and pulse effects. */
+    shimmerDuration: string;
+    /** Easing for the shimmer/pulse cycle. */
+    shimmerEasing: string;
+    /** Fade-in for content/overlays appearing after load. */
+    fadeInDuration: string;
+    /** Rotation cycle for spinners / refresh icons. */
+    spinDuration: string;
+  };
 };
 
 // ---------------------------------------------------------------------------
@@ -454,6 +469,13 @@ export const lightTokens: ThemeTokens = {
   },
 
   deletionWarning: '#f59e0b',
+
+  motion: {
+    shimmerDuration: '1.5s',
+    shimmerEasing: 'ease-in-out',
+    fadeInDuration: '300ms',
+    spinDuration: '1s',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -674,4 +696,11 @@ export const darkTokens: ThemeTokens = {
   },
 
   deletionWarning: '#fbbf24',
+
+  motion: {
+    shimmerDuration: '1.5s',
+    shimmerEasing: 'ease-in-out',
+    fadeInDuration: '300ms',
+    spinDuration: '1s',
+  },
 };

--- a/plugins/openchoreo-observability/src/components/Alerts/AlertsTable.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Alerts/AlertsTable.test.tsx
@@ -78,14 +78,25 @@ describe('AlertsTable', () => {
   it('shows loading skeletons when loading with no alerts', () => {
     renderTable({ alerts: [], loading: true });
 
-    const skeletons = document.querySelectorAll('.MuiSkeleton-root');
+    // SkeletonRows renders decorative (aria-hidden) shimmer placeholders.
+    const skeletons = document.querySelectorAll('[aria-hidden="true"]');
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it('shows spinner when loading with existing alerts', () => {
-    renderTable({ loading: true });
+  it('shows an overlay spinner when refetching with existing alerts', () => {
+    // A background refresh keeps the rows and overlays a spinner — it must NOT
+    // blank the list.
+    renderTable({ isRefetching: true });
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    // Existing rows stay on screen.
+    expect(screen.getByText('High Memory')).toBeInTheDocument();
+  });
+
+  it('does not blank existing alerts during a refetch', () => {
+    renderTable({ isRefetching: true });
+    expect(screen.getByText('High Memory')).toBeInTheDocument();
+    expect(screen.getByText('Error Rate Spike')).toBeInTheDocument();
   });
 
   it('renders severity chips', () => {

--- a/plugins/openchoreo-observability/src/components/Alerts/AlertsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Alerts/AlertsTable.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   CircularProgress,
 } from '@material-ui/core';
-import { Skeleton } from '@material-ui/lab';
+import { SkeletonRows } from '@openchoreo/backstage-plugin-react';
 import type { AlertSummary } from '../../types';
 import { useLogsTableStyles } from '../RuntimeLogs/styles';
 import { AlertRow } from './AlertRow';
@@ -18,6 +18,8 @@ import { AlertRow } from './AlertRow';
 interface AlertsTableProps {
   alerts: AlertSummary[];
   loading: boolean;
+  /** Background refresh while alerts are already shown — overlay, don't blank. */
+  isRefetching?: boolean;
   environmentName?: string;
   projectName?: string;
   componentName?: string;
@@ -29,6 +31,7 @@ interface AlertsTableProps {
 export const AlertsTable: FC<AlertsTableProps> = ({
   alerts,
   loading,
+  isRefetching = false,
   environmentName = '',
   projectName = '',
   componentName = '',
@@ -37,27 +40,6 @@ export const AlertsTable: FC<AlertsTableProps> = ({
   onViewCostAnalysis,
 }) => {
   const classes = useLogsTableStyles();
-
-  const renderLoadingSkeletons = () =>
-    Array.from({ length: 5 }).map((_, i) => (
-      <TableRow key={`skeleton-${i}`}>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-      </TableRow>
-    ));
 
   const renderEmptyState = () => (
     <TableRow>
@@ -100,7 +82,7 @@ export const AlertsTable: FC<AlertsTableProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {loading && renderLoadingSkeletons()}
+            {loading && <SkeletonRows rows={5} cols={5} />}
             {!loading && filteredAlerts.length === 0 && renderEmptyState()}
             {!loading &&
               filteredAlerts.map(alert => (
@@ -118,7 +100,7 @@ export const AlertsTable: FC<AlertsTableProps> = ({
           </TableBody>
         </Table>
       </Box>
-      {loading && filteredAlerts.length > 0 && (
+      {isRefetching && filteredAlerts.length > 0 && (
         <Box className={classes.loadingContainer}>
           <CircularProgress size={24} />
         </Box>

--- a/plugins/openchoreo-observability/src/components/Alerts/ObservabilityAlertsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Alerts/ObservabilityAlertsPage.test.tsx
@@ -144,7 +144,7 @@ describe('ObservabilityAlertsPage', () => {
     setupDefaultMocks();
   });
 
-  it('shows progress while checking permissions', async () => {
+  it('shows a page skeleton while checking permissions', async () => {
     mockUseAlertsPermission.mockReturnValue({
       canViewAlerts: false,
       loading: true,
@@ -153,7 +153,11 @@ describe('ObservabilityAlertsPage', () => {
 
     await renderPage();
 
-    expect(screen.getByTestId('progress')).toBeInTheDocument();
+    // The permission gate now renders a stable page skeleton (role=status,
+    // aria-busy) instead of a top progress bar, so the page frame does not
+    // visibly swap when the check resolves.
+    const skeleton = screen.getByRole('status');
+    expect(skeleton).toHaveAttribute('aria-busy', 'true');
   });
 
   it('shows permission denied when user lacks access', async () => {

--- a/plugins/openchoreo-observability/src/components/Alerts/ObservabilityAlertsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Alerts/ObservabilityAlertsPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
 import { Box, Typography, Button } from '@material-ui/core';
-import { EmptyState, Progress, WarningIcon } from '@backstage/core-components';
+import { EmptyState, WarningIcon } from '@backstage/core-components';
 import { Alert } from '@material-ui/lab';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { AlertsFilter } from './AlertsFilter';
 import { AlertsTable } from './AlertsTable';
 import { AlertsActions } from './AlertsActions';
+import { ObservabilityPageSkeleton } from '../common';
 import {
   useComponentAlerts,
   useGetNamespaceAndProjectByEntity,
@@ -48,6 +49,7 @@ const ObservabilityAlertsContent = () => {
   const {
     alerts,
     loading: alertsLoading,
+    isRefetching: alertsRefetching,
     error: alertsError,
     fetchAlerts,
     refresh,
@@ -244,7 +246,7 @@ const ObservabilityAlertsContent = () => {
         <>
           <AlertsActions
             totalCount={filteredAlerts.length}
-            disabled={alertsLoading || !filters.environment}
+            disabled={alertsLoading || alertsRefetching || !filters.environment}
             onRefresh={handleRefresh}
             filters={filters}
             onFiltersChange={handleFiltersChange}
@@ -254,6 +256,7 @@ const ObservabilityAlertsContent = () => {
           <AlertsTable
             alerts={filteredAlerts}
             loading={alertsLoading}
+            isRefetching={alertsRefetching}
             environmentName={
               selectedEnvironment?.displayName || selectedEnvironment?.name
             }
@@ -276,7 +279,7 @@ export const ObservabilityAlertsPage = () => {
     deniedTooltip,
   } = useAlertsPermission();
 
-  if (permissionLoading) return <Progress />;
+  if (permissionLoading) return <ObservabilityPageSkeleton />;
 
   if (!canViewAlerts) {
     return (

--- a/plugins/openchoreo-observability/src/components/Incidents/IncidentsTable.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/IncidentsTable.test.tsx
@@ -69,8 +69,8 @@ describe('IncidentsTable', () => {
   it('shows loading skeletons when loading', () => {
     renderTable({ loading: true, incidents: [] });
 
-    // 5 skeleton rows × 6 cells each
-    const skeletons = document.querySelectorAll('.MuiSkeleton-root');
+    // SkeletonRows rows={5} cols={6} → 30 decorative shimmer placeholders.
+    const skeletons = document.querySelectorAll('[aria-hidden="true"]');
     expect(skeletons.length).toBe(30);
   });
 

--- a/plugins/openchoreo-observability/src/components/Incidents/IncidentsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/IncidentsTable.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   CircularProgress,
 } from '@material-ui/core';
-import { Skeleton } from '@material-ui/lab';
+import { SkeletonRows } from '@openchoreo/backstage-plugin-react';
 import type { IncidentSummary } from '../../types';
 import { useLogsTableStyles } from '../RuntimeLogs/styles';
 import { IncidentRow } from './IncidentRow';
@@ -41,30 +41,6 @@ export const IncidentsTable: FC<IncidentsTableProps> = ({
   updatingIncidentId,
 }) => {
   const classes = useLogsTableStyles();
-
-  const renderLoadingSkeletons = () =>
-    Array.from({ length: 5 }).map((_, i) => (
-      <TableRow key={`skeleton-${i}`}>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-        <TableCell>
-          <Skeleton variant="text" width="100%" />
-        </TableCell>
-      </TableRow>
-    ));
 
   const renderEmptyState = () => (
     <TableRow>
@@ -108,7 +84,7 @@ export const IncidentsTable: FC<IncidentsTableProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {loading && renderLoadingSkeletons()}
+            {loading && <SkeletonRows rows={5} cols={6} />}
             {!loading && incidents.length === 0 && renderEmptyState()}
             {!loading &&
               incidents.map(incident => (

--- a/plugins/openchoreo-observability/src/components/Incidents/ObservabilityProjectIncidentsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/ObservabilityProjectIncidentsPage.test.tsx
@@ -136,7 +136,7 @@ describe('ObservabilityProjectIncidentsPage', () => {
     setupDefaultMocks();
   });
 
-  it('shows progress while checking permissions', async () => {
+  it('shows a page skeleton while checking permissions', async () => {
     mockUseIncidentsPermission.mockReturnValue({
       canViewIncidents: false,
       loading: true,
@@ -145,7 +145,10 @@ describe('ObservabilityProjectIncidentsPage', () => {
 
     await renderPage();
 
-    expect(screen.getByTestId('progress')).toBeInTheDocument();
+    // Permission gate now renders a stable page skeleton (role=status,
+    // aria-busy) instead of a top progress bar.
+    const skeleton = screen.getByRole('status');
+    expect(skeleton).toHaveAttribute('aria-busy', 'true');
   });
 
   it('shows permission denied when user lacks permission', async () => {

--- a/plugins/openchoreo-observability/src/components/Incidents/ObservabilityProjectIncidentsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Incidents/ObservabilityProjectIncidentsPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
 import { Box, Typography, Button, Snackbar } from '@material-ui/core';
-import { EmptyState, Progress, WarningIcon } from '@backstage/core-components';
+import { EmptyState, WarningIcon } from '@backstage/core-components';
 import { Alert } from '@material-ui/lab';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { IncidentsFilter } from './IncidentsFilter';
 import { IncidentsTable } from './IncidentsTable';
 import { IncidentsActions } from './IncidentsActions';
+import { ObservabilityPageSkeleton } from '../common';
 import {
   useGetComponentsByProject,
   useProjectIncidents,
@@ -334,7 +335,7 @@ export const ObservabilityProjectIncidentsPage = () => {
     deniedTooltip,
   } = useIncidentsPermission();
 
-  if (permissionLoading) return <Progress />;
+  if (permissionLoading) return <ObservabilityPageSkeleton />;
 
   if (!canViewIncidents) {
     return (

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/LogsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/LogsTable.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useEffect, useRef } from 'react';
 import { Paper, Box, Typography, CircularProgress } from '@material-ui/core';
-import { Skeleton } from '@material-ui/lab';
+import { Skeleton } from '@openchoreo/backstage-design-system';
 import {
   VirtualizedLogList,
   useAutoLoadWhenEmpty,

--- a/plugins/openchoreo-observability/src/components/common/ObservabilityPageSkeleton.tsx
+++ b/plugins/openchoreo-observability/src/components/common/ObservabilityPageSkeleton.tsx
@@ -1,0 +1,37 @@
+import { Box } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { Skeleton } from '@openchoreo/backstage-design-system';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    padding: theme.spacing(1, 0),
+  },
+  filterBar: {
+    display: 'flex',
+    gap: theme.spacing(2),
+  },
+}));
+
+/**
+ * A stable, page-shaped placeholder for the observability pages while the
+ * permission check resolves. Replaces the bare `<Progress />` top-bar gate so
+ * the page frame doesn't visibly swap when the check completes.
+ */
+export const ObservabilityPageSkeleton = () => {
+  const classes = useStyles();
+  return (
+    <Box className={classes.root} role="status" aria-busy="true">
+      {/* filter bar */}
+      <Box className={classes.filterBar}>
+        <Skeleton variant="rect" width={220} height={40} />
+        <Skeleton variant="rect" width={160} height={40} />
+        <Skeleton variant="rect" width={120} height={40} />
+      </Box>
+      {/* table / content area */}
+      <Skeleton variant="rect" width="100%" height={360} />
+    </Box>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/common/index.ts
+++ b/plugins/openchoreo-observability/src/components/common/index.ts
@@ -1,0 +1,1 @@
+export { ObservabilityPageSkeleton } from './ObservabilityPageSkeleton';

--- a/plugins/openchoreo-observability/src/hooks/useComponentAlerts.ts
+++ b/plugins/openchoreo-observability/src/hooks/useComponentAlerts.ts
@@ -20,6 +20,8 @@ export interface UseComponentAlertsOptions {
 export interface UseComponentAlertsResult {
   alerts: AlertSummary[];
   loading: boolean;
+  /** True during a background refresh where alerts are already on screen. */
+  isRefetching: boolean;
   error: string | null;
   totalCount: number;
   fetchAlerts: (reset?: boolean) => Promise<void>;
@@ -35,9 +37,14 @@ export function useComponentAlerts(
   const observabilityApi = useApi(observabilityApiRef);
   const [alerts, setAlerts] = useState<AlertSummary[]>([]);
   const [loading, setLoading] = useState(false);
+  const [isRefetching, setIsRefetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [totalCount, setTotalCount] = useState(0);
   const requestVersionRef = useRef(0);
+  // Mirrors whether we currently have alerts, without adding `alerts` to
+  // fetchAlerts' deps (which would re-create the callback on every fetch).
+  const hasAlertsRef = useRef(false);
+  hasAlertsRef.current = alerts.length > 0;
 
   const componentName =
     entity.metadata.annotations?.[CHOREO_ANNOTATIONS.COMPONENT];
@@ -51,7 +58,13 @@ export function useComponentAlerts(
       const version = ++requestVersionRef.current;
 
       try {
-        setLoading(true);
+        // First load shows the skeleton; a refresh with alerts already on
+        // screen keeps them and shows a subtle overlay instead of blanking.
+        if (hasAlertsRef.current) {
+          setIsRefetching(true);
+        } else {
+          setLoading(true);
+        }
         setError(null);
 
         const { startTime, endTime } = calculateTimeRange(options.timeRange, {
@@ -83,6 +96,7 @@ export function useComponentAlerts(
       } finally {
         if (version === requestVersionRef.current) {
           setLoading(false);
+          setIsRefetching(false);
         }
       }
     },
@@ -101,13 +115,15 @@ export function useComponentAlerts(
   );
 
   const refresh = useCallback(() => {
-    setAlerts([]);
+    // Keep the current alerts on screen; fetchAlerts flips isRefetching so the
+    // table shows an overlay spinner instead of clearing to an empty list.
     fetchAlerts(true);
   }, [fetchAlerts]);
 
   return {
     alerts,
     loading,
+    isRefetching,
     error,
     totalCount,
     fetchAlerts,

--- a/plugins/openchoreo-react/src/components/ContentLoader/ContentLoader.test.tsx
+++ b/plugins/openchoreo-react/src/components/ContentLoader/ContentLoader.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ContentLoader } from './ContentLoader';
+
+type Data = { items: string[] };
+
+const renderContent = (d: Data) => (
+  <div data-testid="content">{d.items.join(',')}</div>
+);
+
+describe('ContentLoader', () => {
+  it('shows the skeleton on first load (loading, no data)', () => {
+    const { container } = render(
+      <ContentLoader<Data> loading data={null}>
+        {renderContent}
+      </ContentLoader>,
+    );
+    expect(screen.queryByTestId('content')).not.toBeInTheDocument();
+    // Default skeleton renders decorative placeholder nodes.
+    expect(
+      container.querySelectorAll('[aria-hidden="true"]').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('shows an error state (with retry) when there is no data', () => {
+    const onRetry = jest.fn();
+    render(
+      <ContentLoader<Data>
+        loading={false}
+        error={new Error('boom')}
+        data={null}
+        onRetry={onRetry}
+      >
+        {renderContent}
+      </ContentLoader>,
+    );
+    expect(screen.getByText('boom')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the empty state when data is present but empty', () => {
+    render(
+      <ContentLoader<Data>
+        loading={false}
+        data={{ items: [] }}
+        isEmpty={d => d.items.length === 0}
+      >
+        {renderContent}
+      </ContentLoader>,
+    );
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+    expect(screen.queryByTestId('content')).not.toBeInTheDocument();
+  });
+
+  it('shows the skeleton (not the empty state) on a first load with data=[]', () => {
+    // Hooks that init data to `[]` report "present but empty" from render 1.
+    // A first load must still show the skeleton, not a flash of "No data".
+    const { container } = render(
+      <ContentLoader<Data>
+        loading
+        data={{ items: [] }}
+        isEmpty={d => d.items.length === 0}
+      >
+        {renderContent}
+      </ContentLoader>,
+    );
+    expect(screen.queryByText('No data available')).not.toBeInTheDocument();
+    expect(
+      container.querySelectorAll('[aria-hidden="true"]').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('renders content when data is present', () => {
+    render(
+      <ContentLoader<Data> loading={false} data={{ items: ['a', 'b'] }}>
+        {renderContent}
+      </ContentLoader>,
+    );
+    expect(screen.getByTestId('content')).toHaveTextContent('a,b');
+  });
+
+  // The regression guard: a slow refetch must NOT tear down populated content.
+  it('keeps content mounted and overlays a spinner while refetching', () => {
+    render(
+      <ContentLoader<Data>
+        loading={false}
+        isRefetching
+        data={{ items: ['a', 'b'] }}
+      >
+        {renderContent}
+      </ContentLoader>,
+    );
+    // Content stays on screen...
+    expect(screen.getByTestId('content')).toHaveTextContent('a,b');
+    // ...with an overlay spinner and aria-busy signalling the refresh.
+    expect(screen.getByTestId('refetch-overlay')).toBeInTheDocument();
+    expect(screen.getByLabelText('Refreshing')).toBeInTheDocument();
+  });
+
+  // Even if a hook incorrectly sets loading=true on refetch, existing data wins.
+  it('does not fall back to the skeleton when loading=true but data exists', () => {
+    render(
+      <ContentLoader<Data> loading isRefetching data={{ items: ['x'] }}>
+        {renderContent}
+      </ContentLoader>,
+    );
+    expect(screen.getByTestId('content')).toHaveTextContent('x');
+    expect(screen.getByTestId('refetch-overlay')).toBeInTheDocument();
+  });
+
+  it('prefers showing stale data over an error during refetch', () => {
+    render(
+      <ContentLoader<Data>
+        loading={false}
+        isRefetching
+        error={new Error('transient')}
+        data={{ items: ['cached'] }}
+      >
+        {renderContent}
+      </ContentLoader>,
+    );
+    expect(screen.getByTestId('content')).toHaveTextContent('cached');
+    expect(screen.queryByText('transient')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-react/src/components/ContentLoader/ContentLoader.tsx
+++ b/plugins/openchoreo-react/src/components/ContentLoader/ContentLoader.tsx
@@ -1,0 +1,144 @@
+import { ReactNode } from 'react';
+import { Box, CircularProgress } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { Skeleton } from '@openchoreo/backstage-design-system';
+import { ErrorState } from '../ErrorState';
+import { EmptyState } from '../EmptyState';
+
+const useStyles = makeStyles(theme => ({
+  /** Wraps content so the refetch overlay can position against it. */
+  contentWrap: {
+    position: 'relative',
+  },
+  /**
+   * Refetch overlay: a subtle scrim + centered spinner shown ON TOP of
+   * already-rendered content. Content stays mounted underneath, so views do
+   * not "pop in and out" on a slow background refresh.
+   */
+  refetchOverlay: {
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    paddingTop: theme.spacing(2),
+    backgroundColor: theme.palette.background.paper,
+    opacity: 0.4,
+    pointerEvents: 'none',
+    zIndex: 1,
+  },
+}));
+
+export interface ContentLoaderProps<T> {
+  /** First load, no data yet — shows the skeleton. */
+  loading: boolean;
+  /**
+   * Background refresh while data is already present. Keeps content on screen
+   * and shows a small overlay spinner instead of swapping back to a loader.
+   */
+  isRefetching?: boolean;
+  /** Error to surface (only shown when there is no data to fall back to). */
+  error?: Error | string | null;
+  /** The fetched data. Presence of data decides "have we loaded before?". */
+  data?: T | null;
+  /** Returns true when `data` is present but empty (e.g. `[]`). */
+  isEmpty?: (data: T) => boolean;
+  /** Retry callback surfaced by the error state. */
+  onRetry?: () => void;
+  /** Custom first-load placeholder. Defaults to three stacked skeleton lines. */
+  skeleton?: ReactNode;
+  /** Custom empty state. Defaults to a generic `EmptyState`. */
+  emptyState?: ReactNode;
+  /** Rendered only with real, non-null data. */
+  children: (data: T) => ReactNode;
+}
+
+const errorMessage = (error: Error | string) =>
+  typeof error === 'string' ? error : error.message;
+
+/**
+ * The single loading/error/empty/content decision point for the portal.
+ *
+ * The important behaviour — and the fix for "cards pop in and out on a slow
+ * network" — is that once `data` exists it is ALWAYS rendered; a background
+ * refresh (`isRefetching`) shows a small overlay spinner instead of tearing
+ * the content down. Only a true first load (no data yet) shows the skeleton.
+ *
+ * The caller owns the frame (Card/Paper/page layout); this component only
+ * decides what goes inside it, so the frame never unmounts.
+ *
+ * Data init: prefer initializing your hook's data to `null` so "never loaded"
+ * and "loaded empty" are distinguishable. If your hook inits to `[]` (common
+ * here), pass `isEmpty` — a first load with an empty array still shows the
+ * skeleton rather than a flash of the empty state.
+ *
+ * @example
+ * ```tsx
+ * <ContentLoader
+ *   loading={loading}
+ *   isRefetching={isRefetching}
+ *   error={error}
+ *   data={data}
+ *   isEmpty={d => d.items.length === 0}
+ *   onRetry={refetch}
+ *   emptyState={<EmptyState title="No items" />}
+ * >
+ *   {d => <ItemList items={d.items} />}
+ * </ContentLoader>
+ * ```
+ */
+export function ContentLoader<T>({
+  loading,
+  isRefetching = false,
+  error,
+  data,
+  isEmpty,
+  onRetry,
+  skeleton,
+  emptyState,
+  children,
+}: ContentLoaderProps<T>) {
+  const classes = useStyles();
+  const present = data !== null && data !== undefined;
+  // A hook that inits data to `[]` (the dominant pattern in this repo) reports
+  // "present but empty" from the very first render. Treat that as "no data yet"
+  // during a first load so we show the skeleton, not a flash of the empty state.
+  const emptyOnFirstLoad =
+    present && loading && (isEmpty?.(data as T) ?? false);
+  const hasData = present && !emptyOnFirstLoad;
+
+  // First load, nothing to show yet → skeleton.
+  if (loading && !hasData) {
+    return <>{skeleton ?? <Skeleton count={3} />}</>;
+  }
+
+  // Errored with no data to fall back to → error state.
+  if (error && !hasData) {
+    return (
+      <Box role="status" aria-busy="false">
+        <ErrorState message={errorMessage(error)} onRetry={onRetry} />
+      </Box>
+    );
+  }
+
+  // Have data → always render it. If empty, show the empty state instead.
+  if (hasData) {
+    if (isEmpty?.(data as T)) {
+      return <>{emptyState ?? <EmptyState title="No data available" />}</>;
+    }
+
+    return (
+      <Box className={classes.contentWrap} aria-busy={isRefetching}>
+        {children(data as T)}
+        {isRefetching && (
+          <Box className={classes.refetchOverlay} data-testid="refetch-overlay">
+            <CircularProgress size={24} aria-label="Refreshing" />
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  // No data, not loading, no error (e.g. a not-yet-started fetch) → nothing.
+  return null;
+}

--- a/plugins/openchoreo-react/src/components/ContentLoader/SkeletonRows.tsx
+++ b/plugins/openchoreo-react/src/components/ContentLoader/SkeletonRows.tsx
@@ -1,0 +1,42 @@
+import { TableRow, TableCell } from '@material-ui/core';
+import { Skeleton } from '@openchoreo/backstage-design-system';
+
+export interface SkeletonRowsProps {
+  /**
+   * Number of placeholder rows to render.
+   * @default 5
+   */
+  rows?: number;
+  /** Number of columns per row (should match the table's column count). */
+  cols: number;
+}
+
+/**
+ * Skeleton table-body rows for the "header stays mounted, body swaps" loading
+ * pattern. Replaces the copy-pasted `renderLoadingSkeletons()` helpers so every
+ * table shimmers identically.
+ *
+ * Render inside a `<TableBody>` while first-loading; keep the surrounding
+ * `<Table>`/`<TableHead>` mounted so the frame never pops.
+ *
+ * @example
+ * ```tsx
+ * <TableBody>
+ *   {loading && <SkeletonRows rows={5} cols={5} />}
+ *   {!loading && rows.map(...)}
+ * </TableBody>
+ * ```
+ */
+export const SkeletonRows = ({ rows = 5, cols }: SkeletonRowsProps) => (
+  <>
+    {Array.from({ length: rows }).map((_row, r) => (
+      <TableRow key={`skeleton-row-${r}`}>
+        {Array.from({ length: cols }).map((_col, c) => (
+          <TableCell key={`skeleton-cell-${r}-${c}`}>
+            <Skeleton variant="text" width="100%" />
+          </TableCell>
+        ))}
+      </TableRow>
+    ))}
+  </>
+);

--- a/plugins/openchoreo-react/src/components/ContentLoader/index.ts
+++ b/plugins/openchoreo-react/src/components/ContentLoader/index.ts
@@ -1,0 +1,4 @@
+export { ContentLoader } from './ContentLoader';
+export type { ContentLoaderProps } from './ContentLoader';
+export { SkeletonRows } from './SkeletonRows';
+export type { SkeletonRowsProps } from './SkeletonRows';

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -7,6 +7,12 @@
 // Components
 export { SummaryWidgetWrapper } from './components/SummaryWidgetWrapper';
 export {
+  ContentLoader,
+  type ContentLoaderProps,
+  SkeletonRows,
+  type SkeletonRowsProps,
+} from './components/ContentLoader';
+export {
   FeatureGate,
   FeatureGatedContent,
   withFeatureGate,


### PR DESCRIPTION
Add a token-driven Skeleton primitive (design-system) and a ContentLoader state-wrapper + SkeletonRows helper (openchoreo-react) that keep a persistent frame and overlay a spinner on refetch instead of blanking populated content.

Migrate observability Alerts/Incidents to the shared components and stop useComponentAlerts clearing data on refresh, fixing the cards popping in/out on slow networks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified loading experience with reusable skeleton placeholders and a background refresh overlay.
  * Observability alerts and incidents now keep content visible during refreshes and show a stable page skeleton while permissions load.

* **Bug Fixes**
  * Prevented pages from going blank during refetches.
  * Replaced top progress indicators with more consistent loading states across observability views.

* **Tests**
  * Updated and expanded loading-state tests to cover skeletons, refetch behavior, and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->