### PR TITLE
feat: enhance UI states for deployment pipelines with no environments

### DIFF
--- a/.changeset/deploy-empty-pipeline-no-default-envs.md
+++ b/.changeset/deploy-empty-pipeline-no-default-envs.md
@@ -5,4 +5,6 @@
 
 Fix the Deploy views defaulting to every environment in the namespace when a project's deployment pipeline defines no environments. A resolved pipeline with no promotion paths now yields no environments (the UI shows its empty state), and a pipeline that cannot be resolved (missing `deploymentPipelineRef` or a failed pipeline fetch) surfaces an error state instead of silently listing all environments.
 
+A permission denial on the deployment-pipeline read (`deploymentpipelines:view`) now surfaces as a Forbidden state instead of a misleading "pipeline missing/misconfigured" error.
+
 The Component, Project, and Resource Deploy tabs now share the same empty-state and error-state cards (icon, message, and Retry) with consistent, pipeline-focused copy, replacing the plain text lines previously shown on the Project and Resource tabs.

--- a/.changeset/deploy-empty-pipeline-no-default-envs.md
+++ b/.changeset/deploy-empty-pipeline-no-default-envs.md
@@ -1,0 +1,8 @@
+---
+'@openchoreo/backstage-plugin-backend': patch
+'@openchoreo/backstage-plugin': patch
+---
+
+Fix the Deploy views defaulting to every environment in the namespace when a project's deployment pipeline defines no environments. A resolved pipeline with no promotion paths now yields no environments (the UI shows its empty state), and a pipeline that cannot be resolved (missing `deploymentPipelineRef` or a failed pipeline fetch) surfaces an error state instead of silently listing all environments.
+
+The Component, Project, and Resource Deploy tabs now share the same empty-state and error-state cards (icon, message, and Retry) with consistent, pipeline-focused copy, replacing the plain text lines previously shown on the Project and Resource tabs.

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
@@ -303,13 +303,13 @@ describe('EnvironmentInfoService', () => {
         error: undefined,
         response: { ok: true, status: 200 },
       });
-      // fetchDeploymentInfo calls
+      // fetchDeploymentInfo calls (env, bindings, project, pipeline)
       mockGET.mockResolvedValueOnce(
         createOkResponse({ items: [k8sEnvironment], pagination: {} }),
       );
       mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
-      // project with no pipeline ref
-      mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectNoPipeline));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProject));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sPipeline));
 
       const service = createService();
       const result = await service.deleteReleaseBinding(
@@ -646,7 +646,7 @@ describe('EnvironmentInfoService', () => {
       );
     });
 
-    it('falls back to default ordering when project has no pipeline', async () => {
+    it('throws rather than defaulting to all environments when the pipeline cannot be resolved', async () => {
       mockGET.mockResolvedValueOnce(
         createOkResponse({
           items: [makeK8sEnvironment('dev'), makeK8sEnvironment('staging')],
@@ -654,22 +654,21 @@ describe('EnvironmentInfoService', () => {
         }),
       );
       mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
-      // project without deploymentPipelineRef
+      // project without deploymentPipelineRef → pipeline unresolved
       mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectNoPipeline));
       mockGET.mockResolvedValueOnce(createOkResponse(k8sResource));
 
       const service = createService();
-      const result = await service.fetchResourceEnvironmentInfo(
-        {
-          resourceName: 'analytics-db',
-          projectName: 'my-project',
-          namespaceName: 'test-ns',
-        },
-        'token-123',
-      );
-
-      expect(result).toHaveLength(2);
-      expect(result.every(e => e.promotionTargets === undefined)).toBe(true);
+      await expect(
+        service.fetchResourceEnvironmentInfo(
+          {
+            resourceName: 'analytics-db',
+            projectName: 'my-project',
+            namespaceName: 'test-ns',
+          },
+          'token-123',
+        ),
+      ).rejects.toThrow(/could not be loaded/);
     });
 
     it('returns env-info without latestRelease when resource fetch errors', async () => {
@@ -1071,28 +1070,28 @@ describe('EnvironmentInfoService', () => {
       expect(result[2].name).toBe('Production Environment');
     });
 
-    it('returns all environments when no pipeline exists', async () => {
+    it('throws rather than defaulting to all environments when the pipeline cannot be resolved', async () => {
       mockGET.mockResolvedValueOnce(
         createOkResponse({ items: allEnvs, pagination: {} }),
       );
       mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
-      // project with no pipeline ref
+      // project with no pipeline ref → pipeline unresolved
       mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectNoPipeline));
 
       const service = createService();
-      const result = await service.fetchDeploymentInfo(
-        {
-          projectName: 'my-project',
-          componentName: 'api-service',
-          namespaceName: 'test-ns',
-        },
-        'token-123',
-      );
-
-      expect(result).toHaveLength(5);
+      await expect(
+        service.fetchDeploymentInfo(
+          {
+            projectName: 'my-project',
+            componentName: 'api-service',
+            namespaceName: 'test-ns',
+          },
+          'token-123',
+        ),
+      ).rejects.toThrow(/could not be loaded/);
     });
 
-    it('returns all environments when pipeline has empty promotionPaths', async () => {
+    it('returns no environments when the pipeline has empty promotionPaths', async () => {
       const emptyPipeline = {
         ...pipelineDevStagingProd,
         spec: { promotionPaths: [] },
@@ -1114,8 +1113,9 @@ describe('EnvironmentInfoService', () => {
         'token-123',
       );
 
-      // Empty promotionPaths treated as no pipeline → show all environments
-      expect(result).toHaveLength(5);
+      // A resolved pipeline that defines no promotion paths has no deployable
+      // environments — the UI shows its empty state
+      expect(result).toHaveLength(0);
     });
   });
 
@@ -1266,7 +1266,7 @@ describe('EnvironmentInfoService', () => {
       );
     });
 
-    it('falls back to default ordering when project has no pipeline', async () => {
+    it('throws rather than defaulting to all environments when the pipeline cannot be resolved', async () => {
       mockGET.mockResolvedValueOnce(
         createOkResponse({
           items: [makeK8sEnvironment('dev'), makeK8sEnvironment('staging')],
@@ -1274,22 +1274,21 @@ describe('EnvironmentInfoService', () => {
         }),
       );
       mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
-      // project without deploymentPipelineRef (pipeline fetch)
+      // project without deploymentPipelineRef (pipeline fetch) → unresolved
       mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectNoPipeline));
       // project (latestRelease fetch)
       mockGET.mockResolvedValueOnce(createOkResponse(k8sProjectNoPipeline));
 
       const service = createService();
-      const result = await service.fetchProjectEnvironmentInfo(
-        {
-          projectName: 'my-project',
-          namespaceName: 'test-ns',
-        },
-        'token-123',
-      );
-
-      expect(result).toHaveLength(2);
-      expect(result.every(e => e.promotionTargets === undefined)).toBe(true);
+      await expect(
+        service.fetchProjectEnvironmentInfo(
+          {
+            projectName: 'my-project',
+            namespaceName: 'test-ns',
+          },
+          'token-123',
+        ),
+      ).rejects.toThrow(/could not be loaded/);
     });
 
     it('returns env-info without latestRelease when project fetch errors', async () => {

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.test.ts
@@ -1117,6 +1117,28 @@ describe('EnvironmentInfoService', () => {
       // environments — the UI shows its empty state
       expect(result).toHaveLength(0);
     });
+
+    it('surfaces a Forbidden error (not "pipeline unavailable") when the pipeline read is denied', async () => {
+      mockGET.mockResolvedValueOnce(
+        createOkResponse({ items: allEnvs, pagination: {} }),
+      );
+      mockGET.mockResolvedValueOnce(createOkResponse({ items: [] }));
+      mockGET.mockResolvedValueOnce(createOkResponse(k8sProject));
+      // deploymentpipelines:view denied → 403 on the pipeline read
+      mockGET.mockResolvedValueOnce(createErrorResponse(403));
+
+      const service = createService();
+      await expect(
+        service.fetchDeploymentInfo(
+          {
+            projectName: 'my-project',
+            componentName: 'api-service',
+            namespaceName: 'test-ns',
+          },
+          'token-123',
+        ),
+      ).rejects.toMatchObject({ name: 'NotAllowedError' });
+    });
   });
 
   describe('fetchProjectEnvironmentInfo', () => {

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -58,6 +58,19 @@ export class PipelineUnavailableError extends NotFoundError {
 }
 
 /**
+ * Surfaces auth failures (401/403) encountered while resolving the deployment
+ * pipeline as thrown Backstage errors.
+ */
+function assertPipelineFetchAllowed(
+  result: { data?: unknown; error?: unknown; response: Response },
+  context: string,
+): void {
+  if (result.response.status === 401 || result.response.status === 403) {
+    assertApiResponse(result, context);
+  }
+}
+
+/**
  * Extracts the environment name from a sourceEnvironmentRef which may be
  * a plain string (old API) or an object { kind, name } (new API).
  */
@@ -212,6 +225,14 @@ export class EnvironmentInfoService implements EnvironmentService {
               },
             },
           );
+          assertPipelineFetchAllowed(
+            {
+              data: project,
+              error: projectError,
+              response: projectResponse,
+            },
+            'fetch project',
+          );
           if (
             projectError ||
             !projectResponse.ok ||
@@ -232,6 +253,10 @@ export class EnvironmentInfoService implements EnvironmentService {
                 },
               },
             },
+          );
+          assertPipelineFetchAllowed(
+            { data, error, response },
+            'fetch deployment pipeline',
           );
           if (error || !response.ok) {
             return null;
@@ -1530,6 +1555,14 @@ export class EnvironmentInfoService implements EnvironmentService {
               },
             },
           );
+          assertPipelineFetchAllowed(
+            {
+              data: project,
+              error: projectError,
+              response: projectResponse,
+            },
+            'fetch project',
+          );
           if (
             projectError ||
             !projectResponse.ok ||
@@ -1549,6 +1582,10 @@ export class EnvironmentInfoService implements EnvironmentService {
                 },
               },
             },
+          );
+          assertPipelineFetchAllowed(
+            { data, error, response },
+            'fetch deployment pipeline',
           );
           if (error || !response.ok) {
             return null;
@@ -2177,6 +2214,14 @@ export class EnvironmentInfoService implements EnvironmentService {
               },
             },
           );
+          assertPipelineFetchAllowed(
+            {
+              data: project,
+              error: projectError,
+              response: projectResponse,
+            },
+            'fetch project',
+          );
           if (
             projectError ||
             !projectResponse.ok ||
@@ -2196,6 +2241,10 @@ export class EnvironmentInfoService implements EnvironmentService {
                 },
               },
             },
+          );
+          assertPipelineFetchAllowed(
+            { data, error, response },
+            'fetch deployment pipeline',
           );
           if (error || !response.ok) {
             return null;

--- a/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
+++ b/plugins/openchoreo-backend/src/services/EnvironmentService/EnvironmentInfoService.ts
@@ -1,4 +1,5 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { NotFoundError } from '@backstage/errors';
 import {
   EnvironmentService,
   Environment,
@@ -37,6 +38,24 @@ type NewProjectReleaseBinding =
   OpenChoreoComponents['schemas']['ProjectReleaseBinding'];
 
 type NewProject = OpenChoreoComponents['schemas']['Project'];
+
+/**
+ * Thrown when the deployment pipeline that governs a component/project/resource
+ * cannot be resolved (the owning project has no `deploymentPipelineRef`, or the
+ * referenced pipeline could not be fetched). Deployment views must surface this
+ * as an error rather than silently falling back to every environment in the
+ * namespace. Extends `NotFoundError` (→ HTTP 404) but keeps a distinct class
+ * identity so it can be re-thrown precisely without also re-throwing unrelated
+ * 404s raised by `assertApiResponse`.
+ */
+export class PipelineUnavailableError extends NotFoundError {
+  constructor(message: string) {
+    super(message);
+    // Keep the wire name as NotFoundError so the backend error handler maps it
+    // to a 404; `instanceof` still identifies our own errors.
+    this.name = 'NotFoundError';
+  }
+}
 
 /**
  * Extracts the environment name from a sourceEnvironmentRef which may be
@@ -247,6 +266,12 @@ export class EnvironmentInfoService implements EnvironmentService {
         return [];
       }
 
+      if (!deploymentPipeline) {
+        throw new PipelineUnavailableError(
+          `The deployment pipeline for project "${request.projectName}" could not be loaded. It may be missing or misconfigured.`,
+        );
+      }
+
       // Transform new K8s-style environments to legacy shape
       const environments = newEnvironments.map(transformEnvironment);
 
@@ -276,9 +301,10 @@ export class EnvironmentInfoService implements EnvironmentService {
       return result;
     } catch (error: unknown) {
       if (
-        error instanceof Error &&
-        (error.name === 'NotAllowedError' ||
-          error.name === 'AuthenticationError')
+        error instanceof PipelineUnavailableError ||
+        (error instanceof Error &&
+          (error.name === 'NotAllowedError' ||
+            error.name === 'AuthenticationError'))
       ) {
         throw error;
       }
@@ -323,17 +349,17 @@ export class EnvironmentInfoService implements EnvironmentService {
       bindingsByEnv.set(envName, binding);
     }
 
-    // If no pipeline data, use default ordering
+    // A resolved pipeline with no promotion paths defines no deployable
+    // environments — return an empty list
     if (
       !deploymentPipeline ||
       !deploymentPipeline.promotionPaths ||
       deploymentPipeline.promotionPaths.length === 0
     ) {
-      this.logger.debug('No deployment pipeline found, using default ordering');
-      return this.transformEnvironmentDataWithBindingsOnly(
-        environmentData,
-        bindingsByEnv,
+      this.logger.debug(
+        'Deployment pipeline defines no environments, returning empty list',
       );
+      return [];
     }
 
     // Build promotion map from pipeline data (normalized to actual env names)
@@ -449,17 +475,6 @@ export class EnvironmentInfoService implements EnvironmentService {
     }
 
     return transformedEnv;
-  }
-
-  private transformEnvironmentDataWithBindingsOnly(
-    environmentData: ModelsEnvironment[],
-    bindingsByEnv: Map<string, ReleaseBindingResponse>,
-  ): Environment[] {
-    return environmentData.map(env => {
-      const envName = env.displayName || env.name;
-      const binding = bindingsByEnv.get(envName);
-      return this.createEnvironmentFromBinding(env, binding);
-    });
   }
 
   private getEnvironmentOrder(
@@ -1594,6 +1609,12 @@ export class EnvironmentInfoService implements EnvironmentService {
         return [];
       }
 
+      if (!deploymentPipeline) {
+        throw new PipelineUnavailableError(
+          `The deployment pipeline for project "${request.projectName}" could not be loaded. It may be missing or misconfigured.`,
+        );
+      }
+
       const environments = newEnvironments.map(transformEnvironment);
       const latestRelease = resource?.status?.latestRelease?.name;
 
@@ -1624,9 +1645,10 @@ export class EnvironmentInfoService implements EnvironmentService {
       return result;
     } catch (error: unknown) {
       if (
-        error instanceof Error &&
-        (error.name === 'NotAllowedError' ||
-          error.name === 'AuthenticationError')
+        error instanceof PipelineUnavailableError ||
+        (error instanceof Error &&
+          (error.name === 'NotAllowedError' ||
+            error.name === 'AuthenticationError'))
       ) {
         throw error;
       }
@@ -1669,25 +1691,17 @@ export class EnvironmentInfoService implements EnvironmentService {
       bindingsByEnv.set(envName, binding);
     }
 
+    // A resolved pipeline with no promotion paths defines no deployable
+    // environments — return an empty list
     if (
       !deploymentPipeline ||
       !deploymentPipeline.promotionPaths ||
       deploymentPipeline.promotionPaths.length === 0
     ) {
       this.logger.debug(
-        'No deployment pipeline found for resource, using default ordering',
+        'Deployment pipeline defines no environments for resource, returning empty list',
       );
-      return environmentData.map(env => {
-        const envName = env.displayName || env.name;
-        const binding = bindingsByEnv.get(envName);
-        return this.createResourceEnvironment(
-          env,
-          binding,
-          undefined,
-          latestRelease,
-          resourceTypeRetainPolicyDefault,
-        );
-      });
+      return [];
     }
 
     const promotionMap = new Map<string, any[]>();
@@ -2242,6 +2256,12 @@ export class EnvironmentInfoService implements EnvironmentService {
         return [];
       }
 
+      if (!deploymentPipeline) {
+        throw new PipelineUnavailableError(
+          `The deployment pipeline for project "${request.projectName}" could not be loaded. It may be missing or misconfigured.`,
+        );
+      }
+
       const environments = newEnvironments.map(transformEnvironment);
       const latestRelease = project?.status?.latestRelease?.name;
 
@@ -2260,9 +2280,10 @@ export class EnvironmentInfoService implements EnvironmentService {
       return result;
     } catch (error: unknown) {
       if (
-        error instanceof Error &&
-        (error.name === 'NotAllowedError' ||
-          error.name === 'AuthenticationError')
+        error instanceof PipelineUnavailableError ||
+        (error instanceof Error &&
+          (error.name === 'NotAllowedError' ||
+            error.name === 'AuthenticationError'))
       ) {
         throw error;
       }
@@ -2304,24 +2325,17 @@ export class EnvironmentInfoService implements EnvironmentService {
       bindingsByEnv.set(envName, binding);
     }
 
+    // A resolved pipeline with no promotion paths defines no deployable
+    // environments — return an empty list
     if (
       !deploymentPipeline ||
       !deploymentPipeline.promotionPaths ||
       deploymentPipeline.promotionPaths.length === 0
     ) {
       this.logger.debug(
-        'No deployment pipeline found for project, using default ordering',
+        'Deployment pipeline defines no environments for project, returning empty list',
       );
-      return environmentData.map(env => {
-        const envName = env.displayName || env.name;
-        const binding = bindingsByEnv.get(envName);
-        return this.createProjectEnvironment(
-          env,
-          binding,
-          undefined,
-          latestRelease,
-        );
-      });
+      return [];
     }
 
     const promotionMap = new Map<string, any[]>();

--- a/plugins/openchoreo/src/components/Environments/Environments.tsx
+++ b/plugins/openchoreo/src/components/Environments/Environments.tsx
@@ -47,7 +47,7 @@ export const Environments = ({
   const { navigateToList } = useEnvironmentRouting();
 
   // Data fetching
-  const { environments, loading, isForbidden, refetch } =
+  const { environments, loading, error, isForbidden, refetch } =
     useEnvironmentData(entity);
   const { displayEnvironments, isPending } = useStaleEnvironments(environments);
 
@@ -132,6 +132,7 @@ export const Environments = ({
       environments,
       displayEnvironments,
       loading,
+      error: isForbidden ? undefined : error,
       refetch,
       lowestEnvironment: environments[0]?.name?.toLowerCase() || 'development',
       isWorkloadEditorSupported,
@@ -156,6 +157,8 @@ export const Environments = ({
       environments,
       displayEnvironments,
       loading,
+      error,
+      isForbidden,
       refetch,
       isWorkloadEditorSupported,
       handlePendingActionComplete,

--- a/plugins/openchoreo/src/components/Environments/EnvironmentsContext.tsx
+++ b/plugins/openchoreo/src/components/Environments/EnvironmentsContext.tsx
@@ -50,6 +50,11 @@ interface EnvironmentsContextValue {
   displayEnvironments: Environment[];
   /** Whether environments are currently loading */
   loading: boolean;
+  /**
+   * A non-forbidden error from the environment fetch (e.g. the deployment
+   * pipeline could not be resolved).
+   */
+  error?: Error;
   /** Refetch environments data */
   refetch: () => void;
   /** The lowest environment (first in deployment pipeline) */

--- a/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.test.tsx
@@ -46,6 +46,16 @@ jest.mock('@openchoreo/backstage-plugin-react', () => ({
       <span>{props.message}</span>
     </div>
   ),
+  ErrorState: (props: {
+    title?: string;
+    message: string;
+    onRetry?: () => void;
+  }) => (
+    <div data-testid="error-state">
+      <span>{props.title}</span>
+      <span>{props.message}</span>
+    </div>
+  ),
 }));
 
 jest.mock('@openchoreo/backstage-design-system', () => ({
@@ -73,6 +83,7 @@ interface MockContextValue {
   environments: Environment[];
   displayEnvironments: Environment[];
   loading: boolean;
+  error?: Error;
   refetch: jest.Mock;
   lowestEnvironment: string;
   isWorkloadEditorSupported: boolean;
@@ -89,6 +100,7 @@ const defaultMockContext = (): MockContextValue => ({
   environments: [],
   displayEnvironments: [],
   loading: false,
+  error: undefined,
   refetch: jest.fn(),
   lowestEnvironment: 'development',
   isWorkloadEditorSupported: true,
@@ -214,6 +226,22 @@ describe('PipelineCanvas (deploy split view)', () => {
   it('shows empty state when no environments and user has view permission', () => {
     renderWithRouter(<PipelineCanvas />);
     expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    expect(screen.queryByTestId('deploy-flow-canvas')).not.toBeInTheDocument();
+  });
+
+  it('shows error state (not empty state) when the fetch failed', () => {
+    mockContextValue.error = new Error(
+      'The deployment pipeline for project "p" could not be loaded.',
+    );
+    renderWithRouter(<PipelineCanvas />);
+    expect(screen.getByTestId('error-state')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The deployment pipeline for project "p" could not be loaded.',
+      ),
+    ).toBeInTheDocument();
+    // The empty state must not render at the same time.
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
     expect(screen.queryByTestId('deploy-flow-canvas')).not.toBeInTheDocument();
   });
 

--- a/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.tsx
+++ b/plugins/openchoreo/src/components/Environments/PipelineDAG/PipelineCanvas.tsx
@@ -18,7 +18,11 @@ import { EnvironmentDetailPanel, NotificationBanner } from '../components';
 import { useEnvironmentsContext, type Selection } from '../EnvironmentsContext';
 import { useIncidentsSummary } from '../hooks/useIncidentsSummary';
 import { isForbiddenError, getErrorMessage } from '../../../utils/errorUtils';
-import { EmptyState, ForbiddenState } from '@openchoreo/backstage-plugin-react';
+import {
+  EmptyState,
+  ErrorState,
+  ForbiddenState,
+} from '@openchoreo/backstage-plugin-react';
 import { Card, useChoreoTokens } from '@openchoreo/backstage-design-system';
 import {
   useDeployFlowCanvasStyles,
@@ -128,6 +132,7 @@ export const PipelineCanvas: FC = () => {
     environments,
     displayEnvironments,
     loading,
+    error,
     refetch,
     isWorkloadEditorSupported,
     canViewEnvironments,
@@ -384,7 +389,7 @@ export const PipelineCanvas: FC = () => {
     <>
       <NotificationBanner notification={notification.notification} />
 
-      {/* Permission/empty states when no environments */}
+      {/* Permission/error/empty states when no environments */}
       {!loading &&
         !environmentReadPermissionLoading &&
         environments.length === 0 &&
@@ -399,11 +404,25 @@ export const PipelineCanvas: FC = () => {
       {!loading &&
         !environmentReadPermissionLoading &&
         environments.length === 0 &&
+        canViewEnvironments &&
+        error && (
+          <Card style={{ minHeight: '300px', width: '100%' }}>
+            <ErrorState
+              title="Failed to load environments"
+              message={getErrorMessage(error)}
+              onRetry={refetch}
+            />
+          </Card>
+        )}
+      {!loading &&
+        !environmentReadPermissionLoading &&
+        !error &&
+        environments.length === 0 &&
         canViewEnvironments && (
           <Card style={{ minHeight: '300px', width: '100%' }}>
             <EmptyState
               title="No environments available"
-              description="No deployment environments were found for this component."
+              description="This project's deployment pipeline has no environments configured."
               action={{ label: 'Retry', onClick: refetch }}
             />
           </Card>

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsList.test.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsList.test.tsx
@@ -35,6 +35,22 @@ jest.mock('@openchoreo/backstage-plugin-react', () => ({
   ForbiddenState: ({ message }: any) => (
     <div data-testid="forbidden">{message}</div>
   ),
+  EmptyState: ({ title, description }: any) => (
+    <div data-testid="empty-state">
+      <span>{title}</span>
+      <span>{description}</span>
+    </div>
+  ),
+  ErrorState: ({ title, message }: any) => (
+    <div data-testid="error-state">
+      <span>{title}</span>
+      <span>{message}</span>
+    </div>
+  ),
+}));
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  Card: ({ children }: any) => <div data-testid="card">{children}</div>,
 }));
 
 jest.mock('../../utils/errorUtils', () => ({

--- a/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsList.tsx
+++ b/plugins/openchoreo/src/components/ProjectEnvironments/ProjectEnvironmentsList.tsx
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Box, Typography, makeStyles } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 import { useNavigate } from 'react-router-dom';
 import { Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { ForbiddenState } from '@openchoreo/backstage-plugin-react';
+import {
+  EmptyState,
+  ErrorState,
+  ForbiddenState,
+} from '@openchoreo/backstage-plugin-react';
+import { Card } from '@openchoreo/backstage-design-system';
 import {
   openChoreoClientApiRef,
   type ProjectEnvironment,
@@ -22,16 +27,6 @@ import {
 } from './ProjectEnvironmentsContext';
 import { useProjectDeployFlowCanvasStyles } from './styles';
 
-const useStyles = makeStyles(theme => ({
-  error: {
-    color: theme.palette.error.main,
-  },
-  empty: {
-    color: theme.palette.text.secondary,
-    fontStyle: 'italic',
-  },
-}));
-
 /**
  * Deploy view mounted at the `/` sub-route of the Project entity's
  * `/deploy` tab. Renders the pipeline DAG with the Set up tile + env
@@ -40,7 +35,6 @@ const useStyles = makeStyles(theme => ({
  * from the Set up detail pane's Configure & Deploy button.
  */
 export const ProjectEnvironmentsList = () => {
-  const classes = useStyles();
   const canvasClasses = useProjectDeployFlowCanvasStyles();
   const { entity } = useEntity();
   const client = useApi(openChoreoClientApiRef);
@@ -189,17 +183,28 @@ export const ProjectEnvironmentsList = () => {
 
   if (error) {
     return (
-      <Typography variant="body1" className={classes.error}>
-        Failed to load environments: {getErrorMessage(error)}
-      </Typography>
+      <Card style={{ minHeight: '300px', width: '100%' }}>
+        <ErrorState
+          title="Failed to load environments"
+          message={getErrorMessage(error)}
+          onRetry={() => fetchEnvs({ showProgress: true })}
+        />
+      </Card>
     );
   }
 
   if (envs.length === 0) {
     return (
-      <Typography variant="body1" className={classes.empty}>
-        No environments configured in the project's deployment pipeline.
-      </Typography>
+      <Card style={{ minHeight: '300px', width: '100%' }}>
+        <EmptyState
+          title="No environments available"
+          description="This project's deployment pipeline has no environments configured."
+          action={{
+            label: 'Retry',
+            onClick: () => fetchEnvs({ showProgress: true }),
+          }}
+        />
+      </Card>
     );
   }
 

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironments.test.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironments.test.tsx
@@ -23,6 +23,18 @@ jest.mock('@openchoreo/backstage-plugin-react', () => ({
   ForbiddenState: ({ message }: any) => (
     <div data-testid="forbidden">{message}</div>
   ),
+  EmptyState: ({ title, description }: any) => (
+    <div data-testid="empty-state">
+      <span>{title}</span>
+      <span>{description}</span>
+    </div>
+  ),
+  ErrorState: ({ title, message }: any) => (
+    <div data-testid="error-state">
+      <span>{title}</span>
+      <span>{message}</span>
+    </div>
+  ),
   useResourceReleaseBindingUpdatePermission: () => ({
     canUpdate: true,
     loading: false,

--- a/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironmentsList.tsx
+++ b/plugins/openchoreo/src/components/ResourceEnvironments/ResourceEnvironmentsList.tsx
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Box, Typography, makeStyles } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 import { useNavigate } from 'react-router-dom';
 import { Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { ForbiddenState } from '@openchoreo/backstage-plugin-react';
+import {
+  EmptyState,
+  ErrorState,
+  ForbiddenState,
+} from '@openchoreo/backstage-plugin-react';
+import { Card } from '@openchoreo/backstage-design-system';
 import {
   openChoreoClientApiRef,
   type ResourceEnvironment,
@@ -28,16 +33,6 @@ import {
 import { ResourceRemoveDeploymentDialog } from './ResourceRemoveDeploymentDialog';
 import { useResourceDeployFlowCanvasStyles } from './styles';
 
-const useStyles = makeStyles(theme => ({
-  error: {
-    color: theme.palette.error.main,
-  },
-  empty: {
-    color: theme.palette.text.secondary,
-    fontStyle: 'italic',
-  },
-}));
-
 /**
  * Deploy view mounted at the `/` sub-route of the Resource entity's
  * `/environments` tab. Renders the pipeline DAG with the Set up tile +
@@ -46,7 +41,6 @@ const useStyles = makeStyles(theme => ({
  * reachable from the Set up detail pane's Configure & Deploy button.
  */
 export const ResourceEnvironmentsList = () => {
-  const classes = useStyles();
   const canvasClasses = useResourceDeployFlowCanvasStyles();
   const { entity } = useEntity();
   const client = useApi(openChoreoClientApiRef);
@@ -320,17 +314,28 @@ export const ResourceEnvironmentsList = () => {
 
   if (error) {
     return (
-      <Typography variant="body1" className={classes.error}>
-        Failed to load environments: {getErrorMessage(error)}
-      </Typography>
+      <Card style={{ minHeight: '300px', width: '100%' }}>
+        <ErrorState
+          title="Failed to load environments"
+          message={getErrorMessage(error)}
+          onRetry={() => fetchEnvs({ showProgress: true })}
+        />
+      </Card>
     );
   }
 
   if (envs.length === 0) {
     return (
-      <Typography variant="body1" className={classes.empty}>
-        No environments configured in the project's deployment pipeline.
-      </Typography>
+      <Card style={{ minHeight: '300px', width: '100%' }}>
+        <EmptyState
+          title="No environments available"
+          description="This project's deployment pipeline has no environments configured."
+          action={{
+            label: 'Retry',
+            onClick: () => fetchEnvs({ showProgress: true }),
+          }}
+        />
+      </Card>
     );
   }
 


### PR DESCRIPTION
## Purpose
Related: https://github.com/openchoreo/openchoreo/issues/4073

This pull request improves how deployment environments are determined and surfaced in Deploy views when a project's deployment pipeline is missing, misconfigured, or lacks promotion paths. Instead of defaulting to all environments or showing misleading errors, the system now clearly distinguishes between empty, error, and forbidden states, and surfaces them consistently across Component, Project, and Resource Deploy tabs. Test coverage and error handling have also been updated to reflect these changes.

**Deployment pipeline resolution and error handling:**

* Introduced a new `PipelineUnavailableError` to explicitly signal when a deployment pipeline cannot be resolved (missing `deploymentPipelineRef` or failed fetch), ensuring Deploy views show an error state instead of defaulting to all environments. [[1]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R42-R72) [[2]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R294-R299) [[3]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R1649-R1654) [[4]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R2308-R2313)
* Added `assertPipelineFetchAllowed` to surface permission errors (401/403) as `NotAllowedError`, so forbidden states are shown instead of misleading pipeline errors. [[1]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R42-R72) [[2]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R228-R235) [[3]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R257-R260) [[4]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R1558-R1565) [[5]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R1586-R1589) [[6]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R2217-R2224) [[7]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R2245-R2248)

**Environment listing behavior:**

* Changed logic so that a resolved pipeline with empty `promotionPaths` results in no environments being listed (empty state), rather than defaulting to all environments. [[1]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8L326-R387) [[2]](diffhunk://#diff-b58acbd73837d80ba99ca9955bde6cd4cd061dfc3f458e2c3f0b2c1e871708e8R1731-R1741)
* Removed fallback logic that previously listed all environments when no pipeline was found or had empty promotion paths.

**Test coverage:**

* Updated and added tests to verify the new behaviors: ensuring errors are thrown when pipelines are missing/unresolved, forbidden errors are surfaced, and empty states are shown for pipelines with no promotion paths. [[1]](diffhunk://#diff-a9da8c06870e8391744067d6c1bb0f58dd8260847f737e3641afaf84ddc30868L649-R671) [[2]](diffhunk://#diff-a9da8c06870e8391744067d6c1bb0f58dd8260847f737e3641afaf84ddc30868L1074-R1094) [[3]](diffhunk://#diff-a9da8c06870e8391744067d6c1bb0f58dd8260847f737e3641afaf84ddc30868L1117-R1140) [[4]](diffhunk://#diff-a9da8c06870e8391744067d6c1bb0f58dd8260847f737e3641afaf84ddc30868L1269-R1313) [[5]](diffhunk://#diff-a9da8c06870e8391744067d6c1bb0f58dd8260847f737e3641afaf84ddc30868L306-R312)

**User experience consistency:**

* The Deploy tabs for Component, Project, and Resource now share consistent empty-state and error-state cards, with unified icons, messages, and retry actions, replacing less informative plain text.

**Documentation:**

* Added a changeset describing the new behaviors for Deploy views, error handling, and UI consistency.

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

### Component deploy view
#### Before 
<img width="1512" height="800" alt="Screenshot 2026-07-08 at 11 14 00" src="https://github.com/user-attachments/assets/882a7040-e8b3-4824-baaf-b05294226691" /> 

#### After
<img width="1512" height="799" alt="Screenshot 2026-07-08 at 11 12 26" src="https://github.com/user-attachments/assets/39325efe-ae4d-410d-944f-6dcfbd59d375" />

### Resource deploy view
#### Before 
<img width="1512" height="800" alt="Screenshot 2026-07-08 at 11 14 22" src="https://github.com/user-attachments/assets/49a0cbf2-826a-42eb-864f-ccaec6e1cc49" />

#### After
<img width="1512" height="807" alt="Screenshot 2026-07-08 at 11 12 38" src="https://github.com/user-attachments/assets/d9b27a16-7fc2-46b2-9a5a-4088e75da89c" />

### Project deploy view
#### Before 
<img width="1512" height="802" alt="Screenshot 2026-07-08 at 11 14 30" src="https://github.com/user-attachments/assets/c6962e7c-2943-422d-9f55-50051b667615" />

#### After
<img width="1512" height="801" alt="Screenshot 2026-07-08 at 11 12 50" src="https://github.com/user-attachments/assets/2cf12312-8c68-4ff7-85d9-a00dc0c7c71b" />

### Without DeploymentPipeline view permission
#### Before 
<img width="1512" height="797" alt="image" src="https://github.com/user-attachments/assets/69a61af0-1808-4f7a-88c0-3d25e3777a2c" />

#### After
<img width="1512" height="801" alt="image" src="https://github.com/user-attachments/assets/d07e18cd-b85e-4854-b855-26d121851f37" />

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy views now clearly distinguish between empty pipelines, load failures, and access denied states.
  * Environment, project, and resource views now use consistent cards for empty and error states, with retry actions.

* **Bug Fixes**
  * Projects with no deployment environments no longer show all namespace environments by default.
  * Missing pipeline data now shows an error instead of a misleading fallback view.
  * Permission-denied access is now surfaced correctly as forbidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->