### PR TITLE
feat(openchoreo): add row-level delete to catalog and namespace listings

### DIFF
--- a/.changeset/component-delete-from-project-listing.md
+++ b/.changeset/component-delete-from-project-listing.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin': minor
+---
+
+Add a per-row "Delete" action to the Project Contents table so a component
+can be deleted directly from the project listing without opening the
+component page first. The action surfaces in a row "more actions" kebab for
+component rows (hidden for resources and for rows already marked for
+deletion), reuses the shared delete-confirmation dialog, and refreshes the
+listing once the component is marked for deletion.

--- a/.changeset/component-delete-from-project-listing.md
+++ b/.changeset/component-delete-from-project-listing.md
@@ -4,7 +4,7 @@
 
 Add a per-row "Delete" action to the Project Contents table so a component
 can be deleted directly from the project listing without opening the
-component page first. The action surfaces in a row "more actions" kebab for
-component rows (hidden for resources and for rows already marked for
-deletion), reuses the shared delete-confirmation dialog, and refreshes the
-listing once the component is marked for deletion.
+component page first. The action surfaces as a per-row delete button for
+both component and resource rows (hidden for rows already marked for
+deletion), reuses the shared delete-confirmation dialog, and optimistically
+marks the row for deletion until the next catalog sync drops it.

--- a/.changeset/listing-row-delete-everywhere.md
+++ b/.changeset/listing-row-delete-everywhere.md
@@ -1,0 +1,13 @@
+---
+'@openchoreo/backstage-plugin': minor
+---
+
+Generalize the listing row delete beyond components. The new
+`useDeleteEntityDialog` hook (replacing `useDeleteComponentDialog`) dispatches
+deletes for every kind the OpenChoreo API supports — components, projects,
+namespaces, resources and the platform resource kinds — sharing one dispatch
+with the entity-page context menu. A reusable `RowDeleteButton` +
+`usePendingDeletionOverlay` pair wires per-row delete (with an optimistic
+"marked for deletion" badge) into the catalog "All ..." pages, the namespace
+projects/resources cards, and extends the Project Contents row action to
+resource rows.

--- a/.changeset/listing-row-delete-permission-gate.md
+++ b/.changeset/listing-row-delete-permission-gate.md
@@ -1,0 +1,9 @@
+---
+'@openchoreo/backstage-plugin-react': minor
+---
+
+New `useEntityDeletePermission` hook checks the kind-mapped delete permission
+for a given entity (sharing the mapping used by
+`useResourceDefinitionPermission`), so listings can gate per-row actions. The
+`RowDeleteButton` now renders disabled with an explanatory tooltip when the
+logged-in user lacks permission to delete the row's entity.

--- a/.changeset/refresh-system-on-component-delete.md
+++ b/.changeset/refresh-system-on-component-delete.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin-catalog-backend-module': patch
+---
+
+Refresh the parent System when a component is removed so its now-dangling
+`hasPart` relation is dropped. Without this, deleting a component left the
+project page showing "Some related entities could not be found in the catalog"
+until the catalog was rebuilt, because the System's relations are only
+recomputed when it is re-processed and the periodic full sync re-emits it
+unchanged.

--- a/packages/portal-app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/portal-app/src/components/catalog/CatalogCardList.tsx
@@ -15,6 +15,9 @@ import { useNavigate } from 'react-router-dom';
 import {
   DeletionBadge,
   isMarkedForDeletion,
+  RowDeleteButton,
+  useDeleteEntityDialog,
+  usePendingDeletionOverlay,
 } from '@openchoreo/backstage-plugin';
 import {
   queryClient,
@@ -170,6 +173,15 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
     navigate(url);
   };
 
+  // Row-level delete for every kind the OC API can delete (projects,
+  // components, resources, namespaces, environments, platform types, ...).
+  // The catalog lags a delete by a sync/event, so deleted rows are overlaid
+  // with the deletion mark until the next refetch drops them.
+  const { markDeleted, overlay } = usePendingDeletionOverlay();
+  const { requestDelete, DeleteDialog } = useDeleteEntityDialog({
+    onDeleted: markDeleted,
+  });
+
   // The authoritative selected kind. `filters.kind` (applied filter) and the URL
   // both LAG during an in-app kind switch: the provider only sets `appliedFilters`
   // and rewrites the URL AFTER the new kind's fetch resolves. So on a switch, both
@@ -256,8 +268,11 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
   // seed. On a kind switch the held entities are the wrong kind, so the seed
   // (kind-matched) wins — a cached new kind paints immediately; an uncached one
   // has no seed, leaving nothing to show so the cold-load loader takes over.
-  const displayEntities =
-    entities.length > 0 && heldKindMatches ? entities : seed?.items ?? [];
+  // Deleted rows are overlaid with the deletion mark until a refetch drops
+  // them (`overlay` is an identity pass-through when nothing is pending).
+  const displayEntities = overlay(
+    entities.length > 0 && heldKindMatches ? entities : seed?.items ?? [],
+  );
   // Prefer the live count; fall back to the seed's while it loads.
   const displayTotal = totalItems ?? seed?.totalItems;
 
@@ -584,6 +599,7 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
                       </IconButton>
                     </Tooltip>
                   )}
+                  <RowDeleteButton entity={entity} onDelete={requestDelete} />
                 </Box>
               </Box>
             );
@@ -610,6 +626,8 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
           />
         </Box>
       )}
+
+      <DeleteDialog />
     </Box>
   );
 };

--- a/packages/portal-app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/portal-app/src/components/catalog/CatalogCardList.tsx
@@ -268,10 +268,15 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
   // seed. On a kind switch the held entities are the wrong kind, so the seed
   // (kind-matched) wins — a cached new kind paints immediately; an uncached one
   // has no seed, leaving nothing to show so the cold-load loader takes over.
+  // Only fall back to the seed while the current request hasn't produced a
+  // live result — a COMPLETED empty response must render as empty (e.g. after
+  // the last row of a kind is deleted), not as stale seed rows.
   // Deleted rows are overlaid with the deletion mark until a refetch drops
   // them (`overlay` is an identity pass-through when nothing is pending).
+  const shouldUseLiveEntities =
+    heldKindMatches && (entities.length > 0 || !loading);
   const displayEntities = overlay(
-    entities.length > 0 && heldKindMatches ? entities : seed?.items ?? [],
+    shouldUseLiveEntities ? entities : seed?.items ?? [],
   );
   // Prefer the live count; fall back to the seed's while it loads.
   const displayTotal = totalItems ?? seed?.totalItems;

--- a/packages/portal-app/src/components/catalog/styles.ts
+++ b/packages/portal-app/src/components/catalog/styles.ts
@@ -126,7 +126,7 @@ export const usePersonalFilterStyles = makeStyles(theme => ({
 
 export const useCardListStyles = makeStyles(theme => {
   const mobileGrid = {
-    gridTemplateColumns: '32px 1fr 60px',
+    gridTemplateColumns: '32px 1fr 100px',
   };
 
   return {
@@ -150,32 +150,32 @@ export const useCardListStyles = makeStyles(theme => {
     // Grid templates per kind — icon + actions fixed, rest spread evenly
     // Component: Icon | Name | Description | Namespace | Project | Type | Actions
     gridTemplateComponent: {
-      gridTemplateColumns: '40px 1fr 1.5fr 1fr 1fr 1fr 80px',
+      gridTemplateColumns: '40px 1fr 1.5fr 1fr 1fr 1fr 116px',
       [theme.breakpoints.down('xs')]: mobileGrid,
     },
     // API: Icon | Name | Description | Namespace | Project | Component | Type | Actions
     gridTemplateApi: {
-      gridTemplateColumns: '40px 1.2fr 2fr 0.8fr 0.8fr 0.8fr 0.7fr 80px',
+      gridTemplateColumns: '40px 1.2fr 2fr 0.8fr 0.8fr 0.8fr 0.7fr 116px',
       [theme.breakpoints.down('xs')]: mobileGrid,
     },
     // Environment: Icon | Name | Description | Namespace | Type | Actions
     gridTemplateEnvironment: {
-      gridTemplateColumns: '40px 1fr 1.5fr 1fr 1fr 80px',
+      gridTemplateColumns: '40px 1fr 1.5fr 1fr 1fr 116px',
       [theme.breakpoints.down('xs')]: mobileGrid,
     },
     // Planes: Icon | Name | Description | Namespace | Agent | Actions
     gridTemplatePlane: {
-      gridTemplateColumns: '40px 1fr 1.5fr 1fr 1fr 80px',
+      gridTemplateColumns: '40px 1fr 1.5fr 1fr 1fr 116px',
       [theme.breakpoints.down('xs')]: mobileGrid,
     },
     // Project/simple: Icon | Name | Description | Namespace | Actions
     gridTemplateSimple: {
-      gridTemplateColumns: '40px 1fr 1.5fr 1fr 80px',
+      gridTemplateColumns: '40px 1fr 1.5fr 1fr 116px',
       [theme.breakpoints.down('xs')]: mobileGrid,
     },
     // Namespace/domain: Icon | Name | Description | Actions
     gridTemplateMinimal: {
-      gridTemplateColumns: '40px 1fr 1.5fr 80px',
+      gridTemplateColumns: '40px 1fr 1.5fr 116px',
       [theme.breakpoints.down('xs')]: mobileGrid,
     },
 
@@ -238,6 +238,9 @@ export const useCardListStyles = makeStyles(theme => {
       minWidth: 0,
       '& > :first-child': {
         marginLeft: -8,
+      },
+      '& .MuiIconButton-root': {
+        padding: theme.spacing(0.75),
       },
     },
     columnCell: {

--- a/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.test.ts
@@ -1005,3 +1005,103 @@ describe('EventDeltaApplier custom scaffolder templates', () => {
     expect(addedKinds).toEqual(['ClusterComponentType']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Removing a Component leaves the parent System's reverse `hasPart` relation
+// dangling until the System is re-processed. With a catalog read-side wired,
+// the applier resolves the owning System and forces a refresh so the stale
+// relation (and the "related entities could not be found" warning) clears.
+// ---------------------------------------------------------------------------
+describe('EventDeltaApplier component removal refreshes the parent System', () => {
+  let applyMutation: jest.Mock;
+  let connection: EntityProviderConnection;
+  let getEntityByRef: jest.Mock;
+  let refreshEntity: jest.Mock;
+
+  function newApplierWithCatalog(component: any) {
+    getEntityByRef = jest.fn().mockResolvedValue(component);
+    refreshEntity = jest.fn().mockResolvedValue(undefined);
+    return new EventDeltaApplier({
+      logger: mkLogger(),
+      baseUrl: 'http://test:8080',
+      defaultOwner: 'group:default/test-owner',
+      translatorContext: {
+        providerName: 'OpenChoreoEntityProvider',
+        defaultOwner: 'group:default/test-owner',
+        componentTypeUtils: ComponentTypeUtils.fromConfig(
+          new ConfigReader({
+            openchoreo: { componentTypes: { mappings: [] } },
+          }),
+        ),
+      },
+      getConnection: () => connection,
+      ctdConverter: new CtdToTemplateConverter(mkLogger()),
+      rtdConverter: new RtdToTemplateConverter(mkLogger()),
+      ptdConverter: new PtdToTemplateConverter(mkLogger()),
+      catalogService: { getEntityByRef, refreshEntity } as any,
+      auth: {
+        getOwnServiceCredentials: jest.fn().mockResolvedValue({}),
+      } as any,
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGET.mockResolvedValue(notFound());
+    applyMutation = jest.fn();
+    connection = { applyMutation, refresh: jest.fn() } as any;
+  });
+
+  it('refreshes the System from the component partOf relation', async () => {
+    const applier = newApplierWithCatalog({
+      kind: 'Component',
+      metadata: { name: 'order', namespace: 'test-ns' },
+      spec: { system: 'shop' },
+      relations: [
+        { type: 'partOf', targetRef: 'system:test-ns/shop' },
+        { type: 'ownedBy', targetRef: 'group:default/team' },
+      ],
+    });
+
+    await applier.handleEvent('Component', 'order', 'test-ns', 'deleted');
+
+    // Parent resolved before removal, component removed, parent refreshed.
+    expect(getEntityByRef).toHaveBeenCalledWith(
+      'component:test-ns/order',
+      expect.anything(),
+    );
+    expect(
+      applyMutation.mock.calls[0][0].removed.map((r: any) => r.entityRef),
+    ).toEqual(['component:test-ns/order']);
+    expect(refreshEntity).toHaveBeenCalledWith(
+      'system:test-ns/shop',
+      expect.anything(),
+    );
+  });
+
+  it('falls back to spec.system when there is no partOf relation', async () => {
+    const applier = newApplierWithCatalog({
+      kind: 'Component',
+      metadata: { name: 'order', namespace: 'test-ns' },
+      spec: { system: 'shop' },
+    });
+
+    await applier.handleEvent('Component', 'order', 'test-ns', 'deleted');
+
+    expect(refreshEntity).toHaveBeenCalledWith(
+      'system:test-ns/shop',
+      expect.anything(),
+    );
+  });
+
+  it('removes the component without refreshing when the owner cannot be resolved', async () => {
+    const applier = newApplierWithCatalog(undefined);
+
+    await applier.handleEvent('Component', 'order', 'test-ns', 'deleted');
+
+    expect(
+      applyMutation.mock.calls[0][0].removed.map((r: any) => r.entityRef),
+    ).toEqual(['component:test-ns/order']);
+    expect(refreshEntity).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/EventDeltaApplier.ts
@@ -1,4 +1,8 @@
-import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import {
+  Entity,
+  stringifyEntityRef,
+  RELATION_PART_OF,
+} from '@backstage/catalog-model';
 import { AuthService, LoggerService } from '@backstage/backend-plugin-api';
 import {
   CatalogService,
@@ -674,6 +678,69 @@ export class EventDeltaApplier {
     ]);
   }
 
+  /**
+   * Resolve the Backstage System (OC Project) ref a component belongs to, by
+   * reading the still-present catalog Component entity. Prefers the `partOf`
+   * relation (the exact ref Backstage assigned); falls back to `spec.system`.
+   * Returns undefined when the catalog read-side isn't wired or the owner
+   * can't be resolved — the caller then just skips the parent refresh.
+   */
+  private async findParentSystemRef(
+    ns: string,
+    name: string,
+  ): Promise<string | undefined> {
+    if (!this.catalogService || !this.auth) {
+      return undefined;
+    }
+    try {
+      const credentials = await this.auth.getOwnServiceCredentials();
+      const entity = await this.catalogService.getEntityByRef(
+        this.buildEntityRef('component', ns, name),
+        { credentials },
+      );
+      if (!entity) {
+        return undefined;
+      }
+      const partOf = entity.relations?.find(
+        rel =>
+          rel.type === RELATION_PART_OF && rel.targetRef.startsWith('system:'),
+      );
+      if (partOf) {
+        return partOf.targetRef;
+      }
+      const system = (entity.spec as { system?: string } | undefined)?.system;
+      return system
+        ? this.buildEntityRef(
+            'system',
+            entity.metadata.namespace ?? 'default',
+            system,
+          )
+        : undefined;
+    } catch (err) {
+      this.logger.warn(
+        `Could not resolve parent System for component ${ns}/${name}: ${err}`,
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Force a re-process (and thus re-stitch) of a single entity. Best-effort:
+   * logs and continues on failure so it never blocks the mutation that
+   * triggered it.
+   */
+  private async refreshEntityRef(entityRef: string): Promise<void> {
+    if (!this.catalogService || !this.auth) {
+      return;
+    }
+    try {
+      const credentials = await this.auth.getOwnServiceCredentials();
+      await this.catalogService.refreshEntity(entityRef, { credentials });
+    } catch (err) {
+      this.logger.warn(`Failed to refresh ${entityRef}: ${err}`);
+    }
+  }
+
   private async refreshComponent(
     ns: string,
     name: string,
@@ -687,7 +754,19 @@ export class EventDeltaApplier {
     const client = await this.createApiClient();
     const component = await this.fetchComponent(client, ns, name);
     if (!component) {
+      // Resolve the owning System *before* removing the component — once the
+      // component entity is gone we can no longer read its `partOf` relation.
+      const parentSystemRef = await this.findParentSystemRef(ns, name);
       await this.removeEntityRefs([this.buildEntityRef('component', ns, name)]);
+      // Removing the component leaves the System's reverse `hasPart` relation
+      // dangling: the System's denormalized relations are only recomputed when
+      // it is itself re-processed, and the periodic full sync re-emits it
+      // unchanged (so it isn't). Until then the project page shows "Some
+      // related entities could not be found in the catalog". Force a refresh
+      // of the parent System so it re-stitches and drops the dangling edge.
+      if (parentSystemRef) {
+        await this.refreshEntityRef(parentSystemRef);
+      }
       return;
     }
 

--- a/plugins/openchoreo-react/src/hooks/useEntityDeletePermission.test.ts
+++ b/plugins/openchoreo-react/src/hooks/useEntityDeletePermission.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react';
+import type { Entity } from '@backstage/catalog-model';
+import {
+  openchoreoResourceDeletePermission,
+  openchoreoComponentUpdatePermission,
+  openchoreoProjectUpdatePermission,
+  openchoreoClusterComponentTypeDeletePermission,
+} from '@openchoreo/backstage-plugin-common';
+import { useEntityDeletePermission } from './useEntityDeletePermission';
+
+const mockUsePermission = jest.fn();
+jest.mock('@backstage/plugin-permission-react', () => ({
+  usePermission: (...args: any[]) => mockUsePermission(...args),
+}));
+
+const makeEntity = (kind: string): Entity => ({
+  apiVersion: 'backstage.io/v1alpha1',
+  kind,
+  metadata: { name: 'test', namespace: 'default' },
+});
+
+describe('useEntityDeletePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePermission.mockReturnValue({ allowed: true, loading: false });
+  });
+
+  it('checks the delete permission with the entity ref for resource-scoped kinds', () => {
+    const { result } = renderHook(() =>
+      useEntityDeletePermission(makeEntity('Resource')),
+    );
+
+    expect(mockUsePermission).toHaveBeenCalledWith({
+      permission: openchoreoResourceDeletePermission,
+      resourceRef: 'resource:default/test',
+    });
+    expect(result.current.canDelete).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+
+  it('checks a basic permission without resourceRef for cluster-scoped kinds', () => {
+    renderHook(() =>
+      useEntityDeletePermission(makeEntity('ClusterComponentType')),
+    );
+
+    expect(mockUsePermission).toHaveBeenCalledWith({
+      permission: openchoreoClusterComponentTypeDeletePermission,
+    });
+  });
+
+  it.each([
+    ['Component', openchoreoComponentUpdatePermission],
+    ['System', openchoreoProjectUpdatePermission],
+  ])('falls back to the update permission for %s', (kind, permission) => {
+    renderHook(() => useEntityDeletePermission(makeEntity(kind)));
+
+    expect(mockUsePermission).toHaveBeenCalledWith({
+      permission,
+      resourceRef: `${kind.toLowerCase()}:default/test`,
+    });
+  });
+
+  it('denies kinds without a mapped permission even when allowed', () => {
+    const { result } = renderHook(() =>
+      useEntityDeletePermission(makeEntity('SomethingElse')),
+    );
+
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.deniedTooltip).toBe(
+      'You do not have permission to delete this resource',
+    );
+  });
+
+  it('reports the denied tooltip when the permission is denied', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: false });
+
+    const { result } = renderHook(() =>
+      useEntityDeletePermission(makeEntity('Resource')),
+    );
+
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.deniedTooltip).toBe(
+      'You do not have permission to delete this resource',
+    );
+  });
+
+  it('keeps the tooltip empty while the check is loading', () => {
+    mockUsePermission.mockReturnValue({ allowed: false, loading: true });
+
+    const { result } = renderHook(() =>
+      useEntityDeletePermission(makeEntity('Resource')),
+    );
+
+    expect(result.current.canDelete).toBe(false);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.deniedTooltip).toBe('');
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useEntityDeletePermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useEntityDeletePermission.ts
@@ -1,0 +1,60 @@
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { usePermission } from '@backstage/plugin-permission-react';
+import type {
+  BasicPermission,
+  ResourcePermission,
+} from '@backstage/plugin-permission-common';
+import {
+  KIND_TO_PERMISSIONS,
+  FALLBACK_PERMISSION,
+} from './useResourceDefinitionPermission';
+
+/**
+ * Result of the useEntityDeletePermission hook.
+ */
+export interface UseEntityDeletePermissionResult {
+  /** Whether the user has permission to delete this entity */
+  canDelete: boolean;
+  /** Whether the permission check is still loading */
+  loading: boolean;
+  /** Tooltip message when delete is denied (empty string when allowed/loading) */
+  deniedTooltip: string;
+}
+
+/**
+ * Checks whether the current user may delete the given entity.
+ *
+ * Uses the same kind-to-permission mapping as
+ * `useResourceDefinitionPermission`, but takes the entity as an argument
+ * instead of reading it from entity context, so it can gate per-row actions
+ * in listings. Kinds without a mapped permission are denied, matching
+ * `useResourceDefinitionPermission`. Note that component and project kinds
+ * have no dedicated delete permission — their update permission is checked
+ * instead, with the API's own authorization as the enforcement backstop.
+ */
+export function useEntityDeletePermission(
+  entity: Entity,
+): UseEntityDeletePermissionResult {
+  const permissions = KIND_TO_PERMISSIONS[entity.kind.toLowerCase()];
+  const deletePerm = permissions?.delete ?? FALLBACK_PERMISSION;
+  const isResourceScoped = permissions?.isResourceScoped ?? true;
+
+  const input = isResourceScoped
+    ? {
+        permission: deletePerm as ResourcePermission,
+        resourceRef: stringifyEntityRef(entity),
+      }
+    : { permission: deletePerm as BasicPermission };
+
+  const { allowed, loading } = usePermission(input);
+  const canDelete = permissions ? allowed : false;
+
+  return {
+    canDelete,
+    loading,
+    deniedTooltip:
+      !canDelete && !loading
+        ? 'You do not have permission to delete this resource'
+        : '',
+  };
+}

--- a/plugins/openchoreo-react/src/hooks/useResourceDefinitionPermission.ts
+++ b/plugins/openchoreo-react/src/hooks/useResourceDefinitionPermission.ts
@@ -82,8 +82,11 @@ type PermissionEntry = {
  * Lookup map from entity kind (lowercase) to update/delete permissions.
  * Namespace-scoped kinds use ResourcePermission (require resourceRef).
  * Cluster-scoped kinds use BasicPermission (no resource context).
+ *
+ * Shared with `useEntityDeletePermission` (internal only — not part of the
+ * package's public API).
  */
-const KIND_TO_PERMISSIONS: Record<string, PermissionEntry> = {
+export const KIND_TO_PERMISSIONS: Record<string, PermissionEntry> = {
   system: {
     update: openchoreoProjectUpdatePermission,
     delete: openchoreoProjectUpdatePermission, // Projects use update permission; delete is handled separately
@@ -208,7 +211,7 @@ const KIND_TO_PERMISSIONS: Record<string, PermissionEntry> = {
 
 // Fallback permission used when kind is unsupported to satisfy React hook rules
 // (hooks must always be called the same number of times).
-const FALLBACK_PERMISSION = openchoreoComponentTypeUpdatePermission;
+export const FALLBACK_PERMISSION = openchoreoComponentTypeUpdatePermission;
 
 /**
  * Hook for checking if the current user has permission to update and/or delete

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -193,6 +193,10 @@ export {
   useHasAnyAnnotation,
 } from './hooks/useEntityAnnotation';
 export {
+  useEntityDeletePermission,
+  type UseEntityDeletePermissionResult,
+} from './hooks/useEntityDeletePermission';
+export {
   useOpenChoreoFeatures,
   useWorkflowsEnabled,
   useObservabilityEnabled,

--- a/plugins/openchoreo/src/components/DeleteEntity/components/DeleteEntityDialog.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/components/DeleteEntityDialog.tsx
@@ -1,0 +1,103 @@
+import { type ReactNode } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  CircularProgress,
+} from '@material-ui/core';
+import { useStyles } from '../styles';
+
+export interface DeleteEntityDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Human-friendly type label, e.g. "Component", "Project". */
+  entityDisplayType: string;
+  /** Name of the entity being deleted. */
+  entityName: string;
+  /** True while the delete request is in flight. */
+  deleting: boolean;
+  /** Error message to surface inside the dialog, if any. */
+  error: string | null;
+  /** Optional cascade note (e.g. "all components will also be deleted"). */
+  cascadeNote?: ReactNode;
+  /** Called when the dialog is dismissed (Cancel / backdrop). */
+  onClose: () => void;
+  /** Called when the user confirms the deletion. */
+  onConfirm: () => void;
+}
+
+/**
+ * Presentational confirmation dialog shared by every "delete" entry point
+ * (entity-page context menu and the project-listing row action), so the
+ * wording, styling and busy/error states stay identical across the portal.
+ *
+ * It owns no delete logic — the caller wires `onConfirm`/`onClose` and the
+ * `deleting`/`error` state.
+ */
+export function DeleteEntityDialog({
+  open,
+  entityDisplayType,
+  entityName,
+  deleting,
+  error,
+  cascadeNote,
+  onClose,
+  onConfirm,
+}: DeleteEntityDialogProps) {
+  const classes = useStyles();
+  const lowerType = entityDisplayType.toLowerCase();
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="delete-entity-dialog-title"
+    >
+      <DialogTitle id="delete-entity-dialog-title" disableTypography>
+        <Typography variant="h4">Delete {entityDisplayType}</Typography>
+      </DialogTitle>
+
+      <DialogContent className={classes.deleteDialogContent}>
+        <Typography variant="body1">
+          Are you sure you want to delete the {lowerType}{' '}
+          <span className={classes.entityName}>{entityName}</span>?
+        </Typography>
+
+        <Typography variant="body2" className={classes.warningText}>
+          This action cannot be undone. The {lowerType} and all its associated
+          resources will be permanently deleted.
+        </Typography>
+
+        {cascadeNote}
+
+        {error && (
+          <Typography variant="body2" color="error">
+            Error: {error}
+          </Typography>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={deleting} variant="contained">
+          Cancel
+        </Button>
+        <Button
+          onClick={onConfirm}
+          className={classes.deleteButton}
+          variant="outlined"
+          disabled={deleting}
+          startIcon={
+            deleting ? <CircularProgress size={16} color="inherit" /> : null
+          }
+        >
+          {deleting ? 'Deleting...' : 'Delete'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/plugins/openchoreo/src/components/DeleteEntity/components/RowDeleteButton.test.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/components/RowDeleteButton.test.tsx
@@ -4,6 +4,12 @@ import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import type { Entity } from '@backstage/catalog-model';
 import { RowDeleteButton } from './RowDeleteButton';
 
+const mockUseEntityDeletePermission = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useEntityDeletePermission: (...args: any[]) =>
+    mockUseEntityDeletePermission(...args),
+}));
+
 function makeEntity(
   kind: string,
   name: string,
@@ -24,6 +30,15 @@ function makeEntity(
 }
 
 describe('RowDeleteButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEntityDeletePermission.mockReturnValue({
+      canDelete: true,
+      loading: false,
+      deniedTooltip: '',
+    });
+  });
+
   it.each([
     ['Component', 'my-service'],
     ['System', 'my-project'],
@@ -77,5 +92,35 @@ describe('RowDeleteButton', () => {
 
     expect(onDelete).toHaveBeenCalledWith(entity);
     expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('disables the button when the user lacks delete permission', () => {
+    mockUseEntityDeletePermission.mockReturnValue({
+      canDelete: false,
+      loading: false,
+      deniedTooltip: 'You do not have permission to delete this resource',
+    });
+    render(
+      <RowDeleteButton
+        entity={makeEntity('Component', 'svc')}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /delete svc/i })).toBeDisabled();
+  });
+
+  it('disables the button while the permission check is loading', () => {
+    mockUseEntityDeletePermission.mockReturnValue({
+      canDelete: false,
+      loading: true,
+      deniedTooltip: '',
+    });
+    render(
+      <RowDeleteButton
+        entity={makeEntity('Component', 'svc')}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /delete svc/i })).toBeDisabled();
   });
 });

--- a/plugins/openchoreo/src/components/DeleteEntity/components/RowDeleteButton.test.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/components/RowDeleteButton.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import type { Entity } from '@backstage/catalog-model';
+import { RowDeleteButton } from './RowDeleteButton';
+
+function makeEntity(
+  kind: string,
+  name: string,
+  options?: { markedForDeletion?: boolean },
+): Entity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind,
+    metadata: {
+      name,
+      namespace: 'default',
+      annotations: options?.markedForDeletion
+        ? { [CHOREO_ANNOTATIONS.DELETION_TIMESTAMP]: '2026-01-01T00:00:00Z' }
+        : {},
+    },
+    spec: {},
+  };
+}
+
+describe('RowDeleteButton', () => {
+  it.each([
+    ['Component', 'my-service'],
+    ['System', 'my-project'],
+    ['Domain', 'my-namespace'],
+    ['Resource', 'my-db'],
+    ['Environment', 'dev'],
+    ['ClusterComponentType', 'service'],
+  ])('renders a delete button for %s entities', (kind, name) => {
+    render(
+      <RowDeleteButton entity={makeEntity(kind, name)} onDelete={jest.fn()} />,
+    );
+    expect(
+      screen.getByRole('button', { name: new RegExp(`delete ${name}`, 'i') }),
+    ).toBeInTheDocument();
+  });
+
+  it.each([['API'], ['User'], ['Group'], ['Template'], ['Location']])(
+    'renders nothing for non-deletable kind %s',
+    kind => {
+      const { container } = render(
+        <RowDeleteButton entity={makeEntity(kind, 'x')} onDelete={jest.fn()} />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    },
+  );
+
+  it('renders nothing for an entity already marked for deletion', () => {
+    const { container } = render(
+      <RowDeleteButton
+        entity={makeEntity('Component', 'svc', { markedForDeletion: true })}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('calls onDelete with the entity and stops click propagation', async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+    const onRowClick = jest.fn();
+    const entity = makeEntity('Component', 'svc');
+
+    render(
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <div onClick={onRowClick}>
+        <RowDeleteButton entity={entity} onDelete={onDelete} />
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete svc/i }));
+
+    expect(onDelete).toHaveBeenCalledWith(entity);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/openchoreo/src/components/DeleteEntity/components/RowDeleteButton.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/components/RowDeleteButton.tsx
@@ -2,6 +2,7 @@ import { type MouseEvent } from 'react';
 import { IconButton, Tooltip } from '@material-ui/core';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import { Entity } from '@backstage/catalog-model';
+import { useEntityDeletePermission } from '@openchoreo/backstage-plugin-react';
 import { isMarkedForDeletion } from '../utils';
 import {
   getEntityDisplayType,
@@ -19,16 +20,22 @@ export interface RowDeleteButtonProps {
  * Project Contents, namespace projects/resources cards).
  *
  * Renders nothing for kinds the client can't delete (`api`, `user`, ...) and
- * for rows already marked for deletion. The click is stopped from bubbling so
- * the row's navigate-on-click doesn't fire.
+ * for rows already marked for deletion. Disabled (with an explanatory
+ * tooltip) while the delete-permission check for the entity is loading or
+ * denied. The click is stopped from bubbling so the row's navigate-on-click
+ * doesn't fire.
  */
 export const RowDeleteButton = ({ entity, onDelete }: RowDeleteButtonProps) => {
+  const { canDelete, loading, deniedTooltip } =
+    useEntityDeletePermission(entity);
+
   if (!isDeletableEntityKind(entity.kind) || isMarkedForDeletion(entity)) {
     return null;
   }
 
   const displayType = getEntityDisplayType(entity.kind);
   const displayName = entity.metadata.title || entity.metadata.name;
+  const disabled = loading || !canDelete;
 
   const handleDelete = (event: MouseEvent) => {
     event.stopPropagation();
@@ -36,14 +43,24 @@ export const RowDeleteButton = ({ entity, onDelete }: RowDeleteButtonProps) => {
   };
 
   return (
-    <Tooltip title={`Delete ${displayType.toLowerCase()}`}>
-      <IconButton
-        size="small"
-        aria-label={`Delete ${displayName}`}
-        onClick={handleDelete}
-      >
-        <DeleteOutlineIcon fontSize="small" />
-      </IconButton>
+    <Tooltip
+      title={
+        !loading && !canDelete
+          ? deniedTooltip
+          : `Delete ${displayType.toLowerCase()}`
+      }
+    >
+      {/* span so the tooltip still fires while the button is disabled */}
+      <span>
+        <IconButton
+          size="small"
+          aria-label={`Delete ${displayName}`}
+          onClick={handleDelete}
+          disabled={disabled}
+        >
+          <DeleteOutlineIcon fontSize="small" />
+        </IconButton>
+      </span>
     </Tooltip>
   );
 };

--- a/plugins/openchoreo/src/components/DeleteEntity/components/RowDeleteButton.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/components/RowDeleteButton.tsx
@@ -1,0 +1,49 @@
+import { type MouseEvent } from 'react';
+import { IconButton, Tooltip } from '@material-ui/core';
+import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
+import { Entity } from '@backstage/catalog-model';
+import { isMarkedForDeletion } from '../utils';
+import {
+  getEntityDisplayType,
+  isDeletableEntityKind,
+} from '../hooks/deleteEntityDispatch';
+
+export interface RowDeleteButtonProps {
+  entity: Entity;
+  /** Open the delete-confirmation dialog for this entity. */
+  onDelete: (entity: Entity) => void;
+}
+
+/**
+ * Per-row delete control shared by every listing (catalog "All ..." pages,
+ * Project Contents, namespace projects/resources cards).
+ *
+ * Renders nothing for kinds the client can't delete (`api`, `user`, ...) and
+ * for rows already marked for deletion. The click is stopped from bubbling so
+ * the row's navigate-on-click doesn't fire.
+ */
+export const RowDeleteButton = ({ entity, onDelete }: RowDeleteButtonProps) => {
+  if (!isDeletableEntityKind(entity.kind) || isMarkedForDeletion(entity)) {
+    return null;
+  }
+
+  const displayType = getEntityDisplayType(entity.kind);
+  const displayName = entity.metadata.title || entity.metadata.name;
+
+  const handleDelete = (event: MouseEvent) => {
+    event.stopPropagation();
+    onDelete(entity);
+  };
+
+  return (
+    <Tooltip title={`Delete ${displayType.toLowerCase()}`}>
+      <IconButton
+        size="small"
+        aria-label={`Delete ${displayName}`}
+        onClick={handleDelete}
+      >
+        <DeleteOutlineIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/plugins/openchoreo/src/components/DeleteEntity/components/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/components/index.ts
@@ -2,3 +2,5 @@ export { DeletionBadge } from './DeletionBadge';
 export { DeletionWarning } from './DeletionWarning';
 export { DeleteEntityDialog } from './DeleteEntityDialog';
 export type { DeleteEntityDialogProps } from './DeleteEntityDialog';
+export { RowDeleteButton } from './RowDeleteButton';
+export type { RowDeleteButtonProps } from './RowDeleteButton';

--- a/plugins/openchoreo/src/components/DeleteEntity/components/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/components/index.ts
@@ -1,2 +1,4 @@
 export { DeletionBadge } from './DeletionBadge';
 export { DeletionWarning } from './DeletionWarning';
+export { DeleteEntityDialog } from './DeleteEntityDialog';
+export type { DeleteEntityDialogProps } from './DeleteEntityDialog';

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/deleteEntityDispatch.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/deleteEntityDispatch.tsx
@@ -111,14 +111,14 @@ export function getEntityDeleteCascadeNote(kind: string): ReactNode {
   const kindLower = kind.toLowerCase();
   if (kindLower === 'system') {
     return (
-      <Typography variant="h5">
+      <Typography variant="body2" color="error">
         Note: All components within this project will also be deleted.
       </Typography>
     );
   }
   if (kindLower === 'domain') {
     return (
-      <Typography variant="h5">
+      <Typography variant="body2" color="error">
         Note: All projects and components within this namespace will also be
         deleted.
       </Typography>

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/deleteEntityDispatch.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/deleteEntityDispatch.tsx
@@ -1,0 +1,128 @@
+import { type ReactNode } from 'react';
+import { Typography } from '@material-ui/core';
+import { Entity } from '@backstage/catalog-model';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import {
+  OpenChoreoClientApi,
+  CLUSTER_SCOPED_RESOURCE_KINDS,
+} from '../../../api/OpenChoreoClientApi';
+import {
+  isSupportedKind,
+  mapKindToApiKind,
+} from '../../ResourceDefinition/utils';
+
+/** Human-friendly display names for all deletable entity kinds */
+const KIND_DISPLAY_NAMES: Record<string, string> = {
+  component: 'Component',
+  resource: 'Resource',
+  system: 'Project',
+  domain: 'Namespace',
+  environment: 'Environment',
+  observabilityalertsnotificationchannel: 'Notification Channel',
+  dataplane: 'Dataplane',
+  clusterdataplane: 'Cluster Data Plane',
+  buildplane: 'Build Plane',
+  clusterbuildplane: 'Cluster Build Plane',
+  workflowplane: 'Workflow Plane',
+  clusterworkflowplane: 'Cluster Workflow Plane',
+  observabilityplane: 'Observability Plane',
+  clusterobservabilityplane: 'Cluster Observability Plane',
+  deploymentpipeline: 'Deployment Pipeline',
+  componenttype: 'Component Type',
+  resourcetype: 'Resource Type',
+  clustercomponenttype: 'Cluster Component Type',
+  clusterresourcetype: 'Cluster Resource Type',
+  traittype: 'Trait Type',
+  clustertraittype: 'Cluster Trait Type',
+  workflow: 'Workflow',
+  clusterworkflow: 'Cluster Workflow',
+  componentworkflow: 'Component Workflow',
+};
+
+/** Display label for an entity kind, e.g. "system" -> "Project". */
+export function getEntityDisplayType(kind: string): string {
+  return KIND_DISPLAY_NAMES[kind.toLowerCase()] ?? kind;
+}
+
+/**
+ * Whether the client can delete entities of this kind at all (the OC API has
+ * a delete path for it). Kinds like `api`, `user`, `group`, `template` and
+ * `location` are catalog-only projections and are not deletable.
+ */
+export function isDeletableEntityKind(kind: string): boolean {
+  const kindLower = kind.toLowerCase();
+  return (
+    kindLower === 'component' ||
+    kindLower === 'system' ||
+    kindLower === 'domain' ||
+    isSupportedKind(kindLower)
+  );
+}
+
+/**
+ * Dispatches an entity delete to the right OpenChoreo client call for its
+ * kind. Single source of truth shared by the entity-page context menu
+ * ({@link useDeleteEntityMenuItems}) and the listing row action
+ * ({@link useDeleteEntityDialog}).
+ */
+export async function performEntityDelete(
+  client: OpenChoreoClientApi,
+  entity: Entity,
+): Promise<void> {
+  const entityKind = entity.kind.toLowerCase();
+  const entityName = entity.metadata.name;
+
+  if (entityKind === 'component') {
+    await client.deleteComponent(entity);
+    return;
+  }
+  if (entityKind === 'system') {
+    await client.deleteProject(entity);
+    return;
+  }
+  if (entityKind === 'domain') {
+    await client.deleteNamespace(entity);
+    return;
+  }
+  if (isSupportedKind(entityKind)) {
+    const apiKind = mapKindToApiKind(entityKind);
+    const namespace =
+      entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
+
+    if (!CLUSTER_SCOPED_RESOURCE_KINDS.has(apiKind) && !namespace) {
+      throw new Error(
+        `Missing namespace annotation for ${getEntityDisplayType(
+          entityKind,
+        ).toLowerCase()} "${entityName}"`,
+      );
+    }
+
+    await client.deleteResourceDefinition(apiKind, namespace ?? '', entityName);
+    return;
+  }
+  throw new Error(`Unsupported entity kind for deletion: ${entity.kind}`);
+}
+
+/**
+ * Extra warning line for deletes that cascade to child entities, shown inside
+ * the confirmation dialog. Undefined for kinds without a cascade.
+ */
+export function getEntityDeleteCascadeNote(kind: string): ReactNode {
+  const kindLower = kind.toLowerCase();
+  if (kindLower === 'system') {
+    return (
+      <Typography variant="h5">
+        Note: All components within this project will also be deleted.
+      </Typography>
+    );
+  }
+  if (kindLower === 'domain') {
+    return (
+      <Typography variant="h5">
+        Note: All projects and components within this namespace will also be
+        deleted.
+      </Typography>
+    );
+  }
+  return undefined;
+}

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/index.ts
@@ -2,4 +2,9 @@ export {
   useDeleteEntityMenuItems,
   type DeletePermissionInfo,
 } from './useDeleteEntityMenuItems';
+export {
+  useDeleteComponentDialog,
+  type UseDeleteComponentDialogOptions,
+  type UseDeleteComponentDialogResult,
+} from './useDeleteComponentDialog';
 export { useEntityExistsCheck } from './useEntityExistsCheck';

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/index.ts
@@ -3,8 +3,13 @@ export {
   type DeletePermissionInfo,
 } from './useDeleteEntityMenuItems';
 export {
-  useDeleteComponentDialog,
-  type UseDeleteComponentDialogOptions,
-  type UseDeleteComponentDialogResult,
-} from './useDeleteComponentDialog';
+  useDeleteEntityDialog,
+  type UseDeleteEntityDialogOptions,
+  type UseDeleteEntityDialogResult,
+} from './useDeleteEntityDialog';
+export { usePendingDeletionOverlay } from './usePendingDeletionOverlay';
+export {
+  getEntityDisplayType,
+  isDeletableEntityKind,
+} from './deleteEntityDispatch';
 export { useEntityExistsCheck } from './useEntityExistsCheck';

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteComponentDialog.test.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteComponentDialog.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { TestApiProvider } from '@backstage/test-utils';
+import { alertApiRef } from '@backstage/core-plugin-api';
+import { createMockOpenChoreoClient } from '@openchoreo/test-utils';
+import { openChoreoClientApiRef } from '../../../api/OpenChoreoClientApi';
+import { useDeleteComponentDialog } from './useDeleteComponentDialog';
+import type { Entity } from '@backstage/catalog-model';
+
+// ---- Mocks ----
+
+jest.mock('../../../utils/errorUtils', () => ({
+  isForbiddenError: (err: any) => err?.message?.includes('403'),
+  getErrorMessage: (err: any) =>
+    err instanceof Error ? err.message : String(err),
+}));
+
+// ---- Helpers ----
+
+const mockClient = createMockOpenChoreoClient();
+const mockAlertApi = { post: jest.fn() };
+
+function makeComponent(name: string): Entity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name,
+      namespace: 'default',
+      annotations: { 'openchoreo.io/namespace': 'test-ns' },
+    },
+    spec: {},
+  };
+}
+
+/** Renders the hook: a button per entity opens the shared dialog. */
+function TestHarness({
+  entities,
+  onDeleted,
+}: {
+  entities: Entity[];
+  onDeleted?: () => void;
+}) {
+  const { requestDelete, DeleteDialog } = useDeleteComponentDialog({
+    onDeleted,
+  });
+
+  return (
+    <div>
+      {entities.map(entity => (
+        <button
+          key={entity.metadata.name}
+          data-testid={`open-${entity.metadata.name}`}
+          onClick={() => requestDelete(entity)}
+        >
+          open
+        </button>
+      ))}
+      <DeleteDialog />
+    </div>
+  );
+}
+
+function renderHarness(entities: Entity[], onDeleted?: () => void) {
+  return render(
+    <MemoryRouter>
+      <TestApiProvider
+        apis={[
+          [openChoreoClientApiRef, mockClient],
+          [alertApiRef, mockAlertApi],
+        ]}
+      >
+        <TestHarness entities={entities} onDeleted={onDeleted} />
+      </TestApiProvider>
+    </MemoryRouter>,
+  );
+}
+
+// ---- Tests ----
+
+describe('useDeleteComponentDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dialog stays closed until a delete is requested', () => {
+    renderHarness([makeComponent('my-service')]);
+
+    expect(
+      screen.queryByRole('heading', { name: /delete component/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the confirmation dialog for the requested component', async () => {
+    const user = userEvent.setup();
+    renderHarness([makeComponent('my-service')]);
+
+    await user.click(screen.getByTestId('open-my-service'));
+
+    expect(
+      screen.getByRole('heading', { name: /delete component/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/my-service/)).toBeInTheDocument();
+  });
+
+  it('deletes the component, alerts success and calls onDeleted', async () => {
+    const user = userEvent.setup();
+    const onDeleted = jest.fn();
+    mockClient.deleteComponent.mockResolvedValue(undefined);
+
+    renderHarness([makeComponent('my-service')], onDeleted);
+
+    await user.click(screen.getByTestId('open-my-service'));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(mockClient.deleteComponent).toHaveBeenCalledTimes(1);
+      expect(mockAlertApi.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Component "my-service" has been marked for deletion',
+          severity: 'success',
+        }),
+      );
+      expect(onDeleted).toHaveBeenCalledTimes(1);
+    });
+    // Dialog closes on success.
+    expect(
+      screen.queryByRole('heading', { name: /delete component/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('targets the component whose row requested deletion', async () => {
+    const user = userEvent.setup();
+    mockClient.deleteComponent.mockResolvedValue(undefined);
+
+    renderHarness([makeComponent('svc-a'), makeComponent('svc-b')]);
+
+    await user.click(screen.getByTestId('open-svc-b'));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(mockClient.deleteComponent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ name: 'svc-b' }),
+        }),
+      );
+    });
+  });
+
+  it('shows a permission error on 403 and does not call onDeleted', async () => {
+    const user = userEvent.setup();
+    const onDeleted = jest.fn();
+    mockClient.deleteComponent.mockRejectedValue(new Error('403 Forbidden'));
+
+    renderHarness([makeComponent('my-service')], onDeleted);
+
+    await user.click(screen.getByTestId('open-my-service'));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/You do not have permission to delete this component/),
+      ).toBeInTheDocument();
+    });
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
+  it('shows a generic error on non-403 failure', async () => {
+    const user = userEvent.setup();
+    mockClient.deleteComponent.mockRejectedValue(new Error('Network timeout'));
+
+    renderHarness([makeComponent('my-service')]);
+
+    await user.click(screen.getByTestId('open-my-service'));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Network timeout/)).toBeInTheDocument();
+    });
+  });
+
+  it('closes on cancel without calling the API', async () => {
+    const user = userEvent.setup();
+    renderHarness([makeComponent('my-service')]);
+
+    await user.click(screen.getByTestId('open-my-service'));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: /delete component/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(mockClient.deleteComponent).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteComponentDialog.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteComponentDialog.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useState } from 'react';
+import { useApi, alertApiRef } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+import { openChoreoClientApiRef } from '../../../api/OpenChoreoClientApi';
+import { isForbiddenError, getErrorMessage } from '../../../utils/errorUtils';
+import { DeleteEntityDialog } from '../components';
+
+export interface UseDeleteComponentDialogOptions {
+  /**
+   * Called after a component has been successfully marked for deletion. Use it
+   * to refresh the surrounding list (the deleted row stays visible with a
+   * "marked for deletion" badge until the next catalog sync removes it).
+   */
+  onDeleted?: (entity: Entity) => void;
+}
+
+export interface UseDeleteComponentDialogResult {
+  /** Open the confirmation dialog for the given component entity. */
+  requestDelete: (entity: Entity) => void;
+  /** Render once in the surrounding component; controlled internally. */
+  DeleteDialog: React.FC;
+}
+
+/**
+ * Delete a component from a listing (e.g. the project's Project Contents table)
+ * without leaving the page.
+ *
+ * Unlike {@link useDeleteEntityMenuItems} — which is bound to a single entity
+ * via EntityLayout's context menu and navigates to `/catalog` on success — this
+ * hook is list-oriented: a single dialog instance is reused across rows
+ * (`requestDelete(entity)` targets one), and on success it calls `onDeleted`
+ * (typically a refetch) instead of navigating away. Component-only by design;
+ * the project listing has no client-side delete for Resource entities.
+ */
+export function useDeleteComponentDialog(
+  options?: UseDeleteComponentDialogOptions,
+): UseDeleteComponentDialogResult {
+  const { onDeleted } = options ?? {};
+  const openChoreoClient = useApi(openChoreoClientApiRef);
+  const alertApi = useApi(alertApiRef);
+
+  const [target, setTarget] = useState<Entity | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestDelete = useCallback((entity: Entity) => {
+    setTarget(entity);
+    setError(null);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (deleting) {
+      return;
+    }
+    setTarget(null);
+    setError(null);
+  }, [deleting]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!target) {
+      return;
+    }
+    const entityName = target.metadata.name;
+    setDeleting(true);
+    setError(null);
+
+    try {
+      await openChoreoClient.deleteComponent(target);
+
+      alertApi.post({
+        message: `Component "${entityName}" has been marked for deletion`,
+        severity: 'success',
+        display: 'transient',
+      });
+
+      setTarget(null);
+      onDeleted?.(target);
+    } catch (err) {
+      const errorMessage = isForbiddenError(err)
+        ? 'You do not have permission to delete this component. Contact your administrator.'
+        : getErrorMessage(err);
+      setError(errorMessage);
+      alertApi.post({ message: errorMessage, severity: 'error' });
+    } finally {
+      setDeleting(false);
+    }
+  }, [target, openChoreoClient, alertApi, onDeleted]);
+
+  const DeleteDialog: React.FC = useCallback(
+    () => (
+      <DeleteEntityDialog
+        open={target !== null}
+        entityDisplayType="Component"
+        entityName={target?.metadata.name ?? ''}
+        deleting={deleting}
+        error={error}
+        onClose={handleClose}
+        onConfirm={handleConfirm}
+      />
+    ),
+    [target, deleting, error, handleClose, handleConfirm],
+  );
+
+  return { requestDelete, DeleteDialog };
+}

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteEntityDialog.test.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteEntityDialog.test.tsx
@@ -5,7 +5,7 @@ import { TestApiProvider } from '@backstage/test-utils';
 import { alertApiRef } from '@backstage/core-plugin-api';
 import { createMockOpenChoreoClient } from '@openchoreo/test-utils';
 import { openChoreoClientApiRef } from '../../../api/OpenChoreoClientApi';
-import { useDeleteComponentDialog } from './useDeleteComponentDialog';
+import { useDeleteEntityDialog } from './useDeleteEntityDialog';
 import type { Entity } from '@backstage/catalog-model';
 
 // ---- Mocks ----
@@ -21,10 +21,10 @@ jest.mock('../../../utils/errorUtils', () => ({
 const mockClient = createMockOpenChoreoClient();
 const mockAlertApi = { post: jest.fn() };
 
-function makeComponent(name: string): Entity {
+function makeEntity(kind: string, name: string): Entity {
   return {
     apiVersion: 'backstage.io/v1alpha1',
-    kind: 'Component',
+    kind,
     metadata: {
       name,
       namespace: 'default',
@@ -34,6 +34,8 @@ function makeComponent(name: string): Entity {
   };
 }
 
+const makeComponent = (name: string) => makeEntity('Component', name);
+
 /** Renders the hook: a button per entity opens the shared dialog. */
 function TestHarness({
   entities,
@@ -42,7 +44,7 @@ function TestHarness({
   entities: Entity[];
   onDeleted?: () => void;
 }) {
-  const { requestDelete, DeleteDialog } = useDeleteComponentDialog({
+  const { requestDelete, DeleteDialog } = useDeleteEntityDialog({
     onDeleted,
   });
 
@@ -79,7 +81,7 @@ function renderHarness(entities: Entity[], onDeleted?: () => void) {
 
 // ---- Tests ----
 
-describe('useDeleteComponentDialog', () => {
+describe('useDeleteEntityDialog', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -130,7 +132,71 @@ describe('useDeleteComponentDialog', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('targets the component whose row requested deletion', async () => {
+  it('deletes a project (system) with the cascade note shown', async () => {
+    const user = userEvent.setup();
+    mockClient.deleteProject.mockResolvedValue(undefined);
+
+    renderHarness([makeEntity('System', 'my-project')]);
+
+    await user.click(screen.getByTestId('open-my-project'));
+
+    expect(
+      screen.getByRole('heading', { name: /delete project/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/All components within this project will also be/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(mockClient.deleteProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ name: 'my-project' }),
+        }),
+      );
+      expect(mockAlertApi.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Project "my-project" has been marked for deletion',
+          severity: 'success',
+        }),
+      );
+    });
+  });
+
+  it('deletes a namespace (domain) via deleteNamespace', async () => {
+    const user = userEvent.setup();
+    mockClient.deleteNamespace.mockResolvedValue(undefined);
+
+    renderHarness([makeEntity('Domain', 'my-ns')]);
+
+    await user.click(screen.getByTestId('open-my-ns'));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(mockClient.deleteNamespace).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('deletes a platform resource kind via deleteResourceDefinition', async () => {
+    const user = userEvent.setup();
+    mockClient.deleteResourceDefinition.mockResolvedValue(undefined);
+
+    renderHarness([makeEntity('Resource', 'my-db')]);
+
+    await user.click(screen.getByTestId('open-my-db'));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(mockClient.deleteResourceDefinition).toHaveBeenCalledWith(
+        'resources',
+        'test-ns',
+        'my-db',
+      );
+    });
+  });
+
+  it('targets the entity whose row requested deletion', async () => {
     const user = userEvent.setup();
     mockClient.deleteComponent.mockResolvedValue(undefined);
 

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteEntityDialog.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteEntityDialog.tsx
@@ -4,37 +4,44 @@ import { Entity } from '@backstage/catalog-model';
 import { openChoreoClientApiRef } from '../../../api/OpenChoreoClientApi';
 import { isForbiddenError, getErrorMessage } from '../../../utils/errorUtils';
 import { DeleteEntityDialog } from '../components';
+import {
+  getEntityDeleteCascadeNote,
+  getEntityDisplayType,
+  performEntityDelete,
+} from './deleteEntityDispatch';
 
-export interface UseDeleteComponentDialogOptions {
+export interface UseDeleteEntityDialogOptions {
   /**
-   * Called after a component has been successfully marked for deletion. Use it
+   * Called after an entity has been successfully marked for deletion. Use it
    * to refresh the surrounding list (the deleted row stays visible with a
    * "marked for deletion" badge until the next catalog sync removes it).
    */
   onDeleted?: (entity: Entity) => void;
 }
 
-export interface UseDeleteComponentDialogResult {
-  /** Open the confirmation dialog for the given component entity. */
+export interface UseDeleteEntityDialogResult {
+  /** Open the confirmation dialog for the given entity. */
   requestDelete: (entity: Entity) => void;
   /** Render once in the surrounding component; controlled internally. */
   DeleteDialog: React.FC;
 }
 
 /**
- * Delete a component from a listing (e.g. the project's Project Contents table)
- * without leaving the page.
+ * Delete an entity from a listing (the catalog "All ..." pages, the project's
+ * Project Contents table, the namespace projects/resources cards) without
+ * leaving the page.
  *
  * Unlike {@link useDeleteEntityMenuItems} — which is bound to a single entity
  * via EntityLayout's context menu and navigates to `/catalog` on success — this
  * hook is list-oriented: a single dialog instance is reused across rows
  * (`requestDelete(entity)` targets one), and on success it calls `onDeleted`
- * (typically a refetch) instead of navigating away. Component-only by design;
- * the project listing has no client-side delete for Resource entities.
+ * (typically an optimistic mark + refetch) instead of navigating away. It
+ * supports every kind {@link performEntityDelete} can dispatch: components,
+ * projects, namespaces and the platform resource kinds.
  */
-export function useDeleteComponentDialog(
-  options?: UseDeleteComponentDialogOptions,
-): UseDeleteComponentDialogResult {
+export function useDeleteEntityDialog(
+  options?: UseDeleteEntityDialogOptions,
+): UseDeleteEntityDialogResult {
   const { onDeleted } = options ?? {};
   const openChoreoClient = useApi(openChoreoClientApiRef);
   const alertApi = useApi(alertApiRef);
@@ -61,14 +68,15 @@ export function useDeleteComponentDialog(
       return;
     }
     const entityName = target.metadata.name;
+    const displayType = getEntityDisplayType(target.kind);
     setDeleting(true);
     setError(null);
 
     try {
-      await openChoreoClient.deleteComponent(target);
+      await performEntityDelete(openChoreoClient, target);
 
       alertApi.post({
-        message: `Component "${entityName}" has been marked for deletion`,
+        message: `${displayType} "${entityName}" has been marked for deletion`,
         severity: 'success',
         display: 'transient',
       });
@@ -77,7 +85,7 @@ export function useDeleteComponentDialog(
       onDeleted?.(target);
     } catch (err) {
       const errorMessage = isForbiddenError(err)
-        ? 'You do not have permission to delete this component. Contact your administrator.'
+        ? `You do not have permission to delete this ${displayType.toLowerCase()}. Contact your administrator.`
         : getErrorMessage(err);
       setError(errorMessage);
       alertApi.post({ message: errorMessage, severity: 'error' });
@@ -90,10 +98,13 @@ export function useDeleteComponentDialog(
     () => (
       <DeleteEntityDialog
         open={target !== null}
-        entityDisplayType="Component"
+        entityDisplayType={target ? getEntityDisplayType(target.kind) : ''}
         entityName={target?.metadata.name ?? ''}
         deleting={deleting}
         error={error}
+        cascadeNote={
+          target ? getEntityDeleteCascadeNote(target.kind) : undefined
+        }
         onClose={handleClose}
         onConfirm={handleConfirm}
       />

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteEntityMenuItems.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteEntityMenuItems.tsx
@@ -1,21 +1,18 @@
 import { useState, useCallback, useMemo } from 'react';
-import { Typography } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { useNavigate } from 'react-router-dom';
 import { useApi, alertApiRef, IconComponent } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
-import {
-  openChoreoClientApiRef,
-  CLUSTER_SCOPED_RESOURCE_KINDS,
-} from '../../../api/OpenChoreoClientApi';
+import { openChoreoClientApiRef } from '../../../api/OpenChoreoClientApi';
 import { isForbiddenError, getErrorMessage } from '../../../utils/errorUtils';
 import { isMarkedForDeletion } from '../utils';
 import { DeleteEntityDialog } from '../components';
 import {
-  isSupportedKind,
-  mapKindToApiKind,
-} from '../../ResourceDefinition/utils';
+  getEntityDeleteCascadeNote,
+  getEntityDisplayType,
+  isDeletableEntityKind,
+  performEntityDelete,
+} from './deleteEntityDispatch';
 
 interface ExtraContextMenuItem {
   title: string;
@@ -35,34 +32,6 @@ export interface DeletePermissionInfo {
   loading: boolean;
   deniedTooltip: string;
 }
-
-/** Human-friendly display names for all deletable entity kinds */
-const KIND_DISPLAY_NAMES: Record<string, string> = {
-  component: 'Component',
-  resource: 'Resource',
-  system: 'Project',
-  domain: 'Namespace',
-  environment: 'Environment',
-  observabilityalertsnotificationchannel: 'Notification Channel',
-  dataplane: 'Dataplane',
-  clusterdataplane: 'Cluster Data Plane',
-  buildplane: 'Build Plane',
-  clusterbuildplane: 'Cluster Build Plane',
-  workflowplane: 'Workflow Plane',
-  clusterworkflowplane: 'Cluster Workflow Plane',
-  observabilityplane: 'Observability Plane',
-  clusterobservabilityplane: 'Cluster Observability Plane',
-  deploymentpipeline: 'Deployment Pipeline',
-  componenttype: 'Component Type',
-  resourcetype: 'Resource Type',
-  clustercomponenttype: 'Cluster Component Type',
-  clusterresourcetype: 'Cluster Resource Type',
-  traittype: 'Trait Type',
-  clustertraittype: 'Cluster Trait Type',
-  workflow: 'Workflow',
-  clusterworkflow: 'Cluster Workflow',
-  componentworkflow: 'Component Workflow',
-};
 
 /**
  * Hook that provides delete menu items for EntityLayout's extraContextMenuItems.
@@ -86,17 +55,11 @@ export function useDeleteEntityMenuItems(
 
   const entityKind = entity.kind.toLowerCase();
   const entityName = entity.metadata.name;
-  const isComponent = entityKind === 'component';
-  const isProject = entityKind === 'system';
-  const isDomain = entityKind === 'domain';
-  const isPlatformResource = isSupportedKind(entityKind);
-
-  const entityDisplayType = KIND_DISPLAY_NAMES[entityKind] ?? entityKind;
+  const entityDisplayType = getEntityDisplayType(entityKind);
 
   const alreadyMarkedForDeletion = isMarkedForDeletion(entity);
-  const isDeletableKind =
-    isComponent || isProject || isDomain || isPlatformResource;
-  const canDelete = isDeletableKind && !alreadyMarkedForDeletion;
+  const canDelete =
+    isDeletableEntityKind(entityKind) && !alreadyMarkedForDeletion;
 
   const handleOpenDialog = useCallback(() => {
     setDialogOpen(true);
@@ -115,31 +78,7 @@ export function useDeleteEntityMenuItems(
     setError(null);
 
     try {
-      if (isComponent) {
-        await openChoreoClient.deleteComponent(entity);
-      } else if (isProject) {
-        await openChoreoClient.deleteProject(entity);
-      } else if (isDomain) {
-        await openChoreoClient.deleteNamespace(entity);
-      } else if (isPlatformResource) {
-        const apiKind = mapKindToApiKind(entityKind);
-        const namespace =
-          entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
-
-        if (!CLUSTER_SCOPED_RESOURCE_KINDS.has(apiKind) && !namespace) {
-          throw new Error(
-            `Missing namespace annotation for ${entityDisplayType.toLowerCase()} "${entityName}"`,
-          );
-        }
-
-        await openChoreoClient.deleteResourceDefinition(
-          apiKind,
-          namespace ?? '',
-          entityName,
-        );
-      } else {
-        throw new Error(`Unsupported entity kind for deletion: ${entityKind}`);
-      }
+      await performEntityDelete(openChoreoClient, entity);
 
       alertApi.post({
         message: `${entityDisplayType} "${entityName}" has been marked for deletion`,
@@ -163,13 +102,8 @@ export function useDeleteEntityMenuItems(
     }
   }, [
     entity,
-    entityKind,
     entityName,
     entityDisplayType,
-    isComponent,
-    isProject,
-    isDomain,
-    isPlatformResource,
     openChoreoClient,
     alertApi,
     navigate,
@@ -207,24 +141,10 @@ export function useDeleteEntityMenuItems(
     ];
   }, [canDelete, entityDisplayType, handleOpenDialog, deletePermission]);
 
-  const cascadeNote = useMemo(() => {
-    if (isProject) {
-      return (
-        <Typography variant="h5">
-          Note: All components within this project will also be deleted.
-        </Typography>
-      );
-    }
-    if (isDomain) {
-      return (
-        <Typography variant="h5">
-          Note: All projects and components within this namespace will also be
-          deleted.
-        </Typography>
-      );
-    }
-    return undefined;
-  }, [isProject, isDomain]);
+  const cascadeNote = useMemo(
+    () => getEntityDeleteCascadeNote(entityKind),
+    [entityKind],
+  );
 
   const DeleteConfirmationDialog: React.FC = useCallback(
     () => (

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteEntityMenuItems.tsx
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/useDeleteEntityMenuItems.tsx
@@ -1,13 +1,5 @@
 import { useState, useCallback, useMemo } from 'react';
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  Typography,
-  CircularProgress,
-} from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { useNavigate } from 'react-router-dom';
 import { useApi, alertApiRef, IconComponent } from '@backstage/core-plugin-api';
@@ -18,8 +10,8 @@ import {
   CLUSTER_SCOPED_RESOURCE_KINDS,
 } from '../../../api/OpenChoreoClientApi';
 import { isForbiddenError, getErrorMessage } from '../../../utils/errorUtils';
-import { useStyles } from '../styles';
 import { isMarkedForDeletion } from '../utils';
+import { DeleteEntityDialog } from '../components';
 import {
   isSupportedKind,
   mapKindToApiKind,
@@ -91,7 +83,6 @@ export function useDeleteEntityMenuItems(
   const openChoreoClient = useApi(openChoreoClientApiRef);
   const alertApi = useApi(alertApiRef);
   const navigate = useNavigate();
-  const classes = useStyles();
 
   const entityKind = entity.kind.toLowerCase();
   const entityName = entity.metadata.name;
@@ -216,82 +207,45 @@ export function useDeleteEntityMenuItems(
     ];
   }, [canDelete, entityDisplayType, handleOpenDialog, deletePermission]);
 
+  const cascadeNote = useMemo(() => {
+    if (isProject) {
+      return (
+        <Typography variant="h5">
+          Note: All components within this project will also be deleted.
+        </Typography>
+      );
+    }
+    if (isDomain) {
+      return (
+        <Typography variant="h5">
+          Note: All projects and components within this namespace will also be
+          deleted.
+        </Typography>
+      );
+    }
+    return undefined;
+  }, [isProject, isDomain]);
+
   const DeleteConfirmationDialog: React.FC = useCallback(
     () => (
-      <Dialog
+      <DeleteEntityDialog
         open={dialogOpen}
+        entityDisplayType={entityDisplayType}
+        entityName={entityName}
+        deleting={deleting}
+        error={error}
+        cascadeNote={cascadeNote}
         onClose={handleCloseDialog}
-        maxWidth="sm"
-        fullWidth
-        aria-labelledby="delete-entity-dialog-title"
-      >
-        <DialogTitle id="delete-entity-dialog-title" disableTypography>
-          <Typography variant="h4">Delete {entityDisplayType}</Typography>
-        </DialogTitle>
-
-        <DialogContent className={classes.deleteDialogContent}>
-          <Typography variant="body1">
-            Are you sure you want to delete the{' '}
-            {entityDisplayType.toLowerCase()}{' '}
-            <span className={classes.entityName}>{entityName}</span>?
-          </Typography>
-
-          <Typography variant="body2" className={classes.warningText}>
-            This action cannot be undone. The {entityDisplayType.toLowerCase()}{' '}
-            and all its associated resources will be permanently deleted.
-          </Typography>
-
-          {isProject && (
-            <Typography variant="h5">
-              Note: All components within this project will also be deleted.
-            </Typography>
-          )}
-
-          {isDomain && (
-            <Typography variant="h5">
-              Note: All projects and components within this namespace will also
-              be deleted.
-            </Typography>
-          )}
-
-          {error && (
-            <Typography variant="body2" color="error">
-              Error: {error}
-            </Typography>
-          )}
-        </DialogContent>
-
-        <DialogActions>
-          <Button
-            onClick={handleCloseDialog}
-            disabled={deleting}
-            variant="contained"
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={handleConfirmDelete}
-            className={classes.deleteButton}
-            variant="outlined"
-            disabled={deleting}
-            startIcon={
-              deleting ? <CircularProgress size={16} color="inherit" /> : null
-            }
-          >
-            {deleting ? 'Deleting...' : 'Delete'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onConfirm={handleConfirmDelete}
+      />
     ),
     [
       dialogOpen,
       handleCloseDialog,
       handleConfirmDelete,
-      classes,
       entityDisplayType,
       entityName,
-      isProject,
-      isDomain,
+      cascadeNote,
       error,
       deleting,
     ],

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/usePendingDeletionOverlay.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/usePendingDeletionOverlay.ts
@@ -1,9 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Entity } from '@backstage/catalog-model';
-import {
-  entityDeletionKey,
-  markEntityForDeletionLocally,
-} from '../utils/deletionUtils';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { markEntityForDeletionLocally } from '../utils/deletionUtils';
 
 export interface UsePendingDeletionOverlayResult {
   /** Record that this entity was deleted from the listing this session. */
@@ -31,7 +28,7 @@ export function usePendingDeletionOverlay(): UsePendingDeletionOverlayResult {
   const markDeleted = useCallback((entity: Entity) => {
     setPendingDeletions(prev => {
       const next = new Set(prev);
-      next.add(entityDeletionKey(entity));
+      next.add(stringifyEntityRef(entity));
       return next;
     });
   }, []);
@@ -41,7 +38,7 @@ export function usePendingDeletionOverlay(): UsePendingDeletionOverlayResult {
       pendingDeletions.size === 0
         ? entities
         : entities.map(entity =>
-            pendingDeletions.has(entityDeletionKey(entity))
+            pendingDeletions.has(stringifyEntityRef(entity))
               ? markEntityForDeletionLocally(entity)
               : entity,
           ),

--- a/plugins/openchoreo/src/components/DeleteEntity/hooks/usePendingDeletionOverlay.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/hooks/usePendingDeletionOverlay.ts
@@ -1,0 +1,52 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Entity } from '@backstage/catalog-model';
+import {
+  entityDeletionKey,
+  markEntityForDeletionLocally,
+} from '../utils/deletionUtils';
+
+export interface UsePendingDeletionOverlayResult {
+  /** Record that this entity was deleted from the listing this session. */
+  markDeleted: (entity: Entity) => void;
+  /** Re-map a fetched entity list, marking pending deletions. */
+  overlay: (entities: Entity[]) => Entity[];
+}
+
+/**
+ * Tracks entities deleted from a listing this session and overlays the
+ * "marked for deletion" annotation on top of fetched rows until the catalog
+ * catches up.
+ *
+ * A delete only updates the control plane; the catalog entity (and therefore
+ * the listing row) lags behind by a sync/event, so without this the row would
+ * briefly look alive — and clickable — after a confirmed delete. Pending
+ * deletions are keyed by entity identity, not object reference, so overlaying
+ * survives refetches.
+ */
+export function usePendingDeletionOverlay(): UsePendingDeletionOverlayResult {
+  const [pendingDeletions, setPendingDeletions] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const markDeleted = useCallback((entity: Entity) => {
+    setPendingDeletions(prev => {
+      const next = new Set(prev);
+      next.add(entityDeletionKey(entity));
+      return next;
+    });
+  }, []);
+
+  const overlay = useCallback(
+    (entities: Entity[]) =>
+      pendingDeletions.size === 0
+        ? entities
+        : entities.map(entity =>
+            pendingDeletions.has(entityDeletionKey(entity))
+              ? markEntityForDeletionLocally(entity)
+              : entity,
+          ),
+    [pendingDeletions],
+  );
+
+  return useMemo(() => ({ markDeleted, overlay }), [markDeleted, overlay]);
+}

--- a/plugins/openchoreo/src/components/DeleteEntity/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/index.ts
@@ -1,12 +1,20 @@
 // Hooks
 export {
   useDeleteEntityMenuItems,
+  useDeleteComponentDialog,
   useEntityExistsCheck,
   type DeletePermissionInfo,
+  type UseDeleteComponentDialogOptions,
+  type UseDeleteComponentDialogResult,
 } from './hooks';
 
 // Components
-export { DeletionBadge, DeletionWarning } from './components';
+export {
+  DeletionBadge,
+  DeletionWarning,
+  DeleteEntityDialog,
+} from './components';
+export type { DeleteEntityDialogProps } from './components';
 
 // Utils
 export { isMarkedForDeletion, getDeletionTimestamp } from './utils';

--- a/plugins/openchoreo/src/components/DeleteEntity/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/index.ts
@@ -1,11 +1,14 @@
 // Hooks
 export {
   useDeleteEntityMenuItems,
-  useDeleteComponentDialog,
+  useDeleteEntityDialog,
+  usePendingDeletionOverlay,
   useEntityExistsCheck,
+  getEntityDisplayType,
+  isDeletableEntityKind,
   type DeletePermissionInfo,
-  type UseDeleteComponentDialogOptions,
-  type UseDeleteComponentDialogResult,
+  type UseDeleteEntityDialogOptions,
+  type UseDeleteEntityDialogResult,
 } from './hooks';
 
 // Components
@@ -13,11 +16,20 @@ export {
   DeletionBadge,
   DeletionWarning,
   DeleteEntityDialog,
+  RowDeleteButton,
 } from './components';
-export type { DeleteEntityDialogProps } from './components';
+export type {
+  DeleteEntityDialogProps,
+  RowDeleteButtonProps,
+} from './components';
 
 // Utils
-export { isMarkedForDeletion, getDeletionTimestamp } from './utils';
+export {
+  isMarkedForDeletion,
+  getDeletionTimestamp,
+  entityDeletionKey,
+  markEntityForDeletionLocally,
+} from './utils';
 
 // Types
 export type { EntityStatus, EntityExistsCheckResult } from './types';

--- a/plugins/openchoreo/src/components/DeleteEntity/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/index.ts
@@ -27,7 +27,6 @@ export type {
 export {
   isMarkedForDeletion,
   getDeletionTimestamp,
-  entityDeletionKey,
   markEntityForDeletionLocally,
 } from './utils';
 

--- a/plugins/openchoreo/src/components/DeleteEntity/utils/deletionUtils.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/utils/deletionUtils.ts
@@ -15,3 +15,31 @@ export function isMarkedForDeletion(entity: Entity): boolean {
 export function getDeletionTimestamp(entity: Entity): string | undefined {
   return entity.metadata.annotations?.[CHOREO_ANNOTATIONS.DELETION_TIMESTAMP];
 }
+
+/** Stable identity for a listing row, independent of object reference. */
+export function entityDeletionKey(entity: Entity): string {
+  return `${entity.kind.toLowerCase()}:${
+    entity.metadata.namespace || 'default'
+  }/${entity.metadata.name}`;
+}
+
+/**
+ * Returns a copy of the entity carrying the deletion-timestamp annotation,
+ * so listings can show the "marked for deletion" badge immediately after a
+ * delete — before the catalog re-ingests the deletion from the control plane.
+ */
+export function markEntityForDeletionLocally(entity: Entity): Entity {
+  if (isMarkedForDeletion(entity)) {
+    return entity;
+  }
+  return {
+    ...entity,
+    metadata: {
+      ...entity.metadata,
+      annotations: {
+        ...(entity.metadata.annotations ?? {}),
+        [CHOREO_ANNOTATIONS.DELETION_TIMESTAMP]: new Date().toISOString(),
+      },
+    },
+  };
+}

--- a/plugins/openchoreo/src/components/DeleteEntity/utils/deletionUtils.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/utils/deletionUtils.ts
@@ -16,13 +16,6 @@ export function getDeletionTimestamp(entity: Entity): string | undefined {
   return entity.metadata.annotations?.[CHOREO_ANNOTATIONS.DELETION_TIMESTAMP];
 }
 
-/** Stable identity for a listing row, independent of object reference. */
-export function entityDeletionKey(entity: Entity): string {
-  return `${entity.kind.toLowerCase()}:${
-    entity.metadata.namespace || 'default'
-  }/${entity.metadata.name}`;
-}
-
 /**
  * Returns a copy of the entity carrying the deletion-timestamp annotation,
  * so listings can show the "marked for deletion" badge immediately after a

--- a/plugins/openchoreo/src/components/DeleteEntity/utils/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/utils/index.ts
@@ -1,6 +1,5 @@
 export {
   isMarkedForDeletion,
   getDeletionTimestamp,
-  entityDeletionKey,
   markEntityForDeletionLocally,
 } from './deletionUtils';

--- a/plugins/openchoreo/src/components/DeleteEntity/utils/index.ts
+++ b/plugins/openchoreo/src/components/DeleteEntity/utils/index.ts
@@ -1,1 +1,6 @@
-export { isMarkedForDeletion, getDeletionTimestamp } from './deletionUtils';
+export {
+  isMarkedForDeletion,
+  getDeletionTimestamp,
+  entityDeletionKey,
+  markEntityForDeletionLocally,
+} from './deletionUtils';

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.test.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.test.tsx
@@ -27,6 +27,21 @@ jest.mock('./styles', () => ({
   }),
 }));
 
+// The card is the integration under test; the delete stack has its own suite.
+jest.mock('../../DeleteEntity', () => ({
+  isMarkedForDeletion: () => false,
+  DeletionBadge: () => null,
+  RowDeleteButton: () => null,
+  useDeleteEntityDialog: () => ({
+    requestDelete: jest.fn(),
+    DeleteDialog: () => null,
+  }),
+  usePendingDeletionOverlay: () => ({
+    markDeleted: jest.fn(),
+    overlay: (entities: Entity[]) => entities,
+  }),
+}));
+
 const namespace = {
   apiVersion: 'backstage.io/v1alpha1',
   kind: 'Domain',

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Link, Table, TableColumn } from '@backstage/core-components';
 import { useApp } from '@backstage/core-plugin-api';
 import { Entity, RELATION_HAS_PART } from '@backstage/catalog-model';
@@ -6,7 +7,13 @@ import { Box, Button, Tooltip, Typography } from '@material-ui/core';
 import { Skeleton } from '@openchoreo/backstage-design-system';
 import AddIcon from '@material-ui/icons/Add';
 import { useNavigate } from 'react-router-dom';
-import { isMarkedForDeletion, DeletionBadge } from '../../DeleteEntity';
+import {
+  isMarkedForDeletion,
+  DeletionBadge,
+  RowDeleteButton,
+  useDeleteEntityDialog,
+  usePendingDeletionOverlay,
+} from '../../DeleteEntity';
 import {
   useRelatedEntitiesQuery,
   useScopedProjectCreatePermission,
@@ -29,6 +36,18 @@ export const NamespaceProjectsCard = () => {
     createDeniedTooltip,
   } = useScopedProjectCreatePermission();
   const navigate = useNavigate();
+
+  // Row-level project delete. The related-entities list has no refetch, so
+  // deleted rows are overlaid with the deletion mark until the catalog sync
+  // drops them.
+  const { markDeleted, overlay } = usePendingDeletionOverlay();
+  const { requestDelete, DeleteDialog } = useDeleteEntityDialog({
+    onDeleted: markDeleted,
+  });
+  const displayedSystems = useMemo(
+    () => overlay(systems || []),
+    [systems, overlay],
+  );
 
   const columns: TableColumn<Entity>[] = [
     {
@@ -69,6 +88,15 @@ export const NamespaceProjectsCard = () => {
         </Typography>
       ),
     },
+    {
+      title: '',
+      sorting: false,
+      width: '5%',
+      cellStyle: { textAlign: 'right', paddingRight: 8 },
+      render: (row: Entity) => (
+        <RowDeleteButton entity={row} onDelete={requestDelete} />
+      ),
+    },
   ];
 
   // While loading, render skeleton rows on the card's paper background instead
@@ -90,7 +118,7 @@ export const NamespaceProjectsCard = () => {
       <Table
         title="Has Projects"
         columns={loading ? skeletonColumns : columns}
-        data={loading ? skeletonRows : systems || []}
+        data={loading ? skeletonRows : displayedSystems}
         isLoading={false}
         onRowClick={(event, rowData) => {
           if (
@@ -153,6 +181,7 @@ export const NamespaceProjectsCard = () => {
           ),
         }}
       />
+      <DeleteDialog />
     </Box>
   );
 };

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceResourcesCard/NamespaceResourcesCard.test.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceResourcesCard/NamespaceResourcesCard.test.tsx
@@ -22,6 +22,21 @@ jest.mock('./styles', () => ({
   useNamespaceResourcesCardStyles: () => ({ cardWrapper: '' }),
 }));
 
+// The card is the integration under test; the delete stack has its own suite.
+jest.mock('../../DeleteEntity', () => ({
+  isMarkedForDeletion: () => false,
+  DeletionBadge: () => null,
+  RowDeleteButton: () => null,
+  useDeleteEntityDialog: () => ({
+    requestDelete: jest.fn(),
+    DeleteDialog: () => null,
+  }),
+  usePendingDeletionOverlay: () => ({
+    markDeleted: jest.fn(),
+    overlay: (entities: Entity[]) => entities,
+  }),
+}));
+
 const namespace = {
   apiVersion: 'backstage.io/v1alpha1',
   kind: 'Domain',

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceResourcesCard/NamespaceResourcesCard.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceResourcesCard/NamespaceResourcesCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Link, Table, TableColumn } from '@backstage/core-components';
 import { useApp } from '@backstage/core-plugin-api';
 import { Entity, RELATION_HAS_PART } from '@backstage/catalog-model';
@@ -6,6 +7,13 @@ import { Box, Typography } from '@material-ui/core';
 import { Skeleton } from '@openchoreo/backstage-design-system';
 import { useRelatedEntitiesQuery } from '@openchoreo/backstage-plugin-react';
 import { useNavigate } from 'react-router-dom';
+import {
+  isMarkedForDeletion,
+  DeletionBadge,
+  RowDeleteButton,
+  useDeleteEntityDialog,
+  usePendingDeletionOverlay,
+} from '../../DeleteEntity';
 import { shouldNavigateOnRowClick } from '../../../utils/shouldNavigateOnRowClick';
 import { useNamespaceResourcesCardStyles } from './styles';
 
@@ -28,8 +36,19 @@ export const NamespaceResourcesCard = () => {
     type: RELATION_HAS_PART,
   });
 
-  const resources = (entities || []).filter(
-    e => e.kind.toLowerCase() !== 'system',
+  // Row-level delete (components and resources; RowDeleteButton hides itself
+  // for non-deletable kinds like `api`). The related-entities list has no
+  // refetch, so deleted rows are overlaid with the deletion mark until the
+  // catalog sync drops them.
+  const { markDeleted, overlay } = usePendingDeletionOverlay();
+  const { requestDelete, DeleteDialog } = useDeleteEntityDialog({
+    onDeleted: markDeleted,
+  });
+
+  const resources = useMemo(
+    () =>
+      overlay((entities || []).filter(e => e.kind.toLowerCase() !== 'system')),
+    [entities, overlay],
   );
 
   const columns: TableColumn<Entity>[] = [
@@ -39,16 +58,26 @@ export const NamespaceResourcesCard = () => {
       highlight: true,
       render: (row: Entity) => {
         const Icon = app.getSystemIcon(`kind:${row.kind.toLowerCase()}`);
+        const name = row.metadata.title || row.metadata.name;
         return (
           <Box display="flex" alignItems="center" gridGap={6}>
             {Icon && <Icon fontSize="small" />}
-            <Link
-              to={`/catalog/${
-                row.metadata.namespace || 'default'
-              }/${row.kind.toLowerCase()}/${row.metadata.name}`}
-            >
-              {row.metadata.title || row.metadata.name}
-            </Link>
+            {isMarkedForDeletion(row) ? (
+              <>
+                <Typography variant="body2" color="textSecondary">
+                  {name}
+                </Typography>
+                <DeletionBadge />
+              </>
+            ) : (
+              <Link
+                to={`/catalog/${
+                  row.metadata.namespace || 'default'
+                }/${row.kind.toLowerCase()}/${row.metadata.name}`}
+              >
+                {name}
+              </Link>
+            )}
           </Box>
         );
       },
@@ -67,6 +96,15 @@ export const NamespaceResourcesCard = () => {
         <Typography variant="body2">
           {row.metadata.description || '-'}
         </Typography>
+      ),
+    },
+    {
+      title: '',
+      sorting: false,
+      width: '5%',
+      cellStyle: { textAlign: 'right', paddingRight: 8 },
+      render: (row: Entity) => (
+        <RowDeleteButton entity={row} onDelete={requestDelete} />
       ),
     },
   ];
@@ -93,7 +131,13 @@ export const NamespaceResourcesCard = () => {
         data={loading ? skeletonRows : resources}
         isLoading={false}
         onRowClick={(event, rowData) => {
-          if (loading || !rowData || !shouldNavigateOnRowClick(event)) return;
+          if (
+            loading ||
+            !rowData ||
+            !shouldNavigateOnRowClick(event) ||
+            isMarkedForDeletion(rowData)
+          )
+            return;
           const ns = rowData.metadata.namespace || 'default';
           navigate(
             `/catalog/${ns}/${rowData.kind.toLowerCase()}/${
@@ -119,6 +163,7 @@ export const NamespaceResourcesCard = () => {
         }}
         style={{ minWidth: 0, width: '100%', height: 'calc(100% - 10px)' }}
       />
+      <DeleteDialog />
     </Box>
   );
 };

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.test.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { mockSystemEntity } from '@openchoreo/test-utils';
@@ -66,15 +66,19 @@ jest.mock('@backstage/core-components', () => ({
 }));
 
 const mockRequestDelete = jest.fn();
+let capturedDialogOptions: { onDeleted?: (entity: any) => void } = {};
 jest.mock('../../DeleteEntity', () => ({
   isMarkedForDeletion: () => false,
   DeletionBadge: () => null,
   RowDeleteButton: () => null,
   markEntityForDeletionLocally: (entity: any) => entity,
-  useDeleteEntityDialog: () => ({
-    requestDelete: mockRequestDelete,
-    DeleteDialog: () => null,
-  }),
+  useDeleteEntityDialog: (options: any) => {
+    capturedDialogOptions = options;
+    return {
+      requestDelete: mockRequestDelete,
+      DeleteDialog: () => null,
+    };
+  },
 }));
 jest.mock('../../../utils/errorUtils', () => ({
   isForbiddenError: () => false,
@@ -202,6 +206,26 @@ describe('ProjectContentsCard', () => {
 
     fireEvent.click(screen.getByLabelText('Refresh project contents'));
     expect(pageRefetch).toHaveBeenCalledTimes(1);
+    expect(facetsRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches the facets when a row delete completes', () => {
+    const facetsRefetch = jest.fn().mockResolvedValue(undefined);
+    const deleted = item('component', 'snip-api', 'deployment/service');
+    setup([deleted]);
+    mockUseProjectContentFacets.mockReturnValue({
+      counts: { all: 1, component: 1, resource: 0 },
+      typesByKind: { component: ['deployment/service'], resource: [] },
+      loading: false,
+      isRefetching: false,
+      refetch: facetsRefetch,
+    });
+
+    renderCard();
+
+    act(() => {
+      capturedDialogOptions.onDeleted?.(deleted.entity);
+    });
     expect(facetsRefetch).toHaveBeenCalledTimes(1);
   });
 

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.test.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.test.tsx
@@ -65,9 +65,14 @@ jest.mock('@backstage/core-components', () => ({
   TableColumn: {},
 }));
 
+const mockRequestDelete = jest.fn();
 jest.mock('../../DeleteEntity', () => ({
   isMarkedForDeletion: () => false,
   DeletionBadge: () => null,
+  useDeleteComponentDialog: () => ({
+    requestDelete: mockRequestDelete,
+    DeleteDialog: () => null,
+  }),
 }));
 jest.mock('../../../utils/errorUtils', () => ({
   isForbiddenError: () => false,

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.test.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.test.tsx
@@ -70,8 +70,6 @@ jest.mock('../../DeleteEntity', () => ({
   isMarkedForDeletion: () => false,
   DeletionBadge: () => null,
   RowDeleteButton: () => null,
-  entityDeletionKey: (entity: any) =>
-    `${entity.kind}:${entity.metadata.namespace}/${entity.metadata.name}`,
   markEntityForDeletionLocally: (entity: any) => entity,
   useDeleteEntityDialog: () => ({
     requestDelete: mockRequestDelete,

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.test.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.test.tsx
@@ -69,7 +69,11 @@ const mockRequestDelete = jest.fn();
 jest.mock('../../DeleteEntity', () => ({
   isMarkedForDeletion: () => false,
   DeletionBadge: () => null,
-  useDeleteComponentDialog: () => ({
+  RowDeleteButton: () => null,
+  entityDeletionKey: (entity: any) =>
+    `${entity.kind}:${entity.metadata.namespace}/${entity.metadata.name}`,
+  markEntityForDeletionLocally: (entity: any) => entity,
+  useDeleteEntityDialog: () => ({
     requestDelete: mockRequestDelete,
     DeleteDialog: () => null,
   }),

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import { Table } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useNavigate } from 'react-router-dom';
@@ -35,7 +35,6 @@ import {
   type ProjectContentsOrderBy,
 } from '../hooks';
 import {
-  entityDeletionKey,
   isMarkedForDeletion,
   markEntityForDeletionLocally,
   useDeleteEntityDialog,
@@ -139,7 +138,7 @@ export const ProjectContentsCard = () => {
   const handleDeleted = useCallback((deletedEntity: Entity) => {
     setPendingDeletions(prev => {
       const next = new Set(prev);
-      next.add(entityDeletionKey(deletedEntity));
+      next.add(stringifyEntityRef(deletedEntity));
       return next;
     });
     setRefreshToken(token => token + 1);
@@ -236,7 +235,7 @@ export const ProjectContentsCard = () => {
       pendingDeletions.size === 0
         ? page.items
         : page.items.map(item =>
-            pendingDeletions.has(entityDeletionKey(item.entity))
+            pendingDeletions.has(stringifyEntityRef(item.entity))
               ? withOptimisticDeletion(item)
               : item,
           ),

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.tsx
@@ -1,7 +1,16 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Entity } from '@backstage/catalog-model';
 import { Table } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useNavigate } from 'react-router-dom';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import {
   Box,
   IconButton,
@@ -26,7 +35,10 @@ import {
   type ProjectContentKind,
   type ProjectContentsOrderBy,
 } from '../hooks';
-import { isMarkedForDeletion } from '../../DeleteEntity';
+import {
+  isMarkedForDeletion,
+  useDeleteComponentDialog,
+} from '../../DeleteEntity';
 import { shouldNavigateOnRowClick } from '../../../utils/shouldNavigateOnRowClick';
 import {
   MultiSelectFilter,
@@ -42,6 +54,37 @@ import { useProjectContentsCardStyles } from './styles';
 
 const PAGE_SIZE = 5;
 const KIND_ORDER: ProjectContentKind[] = ['component', 'resource'];
+
+/** Stable identity for a content row, independent of object reference. */
+const entityKey = (entity: Entity): string =>
+  `${entity.kind.toLowerCase()}:${entity.metadata.namespace || 'default'}/${
+    entity.metadata.name
+  }`;
+
+/**
+ * Mark a row as deleted in the UI immediately, before the catalog re-ingests
+ * the deletion. The listing reads "marked for deletion" from the catalog
+ * entity's annotation, but a delete only updates the control plane — the
+ * catalog lags by a sync/event. We inject the annotation locally so the badge
+ * shows right away (the entity page gets the same effect by querying the OC
+ * API directly).
+ */
+const withOptimisticDeletion = (item: ProjectContentItem): ProjectContentItem =>
+  isMarkedForDeletion(item.entity)
+    ? item
+    : {
+        ...item,
+        entity: {
+          ...item.entity,
+          metadata: {
+            ...item.entity.metadata,
+            annotations: {
+              ...(item.entity.metadata.annotations ?? {}),
+              [CHOREO_ANNOTATIONS.DELETION_TIMESTAMP]: new Date().toISOString(),
+            },
+          },
+        },
+      };
 
 function useDebouncedValue<T>(value: T, delayMs: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -72,6 +115,13 @@ export const ProjectContentsCard = () => {
   // Drives the Refresh icon's spin + disabled state while an explicit refresh
   // (page rows + facet counts) is in flight.
   const [isRefreshing, setIsRefreshing] = useState(false);
+  // Bumped after a component is marked for deletion to re-fetch the page.
+  const [refreshToken, setRefreshToken] = useState(0);
+  // Rows deleted from the listing this session — marked optimistically until
+  // the catalog catches up (keyed by entity identity, not object reference).
+  const [pendingDeletions, setPendingDeletions] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const resetToFirstPage = () => {
     setCursor(undefined);
@@ -94,6 +144,22 @@ export const ProjectContentsCard = () => {
     orderDir: sort.dir,
     cursor,
     limit: PAGE_SIZE,
+    refreshToken,
+  });
+
+  // Row-level component delete. On success we (1) optimistically mark the row
+  // so the "marked for deletion" badge shows immediately, and (2) re-fetch so
+  // the row eventually drops off once the catalog removes the component.
+  const handleDeleted = useCallback((deletedEntity: Entity) => {
+    setPendingDeletions(prev => {
+      const next = new Set(prev);
+      next.add(entityKey(deletedEntity));
+      return next;
+    });
+    setRefreshToken(token => token + 1);
+  }, []);
+  const { requestDelete, DeleteDialog } = useDeleteComponentDialog({
+    onDeleted: handleDeleted,
   });
 
   const {
@@ -167,8 +233,28 @@ export const ProjectContentsCard = () => {
         canViewBindings,
         pipelineError,
         environmentsLoading,
+        onDeleteComponent: item => requestDelete(item.entity),
       }),
-    [pipelineEnvironments, canViewBindings, pipelineError, environmentsLoading],
+    [
+      pipelineEnvironments,
+      canViewBindings,
+      pipelineError,
+      environmentsLoading,
+      requestDelete,
+    ],
+  );
+
+  // Apply optimistic deletion marks on top of the fetched page.
+  const displayItems = useMemo(
+    () =>
+      pendingDeletions.size === 0
+        ? page.items
+        : page.items.map(item =>
+            pendingDeletions.has(entityKey(item.entity))
+              ? withOptimisticDeletion(item)
+              : item,
+          ),
+    [page.items, pendingDeletions],
   );
 
   // --- Handlers ----------------------------------------------------------
@@ -350,7 +436,7 @@ export const ProjectContentsCard = () => {
           >
             <Table<ProjectContentItem>
               columns={columns}
-              data={page.items}
+              data={displayItems}
               isLoading={false}
               onOrderChange={handleOrderChange}
               onRowClick={(event, rowData) => {
@@ -421,6 +507,8 @@ export const ProjectContentsCard = () => {
           )}
         </>
       )}
+
+      <DeleteDialog />
     </Box>
   );
 };

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.tsx
@@ -133,16 +133,22 @@ export const ProjectContentsCard = () => {
 
   // Row-level delete (components and resources). On success we (1)
   // optimistically mark the row so the "marked for deletion" badge shows
-  // immediately, and (2) re-fetch so the row eventually drops off once the
-  // catalog removes the entity.
-  const handleDeleted = useCallback((deletedEntity: Entity) => {
-    setPendingDeletions(prev => {
-      const next = new Set(prev);
-      next.add(stringifyEntityRef(deletedEntity));
-      return next;
-    });
-    setRefreshToken(token => token + 1);
-  }, []);
+  // immediately, and (2) re-fetch the page and the facets (count badges,
+  // kind/type filter options) so both eventually reflect the removal once
+  // the catalog drops the entity.
+  const refetchFacets = facets.refetch;
+  const handleDeleted = useCallback(
+    (deletedEntity: Entity) => {
+      setPendingDeletions(prev => {
+        const next = new Set(prev);
+        next.add(stringifyEntityRef(deletedEntity));
+        return next;
+      });
+      setRefreshToken(token => token + 1);
+      refetchFacets();
+    },
+    [refetchFacets],
+  );
   const { requestDelete, DeleteDialog } = useDeleteEntityDialog({
     onDeleted: handleDeleted,
   });

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/ProjectContentsCard.tsx
@@ -10,7 +10,6 @@ import { Entity } from '@backstage/catalog-model';
 import { Table } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useNavigate } from 'react-router-dom';
-import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import {
   Box,
   IconButton,
@@ -36,8 +35,10 @@ import {
   type ProjectContentsOrderBy,
 } from '../hooks';
 import {
+  entityDeletionKey,
   isMarkedForDeletion,
-  useDeleteComponentDialog,
+  markEntityForDeletionLocally,
+  useDeleteEntityDialog,
 } from '../../DeleteEntity';
 import { shouldNavigateOnRowClick } from '../../../utils/shouldNavigateOnRowClick';
 import {
@@ -55,12 +56,6 @@ import { useProjectContentsCardStyles } from './styles';
 const PAGE_SIZE = 5;
 const KIND_ORDER: ProjectContentKind[] = ['component', 'resource'];
 
-/** Stable identity for a content row, independent of object reference. */
-const entityKey = (entity: Entity): string =>
-  `${entity.kind.toLowerCase()}:${entity.metadata.namespace || 'default'}/${
-    entity.metadata.name
-  }`;
-
 /**
  * Mark a row as deleted in the UI immediately, before the catalog re-ingests
  * the deletion. The listing reads "marked for deletion" from the catalog
@@ -69,22 +64,12 @@ const entityKey = (entity: Entity): string =>
  * shows right away (the entity page gets the same effect by querying the OC
  * API directly).
  */
-const withOptimisticDeletion = (item: ProjectContentItem): ProjectContentItem =>
-  isMarkedForDeletion(item.entity)
-    ? item
-    : {
-        ...item,
-        entity: {
-          ...item.entity,
-          metadata: {
-            ...item.entity.metadata,
-            annotations: {
-              ...(item.entity.metadata.annotations ?? {}),
-              [CHOREO_ANNOTATIONS.DELETION_TIMESTAMP]: new Date().toISOString(),
-            },
-          },
-        },
-      };
+const withOptimisticDeletion = (
+  item: ProjectContentItem,
+): ProjectContentItem => {
+  const marked = markEntityForDeletionLocally(item.entity);
+  return marked === item.entity ? item : { ...item, entity: marked };
+};
 
 function useDebouncedValue<T>(value: T, delayMs: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -115,7 +100,7 @@ export const ProjectContentsCard = () => {
   // Drives the Refresh icon's spin + disabled state while an explicit refresh
   // (page rows + facet counts) is in flight.
   const [isRefreshing, setIsRefreshing] = useState(false);
-  // Bumped after a component is marked for deletion to re-fetch the page.
+  // Bumped after a row is marked for deletion to re-fetch the page.
   const [refreshToken, setRefreshToken] = useState(0);
   // Rows deleted from the listing this session — marked optimistically until
   // the catalog catches up (keyed by entity identity, not object reference).
@@ -147,18 +132,19 @@ export const ProjectContentsCard = () => {
     refreshToken,
   });
 
-  // Row-level component delete. On success we (1) optimistically mark the row
-  // so the "marked for deletion" badge shows immediately, and (2) re-fetch so
-  // the row eventually drops off once the catalog removes the component.
+  // Row-level delete (components and resources). On success we (1)
+  // optimistically mark the row so the "marked for deletion" badge shows
+  // immediately, and (2) re-fetch so the row eventually drops off once the
+  // catalog removes the entity.
   const handleDeleted = useCallback((deletedEntity: Entity) => {
     setPendingDeletions(prev => {
       const next = new Set(prev);
-      next.add(entityKey(deletedEntity));
+      next.add(entityDeletionKey(deletedEntity));
       return next;
     });
     setRefreshToken(token => token + 1);
   }, []);
-  const { requestDelete, DeleteDialog } = useDeleteComponentDialog({
+  const { requestDelete, DeleteDialog } = useDeleteEntityDialog({
     onDeleted: handleDeleted,
   });
 
@@ -233,7 +219,7 @@ export const ProjectContentsCard = () => {
         canViewBindings,
         pipelineError,
         environmentsLoading,
-        onDeleteComponent: item => requestDelete(item.entity),
+        onDeleteItem: item => requestDelete(item.entity),
       }),
     [
       pipelineEnvironments,
@@ -250,7 +236,7 @@ export const ProjectContentsCard = () => {
       pendingDeletions.size === 0
         ? page.items
         : page.items.map(item =>
-            pendingDeletions.has(entityKey(item.entity))
+            pendingDeletions.has(entityDeletionKey(item.entity))
               ? withOptimisticDeletion(item)
               : item,
           ),

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.test.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RowActionsCell } from './RowActionsCell';
+import { type ProjectContentItem } from '../hooks';
+
+// isMarkedForDeletion is annotation-driven; mock it so each test controls it.
+const mockIsMarkedForDeletion = jest.fn();
+jest.mock('../../DeleteEntity', () => ({
+  isMarkedForDeletion: (...args: any[]) => mockIsMarkedForDeletion(...args),
+}));
+
+function makeItem(
+  kind: 'component' | 'resource',
+  name: string,
+): ProjectContentItem {
+  return {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: kind === 'component' ? 'Component' : 'Resource',
+      metadata: { name, namespace: 'default' },
+      spec: {},
+    },
+    kind,
+    name,
+    displayName: name,
+    type: 'deployment/service',
+    description: '',
+    deploymentStatus: {},
+    deploymentLoaded: true,
+  };
+}
+
+describe('RowActionsCell', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsMarkedForDeletion.mockReturnValue(false);
+  });
+
+  it('renders a delete button for a component row', () => {
+    render(
+      <RowActionsCell
+        item={makeItem('component', 'svc')}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /delete svc/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onDelete with the item when the delete button is clicked', async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+    const item = makeItem('component', 'svc');
+
+    render(<RowActionsCell item={item} onDelete={onDelete} />);
+
+    await user.click(screen.getByRole('button', { name: /delete svc/i }));
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith(item));
+  });
+
+  it('renders nothing for a resource row', () => {
+    const { container } = render(
+      <RowActionsCell item={makeItem('resource', 'db')} onDelete={jest.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a component already marked for deletion', () => {
+    mockIsMarkedForDeletion.mockReturnValue(true);
+    const { container } = render(
+      <RowActionsCell
+        item={makeItem('component', 'svc')}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.test.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.test.tsx
@@ -4,6 +4,14 @@ import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { RowActionsCell } from './RowActionsCell';
 import { type ProjectContentItem } from '../hooks';
 
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useEntityDeletePermission: () => ({
+    canDelete: true,
+    loading: false,
+    deniedTooltip: '',
+  }),
+}));
+
 function makeItem(
   kind: 'component' | 'resource',
   name: string,

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.test.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.test.tsx
@@ -1,23 +1,25 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
 import { RowActionsCell } from './RowActionsCell';
 import { type ProjectContentItem } from '../hooks';
-
-// isMarkedForDeletion is annotation-driven; mock it so each test controls it.
-const mockIsMarkedForDeletion = jest.fn();
-jest.mock('../../DeleteEntity', () => ({
-  isMarkedForDeletion: (...args: any[]) => mockIsMarkedForDeletion(...args),
-}));
 
 function makeItem(
   kind: 'component' | 'resource',
   name: string,
+  options?: { markedForDeletion?: boolean },
 ): ProjectContentItem {
   return {
     entity: {
       apiVersion: 'backstage.io/v1alpha1',
       kind: kind === 'component' ? 'Component' : 'Resource',
-      metadata: { name, namespace: 'default' },
+      metadata: {
+        name,
+        namespace: 'default',
+        annotations: options?.markedForDeletion
+          ? { [CHOREO_ANNOTATIONS.DELETION_TIMESTAMP]: '2026-01-01T00:00:00Z' }
+          : {},
+      },
       spec: {},
     },
     kind,
@@ -31,11 +33,6 @@ function makeItem(
 }
 
 describe('RowActionsCell', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockIsMarkedForDeletion.mockReturnValue(false);
-  });
-
   it('renders a delete button for a component row', () => {
     render(
       <RowActionsCell
@@ -45,6 +42,15 @@ describe('RowActionsCell', () => {
     );
     expect(
       screen.getByRole('button', { name: /delete svc/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a delete button for a resource row', () => {
+    render(
+      <RowActionsCell item={makeItem('resource', 'db')} onDelete={jest.fn()} />,
+    );
+    expect(
+      screen.getByRole('button', { name: /delete db/i }),
     ).toBeInTheDocument();
   });
 
@@ -60,18 +66,10 @@ describe('RowActionsCell', () => {
     await waitFor(() => expect(onDelete).toHaveBeenCalledWith(item));
   });
 
-  it('renders nothing for a resource row', () => {
-    const { container } = render(
-      <RowActionsCell item={makeItem('resource', 'db')} onDelete={jest.fn()} />,
-    );
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('renders nothing for a component already marked for deletion', () => {
-    mockIsMarkedForDeletion.mockReturnValue(true);
+  it('renders nothing for a row already marked for deletion', () => {
     const { container } = render(
       <RowActionsCell
-        item={makeItem('component', 'svc')}
+        item={makeItem('component', 'svc', { markedForDeletion: true })}
         onDelete={jest.fn()}
       />,
     );

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.tsx
@@ -1,42 +1,17 @@
-import { type MouseEvent } from 'react';
-import { IconButton, Tooltip } from '@material-ui/core';
-import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
-import { isMarkedForDeletion } from '../../DeleteEntity';
+import { RowDeleteButton } from '../../DeleteEntity';
 import { type ProjectContentItem } from '../hooks';
 
 interface RowActionsCellProps {
   item: ProjectContentItem;
-  /** Open the delete-confirmation dialog for this component. */
+  /** Open the delete-confirmation dialog for this row's entity. */
   onDelete: (item: ProjectContentItem) => void;
 }
 
 /**
- * Per-row delete control for the Project Contents table.
- *
- * Only components are deletable from the listing — Resource rows have no
- * client-side delete, and a row already marked for deletion shows nothing.
- * The click is stopped from bubbling so the row's navigate-on-click doesn't
- * fire.
+ * Per-row delete control for the Project Contents table. Both component and
+ * resource rows are deletable; a row already marked for deletion shows
+ * nothing (RowDeleteButton owns that gating and the click-bubbling stop).
  */
-export const RowActionsCell = ({ item, onDelete }: RowActionsCellProps) => {
-  if (item.kind !== 'component' || isMarkedForDeletion(item.entity)) {
-    return null;
-  }
-
-  const handleDelete = (event: MouseEvent) => {
-    event.stopPropagation();
-    onDelete(item);
-  };
-
-  return (
-    <Tooltip title="Delete component">
-      <IconButton
-        size="small"
-        aria-label={`Delete ${item.displayName}`}
-        onClick={handleDelete}
-      >
-        <DeleteOutlineIcon fontSize="small" />
-      </IconButton>
-    </Tooltip>
-  );
-};
+export const RowActionsCell = ({ item, onDelete }: RowActionsCellProps) => (
+  <RowDeleteButton entity={item.entity} onDelete={() => onDelete(item)} />
+);

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/RowActionsCell.tsx
@@ -1,0 +1,42 @@
+import { type MouseEvent } from 'react';
+import { IconButton, Tooltip } from '@material-ui/core';
+import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
+import { isMarkedForDeletion } from '../../DeleteEntity';
+import { type ProjectContentItem } from '../hooks';
+
+interface RowActionsCellProps {
+  item: ProjectContentItem;
+  /** Open the delete-confirmation dialog for this component. */
+  onDelete: (item: ProjectContentItem) => void;
+}
+
+/**
+ * Per-row delete control for the Project Contents table.
+ *
+ * Only components are deletable from the listing — Resource rows have no
+ * client-side delete, and a row already marked for deletion shows nothing.
+ * The click is stopped from bubbling so the row's navigate-on-click doesn't
+ * fire.
+ */
+export const RowActionsCell = ({ item, onDelete }: RowActionsCellProps) => {
+  if (item.kind !== 'component' || isMarkedForDeletion(item.entity)) {
+    return null;
+  }
+
+  const handleDelete = (event: MouseEvent) => {
+    event.stopPropagation();
+    onDelete(item);
+  };
+
+  return (
+    <Tooltip title="Delete component">
+      <IconButton
+        size="small"
+        aria-label={`Delete ${item.displayName}`}
+        onClick={handleDelete}
+      >
+        <DeleteOutlineIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/columns.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/columns.tsx
@@ -124,8 +124,8 @@ interface BuildColumnsArgs {
   pipelineError: unknown;
   /** Pipeline environments / permission still loading — skeleton the column. */
   environmentsLoading: boolean;
-  /** Open the delete-confirmation dialog for a component row. */
-  onDeleteComponent: (item: ProjectContentItem) => void;
+  /** Open the delete-confirmation dialog for a row. */
+  onDeleteItem: (item: ProjectContentItem) => void;
 }
 
 export function buildProjectContentColumns({
@@ -133,7 +133,7 @@ export function buildProjectContentColumns({
   canViewBindings,
   pipelineError,
   environmentsLoading,
-  onDeleteComponent,
+  onDeleteItem,
 }: BuildColumnsArgs): TableColumn<ProjectContentItem>[] {
   return [
     {
@@ -205,9 +205,7 @@ export function buildProjectContentColumns({
       sorting: false,
       cellStyle: { textAlign: 'right', paddingRight: 8 },
       headerStyle: { textAlign: 'right' },
-      render: item => (
-        <RowActionsCell item={item} onDelete={onDeleteComponent} />
-      ),
+      render: item => <RowActionsCell item={item} onDelete={onDeleteItem} />,
     },
   ];
 }

--- a/plugins/openchoreo/src/components/Projects/ProjectContentsCard/columns.tsx
+++ b/plugins/openchoreo/src/components/Projects/ProjectContentsCard/columns.tsx
@@ -9,6 +9,7 @@ import { isForbiddenError } from '../../../utils/errorUtils';
 import { type Environment, type ProjectContentItem } from '../hooks';
 import { KindCell } from './KindCell';
 import { DeploymentStatusCell } from './DeploymentStatusCell';
+import { RowActionsCell } from './RowActionsCell';
 import { useProjectContentsCardStyles } from './styles';
 
 const NameCell = ({ item }: { item: ProjectContentItem }) => {
@@ -123,6 +124,8 @@ interface BuildColumnsArgs {
   pipelineError: unknown;
   /** Pipeline environments / permission still loading — skeleton the column. */
   environmentsLoading: boolean;
+  /** Open the delete-confirmation dialog for a component row. */
+  onDeleteComponent: (item: ProjectContentItem) => void;
 }
 
 export function buildProjectContentColumns({
@@ -130,12 +133,13 @@ export function buildProjectContentColumns({
   canViewBindings,
   pipelineError,
   environmentsLoading,
+  onDeleteComponent,
 }: BuildColumnsArgs): TableColumn<ProjectContentItem>[] {
   return [
     {
       title: 'Name',
       field: 'displayName',
-      width: '16%',
+      width: '15%',
       highlight: true,
       // Ordering is server-side (see onOrderChange); the no-op keeps the
       // clickable header + arrow without reordering the current page locally.
@@ -174,7 +178,7 @@ export function buildProjectContentColumns({
     },
     {
       title: 'Deployment',
-      width: '30%',
+      width: '26%',
       sorting: false,
       render: item => (
         <DeploymentColumnCell
@@ -194,6 +198,16 @@ export function buildProjectContentColumns({
       defaultSort: 'desc',
       customSort: () => 0,
       render: item => <CreatedCell item={item} />,
+    },
+    {
+      title: '',
+      width: '5%',
+      sorting: false,
+      cellStyle: { textAlign: 'right', paddingRight: 8 },
+      headerStyle: { textAlign: 'right' },
+      render: item => (
+        <RowActionsCell item={item} onDelete={onDeleteComponent} />
+      ),
     },
   ];
 }

--- a/plugins/openchoreo/src/components/Projects/hooks/useProjectContentsPage.ts
+++ b/plugins/openchoreo/src/components/Projects/hooks/useProjectContentsPage.ts
@@ -54,6 +54,11 @@ export interface ProjectContentsPageParams {
   /** Cursor for the page to fetch; omit/undefined for the first page. */
   cursor?: string;
   limit: number;
+  /**
+   * Opaque value that re-runs the fetch when it changes. Bump it to refresh the
+   * current page in place (e.g. after a component is marked for deletion).
+   */
+  refreshToken?: number;
 }
 
 export interface ProjectContentsPageResult {
@@ -200,6 +205,7 @@ export function useProjectContentsPage(
     orderDir,
     cursor,
     limit,
+    refreshToken,
   } = params;
   const project = systemEntity.metadata.name;
   const namespace =
@@ -227,6 +233,7 @@ export function useProjectContentsPage(
       orderDir,
       cursor ?? 'first',
       limit,
+      refreshToken ?? 0,
     ],
     async () => {
       // A cursor request carries the original filter/order in the cursor, so we

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -35,12 +35,19 @@ export {
 } from './components/Namespaces';
 export {
   useDeleteEntityMenuItems,
+  useDeleteEntityDialog,
+  usePendingDeletionOverlay,
   useEntityExistsCheck,
+  getEntityDisplayType,
+  isDeletableEntityKind,
   DeletionBadge,
   DeletionWarning,
+  RowDeleteButton,
   isMarkedForDeletion,
   getDeletionTimestamp,
   type DeletePermissionInfo,
+  type UseDeleteEntityDialogOptions,
+  type UseDeleteEntityDialogResult,
 } from './components/DeleteEntity';
 export { useAnnotationEditorMenuItems } from './components/AnnotationEditor';
 export {


### PR DESCRIPTION
## Purpose

To let users delete entities directly from the console listing pages, without opening each entity page first. A delete action is added to the rows of the catalog "All ..." pages, the namespace page's projects/resources cards, and the project's Project Contents table (components and resources).


https://github.com/user-attachments/assets/66a11bd0-0cb4-4613-89f2-9fd653e87ff0



## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

A shared `useDeleteEntityDialog` hook dispatches the delete per entity kind, reusing the same kind mapping and confirmation dialog as the entity-page context menu. A reusable `RowDeleteButton` renders the row action only for kinds the API can delete and hides it for rows already marked for deletion. Deleted rows are overlaid with the "marked for deletion" badge until the catalog sync catches up.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added row-level deletion actions across supported catalog listings, projects, namespaces, resources, and project contents.
- Added confirmation dialogs, cascade warnings, success/error feedback, and permission-specific messaging.
- Deleted items are immediately marked for deletion and remain visible until catalog synchronization completes.
- Added refresh behavior after project-content deletions.

## Bug Fixes

- Parent systems now refresh after component deletion, preventing stale catalog relationship warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->