### PR TITLE
chore: rename RCA chat to portal assistant chat

### DIFF
--- a/.changeset/jolly-jars-learn.md
+++ b/.changeset/jolly-jars-learn.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+---
+
+Rename RCA agent chat to Portal Assistant

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RCAChatDrawer.test.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RCAChatDrawer.test.tsx
@@ -30,7 +30,7 @@ const chatContext = (api: RCAAgentApi) => ({
 
 const openDrawer = async (user: ReturnType<typeof userEvent.setup>) => {
   await user.click(
-    screen.getByRole('button', { name: /chat with rca agent/i }),
+    screen.getByRole('button', { name: /ask portal assistant/i }),
   );
 };
 
@@ -47,15 +47,39 @@ describe('RCAChatDrawer', () => {
 
     // Drawer content is not mounted until the FAB is clicked.
     expect(
-      screen.queryByPlaceholderText('Message RCA Agent'),
+      screen.queryByPlaceholderText('Message Portal Assistant'),
     ).not.toBeInTheDocument();
 
     await openDrawer(user);
 
     expect(screen.getByText(/ask follow-up questions/i)).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText('Message RCA Agent'),
+      screen.getByPlaceholderText('Message Portal Assistant'),
     ).toBeInTheDocument();
+  });
+
+  it('sends a suggestion chip as a turn to the agent', async () => {
+    // The empty-state chips are what make the RCA chat feel like the
+    // Portal Assistant — clicking one must actually fire the turn (with
+    // the chip wording as the user message), not just prefill the box.
+    const user = userEvent.setup();
+    const api = makeApi(async (_req, _routing, onEvent) => {
+      onEvent(ev({ type: 'done', message: 'chip reply' }));
+    });
+    render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
+    await openDrawer(user);
+
+    await user.click(
+      screen.getByRole('button', { name: /explain the root cause/i }),
+    );
+
+    expect(screen.getByText('Explain the root cause')).toBeInTheDocument();
+    expect(await screen.findByText('chip reply')).toBeInTheDocument();
+    expect(api.streamRCAChat).toHaveBeenCalledTimes(1);
+    const [request] = api.streamRCAChat.mock.calls[0];
+    expect(request.messages[request.messages.length - 1].content).toContain(
+      'Explain the root cause',
+    );
   });
 
   it('hides the launcher FAB while the drawer is open', async () => {
@@ -66,13 +90,13 @@ describe('RCAChatDrawer', () => {
     // FAB is the only way in while closed; once open it must not overlap
     // the drawer (its z-index sits above the modal layer).
     expect(
-      screen.getByRole('button', { name: /chat with rca agent/i }),
+      screen.getByRole('button', { name: /ask portal assistant/i }),
     ).toBeInTheDocument();
 
     await openDrawer(user);
 
     expect(
-      screen.queryByRole('button', { name: /chat with rca agent/i }),
+      screen.queryByRole('button', { name: /ask portal assistant/i }),
     ).not.toBeInTheDocument();
   });
 
@@ -90,7 +114,7 @@ describe('RCAChatDrawer', () => {
     await openDrawer(user);
 
     await user.type(
-      screen.getByPlaceholderText('Message RCA Agent'),
+      screen.getByPlaceholderText('Message Portal Assistant'),
       'why did it fail?{Enter}',
     );
 
@@ -118,7 +142,10 @@ describe('RCAChatDrawer', () => {
     render(<RCAChatDrawer reportId="rep-7" chatContext={chatContext(api)} />);
     await openDrawer(user);
 
-    await user.type(screen.getByPlaceholderText('Message RCA Agent'), 'hi');
+    await user.type(
+      screen.getByPlaceholderText('Message Portal Assistant'),
+      'hi',
+    );
     await user.click(screen.getByRole('button', { name: /send message/i }));
 
     expect(await screen.findByText('persisted reply')).toBeInTheDocument();
@@ -155,7 +182,7 @@ describe('RCAChatDrawer', () => {
     await openDrawer(user);
 
     await user.type(
-      screen.getByPlaceholderText('Message RCA Agent'),
+      screen.getByPlaceholderText('Message Portal Assistant'),
       'boom{Enter}',
     );
 
@@ -185,7 +212,7 @@ describe('RCAChatDrawer', () => {
     await openDrawer(user);
 
     await user.type(
-      screen.getByPlaceholderText('Message RCA Agent'),
+      screen.getByPlaceholderText('Message Portal Assistant'),
       'long task{Enter}',
     );
 
@@ -212,7 +239,7 @@ describe('RCAChatDrawer', () => {
     await openDrawer(user);
 
     await user.type(
-      screen.getByPlaceholderText('Message RCA Agent'),
+      screen.getByPlaceholderText('Message Portal Assistant'),
       'boom{Enter}',
     );
 
@@ -225,16 +252,16 @@ describe('RCAChatDrawer', () => {
     render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
     await openDrawer(user);
     expect(
-      screen.getByPlaceholderText('Message RCA Agent'),
+      screen.getByPlaceholderText('Message Portal Assistant'),
     ).toBeInTheDocument();
 
     await user.click(
-      screen.getByRole('button', { name: /close rca agent chat/i }),
+      screen.getByRole('button', { name: /close portal assistant chat/i }),
     );
 
     await waitFor(() =>
       expect(
-        screen.queryByPlaceholderText('Message RCA Agent'),
+        screen.queryByPlaceholderText('Message Portal Assistant'),
       ).not.toBeInTheDocument(),
     );
   });
@@ -245,14 +272,14 @@ describe('RCAChatDrawer', () => {
     render(<RCAChatDrawer reportId="rep-1" chatContext={chatContext(api)} />);
     await openDrawer(user);
     expect(
-      screen.getByPlaceholderText('Message RCA Agent'),
+      screen.getByPlaceholderText('Message Portal Assistant'),
     ).toBeInTheDocument();
 
     await user.keyboard('{Escape}');
 
     await waitFor(() =>
       expect(
-        screen.queryByPlaceholderText('Message RCA Agent'),
+        screen.queryByPlaceholderText('Message Portal Assistant'),
       ).not.toBeInTheDocument(),
     );
   });
@@ -266,7 +293,7 @@ describe('RCAChatDrawer', () => {
     await openDrawer(user);
 
     await user.type(
-      screen.getByPlaceholderText('Message RCA Agent'),
+      screen.getByPlaceholderText('Message Portal Assistant'),
       'hi{Enter}',
     );
 

--- a/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RCAChatDrawer.tsx
+++ b/plugins/openchoreo-observability/src/components/RCA/RCAReport/sections/RCAChatDrawer.tsx
@@ -9,6 +9,7 @@ import {
 import {
   Typography,
   Box,
+  Chip,
   IconButton,
   TextField,
   InputAdornment,
@@ -94,6 +95,15 @@ const markdownComponents = {
 
 const DRAWER_WIDTH = 440;
 
+// Starter prompts shown on the empty chat — mirrors the Portal Assistant
+// drawer's suggestion chips, scoped to follow-ups on an RCA report so the
+// two chats read as the same assistant.
+const CHAT_SUGGESTIONS = [
+  'Explain the root cause',
+  'What are the recommended fixes?',
+  'Any related incidents?',
+];
+
 const useStyles = makeStyles(theme => ({
   fabRoot: {
     position: 'fixed',
@@ -140,6 +150,27 @@ const useStyles = makeStyles(theme => ({
   statusStrip: {
     padding: theme.spacing(0.25, 2, 0, 2),
     textAlign: 'left',
+  },
+  emptyState: {
+    padding: theme.spacing(2, 2, 1),
+  },
+  // Pill-strip of suggestion chips shown only on the empty timeline —
+  // matches the Portal Assistant drawer's ``suggestionStrip``.
+  suggestionStrip: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: theme.spacing(0.75),
+    marginTop: theme.spacing(2),
+  },
+  suggestionChip: {
+    height: 'auto',
+    cursor: 'pointer',
+    '& .MuiChip-label': {
+      whiteSpace: 'normal',
+      paddingTop: theme.spacing(0.25),
+      paddingBottom: theme.spacing(0.25),
+    },
   },
 }));
 
@@ -205,104 +236,123 @@ export const RCAChatDrawer = ({
     }
   }, [messages, streamingContent, open]);
 
-  const handleSendMessage = useCallback(async () => {
-    if (!chatMessage.trim() || isSending) return;
+  const sendText = useCallback(
+    async (rawText: string) => {
+      if (!rawText.trim() || isSending) return;
 
-    const trimmedMessage = chatMessage.trim();
-    const userMessage: ChatMessage = { role: 'user', content: trimmedMessage };
-    const updatedMessages = [...messages, userMessage];
-    const messagesToSend = [
-      ...messages,
-      {
-        role: 'user' as const,
-        content: `[${new Date().toISOString()}] \n${trimmedMessage}`,
-      },
-    ];
-
-    setMessages(updatedMessages);
-    setChatMessage('');
-    setIsSending(true);
-    setStreamingContent('');
-    setToolStatus(null);
-    setChatError(null);
-
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-
-    // Local mirror of the streamed text. The streamingContent STATE can't
-    // be read back inside this same invocation (the closure captured its
-    // value — '' — at send time), so accumulate here to preserve partial
-    // output if the user cancels mid-stream.
-    let assembled = '';
-
-    try {
-      await chatContext.rcaAgentApi.streamRCAChat(
+      const trimmedMessage = rawText.trim();
+      const userMessage: ChatMessage = {
+        role: 'user',
+        content: trimmedMessage,
+      };
+      const updatedMessages = [...messages, userMessage];
+      const messagesToSend = [
+        ...messages,
         {
-          reportId: reportId || '',
-          namespace: chatContext.namespaceName,
-          project: chatContext.projectName,
-          environment: chatContext.environmentName,
-          messages: messagesToSend,
+          role: 'user' as const,
+          content: `[${new Date().toISOString()}] \n${trimmedMessage}`,
         },
-        {
-          namespaceName: chatContext.namespaceName,
-          environmentName: chatContext.environmentName,
-        },
-        (event: StreamEvent) => {
-          switch (event.type) {
-            case 'message_chunk':
-              assembled += event.content;
-              setStreamingContent(prev => prev + event.content);
-              setToolStatus(null);
-              break;
-            case 'tool_call':
-              setToolStatus(event.activeForm || 'Digging deeper...');
-              break;
-            case 'done':
-              // Finalize the assistant message
-              setMessages(prev => [
-                ...prev,
-                { role: 'assistant', content: event.message },
-              ]);
-              setStreamingContent('');
-              setToolStatus(null);
-              break;
-            case 'error':
-              setChatError(event.message);
-              setStreamingContent('');
-              setToolStatus(null);
-              break;
-            case 'actions':
-              // TODO: Handle actions
-              break;
-            default:
-              // Unknown event type, ignore
-              break;
-          }
-        },
-        controller.signal,
-      );
-    } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
-        // User cancelled - add partial content as message if any
-        if (assembled) {
-          setMessages(prev => [
-            ...prev,
-            { role: 'assistant', content: `${assembled} (cancelled)` },
-          ]);
-        }
-      } else {
-        setChatError(
-          err instanceof Error ? err.message : 'Failed to send message',
-        );
-      }
-    } finally {
-      setIsSending(false);
+      ];
+
+      setMessages(updatedMessages);
+      setChatMessage('');
+      setIsSending(true);
       setStreamingContent('');
       setToolStatus(null);
-      abortControllerRef.current = null;
-    }
-  }, [chatMessage, isSending, messages, chatContext, reportId]);
+      setChatError(null);
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      // Local mirror of the streamed text. The streamingContent STATE can't
+      // be read back inside this same invocation (the closure captured its
+      // value — '' — at send time), so accumulate here to preserve partial
+      // output if the user cancels mid-stream.
+      let assembled = '';
+
+      try {
+        await chatContext.rcaAgentApi.streamRCAChat(
+          {
+            reportId: reportId || '',
+            namespace: chatContext.namespaceName,
+            project: chatContext.projectName,
+            environment: chatContext.environmentName,
+            messages: messagesToSend,
+          },
+          {
+            namespaceName: chatContext.namespaceName,
+            environmentName: chatContext.environmentName,
+          },
+          (event: StreamEvent) => {
+            switch (event.type) {
+              case 'message_chunk':
+                assembled += event.content;
+                setStreamingContent(prev => prev + event.content);
+                setToolStatus(null);
+                break;
+              case 'tool_call':
+                setToolStatus(event.activeForm || 'Digging deeper...');
+                break;
+              case 'done':
+                // Finalize the assistant message
+                setMessages(prev => [
+                  ...prev,
+                  { role: 'assistant', content: event.message },
+                ]);
+                setStreamingContent('');
+                setToolStatus(null);
+                break;
+              case 'error':
+                setChatError(event.message);
+                setStreamingContent('');
+                setToolStatus(null);
+                break;
+              case 'actions':
+                // TODO: Handle actions
+                break;
+              default:
+                // Unknown event type, ignore
+                break;
+            }
+          },
+          controller.signal,
+        );
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          // User cancelled - add partial content as message if any
+          if (assembled) {
+            setMessages(prev => [
+              ...prev,
+              { role: 'assistant', content: `${assembled} (cancelled)` },
+            ]);
+          }
+        } else {
+          setChatError(
+            err instanceof Error ? err.message : 'Failed to send message',
+          );
+        }
+      } finally {
+        setIsSending(false);
+        setStreamingContent('');
+        setToolStatus(null);
+        abortControllerRef.current = null;
+      }
+    },
+    [isSending, messages, chatContext, reportId],
+  );
+
+  const handleSendMessage = useCallback(() => {
+    void sendText(chatMessage);
+  }, [chatMessage, sendText]);
+
+  // Empty-state suggestion chips fire a turn immediately with pre-vetted
+  // wording — mirrors the Portal Assistant drawer's starter prompts.
+  const handleSuggestion = useCallback(
+    (text: string) => {
+      void sendText(text);
+    },
+    [sendText],
+  );
 
   const handleCancelSend = useCallback(() => {
     abortControllerRef.current?.abort();
@@ -339,14 +389,14 @@ export const RCAChatDrawer = ({
           clicks at the bottom-right. The header close button handles
           dismissal. */}
       {!open && (
-        <Tooltip title="Chat with RCA Agent" placement="left">
+        <Tooltip title="Ask Portal Assistant" placement="left">
           <Fab
             color="primary"
             size="medium"
             className={drawerClasses.fab}
             classes={{ root: drawerClasses.fabRoot }}
             onClick={() => setOpen(true)}
-            aria-label="Chat with RCA Agent"
+            aria-label="Ask Portal Assistant"
           >
             <ChatOutlinedIcon />
           </Fab>
@@ -360,7 +410,7 @@ export const RCAChatDrawer = ({
       >
         <Box className={drawerClasses.drawerHeader}>
           <Typography variant="subtitle1" className={drawerClasses.headerTitle}>
-            Chat with RCA Agent
+            Portal Assistant
           </Typography>
           <Box className={drawerClasses.drawerHeaderActions}>
             <Tooltip title="Clear conversation">
@@ -378,7 +428,7 @@ export const RCAChatDrawer = ({
             <IconButton
               size="small"
               onClick={() => setOpen(false)}
-              aria-label="Close RCA Agent chat"
+              aria-label="Close Portal Assistant chat"
             >
               <CloseIcon fontSize="small" />
             </IconButton>
@@ -389,9 +439,29 @@ export const RCAChatDrawer = ({
             {/* To push messages to bottom */}
             <div style={{ marginTop: 'auto' }} />
             {messages.length === 0 && !streamingContent && !toolStatus ? (
-              <Typography variant="body2" color="textSecondary" align="center">
-                Ask follow-up questions, search logs, or explore related issues
-              </Typography>
+              <Box className={drawerClasses.emptyState}>
+                <Typography
+                  variant="body2"
+                  color="textSecondary"
+                  align="center"
+                >
+                  Ask follow-up questions, search logs, or explore related
+                  issues
+                </Typography>
+                <Box className={drawerClasses.suggestionStrip}>
+                  {CHAT_SUGGESTIONS.map(suggestion => (
+                    <Chip
+                      key={suggestion}
+                      label={suggestion}
+                      variant="outlined"
+                      size="small"
+                      clickable
+                      className={drawerClasses.suggestionChip}
+                      onClick={() => handleSuggestion(suggestion)}
+                    />
+                  ))}
+                </Box>
+              </Box>
             ) : (
               <>
                 {messages.map((msg, index) => (
@@ -449,7 +519,7 @@ export const RCAChatDrawer = ({
               maxRows={4}
               variant="outlined"
               size="small"
-              placeholder="Message RCA Agent"
+              placeholder="Message Portal Assistant"
               value={chatMessage}
               onChange={e => setChatMessage(e.target.value)}
               onKeyDown={handleKeyDown}

--- a/plugins/openchoreo-portal-assistant/src/api/PerchAgentApi.ts
+++ b/plugins/openchoreo-portal-assistant/src/api/PerchAgentApi.ts
@@ -134,6 +134,15 @@ export type ChatScope = {
    * the URL itself; it just passes it through into the generated prompt.
    */
   repoUrl?: string;
+  /**
+   * In-repo build path (the component's workflow ``repository.appPath``)
+   * pulled off the schema next to ``repoUrl``. The portal-assistant prompt
+   * adds it as a ``Path:`` line in the ``fix_prompt`` so the external coding
+   * bot knows which sub-directory of a monorepo the failing build ran in.
+   * Optional — root-of-repo builds omit it; the agent passes it through
+   * verbatim and never reads it itself.
+   */
+  componentPath?: string;
 };
 
 export type ChatRequest = {

--- a/plugins/openchoreo-portal-assistant/src/components/AssistantChatDrawer/AssistantChatDrawer.tsx
+++ b/plugins/openchoreo-portal-assistant/src/components/AssistantChatDrawer/AssistantChatDrawer.tsx
@@ -152,9 +152,11 @@ export const AssistantChatDrawer = ({
           workflowName: pin.workflowName,
           workflowKind: pin.workflowKind,
           caseType: pin.caseType,
-          // Forwarded so the agent can drop the URL into the
-          // ``fix_prompt`` it generates on build_failure turns.
+          // Forwarded so the agent can drop the URL and in-repo build
+          // path into the ``fix_prompt`` it generates on build_failure
+          // turns (``Repo:`` + ``Path:`` lines).
           repoUrl: pin.repoUrl,
+          componentPath: pin.componentPath,
         }
       : fromPath;
     return scopeOverrides ? { ...fromPin, ...scopeOverrides } : fromPin;

--- a/plugins/openchoreo-portal-assistant/src/components/AssistantContext/AssistantDrawerContext.tsx
+++ b/plugins/openchoreo-portal-assistant/src/components/AssistantContext/AssistantDrawerContext.tsx
@@ -41,6 +41,14 @@ export type PinnedContext = {
    */
   repoUrl?: string;
   /**
+   * In-repo build path (the component's workflow ``repository.appPath``)
+   * extracted alongside ``repoUrl``. Plumbed through so the build_failure
+   * "Copy as prompt" button can tell an external coding bot which
+   * sub-directory of the repo the failing build ran in. Optional —
+   * components built from the repo root omit it.
+   */
+  componentPath?: string;
+  /**
    * Optional case discriminator forwarded into ChatScope.caseType so the
    * agent layers in case-specific guidance. Launchers built for a single
    * scenario (e.g. failed builds) set this; the generic FAB leaves it

--- a/plugins/openchoreo-portal-assistant/src/components/BuildPagePromptLauncher/BuildPagePromptLauncher.tsx
+++ b/plugins/openchoreo-portal-assistant/src/components/BuildPagePromptLauncher/BuildPagePromptLauncher.tsx
@@ -122,9 +122,11 @@ export const BuildPagePromptLauncher = () => {
         // Fall back to entity metadata if relationship resolution fails.
       }
 
-      const repoUrl = componentDetails
-        ? getRepositoryInfo(componentDetails).url
+      const repoInfo = componentDetails
+        ? getRepositoryInfo(componentDetails)
         : undefined;
+      const repoUrl = repoInfo?.url;
+      const componentPath = repoInfo?.path;
 
       openDrawer({
         initialMessage: isRunDetails
@@ -142,6 +144,7 @@ export const BuildPagePromptLauncher = () => {
           workflowKind: componentDetails?.componentWorkflow?.kind,
           caseType: 'build_failure',
           repoUrl,
+          componentPath,
         },
         conversationKey,
         resetConversation,

--- a/plugins/openchoreo-portal-assistant/src/components/FailedBuildSnackbar/FailedBuildSnackbar.tsx
+++ b/plugins/openchoreo-portal-assistant/src/components/FailedBuildSnackbar/FailedBuildSnackbar.tsx
@@ -86,9 +86,11 @@ export const FailedBuildSnackbar = () => {
       // Fall back to entity metadata if relationship resolution fails.
     }
 
-    const repoUrl = componentDetails
-      ? getRepositoryInfo(componentDetails).url
+    const repoInfo = componentDetails
+      ? getRepositoryInfo(componentDetails)
       : undefined;
+    const repoUrl = repoInfo?.url;
+    const componentPath = repoInfo?.path;
 
     openDrawer({
       initialMessage: `Why did the latest build fail?`,
@@ -104,6 +106,7 @@ export const FailedBuildSnackbar = () => {
         workflowKind: componentDetails?.componentWorkflow?.kind,
         caseType: 'build_failure',
         repoUrl,
+        componentPath,
       },
       // Shared with BuildPagePromptLauncher so opening from either
       // surface continues the same conversation.


### PR DESCRIPTION
## Purpose

Need to provide a unified experience by updating the name to Portal assistant chat from RCA agent.

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.


https://github.com/user-attachments/assets/58dfb8d5-e489-4415-80ad-f0fb6c0f80bc



## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portal Assistant now receives the component’s repository path when opened from failed-build workflows, providing more relevant troubleshooting context.
* **Updates**
  * Renamed RCA chat launcher, drawer title, close control, and message field to use “Portal Assistant” terminology.
  * Updated chat interactions and accessibility labels to match the new wording.
* **Bug Fixes**
  * Improved failed-build assistance context by passing both repository URL and component path for troubleshooting prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->