### PR TITLE
feat(caching): self-contain the QueryClient provider so hosts need no wiring

### DIFF
--- a/.changeset/self-contained-query-provider.md
+++ b/.changeset/self-contained-query-provider.md
@@ -1,0 +1,30 @@
+---
+'@openchoreo/backstage-plugin-react': patch
+'@openchoreo/backstage-plugin': patch
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+'@openchoreo/backstage-plugin-openchoreo-ci': patch
+'@openchoreo/backstage-plugin-openchoreo-workflows': patch
+'@openchoreo/backstage-plugin-platform-engineer-core': patch
+---
+
+Self-contain the response cache for NFS-mounted OpenChoreo surfaces. Each
+OpenChoreo plugin now wraps its own extensions in a TanStack Query
+`QueryClientProvider` via `PluginWrapperBlueprint`, around a shared `queryClient`
+singleton exported from `@openchoreo/backstage-plugin-react`. A host that mounts
+the plugins' `/alpha` features (auto-mounted entity tabs/cards and the standalone
+plugin pages) gets response caching with no provider wiring — previously those
+surfaces would crash with "No QueryClient set" when a cached tab rendered.
+
+Scope: this covers surfaces rendered through a plugin's own extension boundary
+(NFS auto-mounted tabs/cards and standalone plugin pages). A host that instead
+composes OpenChoreo tab components itself via legacy `EntityLayout.Route` JSX
+renders them outside the plugin wrapper, so that host still mounts its own
+provider — `OpenChoreoQueryProvider` (also exported here) bundles the
+`QueryClientProvider` and the user-scoping context for that case.
+
+Cross-user isolation is structural: every cache key is namespaced by the
+signed-in user's entityRef inside the cache seam (`useOpenChoreoQuery`,
+`useOpenChoreoInfiniteQuery`, `useOpenChoreoMutation`, `useOpenChoreoCache`), so
+a different user occupies a disjoint key space and can never read the previous
+user's permission-scoped responses from the cache — no cache-clearing needed.
+Multiple OpenChoreo plugins share the same `queryClient`, so there is one cache.

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -39,10 +39,19 @@ import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 import CategoryIcon from '@material-ui/icons/Category';
 import BubbleChartIcon from '@material-ui/icons/BubbleChart';
 import { AssistantDrawerProvider } from '@openchoreo/backstage-plugin-openchoreo-portal-assistant';
-import { QueryClientProvider } from '@tanstack/react-query';
+// This app composes some OpenChoreo entity tabs itself via legacy
+// `EntityLayout.Route` JSX (see EntityPage.tsx), so they render OUTSIDE the
+// plugins' `PluginWrapperBlueprint` scope. Mount `OpenChoreoQueryProvider` here
+// (QueryClientProvider + the user-scoping context) so those host-composed tabs
+// still get a QueryClient and per-user cache-key namespacing. It shares the same
+// `queryClient` singleton the plugin wrappers use, so there is one cache; the
+// SignOutButton clears that exact client on sign-out.
+import {
+  OpenChoreoQueryProvider,
+  queryClient,
+} from '@openchoreo/backstage-plugin-react';
 import { ScaffolderPreselectionProvider } from '../../scaffolder/ScaffolderPreselectionContext';
 import { DependencyGraphZoomOverrides } from '../graph/DependencyGraphZoomOverrides';
-import { queryClient } from '../../queryClient';
 
 const isMac =
   typeof navigator !== 'undefined' &&
@@ -177,7 +186,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
   useSearchModalStyles();
   const a11yClasses = useA11yStyles();
   return (
-    <QueryClientProvider client={queryClient}>
+    <OpenChoreoQueryProvider>
       <ScaffolderPreselectionProvider>
         <AssistantDrawerProvider>
           {/*
@@ -262,6 +271,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
           </SidebarPage>
         </AssistantDrawerProvider>
       </ScaffolderPreselectionProvider>
-    </QueryClientProvider>
+    </OpenChoreoQueryProvider>
   );
 };

--- a/plugins/openchoreo-ci/src/alpha.tsx
+++ b/plugins/openchoreo-ci/src/alpha.tsx
@@ -3,6 +3,7 @@ import {
   createFrontendPlugin,
   discoveryApiRef,
   fetchApiRef,
+  PluginWrapperBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
 
@@ -18,6 +19,22 @@ const ciClientApi = ApiBlueprint.make({
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>
         new OpenChoreoCiClient(discoveryApi, fetchApi),
+    }),
+});
+
+// Wraps this plugin's own extensions in the TanStack Query provider (see the
+// openchoreo plugin's alpha for the full rationale). Shares the one `queryClient`
+// singleton across all OpenChoreo plugins.
+const queryProvider = PluginWrapperBlueprint.make({
+  name: 'query-provider',
+  params: defineParams =>
+    defineParams({
+      loader: async () => {
+        const { OpenChoreoQueryProvider } = await import(
+          '@openchoreo/backstage-plugin-react'
+        );
+        return { component: OpenChoreoQueryProvider };
+      },
     }),
 });
 
@@ -37,5 +54,5 @@ const workflowsEntityContent = EntityContentBlueprint.make({
 export default createFrontendPlugin({
   pluginId: 'openchoreo-ci',
   routes: { root: rootRouteRef },
-  extensions: [ciClientApi, workflowsEntityContent],
+  extensions: [ciClientApi, queryProvider, workflowsEntityContent],
 });

--- a/plugins/openchoreo-observability/src/alpha.test.tsx
+++ b/plugins/openchoreo-observability/src/alpha.test.tsx
@@ -27,6 +27,8 @@ describe('openchoreo-observability alpha plugin', () => {
     for (const expected of [
       // backend client apis
       `api:${plugin}/observability`,
+      // self-contained response-cache provider
+      `plugin-wrapper:${plugin}/query-provider`,
       `api:${plugin}/rca-agent`,
       `api:${plugin}/finops-agent`,
       // host-injection registry

--- a/plugins/openchoreo-observability/src/alpha.tsx
+++ b/plugins/openchoreo-observability/src/alpha.tsx
@@ -4,6 +4,7 @@ import {
   createFrontendPlugin,
   discoveryApiRef,
   fetchApiRef,
+  PluginWrapperBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
 import { FeatureGatedContent } from '@openchoreo/backstage-plugin-react';
@@ -35,6 +36,22 @@ const observabilityApi = ApiBlueprint.make({
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>
         new ObservabilityClient({ discoveryApi, fetchApi }),
+    }),
+});
+
+// Wraps this plugin's own extensions in the TanStack Query provider (see the
+// openchoreo plugin's alpha for the full rationale). Shares the one `queryClient`
+// singleton across all OpenChoreo plugins.
+const queryProvider = PluginWrapperBlueprint.make({
+  name: 'query-provider',
+  params: defineParams =>
+    defineParams({
+      loader: async () => {
+        const { OpenChoreoQueryProvider } = await import(
+          '@openchoreo/backstage-plugin-react'
+        );
+        return { component: OpenChoreoQueryProvider };
+      },
     }),
 });
 
@@ -274,6 +291,7 @@ export default createFrontendPlugin({
   routes: { root: rootRouteRef },
   extensions: [
     observabilityApi,
+    queryProvider,
     rcaAgentApi,
     finopsAgentApi,
     logRowActionRendererApi,

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoCache.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoCache.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useQueryClient, type QueryKey } from '@tanstack/react-query';
+import { useUserScopedKey } from '../query/OpenChoreoQueryProvider';
 
 /**
  * Imperative cache handle for the rare hooks that need to touch a cached query
@@ -45,25 +46,33 @@ export interface OpenChoreoCache {
  */
 export function useOpenChoreoCache(): OpenChoreoCache {
   const queryClient = useQueryClient();
+  // Namespace every key by the signed-in user, identically to the query hooks,
+  // so imperative reads/writes/invalidations hit the same entries the queries
+  // stored (see useUserScopedKey). `scopeKey` is stable for the user's scope.
+  const scopeKey = useUserScopedKey();
   // `useQueryClient()` returns a stable client for the provider's lifetime, so
   // memoise the handle: without this, a fresh object + 5 closures every render
   // would break any consumer that lists `cache` in a useCallback/useEffect dep.
   return useMemo<OpenChoreoCache>(
     () => ({
       setData: (queryKey, updater) =>
-        queryClient.setQueryData(queryKey, updater),
+        queryClient.setQueryData(scopeKey(queryKey), updater),
       invalidate: queryKey => {
-        void queryClient.invalidateQueries({ queryKey });
+        void queryClient.invalidateQueries({ queryKey: scopeKey(queryKey) });
       },
       fetchQuery: (queryKey, fetcher, options) =>
         queryClient.fetchQuery({
-          queryKey,
+          queryKey: scopeKey(queryKey),
           queryFn: fetcher,
           staleTime: options?.staleTime,
         }),
-      getData: queryKey => queryClient.getQueryData(queryKey),
-      remove: queryKey => queryClient.removeQueries({ queryKey, exact: true }),
+      getData: queryKey => queryClient.getQueryData(scopeKey(queryKey)),
+      remove: queryKey =>
+        queryClient.removeQueries({
+          queryKey: scopeKey(queryKey),
+          exact: true,
+        }),
     }),
-    [queryClient],
+    [queryClient, scopeKey],
   );
 }

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoInfiniteQuery.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoInfiniteQuery.ts
@@ -3,6 +3,7 @@ import {
   type QueryKey,
   type InfiniteData,
 } from '@tanstack/react-query';
+import { useUserScopedKey } from '../query/OpenChoreoQueryProvider';
 
 /**
  * A single page returned by the fetcher. `items` are the rows for this page and
@@ -88,6 +89,10 @@ export function useOpenChoreoInfiniteQuery<TItem>(
 ): UseOpenChoreoInfiniteQueryResult<TItem> {
   const { enabled, refetchInterval, staleTime, getCursor, pageSize } = options;
 
+  // Namespace by the signed-in user (see useUserScopedKey) for cross-user
+  // isolation, consistent with useOpenChoreoQuery.
+  const scopeKey = useUserScopedKey();
+
   const {
     data,
     error,
@@ -104,7 +109,7 @@ export function useOpenChoreoInfiniteQuery<TItem>(
     QueryKey,
     string | undefined
   >({
-    queryKey,
+    queryKey: scopeKey(queryKey),
     initialPageParam: undefined,
     queryFn: ({ pageParam }) => fetcher(pageParam),
     getNextPageParam: lastPage => {

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoMutation.test.tsx
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoMutation.test.tsx
@@ -1,11 +1,8 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { ReactNode } from 'react';
-import {
-  QueryClient,
-  QueryClientProvider,
-  useQuery,
-} from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useOpenChoreoMutation } from './useOpenChoreoMutation';
+import { useOpenChoreoQuery } from './useOpenChoreoQuery';
 
 function freshClient() {
   return new QueryClient({
@@ -71,9 +68,13 @@ describe('useOpenChoreoMutation', () => {
       .mockResolvedValueOnce('v1')
       .mockResolvedValueOnce('v2');
 
-    // A query we expect to be refetched by the mutation's invalidation.
+    // A query we expect to be refetched by the mutation's invalidation. Use the
+    // real seam (useOpenChoreoQuery), not raw useQuery, so its key is namespaced
+    // by the same user scope the mutation's invalidation uses — otherwise the
+    // prefix-match wouldn't line up (both resolve to the pending-user scope here,
+    // since no OpenChoreoQueryProvider is mounted).
     const { result: query } = renderHook(
-      () => useQuery({ queryKey: ['thing'], queryFn: fetcher }),
+      () => useOpenChoreoQuery(['thing'], fetcher),
       { wrapper: wrapperWith(client) },
     );
     await waitFor(() => expect(query.current.data).toBe('v1'));

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoMutation.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoMutation.ts
@@ -4,6 +4,7 @@ import {
   useQueryClient,
   type QueryKey,
 } from '@tanstack/react-query';
+import { useUserScopedKey } from '../query/OpenChoreoQueryProvider';
 
 /** Options for {@link useOpenChoreoMutation}. */
 export interface UseOpenChoreoMutationOptions<TArgs extends unknown[], TData> {
@@ -66,6 +67,7 @@ export function useOpenChoreoMutation<TArgs extends unknown[], TData>(
   opts: UseOpenChoreoMutationOptions<TArgs, TData> = {},
 ): UseOpenChoreoMutationResult<TArgs, TData> {
   const queryClient = useQueryClient();
+  const scopeKey = useUserScopedKey();
   const { invalidates, onSuccess, onError } = opts;
 
   const mutation = useMutation<TData, Error, TArgs>({
@@ -74,8 +76,10 @@ export function useOpenChoreoMutation<TArgs extends unknown[], TData>(
     onSuccess: async (data, args) => {
       if (invalidates?.length) {
         await Promise.all(
+          // Scope the invalidation keys the same way the queries were stored
+          // (see useUserScopedKey), or the prefix match would miss them.
           invalidates.map(queryKey =>
-            queryClient.invalidateQueries({ queryKey }),
+            queryClient.invalidateQueries({ queryKey: scopeKey(queryKey) }),
           ),
         );
       }

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoQuery.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoQuery.ts
@@ -3,6 +3,7 @@ import {
   type QueryKey,
   type UseQueryOptions,
 } from '@tanstack/react-query';
+import { useUserScopedKey } from '../query/OpenChoreoQueryProvider';
 
 /**
  * The `refetchInterval` accepted by a `useQuery<T, Error>`. Kept as a named
@@ -110,8 +111,11 @@ export function useOpenChoreoQuery<T>(
   fetcher: (context: { signal: AbortSignal }) => Promise<T>,
   options: UseOpenChoreoQueryOptions<T> = {},
 ): UseOpenChoreoQueryResult<T> {
+  // Namespace the key by the signed-in user so one user's cached responses are
+  // never served to another (structural cross-user isolation — no clearing).
+  const scopeKey = useUserScopedKey();
   const { data, error, isPending, isFetching, refetch } = useQuery<T, Error>({
-    queryKey,
+    queryKey: scopeKey(queryKey),
     queryFn: ({ signal }) => fetcher({ signal }),
     // Only forward each option when the caller actually set it. Passing an
     // explicit `undefined` does NOT inherit the QueryClient default — TanStack

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -535,6 +535,8 @@ export {
   type UseOpenChoreoInfiniteQueryOptions,
   type UseOpenChoreoInfiniteQueryResult,
 } from './hooks/useOpenChoreoInfiniteQuery';
+export { queryClient } from './query/queryClient';
+export { OpenChoreoQueryProvider } from './query/OpenChoreoQueryProvider';
 
 // Change Detection Components
 export { ChangeDiff, type ChangeDiffProps } from './components/ChangeDiff';

--- a/plugins/openchoreo-react/src/query/OpenChoreoQueryProvider.test.tsx
+++ b/plugins/openchoreo-react/src/query/OpenChoreoQueryProvider.test.tsx
@@ -1,0 +1,101 @@
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import { identityApiRef } from '@backstage/core-plugin-api';
+import { TestApiProvider } from '@backstage/test-utils';
+import {
+  OpenChoreoQueryProvider,
+  useUserScopedKey,
+} from './OpenChoreoQueryProvider';
+
+function identity(userEntityRef: string) {
+  return {
+    getBackstageIdentity: jest.fn().mockResolvedValue({ userEntityRef }),
+  };
+}
+
+function wrapperFor(
+  api: Partial<import('@backstage/core-plugin-api').IdentityApi>,
+) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <TestApiProvider apis={[[identityApiRef, api]]}>
+      <OpenChoreoQueryProvider>{children}</OpenChoreoQueryProvider>
+    </TestApiProvider>
+  );
+}
+
+describe('OpenChoreoQueryProvider', () => {
+  it('renders its children (so a QueryClient is in the tree for them)', async () => {
+    render(
+      <TestApiProvider
+        apis={[[identityApiRef, identity('user:default/alice')]]}
+      >
+        <OpenChoreoQueryProvider>
+          <div data-testid="child">hello</div>
+        </OpenChoreoQueryProvider>
+      </TestApiProvider>,
+    );
+    expect(await screen.findByTestId('child')).toHaveTextContent('hello');
+  });
+});
+
+describe('useUserScopedKey', () => {
+  it('namespaces the key under a pending sentinel before the user resolves', () => {
+    // A never-resolving identity keeps the scope in its pre-resolution state.
+    const api = {
+      getBackstageIdentity: jest.fn(() => new Promise<never>(() => {})),
+    };
+    const { result } = renderHook(() => useUserScopedKey(), {
+      wrapper: wrapperFor(api),
+    });
+    const key = result.current(['components', 'c1']);
+    // Prefixed and namespaced, but NOT under any real user's scope.
+    expect(key[0]).toBe('@user');
+    expect(key[1]).toBe('@openchoreo/pending-user');
+    expect(key.slice(2)).toEqual(['components', 'c1']);
+  });
+
+  it('namespaces the key under the signed-in user once resolved', async () => {
+    const { result } = renderHook(() => useUserScopedKey(), {
+      wrapper: wrapperFor(identity('user:default/alice')),
+    });
+    await waitFor(() =>
+      expect(result.current(['components'])).toEqual([
+        '@user',
+        'user:default/alice',
+        'components',
+      ]),
+    );
+  });
+
+  it('gives different users disjoint key spaces (structural isolation)', async () => {
+    const aliceHook = renderHook(() => useUserScopedKey(), {
+      wrapper: wrapperFor(identity('user:default/alice')),
+    });
+    const bobHook = renderHook(() => useUserScopedKey(), {
+      wrapper: wrapperFor(identity('user:default/bob')),
+    });
+
+    await waitFor(() =>
+      expect(aliceHook.result.current(['x'])[1]).toBe('user:default/alice'),
+    );
+    await waitFor(() =>
+      expect(bobHook.result.current(['x'])[1]).toBe('user:default/bob'),
+    );
+
+    // Same caller key → different namespaced keys → cannot collide in the cache.
+    expect(aliceHook.result.current(['x'])).not.toEqual(
+      bobHook.result.current(['x']),
+    );
+  });
+
+  it('returns a stable function per user (safe as a memo/effect dep)', async () => {
+    const { result, rerender } = renderHook(() => useUserScopedKey(), {
+      wrapper: wrapperFor(identity('user:default/alice')),
+    });
+    await waitFor(() =>
+      expect(result.current(['x'])[1]).toBe('user:default/alice'),
+    );
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/plugins/openchoreo-react/src/query/OpenChoreoQueryProvider.tsx
+++ b/plugins/openchoreo-react/src/query/OpenChoreoQueryProvider.tsx
@@ -1,0 +1,112 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+import { identityApiRef, useApi } from '@backstage/core-plugin-api';
+import { QueryClientProvider, type QueryKey } from '@tanstack/react-query';
+import { queryClient } from './queryClient';
+
+/**
+ * The signed-in user's entityRef, used to namespace every cache key so one
+ * user can never read another user's permission-scoped responses (see
+ * {@link useUserScopedKey}). `undefined` until the identity resolves; the
+ * sentinel below is used for keys built in that window.
+ */
+const UserScopeContext = createContext<string | undefined>(undefined);
+
+/**
+ * Key prefix used before the identity has resolved. Distinct from any real
+ * entityRef, so a query started pre-resolution keys under its own scope and
+ * simply re-keys (one refetch) once the real user is known — it never lands in
+ * a different user's scope.
+ */
+const PENDING_USER = '@openchoreo/pending-user';
+
+/**
+ * Returns a function that namespaces a caller's query key with the signed-in
+ * user, so different users occupy disjoint key spaces in the shared cache.
+ * User B structurally cannot hit user A's cached entry — no clearing needed,
+ * no cross-user leak possible. Applied inside every OpenChoreo cache seam
+ * (`useOpenChoreoQuery`, `useOpenChoreoInfiniteQuery`, `useOpenChoreoMutation`,
+ * `useOpenChoreoCache`) so all 4 agree on the same namespaced key for a given
+ * caller key — critical because mutations/`useOpenChoreoCache` invalidate and
+ * read BY that key.
+ *
+ * Outside an {@link OpenChoreoQueryProvider} the scope is the pending sentinel
+ * (still a valid, consistent namespace), so the seam degrades safely.
+ */
+export function useUserScopedKey(): (key: QueryKey) => QueryKey {
+  const user = useContext(UserScopeContext) ?? PENDING_USER;
+  // Stable per user so callers can safely list it in useMemo/useCallback deps
+  // (e.g. useOpenChoreoCache memoises its handle on it).
+  return useCallback((key: QueryKey) => ['@user', user, ...key], [user]);
+}
+
+/**
+ * Resolves the signed-in user's entityRef and publishes it on
+ * {@link UserScopeContext}. `identityApi` is a stable singleton, so this runs
+ * once on mount; `getBackstageIdentity()` is a local token decode that resolves
+ * near-instantly for an already-signed-in user (the app is always behind
+ * sign-in before OpenChoreo content renders).
+ */
+const UserScopeProvider = ({ children }: PropsWithChildren<{}>) => {
+  const identityApi = useApi(identityApiRef);
+  const [user, setUser] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    identityApi
+      .getBackstageIdentity()
+      .then(({ userEntityRef }) => {
+        if (!cancelled) setUser(userEntityRef);
+      })
+      .catch(() => {
+        // No resolvable identity yet; keys stay under the pending sentinel
+        // until a later successful resolve (which remounts nothing — the
+        // context value simply updates).
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [identityApi]);
+
+  return (
+    <UserScopeContext.Provider value={user}>
+      {children}
+    </UserScopeContext.Provider>
+  );
+};
+
+/**
+ * Wraps children in the OpenChoreo-wide `QueryClientProvider` (see
+ * {@link queryClient}) plus the user-scoping context. Each OpenChoreo NFS
+ * feature mounts this around its own extensions via `PluginWrapperBlueprint`
+ * (not `AppRootWrapperBlueprint`, whose `app/root` input is internal and
+ * silently ignores plugin-contributed wrappers), so NFS-mounted OpenChoreo
+ * surfaces — auto-mounted entity tabs/cards and standalone plugin pages — are
+ * self-contained: hosts wire nothing and always have a `QueryClient` in the
+ * tree. A host that composes tab components itself via legacy
+ * `EntityLayout.Route` JSX renders them outside this wrapper and mounts this
+ * provider directly instead (as this repo's `packages/app` does).
+ *
+ * Cross-user isolation is structural, not imperative: every cache key is
+ * namespaced by the signed-in user (see {@link useUserScopedKey}), so a user
+ * switch moves into a disjoint key space and can never read the previous user's
+ * cached data. No cache-clearing guard is needed.
+ *
+ * Nesting is safe. When a host installs several OpenChoreo plugins, each
+ * contributes one wrapper and they nest — but every wrapper references the same
+ * `queryClient` singleton, so the inner providers are harmless no-ops and there
+ * is exactly one cache.
+ */
+export const OpenChoreoQueryProvider = ({
+  children,
+}: PropsWithChildren<{}>) => (
+  <QueryClientProvider client={queryClient}>
+    <UserScopeProvider>{children}</UserScopeProvider>
+  </QueryClientProvider>
+);

--- a/plugins/openchoreo-react/src/query/queryClient.ts
+++ b/plugins/openchoreo-react/src/query/queryClient.ts
@@ -1,9 +1,16 @@
 import { QueryClient } from '@tanstack/react-query';
 
 /**
- * The single app-wide TanStack Query client. Its defaults are the portal's
- * caching policy — individual hooks (via `useOpenChoreoQuery`) only override
- * `staleTime`/`refetchInterval` where a data class needs it.
+ * The single OpenChoreo-wide TanStack Query client. Its defaults are the
+ * portal's caching policy — individual hooks (via `useOpenChoreoQuery`) only
+ * override `staleTime`/`refetchInterval` where a data class needs it.
+ *
+ * This lives in `openchoreo-react` (not the host app) so the OpenChoreo NFS
+ * features can mount their own `QueryClientProvider` around this exact
+ * singleton — see {@link OpenChoreoQueryProvider}. That makes response caching
+ * self-contained: an external Backstage host installs the plugins and gets
+ * caching with no provider wiring, and the OpenChoreo tabs can never hit the
+ * "No QueryClient set" crash from a missing provider.
  *
  * Rationale for the defaults:
  * - `staleTime: 30s` — within this window a revisited tab paints from cache
@@ -13,7 +20,6 @@ import { QueryClient } from '@tanstack/react-query';
  *   observer unmounts, so navigating away and back still hits warm cache.
  * - `refetchOnWindowFocus: false` — this is an internal platform tool; data
  *   isn't second-to-second critical and focus-refetch is surprising here.
- *   (Flagged as an open question in the RFC; easy to flip later.)
  * - `retry: 1` — one retry smooths a transient blip without hammering a slow
  *   BFF or masking a real error for long.
  */

--- a/plugins/openchoreo-workflows/src/alpha.test.tsx
+++ b/plugins/openchoreo-workflows/src/alpha.test.tsx
@@ -15,6 +15,7 @@ describe('openchoreo-workflows alpha plugin', () => {
     const plugin = 'openchoreo-workflows';
     for (const expected of [
       `api:${plugin}/generic-workflows-client`,
+      `plugin-wrapper:${plugin}/query-provider`,
       `page:${plugin}/generic-workflows`,
       `entity-content:${plugin}/workflow-runs`,
     ]) {

--- a/plugins/openchoreo-workflows/src/alpha.tsx
+++ b/plugins/openchoreo-workflows/src/alpha.tsx
@@ -4,6 +4,7 @@ import {
   discoveryApiRef,
   fetchApiRef,
   PageBlueprint,
+  PluginWrapperBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
 
@@ -19,6 +20,22 @@ const genericWorkflowsClientApi = ApiBlueprint.make({
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>
         new GenericWorkflowsClient(discoveryApi, fetchApi),
+    }),
+});
+
+// Wraps this plugin's own extensions in the TanStack Query provider (see the
+// openchoreo plugin's alpha for the full rationale). Shares the one `queryClient`
+// singleton across all OpenChoreo plugins.
+const queryProvider = PluginWrapperBlueprint.make({
+  name: 'query-provider',
+  params: defineParams =>
+    defineParams({
+      loader: async () => {
+        const { OpenChoreoQueryProvider } = await import(
+          '@openchoreo/backstage-plugin-react'
+        );
+        return { component: OpenChoreoQueryProvider };
+      },
     }),
 });
 
@@ -68,6 +85,7 @@ export default createFrontendPlugin({
   routes: { root: rootRouteRef },
   extensions: [
     genericWorkflowsClientApi,
+    queryProvider,
     genericWorkflowsPage,
     workflowRunsEntityContent,
   ],

--- a/plugins/openchoreo/src/alpha.test.tsx
+++ b/plugins/openchoreo/src/alpha.test.tsx
@@ -3,6 +3,8 @@ import openchoreoPlugin from './alpha';
 const ALPHA_EXTENSION_NAMES = [
   // backend client
   ['api', 'open-choreo-client'],
+  // self-contained response-cache provider
+  ['plugin-wrapper', 'query-provider'],
   // shared
   ['entity-content', 'resource-definition'],
   // component-page

--- a/plugins/openchoreo/src/alpha.tsx
+++ b/plugins/openchoreo/src/alpha.tsx
@@ -3,6 +3,7 @@ import {
   createFrontendPlugin,
   discoveryApiRef,
   fetchApiRef,
+  PluginWrapperBlueprint,
 } from '@backstage/frontend-plugin-api';
 import {
   EntityCardBlueprint,
@@ -27,6 +28,26 @@ const openChoreoClientApi = ApiBlueprint.make({
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>
         new OpenChoreoClient(discoveryApi, fetchApi),
+    }),
+});
+
+// Wraps this plugin's own extensions (tabs/cards) in the TanStack Query
+// provider, so every OpenChoreo surface has a QueryClient in the tree —
+// response caching is self-contained, the host wires nothing. Uses
+// PluginWrapperBlueprint (not AppRootWrapperBlueprint, whose app/root input is
+// internal and silently ignores plugin-contributed wrappers). The provider
+// references the shared `queryClient` singleton, so multiple OpenChoreo plugins
+// each wrapping their own surfaces still share exactly one cache.
+const queryProvider = PluginWrapperBlueprint.make({
+  name: 'query-provider',
+  params: defineParams =>
+    defineParams({
+      loader: async () => {
+        const { OpenChoreoQueryProvider } = await import(
+          '@openchoreo/backstage-plugin-react'
+        );
+        return { component: OpenChoreoQueryProvider };
+      },
     }),
 });
 
@@ -528,6 +549,7 @@ export default createFrontendPlugin({
   },
   extensions: [
     openChoreoClientApi,
+    queryProvider,
     resourceDefinitionEntityContent,
     componentDeployEntityContent,
     deploymentStatusCard,

--- a/plugins/platform-engineer-core/src/alpha.tsx
+++ b/plugins/platform-engineer-core/src/alpha.tsx
@@ -1,6 +1,7 @@
 import {
   createFrontendPlugin,
   PageBlueprint,
+  PluginWrapperBlueprint,
 } from '@backstage/frontend-plugin-api';
 
 import { rootRouteRef } from './routes';
@@ -17,11 +18,27 @@ const platformEngineerDashboardPage = PageBlueprint.make({
   },
 });
 
+// Wraps this plugin's own extensions in the TanStack Query provider (see the
+// openchoreo plugin's alpha for the full rationale). Shares the one `queryClient`
+// singleton across all OpenChoreo plugins.
+const queryProvider = PluginWrapperBlueprint.make({
+  name: 'query-provider',
+  params: defineParams =>
+    defineParams({
+      loader: async () => {
+        const { OpenChoreoQueryProvider } = await import(
+          '@openchoreo/backstage-plugin-react'
+        );
+        return { component: OpenChoreoQueryProvider };
+      },
+    }),
+});
+
 /**
  * NFS entry point for the Platform Engineer Core plugin.
  */
 export default createFrontendPlugin({
   pluginId: 'platform-engineer-core',
   routes: { root: rootRouteRef },
-  extensions: [platformEngineerDashboardPage],
+  extensions: [queryProvider, platformEngineerDashboardPage],
 });


### PR DESCRIPTION
Follow-up to #676. Makes the frontend response cache **self-contained**: each
OpenChoreo NFS feature now mounts its own TanStack Query `QueryClientProvider` at
the app root, so an external Backstage host gets caching automatically with **zero
wiring**.

Before this change the provider lived only in this repo's `packages/app`, which
external hosts don't use. A host that installed the plugins and rendered an
OpenChoreo tab without adding their own `QueryClientProvider` would crash with
**`No QueryClient set, use QueryClientProvider to set one`** — because every
migrated hook calls `useQuery`, which throws when no provider is above it in the
tree. This closes that gap without asking hosts to change anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenChoreo surfaces now provide their own response caching automatically, without additional host configuration.
  * Cached data is isolated by signed-in user to prevent cross-user data access.
  * Multiple OpenChoreo plugins share a unified cache.

* **Bug Fixes**
  * Prevented “No QueryClient set” crashes when using cached tabs and plugin features.
  * Improved cache consistency after mutations and invalidations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->