### PR TITLE
fix(app): sidebar separators render dark in production builds

### DIFF
--- a/.changeset/fix-sidebar-divider-prod.md
+++ b/.changeset/fix-sidebar-divider-prod.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-design-system': patch
+'@openchoreo/backstage-plugin': patch
+---
+
+Fix sidebar section separators rendering as dark near-black lines in production
+builds. The softening rule targeted the divider by its `BackstageSidebarDivider-root`
+class prefix, which JSS mangles away in the production bundle; it now targets the
+sidebar-nav `hr` element directly, so the light-mode divider stays a subtle grey in
+both dev and prod.

--- a/packages/app/src/buiOverrides.css
+++ b/packages/app/src/buiOverrides.css
@@ -35,12 +35,19 @@ article.bui-Card {
  * white in light mode, so #383838 reads as hard near-black lines. Soften
  * to a subtle grey in light mode; keep #383838 in dark mode where it
  * blends correctly with the dark sidebar.
+ *
+ * Target the divider via the sidebar-nav `hr` element, NOT a
+ * `BackstageSidebarDivider-root` class prefix: in the production bundle JSS
+ * mangles the class to a bare `jss4-NN` (no component-name prefix), so the
+ * class-prefix selector matched nothing and the dark #383838 leaked through
+ * (fine in dev, broken in prod). The `nav[aria-label="sidebar nav"] hr`
+ * selector is class-independent and stable across dev and prod.
  */
-[class*='BackstageSidebarDivider-root'] {
+nav[aria-label='sidebar nav'] hr {
   background-color: #f3f4f6 !important;
 }
 
-[data-theme-mode='dark'] [class*='BackstageSidebarDivider-root'] {
+[data-theme-mode='dark'] nav[aria-label='sidebar nav'] hr {
   background-color: #383838 !important;
 }
 

--- a/packages/design-system/src/theme/buildOpenChoreoTheme.ts
+++ b/packages/design-system/src/theme/buildOpenChoreoTheme.ts
@@ -203,9 +203,6 @@ export function buildOpenChoreoTheme(t: ThemeTokens): UnifiedTheme {
           'body, html': {
             fontFamily: `${fontFamily} !important`,
           },
-          'nav[aria-label="sidebar nav"] hr': {
-            opacity: 0.2,
-          },
           'g[data-testid="node"] rect': {
             '&.primary': {
               fill: `${t.primary.dark} !important`,


### PR DESCRIPTION
The sidebar section separators showed as faint grey in the dev server but dark near-black lines in production builds.

Cause: the light-mode softening rule in buiOverrides.css targeted the divider by its BackstageSidebarDivider-root class prefix, which JSS mangles to a bare jss4-NN in the production bundle — so the selector matched nothing in prod and the base #383838 leaked through (fine in dev, where the readable class prefix survives).

Fix: target the sidebar-nav hr element directly (nav[aria-label='sidebar nav'] hr), which is class-independent and stable across dev and prod. Also removed a now-inert opacity: 0.2 sidebar rule from the theme (dead since the v1.51 upgrade dropped <CssBaseline>).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sidebar divider styling so it appears as a subtle grey line in both development and production.
  - Improved light-mode contrast while preserving the existing dark-mode appearance.
  - Ensured divider styling remains reliable across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->