### PR TITLE
fix: fix non-matching cacheKey by  simplifying span key generation in useTraceSpans hook

### DIFF
--- a/.changeset/trace-spans-cache-key.md
+++ b/.changeset/trace-spans-cache-key.md
@@ -1,0 +1,9 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+---
+
+Fix trace span details never loading from cache. The span cache key included
+the filter scope and time window, whose timestamps changed every render, so the
+key used to read spans (`getSpans`) no longer matched the one they were cached
+under and always returned `undefined`. Spans are now keyed by trace id alone —
+a trace id uniquely identifies its spans regardless of the query scope.

--- a/plugins/openchoreo-observability/src/hooks/useTraceSpans.ts
+++ b/plugins/openchoreo-observability/src/hooks/useTraceSpans.ts
@@ -28,7 +28,7 @@ export function useTraceSpans(options: UseTraceSpansOptions) {
   // Bumped whenever a fetch resolves so cache-backed reads re-render.
   const [, setVersion] = useState(0);
 
-    // A trace id is globally unique and a trace is atomic, so its spans are the
+  // A trace id is globally unique and a trace is atomic, so its spans are the
   // same regardless of the filter/time scope used to find it in the list. Key
   // by trace id alone (user-scoped by the cache) — the scope/time only belong
   // in the trace-list key, which does depend on the filters.

--- a/plugins/openchoreo-observability/src/hooks/useTraceSpans.ts
+++ b/plugins/openchoreo-observability/src/hooks/useTraceSpans.ts
@@ -28,25 +28,13 @@ export function useTraceSpans(options: UseTraceSpansOptions) {
   // Bumped whenever a fetch resolves so cache-backed reads re-render.
   const [, setVersion] = useState(0);
 
+    // A trace id is globally unique and a trace is atomic, so its spans are the
+  // same regardless of the filter/time scope used to find it in the list. Key
+  // by trace id alone (user-scoped by the cache) — the scope/time only belong
+  // in the trace-list key, which does depend on the filters.
   const spanKey = useCallback(
-    (traceId: string) => [
-      'trace-spans',
-      options.namespaceName,
-      options.projectName,
-      options.environmentName,
-      options.componentName ?? null,
-      options.startTime ?? null,
-      options.endTime ?? null,
-      traceId,
-    ],
-    [
-      options.namespaceName,
-      options.projectName,
-      options.environmentName,
-      options.componentName,
-      options.startTime,
-      options.endTime,
-    ],
+    (traceId: string) => ['trace-spans', traceId],
+    [],
   );
 
   const fetchSpans = useCallback(


### PR DESCRIPTION
## Purpose

fix non-matching cacheKey by  simplifying span key generation in useTraceSpans hook

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where trace span details could fail to load from cache.
  - Trace spans now load reliably for a trace across different filter scopes and time ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->