### PR TITLE
 feat(caching): route the catalog through the response cache (instant paint, no skeleton flash)

### DIFF
--- a/.changeset/cache-catalog-always-revalidate.md
+++ b/.changeset/cache-catalog-always-revalidate.md
@@ -25,3 +25,9 @@ lists) now read their data through `useOpenChoreoQuery` instead of an imperative
 `await catalogApi.getEntities(...)`, so reopening a level renders the cached list
 instantly (no loading spinner) and only revalidates in the background, rather
 than blocking on the network every open.
+
+The catalog list page seeds its initial rows from the cached `queryEntities`
+response (via the newly exported `useUserScopedKey`), so returning to a
+previously viewed list paints instantly from cache instead of flashing a
+skeleton while `useEntityList` re-fetches. `useUserScopedKey` is now exported
+from `@openchoreo/backstage-plugin-react`.

--- a/.changeset/cache-catalog-always-revalidate.md
+++ b/.changeset/cache-catalog-always-revalidate.md
@@ -19,3 +19,9 @@ The `queryClient` default `staleTime` changes from 30s to 0 (always
 stale-while-revalidate): a revisited surface paints cached data instantly and
 always runs a background refresh, so nothing on screen is left silently stale.
 The two hooks that set an explicit 30s `staleTime` now inherit this default.
+
+The entity-header breadcrumb dropdowns (namespace/project/component sibling
+lists) now read their data through `useOpenChoreoQuery` instead of an imperative
+`await catalogApi.getEntities(...)`, so reopening a level renders the cached list
+instantly (no loading spinner) and only revalidates in the background, rather
+than blocking on the network every open.

--- a/.changeset/cache-catalog-always-revalidate.md
+++ b/.changeset/cache-catalog-always-revalidate.md
@@ -1,0 +1,21 @@
+---
+'@openchoreo/backstage-plugin-react': patch
+'@openchoreo/backstage-plugin': patch
+---
+
+Cache catalog reads and switch the response cache to always-revalidate.
+
+The catalog list and entity pages now read through a `CachingCatalogApi` wrapper
+(exported from `@openchoreo/backstage-plugin-react`) that routes
+`getEntities`/`queryEntities`/`getEntityByRef`/`getEntitiesByRefs` through the
+shared `queryClient`, keyed per signed-in user. Previously the catalog used
+Backstage's `CatalogApi` directly, so every visit re-fetched from scratch and
+flashed a loading skeleton; now a revisited catalog list or entity page paints
+instantly from the warm cache. Catalog writes (`refreshEntity`, location
+add/remove/update, `removeEntityByUid`) invalidate the cache so user changes show
+immediately.
+
+The `queryClient` default `staleTime` changes from 30s to 0 (always
+stale-while-revalidate): a revisited surface paints cached data instantly and
+always runs a background refresh, so nothing on screen is left silently stale.
+The two hooks that set an explicit 30s `staleTime` now inherit this default.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,6 +22,7 @@
     "@backstage-community/plugin-github-actions": "^0.20.0",
     "@backstage-community/plugin-jenkins": "^0.28.0",
     "@backstage/app-defaults": "^1.7.8",
+    "@backstage/catalog-client": "^1.15.1",
     "@backstage/catalog-model": "^1.9.0",
     "@backstage/cli": "^0.36.2",
     "@backstage/config": "^1.3.8",

--- a/packages/app/src/apis/customOverrides.test.tsx
+++ b/packages/app/src/apis/customOverrides.test.tsx
@@ -1,9 +1,56 @@
+import { CachingCatalogApi } from '@openchoreo/backstage-plugin-react';
 import {
   catalogGraphPluginAlpha,
   catalogPluginAlpha,
+  createCachingCatalogApi,
   customAppModule,
   scaffolderPluginAlpha,
 } from './customOverrides';
+
+const makeDeps = (identity: unknown) =>
+  ({
+    discoveryApi: { getBaseUrl: async () => 'http://localhost/api' },
+    fetchApi: { fetch: async () => new Response('{}') },
+    identityApi: identity,
+  } as unknown as Parameters<typeof createCachingCatalogApi>[0]);
+
+describe('createCachingCatalogApi', () => {
+  it('builds a CachingCatalogApi from the catalog deps', () => {
+    const api = createCachingCatalogApi(
+      makeDeps({
+        getBackstageIdentity: jest
+          .fn()
+          .mockResolvedValue({ userEntityRef: 'user:default/alice' }),
+      }),
+    );
+    expect(api).toBeInstanceOf(CachingCatalogApi);
+  });
+
+  it('resolves the user ref via identityApi when a read runs', async () => {
+    const getBackstageIdentity = jest
+      .fn()
+      .mockResolvedValue({ userEntityRef: 'user:default/alice' });
+    const api = createCachingCatalogApi(makeDeps({ getBackstageIdentity }));
+
+    // Exercise reads so getUserRef (which calls getBackstageIdentity) fires.
+    await api.getEntities({ filter: { kind: 'component' } });
+    await api.getEntities({ filter: { kind: 'api' } });
+    expect(getBackstageIdentity).toHaveBeenCalled();
+  });
+
+  it('falls back to an unscoped ref when identity rejects, without throwing', async () => {
+    const api = createCachingCatalogApi(
+      makeDeps({
+        getBackstageIdentity: jest.fn().mockRejectedValue(new Error('no auth')),
+      }),
+    );
+    // A read must still succeed (keys fall back to the pending sentinel) rather
+    // than surfacing the identity rejection.
+    await expect(
+      api.getEntities({ filter: { kind: 'component' } }),
+    ).resolves.toBeDefined();
+  });
+});
 
 describe('customOverrides', () => {
   it('exports a catalog-graph plugin override', () => {

--- a/packages/app/src/apis/customOverrides.tsx
+++ b/packages/app/src/apis/customOverrides.tsx
@@ -35,6 +35,9 @@ import {
   discoveryApiRef,
   fetchApiRef,
   identityApiRef,
+  type DiscoveryApi,
+  type FetchApi,
+  type IdentityApi,
 } from '@backstage/core-plugin-api';
 import { CatalogClient } from '@backstage/catalog-client';
 import { CachingCatalogApi } from '@openchoreo/backstage-plugin-react';
@@ -115,6 +118,37 @@ export const catalogGraphPluginAlpha =
   });
 
 /**
+ * Factory for the caching `catalogApiRef` implementation (the `api:catalog`
+ * override below). Builds the same `CatalogClient` upstream does, then wraps it
+ * in `CachingCatalogApi` so catalog reads flow through the shared OpenChoreo
+ * `queryClient`.
+ *
+ * `getUserRef` resolves the signed-in user's entityRef per call (used only to
+ * namespace cache keys). It deliberately does NOT memoize the promise:
+ * `identityApi` already caches the session and dedupes token refresh internally,
+ * and memoizing here would permanently pin the cache namespace to the pending
+ * sentinel if the very first call resolved to undefined or rejected (e.g. a
+ * query before sign-in completes) — it would never recover for the app's life.
+ *
+ * Exported so the wrapper wiring is unit-testable without driving the extension
+ * blueprint machinery.
+ */
+export function createCachingCatalogApi(deps: {
+  discoveryApi: DiscoveryApi;
+  fetchApi: FetchApi;
+  identityApi: IdentityApi;
+}): CachingCatalogApi {
+  const { discoveryApi, fetchApi, identityApi } = deps;
+  const base = new CatalogClient({ discoveryApi, fetchApi });
+  const getUserRef = () =>
+    identityApi
+      .getBackstageIdentity()
+      .then(({ userEntityRef }) => userEntityRef)
+      .catch(() => undefined);
+  return new CachingCatalogApi(base, getUserRef);
+}
+
+/**
  * Override `catalog`'s default `api:catalog/entity-presentation` to provide
  * kind icons for OpenChoreo-specific entity kinds (Environment, DataPlane,
  * DeploymentPipeline, etc.) in the catalog graph and entity views.
@@ -174,22 +208,7 @@ export const catalogPluginAlpha = catalogPluginAlphaBase.withOverrides({
             fetchApi: fetchApiRef,
             identityApi: identityApiRef,
           },
-          factory: ({ discoveryApi, fetchApi, identityApi }) => {
-            const base = new CatalogClient({ discoveryApi, fetchApi });
-            // Resolve the signed-in user's entityRef per call (used only to
-            // namespace cache keys). Don't memoize the promise: `identityApi`
-            // already caches the session and dedupes token refresh internally,
-            // and memoizing here would permanently pin the cache namespace to
-            // the pending sentinel if the very first call resolved to undefined
-            // or rejected (e.g. queried before sign-in completes) — it would
-            // never recover for the app's lifetime.
-            const getUserRef = () =>
-              identityApi
-                .getBackstageIdentity()
-                .then(({ userEntityRef }) => userEntityRef)
-                .catch(() => undefined);
-            return new CachingCatalogApi(base, getUserRef);
-          },
+          factory: createCachingCatalogApi,
         }),
     }),
     catalogPluginAlphaBase

--- a/packages/app/src/apis/customOverrides.tsx
+++ b/packages/app/src/apis/customOverrides.tsx
@@ -32,6 +32,13 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 import {
+  discoveryApiRef,
+  fetchApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { CatalogClient } from '@backstage/catalog-client';
+import { CachingCatalogApi } from '@openchoreo/backstage-plugin-react';
+import {
   formDecoratorsApiRef,
   DefaultScaffolderFormDecoratorsApi,
 } from '@backstage/plugin-scaffolder/alpha';
@@ -149,6 +156,38 @@ export const catalogPluginAlpha = catalogPluginAlphaBase.withOverrides({
             <m.CustomCatalogPage initialKind="system" />
           )),
       },
+    }),
+    // Wrap `api:catalog` with a caching CatalogApi so the catalog list
+    // (`useEntityList` → getEntities/queryEntities) and the entity page
+    // (getEntityByRef) read through the shared OpenChoreo `queryClient`.
+    // Without this, Backstage's own catalog hooks re-fetch on every mount and
+    // flash a skeleton on revisit; with it, a revisited catalog surface paints
+    // instantly from the warm cache and revalidates in the background. Mirrors
+    // upstream's factory (`new CatalogClient({ discoveryApi, fetchApi })`) and
+    // adds `identityApi` to namespace cache keys per signed-in user.
+    catalogPluginAlphaBase.getExtension('api:catalog').override({
+      params: defineParams =>
+        defineParams({
+          api: catalogApiRef,
+          deps: {
+            discoveryApi: discoveryApiRef,
+            fetchApi: fetchApiRef,
+            identityApi: identityApiRef,
+          },
+          factory: ({ discoveryApi, fetchApi, identityApi }) => {
+            const base = new CatalogClient({ discoveryApi, fetchApi });
+            // Resolve the signed-in user's entityRef once and reuse it — the
+            // identity is stable for the session, and the wrapper only needs it
+            // to build per-user cache keys.
+            let cachedUserRef: Promise<string | undefined> | undefined;
+            const getUserRef = () =>
+              (cachedUserRef ??= identityApi
+                .getBackstageIdentity()
+                .then(({ userEntityRef }) => userEntityRef)
+                .catch(() => undefined));
+            return new CachingCatalogApi(base, getUserRef);
+          },
+        }),
     }),
     catalogPluginAlphaBase
       .getExtension('api:catalog/entity-presentation')

--- a/packages/app/src/apis/customOverrides.tsx
+++ b/packages/app/src/apis/customOverrides.tsx
@@ -176,15 +176,18 @@ export const catalogPluginAlpha = catalogPluginAlphaBase.withOverrides({
           },
           factory: ({ discoveryApi, fetchApi, identityApi }) => {
             const base = new CatalogClient({ discoveryApi, fetchApi });
-            // Resolve the signed-in user's entityRef once and reuse it — the
-            // identity is stable for the session, and the wrapper only needs it
-            // to build per-user cache keys.
-            let cachedUserRef: Promise<string | undefined> | undefined;
+            // Resolve the signed-in user's entityRef per call (used only to
+            // namespace cache keys). Don't memoize the promise: `identityApi`
+            // already caches the session and dedupes token refresh internally,
+            // and memoizing here would permanently pin the cache namespace to
+            // the pending sentinel if the very first call resolved to undefined
+            // or rejected (e.g. queried before sign-in completes) — it would
+            // never recover for the app's lifetime.
             const getUserRef = () =>
-              (cachedUserRef ??= identityApi
+              identityApi
                 .getBackstageIdentity()
                 .then(({ userEntityRef }) => userEntityRef)
-                .catch(() => undefined));
+                .catch(() => undefined);
             return new CachingCatalogApi(base, getUserRef);
           },
         }),

--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -149,6 +149,7 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
     totalItems,
     loading,
     filters,
+    queryParameters,
     limit,
     offset,
     setLimit,
@@ -164,7 +165,15 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
     navigate(url);
   };
 
-  const selectedKind = filters.kind?.value?.toLowerCase();
+  // Prefer the applied filter's kind, but fall back to the URL query param on a
+  // fresh mount: `filters.kind` is only populated once ChoreoEntityKindPicker's
+  // effect re-registers it (which waits on an async kind fetch), so for the
+  // instant-paint window `filters.kind` is undefined while the URL already
+  // carries the kind. The picker reads the same `queryParameters.kind` first.
+  const urlKind = (
+    [queryParameters?.kind].flat()[0] as string | undefined
+  )?.toLowerCase();
+  const selectedKind = filters.kind?.value?.toLowerCase() ?? urlKind;
   const gridTemplateClass = classes[getGridTemplate(selectedKind)];
   const headerColumns = getHeaderColumns(selectedKind);
 
@@ -175,38 +184,79 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
   // `queryEntities` entry for the current kind straight out of the shared
   // queryClient. This is READ-ONLY (a miss just falls back to the skeleton) and
   // scoped to the signed-in user via useUserScopedKey, so it can't cross-serve.
+  // The seed only paints while the live list is empty AND the view is the plain
+  // first page of a kind — no chip/search filter, no pagination offset. Any
+  // other filter narrows the query in ways we can't reconstruct from the cache
+  // key alone, so seeding then would risk showing a broader page's rows (wrong
+  // scope) or stale rows for a filter that now returns nothing. Restricting to
+  // the unfiltered first page keeps the seed correct-by-construction.
+  // `project`/`component` are custom OpenChoreo filters registered via
+  // `updateFilters` (typed as `any` at their call sites), so they aren't on the
+  // `DefaultEntityFilters` shape — read them through a widened view.
+  const activeFilters = filters as Record<string, unknown>;
+  const hasNarrowingFilter = Boolean(
+    activeFilters.namespace ||
+      activeFilters.project ||
+      activeFilters.component ||
+      activeFilters.type ||
+      activeFilters.user ||
+      activeFilters.text,
+  );
+  const seedEligible =
+    entities.length === 0 && !hasNarrowingFilter && !offset && !!selectedKind;
+
   const scopeKey = useUserScopedKey();
   const seed = useMemo<QueryEntitiesResponse | undefined>(() => {
-    // Only needed while useEntityList has nothing of its own to show.
-    if (entities.length > 0) return undefined;
-    // Prefix match instead of reconstructing the exact request object (which
-    // Backstage builds via a non-exported reducer with `fullTextFilter:
-    // undefined` / `offset: undefined` subtleties). Pick the newest cached
-    // page whose request kind matches the current kind.
+    if (!seedEligible) return undefined;
+    // Read the warm queryEntities entry the CachingCatalogApi stored. Match on
+    // the current kind AND require an unfiltered, first-page request (filter is
+    // kind-only, no fullTextFilter, offset falsy) so we can't pick a filtered or
+    // paginated page. Among matches, take the most recently updated (findAll has
+    // no recency order, so an unsorted [0] could be an older/wrong page).
     const prefix = scopeKey(['catalog', 'queryEntities']);
-    const matches = queryClient
+    const match = queryClient
       .getQueryCache()
       .findAll({ queryKey: prefix })
       .map(q => ({
-        req: q.queryKey[4] as { filter?: { kind?: unknown } } | undefined,
+        req: q.queryKey[4] as
+          | {
+              filter?: { kind?: unknown };
+              fullTextFilter?: unknown;
+              offset?: number;
+            }
+          | undefined,
         data: q.state.data as QueryEntitiesResponse | undefined,
+        updatedAt: q.state.dataUpdatedAt,
       }))
       .filter(({ data }) => data !== undefined)
       .filter(({ req }) => {
-        if (!selectedKind) return true;
-        const reqKind = req?.filter?.kind;
+        if (!req || req.fullTextFilter || req.offset) return false;
+        // Only the kind may be present in the filter — reject any page that
+        // carried extra filter facets (project/namespace/type/...).
+        const filter = (req.filter ?? {}) as Record<string, unknown>;
+        const keys = Object.keys(filter);
+        if (keys.length !== 1 || keys[0] !== 'kind') return false;
+        const reqKind = filter.kind;
         const kinds = Array.isArray(reqKind) ? reqKind : [reqKind];
         return kinds.some(k => String(k).toLowerCase() === selectedKind);
-      });
-    return matches[0]?.data;
-  }, [entities.length, scopeKey, selectedKind]);
+      })
+      .sort((a, b) => b.updatedAt - a.updatedAt)[0];
+    return match?.data;
+  }, [seedEligible, scopeKey, selectedKind]);
 
   // Rows to render: the live list once it has resolved, else the cached seed.
   const displayEntities = entities.length > 0 ? entities : seed?.items ?? [];
   // Prefer the live count; fall back to the seed's while it loads.
   const displayTotal = totalItems ?? seed?.totalItems;
 
-  const kindLabel = filters.kind?.label || filters.kind?.value || 'Entity';
+  // Fall back to the URL-derived kind (capitalized to match kindPluralNames
+  // keys) while filters.kind is still catching up, so the title reads correctly
+  // during the seed window instead of the generic "Entity".
+  const capitalizedKind = selectedKind
+    ? selectedKind.charAt(0).toUpperCase() + selectedKind.slice(1)
+    : undefined;
+  const kindLabel =
+    filters.kind?.label || filters.kind?.value || capitalizedKind || 'Entity';
   const pluralLabel = kindPluralNames[kindLabel] || `${kindLabel}s`;
   const titleText = `All ${displayTotal === 1 ? kindLabel : pluralLabel}${
     displayTotal !== undefined ? ` (${displayTotal})` : ''
@@ -226,7 +276,10 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
   const heldKindMatches =
     entities.length === 0 ||
     !selectedKind ||
-    entities[0].kind?.toLowerCase() === selectedKind;
+    // A held entity with no kind can't be proven a mismatch — don't force a
+    // cold reload over it (that would wipe otherwise-valid rows to the loader).
+    !entities[0].kind ||
+    entities[0].kind.toLowerCase() === selectedKind;
   const firstLoad =
     loading &&
     displayEntities.length === 0 &&

--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -169,6 +169,23 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
   const gridTemplateClass = classes[getGridTemplate(selectedKind)];
   const headerColumns = getHeaderColumns(selectedKind);
 
+  // Show the skeleton only on a COLD load — when there is nothing safe to keep
+  // on screen. On a same-kind revisit, `useEntityList` keeps the previously
+  // resolved entities painted while a background refetch runs (the catalog
+  // reads route through the cached CatalogApi), so we keep the rows instead of
+  // wiping to a skeleton.
+  //
+  // A kind SWITCH is treated as cold even though `useEntityList` still holds
+  // the old kind's entities: the column set is derived from `selectedKind`, so
+  // rendering the previous kind's rows under the new kind's headers would
+  // misalign columns. Detect it by comparing the held entities' kind to the
+  // selected kind.
+  const heldKindMatches =
+    entities.length === 0 ||
+    !selectedKind ||
+    entities[0].kind?.toLowerCase() === selectedKind;
+  const firstLoad = loading && (entities.length === 0 || !heldKindMatches);
+
   return (
     <Box>
       <Box className={classes.searchAndTitle}>
@@ -186,11 +203,11 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
         </Box>
       </Box>
 
-      {loading && <PageLoader minHeight={240} />}
+      {firstLoad && <PageLoader minHeight={240} />}
       {!loading && entities.length === 0 && (
         <Box className={classes.emptyState}>No entities found</Box>
       )}
-      {!loading && entities.length > 0 && (
+      {!firstLoad && entities.length > 0 && (
         <Box className={classes.listContainer}>
           {/* Header row */}
           <Box className={`${classes.headerRow} ${gridTemplateClass}`}>
@@ -440,7 +457,7 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
         </Box>
       )}
 
-      {!loading && totalItems !== undefined && totalItems > 0 && (
+      {!firstLoad && totalItems !== undefined && totalItems > 0 && (
         <Box className={classes.paginationContainer}>
           <TablePagination
             count={totalItems}

--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { Box, Chip, IconButton, Tooltip, Typography } from '@material-ui/core';
 import { PageLoader } from '@openchoreo/backstage-design-system';
 import { TablePagination } from '@material-ui/core';
@@ -16,6 +16,11 @@ import {
   DeletionBadge,
   isMarkedForDeletion,
 } from '@openchoreo/backstage-plugin';
+import {
+  queryClient,
+  useUserScopedKey,
+} from '@openchoreo/backstage-plugin-react';
+import type { QueryEntitiesResponse } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import { useCardListStyles } from './styles';
 import {
@@ -159,32 +164,73 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
     navigate(url);
   };
 
-  const kindLabel = filters.kind?.label || filters.kind?.value || 'Entity';
-  const pluralLabel = kindPluralNames[kindLabel] || `${kindLabel}s`;
-  const titleText = `All ${totalItems === 1 ? kindLabel : pluralLabel}${
-    totalItems !== undefined ? ` (${totalItems})` : ''
-  }`;
-
   const selectedKind = filters.kind?.value?.toLowerCase();
   const gridTemplateClass = classes[getGridTemplate(selectedKind)];
   const headerColumns = getHeaderColumns(selectedKind);
 
+  // On a fresh mount (navigating back to /catalog) `useEntityList` starts with
+  // empty `entities` and re-runs its own async fetch, so it can't paint from
+  // cache synchronously — that's the skeleton flash. Seed the first render from
+  // the response our CachingCatalogApi already stored: read the warm
+  // `queryEntities` entry for the current kind straight out of the shared
+  // queryClient. This is READ-ONLY (a miss just falls back to the skeleton) and
+  // scoped to the signed-in user via useUserScopedKey, so it can't cross-serve.
+  const scopeKey = useUserScopedKey();
+  const seed = useMemo<QueryEntitiesResponse | undefined>(() => {
+    // Only needed while useEntityList has nothing of its own to show.
+    if (entities.length > 0) return undefined;
+    // Prefix match instead of reconstructing the exact request object (which
+    // Backstage builds via a non-exported reducer with `fullTextFilter:
+    // undefined` / `offset: undefined` subtleties). Pick the newest cached
+    // page whose request kind matches the current kind.
+    const prefix = scopeKey(['catalog', 'queryEntities']);
+    const matches = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: prefix })
+      .map(q => ({
+        req: q.queryKey[4] as { filter?: { kind?: unknown } } | undefined,
+        data: q.state.data as QueryEntitiesResponse | undefined,
+      }))
+      .filter(({ data }) => data !== undefined)
+      .filter(({ req }) => {
+        if (!selectedKind) return true;
+        const reqKind = req?.filter?.kind;
+        const kinds = Array.isArray(reqKind) ? reqKind : [reqKind];
+        return kinds.some(k => String(k).toLowerCase() === selectedKind);
+      });
+    return matches[0]?.data;
+  }, [entities.length, scopeKey, selectedKind]);
+
+  // Rows to render: the live list once it has resolved, else the cached seed.
+  const displayEntities = entities.length > 0 ? entities : seed?.items ?? [];
+  // Prefer the live count; fall back to the seed's while it loads.
+  const displayTotal = totalItems ?? seed?.totalItems;
+
+  const kindLabel = filters.kind?.label || filters.kind?.value || 'Entity';
+  const pluralLabel = kindPluralNames[kindLabel] || `${kindLabel}s`;
+  const titleText = `All ${displayTotal === 1 ? kindLabel : pluralLabel}${
+    displayTotal !== undefined ? ` (${displayTotal})` : ''
+  }`;
+
   // Show the skeleton only on a COLD load — when there is nothing safe to keep
-  // on screen. On a same-kind revisit, `useEntityList` keeps the previously
-  // resolved entities painted while a background refetch runs (the catalog
-  // reads route through the cached CatalogApi), so we keep the rows instead of
+  // on screen: no live entities, no cached seed. On a same-kind revisit,
+  // `useEntityList` keeps the previously resolved entities (or we paint the
+  // cached seed) while a background refetch runs, so we keep rows instead of
   // wiping to a skeleton.
   //
   // A kind SWITCH is treated as cold even though `useEntityList` still holds
   // the old kind's entities: the column set is derived from `selectedKind`, so
   // rendering the previous kind's rows under the new kind's headers would
   // misalign columns. Detect it by comparing the held entities' kind to the
-  // selected kind.
+  // selected kind. (The seed is already kind-matched, so it never trips this.)
   const heldKindMatches =
     entities.length === 0 ||
     !selectedKind ||
     entities[0].kind?.toLowerCase() === selectedKind;
-  const firstLoad = loading && (entities.length === 0 || !heldKindMatches);
+  const firstLoad =
+    loading &&
+    displayEntities.length === 0 &&
+    (entities.length === 0 || !heldKindMatches);
 
   return (
     <Box>
@@ -204,10 +250,10 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
       </Box>
 
       {firstLoad && <PageLoader minHeight={240} />}
-      {!loading && entities.length === 0 && (
+      {!loading && displayEntities.length === 0 && (
         <Box className={classes.emptyState}>No entities found</Box>
       )}
-      {!firstLoad && entities.length > 0 && (
+      {!firstLoad && displayEntities.length > 0 && (
         <Box className={classes.listContainer}>
           {/* Header row */}
           <Box className={`${classes.headerRow} ${gridTemplateClass}`}>
@@ -218,7 +264,7 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
             ))}
           </Box>
 
-          {entities.map(entity => {
+          {displayEntities.map(entity => {
             const name =
               entity.metadata.title || entity.metadata.name || 'Unnamed';
             const description = entity.metadata.description || '';
@@ -457,10 +503,10 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
         </Box>
       )}
 
-      {!firstLoad && totalItems !== undefined && totalItems > 0 && (
+      {!firstLoad && displayTotal !== undefined && displayTotal > 0 && (
         <Box className={classes.paginationContainer}>
           <TablePagination
-            count={totalItems}
+            count={displayTotal}
             page={
               offset !== undefined && limit > 0 ? Math.floor(offset / limit) : 0
             }

--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -23,6 +23,7 @@ import {
 import type { QueryEntitiesResponse } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import { useCardListStyles } from './styles';
+import { pickCatalogSeed, type CatalogSeedEntry } from './catalogSeed';
 import {
   StarredChip,
   TypeChip,
@@ -180,16 +181,13 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
   // On a fresh mount (navigating back to /catalog) `useEntityList` starts with
   // empty `entities` and re-runs its own async fetch, so it can't paint from
   // cache synchronously — that's the skeleton flash. Seed the first render from
-  // the response our CachingCatalogApi already stored: read the warm
-  // `queryEntities` entry for the current kind straight out of the shared
-  // queryClient. This is READ-ONLY (a miss just falls back to the skeleton) and
-  // scoped to the signed-in user via useUserScopedKey, so it can't cross-serve.
-  // The seed only paints while the live list is empty AND the view is the plain
-  // first page of a kind — no chip/search filter, no pagination offset. Any
-  // other filter narrows the query in ways we can't reconstruct from the cache
-  // key alone, so seeding then would risk showing a broader page's rows (wrong
-  // scope) or stale rows for a filter that now returns nothing. Restricting to
-  // the unfiltered first page keeps the seed correct-by-construction.
+  // the warm `queryEntities` response our CachingCatalogApi already stored,
+  // read straight out of the shared queryClient. This is READ-ONLY (a miss just
+  // falls back to the loader) and scoped to the signed-in user via
+  // useUserScopedKey, so it can't cross-serve. Selection rules (unfiltered
+  // first page only, kind-only request, recency-ranked) live in the tested pure
+  // helper `pickCatalogSeed`; here we just gather the cache entries and criteria.
+  //
   // `project`/`component` are custom OpenChoreo filters registered via
   // `updateFilters` (typed as `any` at their call sites), so they aren't on the
   // `DefaultEntityFilters` shape — read them through a widened view.
@@ -202,47 +200,25 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
       activeFilters.user ||
       activeFilters.text,
   );
-  const seedEligible =
-    entities.length === 0 && !hasNarrowingFilter && !offset && !!selectedKind;
 
   const scopeKey = useUserScopedKey();
   const seed = useMemo<QueryEntitiesResponse | undefined>(() => {
-    if (!seedEligible) return undefined;
-    // Read the warm queryEntities entry the CachingCatalogApi stored. Match on
-    // the current kind AND require an unfiltered, first-page request (filter is
-    // kind-only, no fullTextFilter, offset falsy) so we can't pick a filtered or
-    // paginated page. Among matches, take the most recently updated (findAll has
-    // no recency order, so an unsorted [0] could be an older/wrong page).
     const prefix = scopeKey(['catalog', 'queryEntities']);
-    const match = queryClient
+    const entries: CatalogSeedEntry[] = queryClient
       .getQueryCache()
       .findAll({ queryKey: prefix })
       .map(q => ({
-        req: q.queryKey[4] as
-          | {
-              filter?: { kind?: unknown };
-              fullTextFilter?: unknown;
-              offset?: number;
-            }
-          | undefined,
+        request: q.queryKey[4] as CatalogSeedEntry['request'],
         data: q.state.data as QueryEntitiesResponse | undefined,
         updatedAt: q.state.dataUpdatedAt,
-      }))
-      .filter(({ data }) => data !== undefined)
-      .filter(({ req }) => {
-        if (!req || req.fullTextFilter || req.offset) return false;
-        // Only the kind may be present in the filter — reject any page that
-        // carried extra filter facets (project/namespace/type/...).
-        const filter = (req.filter ?? {}) as Record<string, unknown>;
-        const keys = Object.keys(filter);
-        if (keys.length !== 1 || keys[0] !== 'kind') return false;
-        const reqKind = filter.kind;
-        const kinds = Array.isArray(reqKind) ? reqKind : [reqKind];
-        return kinds.some(k => String(k).toLowerCase() === selectedKind);
-      })
-      .sort((a, b) => b.updatedAt - a.updatedAt)[0];
-    return match?.data;
-  }, [seedEligible, scopeKey, selectedKind]);
+      }));
+    return pickCatalogSeed(entries, {
+      selectedKind,
+      hasNarrowingFilter,
+      offset,
+      hasLiveEntities: entities.length > 0,
+    });
+  }, [scopeKey, selectedKind, hasNarrowingFilter, offset, entities.length]);
 
   // Rows to render: the live list once it has resolved, else the cached seed.
   const displayEntities = entities.length > 0 ? entities : seed?.items ?? [];

--- a/packages/app/src/components/catalog/catalogSeed.test.ts
+++ b/packages/app/src/components/catalog/catalogSeed.test.ts
@@ -1,0 +1,159 @@
+import type { QueryEntitiesResponse } from '@backstage/catalog-client';
+import {
+  isCatalogSeedEligible,
+  pickCatalogSeed,
+  type CatalogSeedEntry,
+  type CatalogSeedCriteria,
+} from './catalogSeed';
+
+const resp = (n: number): QueryEntitiesResponse => ({
+  items: Array.from({ length: n }, (_, i) => ({
+    apiVersion: 'v1',
+    kind: 'Component',
+    metadata: { name: `c${i}` },
+  })) as QueryEntitiesResponse['items'],
+  totalItems: n,
+  pageInfo: {},
+});
+
+/** A kind-only, first-page cached entry (the shape the seed accepts). */
+const firstPageEntry = (
+  kind: string,
+  n: number,
+  updatedAt = 1,
+): CatalogSeedEntry => ({
+  request: { filter: { kind }, offset: 0 },
+  data: resp(n),
+  updatedAt,
+});
+
+const eligible: CatalogSeedCriteria = {
+  selectedKind: 'component',
+  hasNarrowingFilter: false,
+  offset: 0,
+  hasLiveEntities: false,
+};
+
+describe('isCatalogSeedEligible', () => {
+  it('is eligible on the unfiltered first page with no live rows', () => {
+    expect(isCatalogSeedEligible(eligible)).toBe(true);
+  });
+
+  it('is not eligible once the live list has rows', () => {
+    expect(isCatalogSeedEligible({ ...eligible, hasLiveEntities: true })).toBe(
+      false,
+    );
+  });
+
+  it('is not eligible when a narrowing filter is active', () => {
+    expect(
+      isCatalogSeedEligible({ ...eligible, hasNarrowingFilter: true }),
+    ).toBe(false);
+  });
+
+  it('is not eligible on a paginated view (offset > 0)', () => {
+    expect(isCatalogSeedEligible({ ...eligible, offset: 25 })).toBe(false);
+  });
+
+  it('is not eligible before the kind resolves', () => {
+    expect(
+      isCatalogSeedEligible({ ...eligible, selectedKind: undefined }),
+    ).toBe(false);
+  });
+});
+
+describe('pickCatalogSeed', () => {
+  it('returns undefined when the view is not eligible', () => {
+    expect(
+      pickCatalogSeed([firstPageEntry('component', 5)], {
+        ...eligible,
+        hasNarrowingFilter: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined on an empty cache (cold miss)', () => {
+    expect(pickCatalogSeed([], eligible)).toBeUndefined();
+  });
+
+  it('seeds the matching kind-only first page', () => {
+    const seed = pickCatalogSeed([firstPageEntry('component', 5)], eligible);
+    expect(seed?.totalItems).toBe(5);
+  });
+
+  it('ignores a cached page for a different kind', () => {
+    expect(
+      pickCatalogSeed([firstPageEntry('api', 9)], eligible),
+    ).toBeUndefined();
+  });
+
+  it('rejects a page that carried extra filter facets (e.g. a project filter)', () => {
+    const filtered: CatalogSeedEntry = {
+      request: {
+        filter: {
+          kind: 'component',
+          'metadata.annotations.openchoreo.io/project': 'foo',
+        } as Record<string, unknown>,
+        offset: 0,
+      },
+      data: resp(2),
+      updatedAt: 1,
+    };
+    expect(pickCatalogSeed([filtered], eligible)).toBeUndefined();
+  });
+
+  it('rejects a page that had a fullTextFilter (search active)', () => {
+    const searched: CatalogSeedEntry = {
+      request: { filter: { kind: 'component' }, fullTextFilter: { term: 'x' } },
+      data: resp(1),
+      updatedAt: 1,
+    };
+    expect(pickCatalogSeed([searched], eligible)).toBeUndefined();
+  });
+
+  it('rejects a non-first-page (offset > 0) cached entry', () => {
+    const page2: CatalogSeedEntry = {
+      request: { filter: { kind: 'component' }, offset: 25 },
+      data: resp(5),
+      updatedAt: 1,
+    };
+    expect(pickCatalogSeed([page2], eligible)).toBeUndefined();
+  });
+
+  it('skips entries whose data is still undefined (fetch in flight)', () => {
+    const pending: CatalogSeedEntry = {
+      request: { filter: { kind: 'component' }, offset: 0 },
+      data: undefined,
+      updatedAt: 5,
+    };
+    expect(
+      pickCatalogSeed([pending, firstPageEntry('component', 3, 1)], eligible)
+        ?.totalItems,
+    ).toBe(3);
+  });
+
+  it('prefers the most recently updated match (not insertion order)', () => {
+    const older = firstPageEntry('component', 2, 100);
+    const newer = firstPageEntry('component', 7, 200);
+    // Pass older first to prove selection is by recency, not array order.
+    expect(pickCatalogSeed([older, newer], eligible)?.totalItems).toBe(7);
+  });
+
+  it('matches a kind supplied as a single-element array', () => {
+    const arrayKind: CatalogSeedEntry = {
+      request: { filter: { kind: ['Component'] }, offset: 0 },
+      data: resp(4),
+      updatedAt: 1,
+    };
+    expect(pickCatalogSeed([arrayKind], eligible)?.totalItems).toBe(4);
+  });
+
+  it('treats offset 0 and absent offset as first page', () => {
+    const noOffset: CatalogSeedEntry = {
+      request: { filter: { kind: 'component' } },
+      data: resp(6),
+      updatedAt: 1,
+    };
+    expect(pickCatalogSeed([noOffset], eligible)?.totalItems).toBe(6);
+  });
+});

--- a/packages/app/src/components/catalog/catalogSeed.ts
+++ b/packages/app/src/components/catalog/catalogSeed.ts
@@ -1,0 +1,92 @@
+import type { QueryEntitiesResponse } from '@backstage/catalog-client';
+
+/**
+ * A cached `queryEntities` entry, reduced to just what the seed selection needs.
+ * `request` is the object the CachingCatalogApi stored at `queryKey[4]`.
+ */
+export interface CatalogSeedEntry {
+  request:
+    | {
+        filter?: { kind?: unknown };
+        fullTextFilter?: unknown;
+        offset?: number;
+      }
+    | undefined;
+  data: QueryEntitiesResponse | undefined;
+  /** TanStack's `dataUpdatedAt` — used to prefer the freshest match. */
+  updatedAt: number;
+}
+
+/** The current catalog list view, as far as seed selection cares. */
+export interface CatalogSeedCriteria {
+  /** Lowercased selected kind, or undefined before it resolves. */
+  selectedKind: string | undefined;
+  /** True when any chip/search filter narrows the query. */
+  hasNarrowingFilter: boolean;
+  /** Pagination offset (0/undefined = first page). */
+  offset: number | undefined;
+  /** Whether the live list already has rows of its own to show. */
+  hasLiveEntities: boolean;
+}
+
+/**
+ * Whether the current view is eligible to paint from a cached seed at all.
+ *
+ * Only the plain first page of a kind qualifies: no chip/search filter and no
+ * pagination offset. Any narrowing filter changes the query in ways we can't
+ * reconstruct from the cache key alone, so seeding then could show a broader
+ * page's rows (wrong scope) or stale rows for a filter that now returns nothing.
+ * The seed also only matters while the live list has nothing of its own.
+ */
+export function isCatalogSeedEligible(criteria: CatalogSeedCriteria): boolean {
+  return (
+    !criteria.hasLiveEntities &&
+    !criteria.hasNarrowingFilter &&
+    !criteria.offset &&
+    !!criteria.selectedKind
+  );
+}
+
+/**
+ * True when a cached entry is a safe seed for the given unfiltered, first-page
+ * kind view: its request must be kind-only (exactly `{ kind }` in `filter`, no
+ * extra facets), carry no `fullTextFilter`, sit at offset 0, hold data, and its
+ * kind must match. This mirrors the eligibility guard on the read side so a
+ * filtered/paginated cached page can never be selected.
+ */
+function isSeedMatch(entry: CatalogSeedEntry, selectedKind: string): boolean {
+  const { request, data } = entry;
+  if (data === undefined) return false;
+  if (!request || request.fullTextFilter || request.offset) return false;
+
+  const filter = (request.filter ?? {}) as Record<string, unknown>;
+  const keys = Object.keys(filter);
+  if (keys.length !== 1 || keys[0] !== 'kind') return false;
+
+  const reqKind = filter.kind;
+  const kinds = Array.isArray(reqKind) ? reqKind : [reqKind];
+  return kinds.some(k => String(k).toLowerCase() === selectedKind);
+}
+
+/**
+ * Pick the cached `queryEntities` response to seed the catalog list with, or
+ * `undefined` when nothing safe is cached. Among matching kind-only first-page
+ * entries, the most recently updated wins (the caller's `findAll` has no recency
+ * order, so an unsorted pick could return an older/wrong page).
+ *
+ * Pure and side-effect-free: the caller extracts the cache entries and passes
+ * the criteria; this decides which entry (if any) to paint.
+ */
+export function pickCatalogSeed(
+  entries: CatalogSeedEntry[],
+  criteria: CatalogSeedCriteria,
+): QueryEntitiesResponse | undefined {
+  if (!isCatalogSeedEligible(criteria)) return undefined;
+  const selectedKind = criteria.selectedKind as string; // guaranteed by eligibility
+
+  const best = entries
+    .filter(entry => isSeedMatch(entry, selectedKind))
+    .sort((a, b) => b.updatedAt - a.updatedAt)[0];
+
+  return best?.data;
+}

--- a/plugins/openchoreo-react/package.json
+++ b/plugins/openchoreo-react/package.json
@@ -30,9 +30,11 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
+    "@backstage/catalog-client": "^1.15.1",
     "@backstage/catalog-model": "^1.9.0",
     "@backstage/core-components": "^0.18.10",
     "@backstage/core-plugin-api": "^1.12.6",
+    "@backstage/plugin-catalog-common": "^1.1.10",
     "@backstage/plugin-catalog-graph": "^0.6.4",
     "@backstage/plugin-catalog-react": "^3.0.0",
     "@backstage/plugin-permission-react": "^0.5.1",

--- a/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
+++ b/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
@@ -3,10 +3,10 @@ import {
   type ReactNode,
   useCallback,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import useAsync from 'react-use/esm/useAsync';
+import { useOpenChoreoQuery } from '../../hooks/useOpenChoreoQuery';
 import Box from '@material-ui/core/Box';
 import MaterialBreadcrumbs from '@material-ui/core/Breadcrumbs';
 import Chip from '@material-ui/core/Chip';
@@ -369,17 +369,11 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
   const catalogApi = useApi(catalogApiRef);
   const [breadcrumbMenuAnchor, setBreadcrumbMenuAnchor] =
     useState<HTMLElement | null>(null);
-  const [breadcrumbMenuItems, setBreadcrumbMenuItems] = useState<
-    Array<{
-      key: string;
-      value: string;
-      path: string | null;
-      isCurrent?: boolean;
-    }>
-  >([]);
-  const [breadcrumbMenuTitle, setBreadcrumbMenuTitle] = useState('Resources');
-  const [isBreadcrumbMenuLoading, setIsBreadcrumbMenuLoading] = useState(false);
-  const breadcrumbMenuRequestIdRef = useRef(0);
+  // Which breadcrumb level's sibling menu is open (null = closed). Drives the
+  // keyed useOpenChoreoQuery below so the sibling list renders cached-first —
+  // reopening a level shows the cached list instantly (no spinner) and only
+  // revalidates in the background.
+  const [openNodeIndex, setOpenNodeIndex] = useState<number | null>(null);
 
   const kindLabel = kindDisplayNames?.[kind.toLowerCase()] ?? kind;
 
@@ -514,94 +508,92 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
     [breadcrumbNodes],
   );
 
-  const loadBreadcrumbLevelItems = useCallback(
-    async (targetNodeIndex: number, requestId: number) => {
-      const isCurrentRequest = () =>
-        breadcrumbMenuRequestIdRef.current === requestId;
-      const leftNode = breadcrumbNodes[targetNodeIndex - 1];
-      const targetNode = breadcrumbNodes[targetNodeIndex];
-      const fallbackItems = targetNode
-        ? [
-            {
-              key: targetNode.key,
-              value: targetNode.value,
-              path: targetNode.path,
-              isCurrent: true,
-            },
-          ]
-        : [];
+  // The breadcrumb level whose sibling menu is currently open (if any).
+  const openTargetNode =
+    openNodeIndex !== null ? breadcrumbNodes[openNodeIndex] : undefined;
+  const openLeftNode =
+    openNodeIndex !== null ? breadcrumbNodes[openNodeIndex - 1] : undefined;
 
-      if (!isCurrentRequest()) {
-        return;
-      }
-      setIsBreadcrumbMenuLoading(true);
-      setBreadcrumbMenuItems(fallbackItems);
-      setBreadcrumbMenuTitle(getMenuTitleForNodeIndex(targetNodeIndex));
+  const breadcrumbMenuTitle =
+    openNodeIndex !== null
+      ? getMenuTitleForNodeIndex(openNodeIndex)
+      : 'Resources';
 
-      if (!targetNode) {
-        if (isCurrentRequest()) {
-          setIsBreadcrumbMenuLoading(false);
-        }
-        return;
-      }
-
-      try {
-        const response = await catalogApi.getEntities({
+  // Sibling entities for the open level, fetched through the cached catalog API
+  // via useQuery. Keyed by kind+namespace so reopening the same level renders
+  // the cached list instantly (cached-first) and only revalidates in the
+  // background — the imperative await-before-render version always blocked on
+  // the network, even for a list loaded moments earlier.
+  const { data: siblingEntities, loading: siblingsLoading } =
+    useOpenChoreoQuery(
+      ['breadcrumb-siblings', openTargetNode?.kind, openTargetNode?.namespace],
+      () =>
+        catalogApi.getEntities({
           filter: [
             {
-              kind: targetNode.kind,
-              'metadata.namespace': targetNode.namespace,
+              kind: openTargetNode!.kind,
+              'metadata.namespace': openTargetNode!.namespace,
             },
           ],
-        });
-        if (!isCurrentRequest()) {
-          return;
-        }
+        }),
+      { enabled: Boolean(openTargetNode) },
+    );
 
-        const sameKindCandidates = response.items;
-        const siblingCandidates =
-          typeof leftNode?.normalizedRef === 'string'
-            ? sameKindCandidates.filter(candidate =>
-                (candidate.relations ?? []).some(
-                  relation =>
-                    normalizeEntityRef(relation.targetRef) ===
-                      leftNode.normalizedRef &&
-                    (targetNode.relationType
-                      ? relation.type === targetNode.relationType
-                      : true),
-                ),
-              )
-            : sameKindCandidates;
+  // Derive the menu items from the fetched siblings, applying the same
+  // relation-based sibling filtering, current-entity flagging, and alpha sort
+  // the imperative version did. Falls back to just the current node until data
+  // arrives (matching the old fallbackItems behavior).
+  const breadcrumbMenuItems = useMemo(() => {
+    if (!openTargetNode) return [];
 
-        const effectiveCandidates =
-          siblingCandidates.length > 0 ? siblingCandidates : sameKindCandidates;
+    const currentOnly = [
+      {
+        key: openTargetNode.key,
+        value: openTargetNode.value,
+        path: openTargetNode.path,
+        isCurrent: true,
+      },
+    ];
 
-        const siblingItems = effectiveCandidates
-          .map(candidate => {
-            const candidateRef = stringifyEntityRef(candidate);
-            return {
-              key: `${targetNode.kind}-${candidateRef}`,
-              value: candidate.metadata.title ?? candidate.metadata.name,
-              path: buildCatalogEntityPathFromEntity(candidate),
-              isCurrent:
-                normalizeEntityRef(candidateRef) === targetNode.normalizedRef,
-            };
-          })
-          .sort((a, b) => a.value.localeCompare(b.value));
+    if (!siblingEntities) return currentOnly;
 
-        setBreadcrumbMenuItems(siblingItems);
-      } catch {
-        if (isCurrentRequest()) {
-          setBreadcrumbMenuItems(fallbackItems);
-        }
-      } finally {
-        if (isCurrentRequest()) {
-          setIsBreadcrumbMenuLoading(false);
-        }
-      }
-    },
-    [breadcrumbNodes, getMenuTitleForNodeIndex, catalogApi],
-  );
+    const sameKindCandidates = siblingEntities.items;
+    const siblingCandidates =
+      typeof openLeftNode?.normalizedRef === 'string'
+        ? sameKindCandidates.filter(candidate =>
+            (candidate.relations ?? []).some(
+              relation =>
+                normalizeEntityRef(relation.targetRef) ===
+                  openLeftNode.normalizedRef &&
+                (openTargetNode.relationType
+                  ? relation.type === openTargetNode.relationType
+                  : true),
+            ),
+          )
+        : sameKindCandidates;
+
+    const effectiveCandidates =
+      siblingCandidates.length > 0 ? siblingCandidates : sameKindCandidates;
+
+    const siblingItems = effectiveCandidates
+      .map(candidate => {
+        const candidateRef = stringifyEntityRef(candidate);
+        return {
+          key: `${openTargetNode.kind}-${candidateRef}`,
+          value: candidate.metadata.title ?? candidate.metadata.name,
+          path: buildCatalogEntityPathFromEntity(candidate),
+          isCurrent:
+            normalizeEntityRef(candidateRef) === openTargetNode.normalizedRef,
+        };
+      })
+      .sort((a, b) => a.value.localeCompare(b.value));
+
+    return siblingItems.length > 0 ? siblingItems : currentOnly;
+  }, [openTargetNode, openLeftNode, siblingEntities]);
+
+  // "Loading" only for the true first fetch (no cached data yet) — a background
+  // revalidation of an already-cached list must NOT show the spinner.
+  const isBreadcrumbMenuLoading = siblingsLoading;
 
   const buildKindCatalogPath = useCallback(
     (targetNodeIndex: number): string => {
@@ -661,21 +653,18 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
       );
     }
     event.currentTarget.classList.add(classes.breadcrumbSeparatorButtonOpen);
-    const requestId = breadcrumbMenuRequestIdRef.current + 1;
-    breadcrumbMenuRequestIdRef.current = requestId;
     setBreadcrumbMenuAnchor(event.currentTarget);
-    setBreadcrumbMenuTitle(getMenuTitleForNodeIndex(targetNodeIndex));
-    void loadBreadcrumbLevelItems(targetNodeIndex, requestId);
+    setOpenNodeIndex(targetNodeIndex);
   };
 
   const closeBreadcrumbMenu = () => {
-    breadcrumbMenuRequestIdRef.current += 1;
     if (breadcrumbMenuAnchor) {
       breadcrumbMenuAnchor.classList.remove(
         classes.breadcrumbSeparatorButtonOpen,
       );
     }
     setBreadcrumbMenuAnchor(null);
+    setOpenNodeIndex(null);
   };
 
   const navigateFromBreadcrumbMenu = (

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoQuery.test.tsx
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoQuery.test.tsx
@@ -103,10 +103,12 @@ describe('useOpenChoreoQuery', () => {
   it('inherits the QueryClient staleTime when the caller omits it (no refetch on remount)', async () => {
     // Regression: the hook must NOT forward `staleTime: undefined` to useQuery.
     // TanStack treats an explicit `undefined` as an override that resolves to 0,
-    // which marks the query stale immediately and refetches on every remount —
-    // silently defeating the app-level 30s cache. A caller with no staleTime
-    // should inherit the client default, so a remount within that window serves
-    // from cache without re-invoking the fetcher.
+    // which marks the query stale immediately and refetches on every remount. A
+    // caller with no staleTime should inherit whatever the client default is —
+    // proven here with a client that sets a nonzero staleTime, so a remount
+    // within that window serves from cache without re-invoking the fetcher. (The
+    // app-level default is 0/always-revalidate; this test uses 60s locally to
+    // exercise the inherit-the-default path, which is what the regression guards.)
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
     });

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -542,7 +542,10 @@ export {
   type UseOpenChoreoInfiniteQueryResult,
 } from './hooks/useOpenChoreoInfiniteQuery';
 export { queryClient } from './query/queryClient';
-export { OpenChoreoQueryProvider } from './query/OpenChoreoQueryProvider';
+export {
+  OpenChoreoQueryProvider,
+  useUserScopedKey,
+} from './query/OpenChoreoQueryProvider';
 export { CachingCatalogApi, type GetUserRef } from './query/CachingCatalogApi';
 
 // Change Detection Components

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -543,6 +543,7 @@ export {
 } from './hooks/useOpenChoreoInfiniteQuery';
 export { queryClient } from './query/queryClient';
 export { OpenChoreoQueryProvider } from './query/OpenChoreoQueryProvider';
+export { CachingCatalogApi, type GetUserRef } from './query/CachingCatalogApi';
 
 // Change Detection Components
 export { ChangeDiff, type ChangeDiffProps } from './components/ChangeDiff';

--- a/plugins/openchoreo-react/src/query/CachingCatalogApi.test.ts
+++ b/plugins/openchoreo-react/src/query/CachingCatalogApi.test.ts
@@ -1,0 +1,199 @@
+import type { CatalogApi } from '@backstage/catalog-client';
+import { queryClient } from './queryClient';
+import { CachingCatalogApi } from './CachingCatalogApi';
+
+/**
+ * A minimal `CatalogApi` stub whose read methods are jest mocks, so we can
+ * assert exactly how often the wrapper hits the delegate.
+ */
+function makeDelegate(overrides: Partial<CatalogApi> = {}): CatalogApi {
+  const base = {
+    getEntities: jest.fn().mockResolvedValue({ items: [] }),
+    getEntitiesByRefs: jest.fn().mockResolvedValue({ items: [] }),
+    queryEntities: jest.fn().mockResolvedValue({ items: [], totalItems: 0 }),
+    getEntityByRef: jest.fn().mockResolvedValue({ kind: 'Component' }),
+    refreshEntity: jest.fn().mockResolvedValue(undefined),
+    removeEntityByUid: jest.fn().mockResolvedValue(undefined),
+    addLocation: jest.fn().mockResolvedValue({}),
+    removeLocationById: jest.fn().mockResolvedValue(undefined),
+    updateLocation: jest.fn().mockResolvedValue({}),
+    getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
+    getLocations: jest.fn(),
+    queryLocations: jest.fn(),
+    streamLocations: jest.fn(),
+    getLocationById: jest.fn(),
+    getLocationByRef: jest.fn(),
+    getLocationByEntity: jest.fn(),
+    validateEntity: jest.fn(),
+    analyzeLocation: jest.fn(),
+    streamEntities: jest.fn(),
+  } as unknown as CatalogApi;
+  return { ...base, ...overrides };
+}
+
+const userA = () => Promise.resolve('user:default/alice');
+const userB = () => Promise.resolve('user:default/bob');
+
+describe('CachingCatalogApi', () => {
+  beforeEach(() => {
+    // The wrapper uses the shared singleton; isolate each test.
+    queryClient.clear();
+  });
+
+  it('dedupes concurrent identical reads to a single delegate call', async () => {
+    const delegate = makeDelegate();
+    const api = new CachingCatalogApi(delegate, userA);
+
+    await Promise.all([
+      api.getEntities({ filter: { kind: 'component' } }),
+      api.getEntities({ filter: { kind: 'component' } }),
+    ]);
+
+    expect(delegate.getEntities).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches the read so the value is available synchronously after resolve', async () => {
+    const delegate = makeDelegate({
+      getEntityByRef: jest.fn().mockResolvedValue({ kind: 'Component' }),
+    });
+    const api = new CachingCatalogApi(delegate, userA);
+
+    await api.getEntityByRef('component:default/svc');
+
+    // Warm cache entry under the per-user key: this is what lets a revisit
+    // paint instantly before the background revalidation resolves.
+    const cached = queryClient.getQueryData([
+      '@user',
+      'user:default/alice',
+      'catalog',
+      'getEntityByRef',
+      'component:default/svc',
+    ]);
+    expect(cached).toEqual({ kind: 'Component' });
+  });
+
+  it('returns undefined (no throw) when getEntityByRef resolves to undefined', async () => {
+    // Regression: getEntityByRef returns Promise<Entity | undefined>, and
+    // TanStack's fetchQuery rejects on a resolved `undefined` ("Query data
+    // cannot be undefined"). The wrapper must cache a null sentinel and hand
+    // back undefined so a missing/404 entity stays a graceful not-found.
+    const delegate = makeDelegate({
+      getEntityByRef: jest.fn().mockResolvedValue(undefined),
+    });
+    const api = new CachingCatalogApi(delegate, userA);
+
+    await expect(
+      api.getEntityByRef('component:default/missing'),
+    ).resolves.toBeUndefined();
+
+    // A second call still resolves to undefined (the null sentinel is cached,
+    // mapped back to undefined) — never a throw.
+    await expect(
+      api.getEntityByRef('component:default/missing'),
+    ).resolves.toBeUndefined();
+
+    // The cache holds the null sentinel, not undefined (which TanStack rejects).
+    expect(
+      queryClient.getQueryData([
+        '@user',
+        'user:default/alice',
+        'catalog',
+        'getEntityByRef',
+        'component:default/missing',
+      ]),
+    ).toBeNull();
+  });
+
+  it('keys reads by the request, so different requests do not collide', async () => {
+    const delegate = makeDelegate();
+    const api = new CachingCatalogApi(delegate, userA);
+
+    await api.getEntities({ filter: { kind: 'component' } });
+    await api.getEntities({ filter: { kind: 'api' } });
+
+    // Two distinct requests → two distinct cache entries → two delegate calls.
+    expect(delegate.getEntities).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates the cache per user (no cross-serve between users)', async () => {
+    const delegate = makeDelegate();
+    const apiA = new CachingCatalogApi(delegate, userA);
+    const apiB = new CachingCatalogApi(delegate, userB);
+
+    await apiA.getEntities({ filter: { kind: 'component' } });
+    await apiB.getEntities({ filter: { kind: 'component' } });
+
+    // Same request, different users → disjoint key spaces → the delegate is
+    // hit once per user; neither reads the other's entry.
+    expect(delegate.getEntities).toHaveBeenCalledTimes(2);
+    expect(
+      queryClient.getQueryData([
+        '@user',
+        'user:default/alice',
+        'catalog',
+        'getEntities',
+        { filter: { kind: 'component' } },
+      ]),
+    ).toBeDefined();
+    expect(
+      queryClient.getQueryData([
+        '@user',
+        'user:default/bob',
+        'catalog',
+        'getEntities',
+        { filter: { kind: 'component' } },
+      ]),
+    ).toBeDefined();
+  });
+
+  it('invalidates the user catalog cache after refreshEntity', async () => {
+    const delegate = makeDelegate();
+    const api = new CachingCatalogApi(delegate, userA);
+
+    await api.getEntities({ filter: { kind: 'component' } });
+    expect(delegate.getEntities).toHaveBeenCalledTimes(1);
+
+    await api.refreshEntity('component:default/svc');
+
+    // The catalog subtree was invalidated → the next read re-hits the delegate
+    // rather than serving the now-stale cached list.
+    await api.getEntities({ filter: { kind: 'component' } });
+    expect(delegate.refreshEntity).toHaveBeenCalledWith(
+      'component:default/svc',
+      undefined,
+    );
+    expect(delegate.getEntities).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes streamEntities through unchanged (not promise-wrapped)', () => {
+    async function* stream(): AsyncIterable<never[]> {
+      yield [];
+    }
+    const iterable = stream();
+    const delegate = makeDelegate({
+      streamEntities: jest.fn().mockReturnValue(iterable),
+    });
+    const api = new CachingCatalogApi(delegate, userA);
+
+    // Must return the delegate's AsyncIterable verbatim — wrapping it in a
+    // promise (via fetchQuery) would break `for await` consumers.
+    expect(api.streamEntities()).toBe(iterable);
+    expect(typeof (api.streamEntities() as any)[Symbol.asyncIterator]).toBe(
+      'function',
+    );
+  });
+
+  it('delegates a pass-through read (getLocations) without caching', async () => {
+    const delegate = makeDelegate({
+      getLocations: jest.fn().mockResolvedValue({ items: [] }),
+    });
+    const api = new CachingCatalogApi(delegate, userA);
+
+    await api.getLocations();
+    await api.getLocations();
+
+    // No fetchQuery wrapping → every call reaches the delegate.
+    expect(delegate.getLocations).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/openchoreo-react/src/query/CachingCatalogApi.ts
+++ b/plugins/openchoreo-react/src/query/CachingCatalogApi.ts
@@ -79,39 +79,45 @@ export class CachingCatalogApi implements CatalogApi {
   }
 
   /**
-   * Read-through cache: fetch-and-cache under the per-user key, deduping
-   * concurrent callers and serving the warm entry. `staleTime` inherits the
-   * client default (0 → always revalidate on revisit); the warm `gcTime` entry
-   * is what paints instantly.
+   * Read-through cache: serve the warm entry immediately and revalidate in the
+   * background. Uses `ensureQueryData({ revalidateIfStale: true })` rather than
+   * `fetchQuery`: with the client default `staleTime: 0` every entry is stale,
+   * and `fetchQuery` would AWAIT the network on a stale entry (never painting
+   * cached-first). `ensureQueryData` returns the cached value synchronously when
+   * present and kicks a background refetch, which is the actual instant-paint +
+   * stale-while-revalidate behavior an already-warm revisit wants. Concurrent
+   * callers still dedupe on the shared key.
    */
   private async cachedRead<T>(
     method: string,
     args: unknown[],
     fetch: () => Promise<T>,
   ): Promise<T> {
-    return queryClient.fetchQuery({
+    return queryClient.ensureQueryData({
       queryKey: await this.keyFor(method, args),
       queryFn: fetch,
+      revalidateIfStale: true,
     });
   }
 
   /**
    * Read-through cache for a method that may resolve to `undefined` (e.g.
-   * `getEntityByRef` on a missing/404 entity). TanStack's `fetchQuery` REJECTS
-   * when the queryFn resolves to `undefined` ("Query data cannot be undefined"),
-   * which would turn a normal not-found into a thrown error and break callers
-   * (the entity page and header breadcrumb tolerate `undefined`). Cache a `null`
-   * sentinel instead (which TanStack does accept) and map it back to `undefined`
-   * so the `CatalogApi` contract is preserved.
+   * `getEntityByRef` on a missing/404 entity). TanStack's `ensureQueryData`
+   * (like `fetchQuery`) REJECTS when the queryFn resolves to `undefined`
+   * ("Query data cannot be undefined"), which would turn a normal not-found into
+   * a thrown error and break callers (the entity page and header breadcrumb
+   * tolerate `undefined`). Cache a `null` sentinel instead (which TanStack does
+   * accept) and map it back to `undefined` so the `CatalogApi` contract holds.
    */
   private async cachedReadNullable<T>(
     method: string,
     args: unknown[],
     fetch: () => Promise<T | undefined>,
   ): Promise<T | undefined> {
-    const value = await queryClient.fetchQuery<T | null>({
+    const value = await queryClient.ensureQueryData<T | null>({
       queryKey: await this.keyFor(method, args),
       queryFn: async () => (await fetch()) ?? null,
+      revalidateIfStale: true,
     });
     return value ?? undefined;
   }

--- a/plugins/openchoreo-react/src/query/CachingCatalogApi.ts
+++ b/plugins/openchoreo-react/src/query/CachingCatalogApi.ts
@@ -1,0 +1,291 @@
+import type {
+  CatalogApi,
+  GetEntitiesRequest,
+  GetEntitiesResponse,
+  GetEntitiesByRefsRequest,
+  GetEntitiesByRefsResponse,
+  QueryEntitiesRequest,
+  QueryEntitiesResponse,
+  GetEntityAncestorsRequest,
+  GetEntityAncestorsResponse,
+  GetEntityFacetsRequest,
+  GetEntityFacetsResponse,
+  GetLocationsResponse,
+  QueryLocationsRequest,
+  QueryLocationsResponse,
+  QueryLocationsInitialRequest,
+  StreamEntitiesRequest,
+  AddLocationRequest,
+  AddLocationResponse,
+  ValidateEntityResponse,
+  CatalogRequestOptions,
+  Location,
+} from '@backstage/catalog-client';
+import type {
+  AnalyzeLocationRequest,
+  AnalyzeLocationResponse,
+} from '@backstage/plugin-catalog-common';
+import type { CompoundEntityRef, Entity } from '@backstage/catalog-model';
+import type { QueryKey } from '@tanstack/react-query';
+import { queryClient } from './queryClient';
+
+/**
+ * Resolves the signed-in user's `entityRef`, used to namespace the catalog
+ * cache keys. Returns `undefined` until identity resolves (the caller then
+ * keys under the pending sentinel).
+ */
+export type GetUserRef = () => Promise<string | undefined>;
+
+/** Matches {@link OpenChoreoQueryProvider}'s sentinel for the pre-identity window. */
+const PENDING_USER = '@openchoreo/pending-user';
+
+/**
+ * A {@link CatalogApi} that routes catalog READS through the shared OpenChoreo
+ * `queryClient`, so a revisited catalog list or entity page paints instantly
+ * from cache (and revalidates in the background per the client's `staleTime: 0`
+ * policy) instead of re-fetching from scratch and flashing a skeleton.
+ *
+ * Backstage's own catalog hooks (`useEntityList` → `getEntities`/`queryEntities`,
+ * the entity page → `getEntityByRef`) call this API directly, so wrapping it is
+ * the only way to bring the catalog under the same cache as the OpenChoreo BFF
+ * hooks. All other methods delegate straight through to the real client.
+ *
+ * Keys mirror the hook convention exactly (`['@user', userEntityRef, ...]`, see
+ * `useUserScopedKey`) so per-user isolation is structural: a different user
+ * occupies a disjoint key space and can never read the previous user's
+ * permission-scoped catalog results. The auth token is deliberately NOT part of
+ * the key — the `userEntityRef` already isolates users, and the token rotates,
+ * which would otherwise bust the cache on every refresh.
+ *
+ * Writes that change catalog state (`refreshEntity`, `removeEntityByUid`,
+ * location add/remove/update) invalidate the whole `['@user', ref, 'catalog']`
+ * subtree so the next read re-fetches. The two `AsyncIterable` streamers and the
+ * rarely-hot reads (facets, locations, ancestors) pass through uncached.
+ */
+export class CachingCatalogApi implements CatalogApi {
+  constructor(
+    private readonly delegate: CatalogApi,
+    private readonly getUserRef: GetUserRef,
+  ) {}
+
+  /**
+   * Build the per-user cache key for a catalog method call. `['@user', ref,
+   * 'catalog', method, ...args]` — the same shape (and literal `'@user'` prefix)
+   * the query hooks use, so the two never collide or cross-serve.
+   */
+  private async keyFor(method: string, args: unknown[]): Promise<QueryKey> {
+    const user = (await this.getUserRef()) ?? PENDING_USER;
+    return ['@user', user, 'catalog', method, ...args];
+  }
+
+  /**
+   * Read-through cache: fetch-and-cache under the per-user key, deduping
+   * concurrent callers and serving the warm entry. `staleTime` inherits the
+   * client default (0 → always revalidate on revisit); the warm `gcTime` entry
+   * is what paints instantly.
+   */
+  private async cachedRead<T>(
+    method: string,
+    args: unknown[],
+    fetch: () => Promise<T>,
+  ): Promise<T> {
+    return queryClient.fetchQuery({
+      queryKey: await this.keyFor(method, args),
+      queryFn: fetch,
+    });
+  }
+
+  /**
+   * Read-through cache for a method that may resolve to `undefined` (e.g.
+   * `getEntityByRef` on a missing/404 entity). TanStack's `fetchQuery` REJECTS
+   * when the queryFn resolves to `undefined` ("Query data cannot be undefined"),
+   * which would turn a normal not-found into a thrown error and break callers
+   * (the entity page and header breadcrumb tolerate `undefined`). Cache a `null`
+   * sentinel instead (which TanStack does accept) and map it back to `undefined`
+   * so the `CatalogApi` contract is preserved.
+   */
+  private async cachedReadNullable<T>(
+    method: string,
+    args: unknown[],
+    fetch: () => Promise<T | undefined>,
+  ): Promise<T | undefined> {
+    const value = await queryClient.fetchQuery<T | null>({
+      queryKey: await this.keyFor(method, args),
+      queryFn: async () => (await fetch()) ?? null,
+    });
+    return value ?? undefined;
+  }
+
+  /** Drop every cached catalog read for the current user after a write. */
+  private async invalidateCatalog(): Promise<void> {
+    const user = (await this.getUserRef()) ?? PENDING_USER;
+    await queryClient.invalidateQueries({
+      queryKey: ['@user', user, 'catalog'],
+    });
+  }
+
+  // ---- Cached reads -------------------------------------------------------
+
+  getEntities(
+    request?: GetEntitiesRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<GetEntitiesResponse> {
+    return this.cachedRead('getEntities', [request], () =>
+      this.delegate.getEntities(request, options),
+    );
+  }
+
+  getEntitiesByRefs(
+    request: GetEntitiesByRefsRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<GetEntitiesByRefsResponse> {
+    return this.cachedRead('getEntitiesByRefs', [request], () =>
+      this.delegate.getEntitiesByRefs(request, options),
+    );
+  }
+
+  queryEntities(
+    request?: QueryEntitiesRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<QueryEntitiesResponse> {
+    return this.cachedRead('queryEntities', [request], () =>
+      this.delegate.queryEntities(request, options),
+    );
+  }
+
+  getEntityByRef(
+    entityRef: string | CompoundEntityRef,
+    options?: CatalogRequestOptions,
+  ): Promise<Entity | undefined> {
+    // Nullable: a missing entity resolves to `undefined`, which fetchQuery
+    // cannot cache — see cachedReadNullable.
+    return this.cachedReadNullable('getEntityByRef', [entityRef], () =>
+      this.delegate.getEntityByRef(entityRef, options),
+    );
+  }
+
+  // ---- Writes: delegate then invalidate the user's catalog cache ----------
+
+  async removeEntityByUid(
+    uid: string,
+    options?: CatalogRequestOptions,
+  ): Promise<void> {
+    await this.delegate.removeEntityByUid(uid, options);
+    await this.invalidateCatalog();
+  }
+
+  async refreshEntity(
+    entityRef: string,
+    options?: CatalogRequestOptions,
+  ): Promise<void> {
+    await this.delegate.refreshEntity(entityRef, options);
+    await this.invalidateCatalog();
+  }
+
+  async addLocation(
+    location: AddLocationRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<AddLocationResponse> {
+    const result = await this.delegate.addLocation(location, options);
+    await this.invalidateCatalog();
+    return result;
+  }
+
+  async removeLocationById(
+    id: string,
+    options?: CatalogRequestOptions,
+  ): Promise<void> {
+    await this.delegate.removeLocationById(id, options);
+    await this.invalidateCatalog();
+  }
+
+  async updateLocation(
+    id: string,
+    location: { type?: string; target: string },
+    options?: CatalogRequestOptions,
+  ): Promise<Location> {
+    const result = await this.delegate.updateLocation(id, location, options);
+    await this.invalidateCatalog();
+    return result;
+  }
+
+  // ---- Pass-through (uncached reads + streams + validate/analyze) ----------
+
+  getEntityAncestors(
+    request: GetEntityAncestorsRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<GetEntityAncestorsResponse> {
+    return this.delegate.getEntityAncestors(request, options);
+  }
+
+  getEntityFacets(
+    request: GetEntityFacetsRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<GetEntityFacetsResponse> {
+    return this.delegate.getEntityFacets(request, options);
+  }
+
+  getLocations(
+    request?: {},
+    options?: CatalogRequestOptions,
+  ): Promise<GetLocationsResponse> {
+    return this.delegate.getLocations(request, options);
+  }
+
+  queryLocations(
+    request?: QueryLocationsRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<QueryLocationsResponse> {
+    return this.delegate.queryLocations(request, options);
+  }
+
+  streamLocations(
+    request?: QueryLocationsInitialRequest,
+    options?: CatalogRequestOptions,
+  ): AsyncIterable<Location[]> {
+    return this.delegate.streamLocations(request, options);
+  }
+
+  getLocationById(
+    id: string,
+    options?: CatalogRequestOptions,
+  ): Promise<Location | undefined> {
+    return this.delegate.getLocationById(id, options);
+  }
+
+  getLocationByRef(
+    locationRef: string,
+    options?: CatalogRequestOptions,
+  ): Promise<Location | undefined> {
+    return this.delegate.getLocationByRef(locationRef, options);
+  }
+
+  getLocationByEntity(
+    entityRef: string | CompoundEntityRef,
+    options?: CatalogRequestOptions,
+  ): Promise<Location | undefined> {
+    return this.delegate.getLocationByEntity(entityRef, options);
+  }
+
+  validateEntity(
+    entity: Entity,
+    locationRef: string,
+    options?: CatalogRequestOptions,
+  ): Promise<ValidateEntityResponse> {
+    return this.delegate.validateEntity(entity, locationRef, options);
+  }
+
+  analyzeLocation(
+    location: AnalyzeLocationRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<AnalyzeLocationResponse> {
+    return this.delegate.analyzeLocation(location, options);
+  }
+
+  streamEntities(
+    request?: StreamEntitiesRequest,
+    options?: CatalogRequestOptions,
+  ): AsyncIterable<Entity[]> {
+    return this.delegate.streamEntities(request, options);
+  }
+}

--- a/plugins/openchoreo-react/src/query/queryClient.ts
+++ b/plugins/openchoreo-react/src/query/queryClient.ts
@@ -13,11 +13,16 @@ import { QueryClient } from '@tanstack/react-query';
  * "No QueryClient set" crash from a missing provider.
  *
  * Rationale for the defaults:
- * - `staleTime: 30s` — within this window a revisited tab paints from cache
- *   with no refetch; after it, cached data still paints instantly and a silent
- *   background revalidation runs. Status-y hooks pass a shorter value.
+ * - `staleTime: 0` — stale-while-revalidate: a revisited surface paints cached
+ *   data instantly (from the still-warm `gcTime` entry) AND always kicks a
+ *   background revalidation, so data on screen is never left silently stale.
+ *   Data is fresh cluster/BFF state, so we prefer an always-up-to-date view
+ *   over suppressing refetches within a freshness window. Concurrent callers
+ *   still dedupe to one request; an explicit `refetch()`/invalidate is
+ *   immediate regardless. Pollers set their own `refetchInterval`.
  * - `gcTime: 5m` — how long an unused cache entry survives after its last
- *   observer unmounts, so navigating away and back still hits warm cache.
+ *   observer unmounts, so navigating away and back still hits warm cache. With
+ *   `staleTime: 0` this is what carries the instant-paint on revisit.
  * - `refetchOnWindowFocus: false` — this is an internal platform tool; data
  *   isn't second-to-second critical and focus-refetch is surprising here.
  * - `retry: 1` — one retry smooths a transient blip without hammering a slow
@@ -26,7 +31,7 @@ import { QueryClient } from '@tanstack/react-query';
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30_000,
+      staleTime: 0,
       gcTime: 5 * 60_000,
       refetchOnWindowFocus: false,
       retry: 1,

--- a/plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts
+++ b/plugins/openchoreo/src/components/Environments/hooks/useIncidentsSummary.ts
@@ -105,8 +105,8 @@ export function useIncidentsSummary(
       return counts;
     },
     {
-      // Freshness matches the old 1h window intent; short so revisits refresh.
-      staleTime: 30_000,
+      // staleTime inherits the client default (0) — revisits paint cache and
+      // always revalidate in the background.
       enabled:
         !!observabilityApi &&
         !!componentName &&

--- a/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
+++ b/plugins/openchoreo/src/components/RuntimeLogs/OverviewCard/useLogsSummary.ts
@@ -103,7 +103,7 @@ export function useLogsSummary() {
           lastActivityTime: logs.length > 0 ? logs[0].timestamp ?? null : null,
         };
       },
-      { staleTime: 30_000, enabled: !!observabilityApi },
+      { enabled: !!observabilityApi },
     );
 
   // "Observability disabled" = the plugin isn't installed (no API) OR the backend

--- a/yarn.lock
+++ b/yarn.lock
@@ -10164,10 +10164,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openchoreo/backstage-plugin-react@workspace:plugins/openchoreo-react"
   dependencies:
+    "@backstage/catalog-client": "npm:^1.15.1"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.2"
     "@backstage/core-components": "npm:^0.18.10"
     "@backstage/core-plugin-api": "npm:^1.12.6"
+    "@backstage/plugin-catalog-common": "npm:^1.1.10"
     "@backstage/plugin-catalog-graph": "npm:^0.6.4"
     "@backstage/plugin-catalog-react": "npm:^3.0.0"
     "@backstage/plugin-permission-react": "npm:^0.5.1"
@@ -16937,6 +16939,7 @@ __metadata:
     "@backstage-community/plugin-github-actions": "npm:^0.20.0"
     "@backstage-community/plugin-jenkins": "npm:^0.28.0"
     "@backstage/app-defaults": "npm:^1.7.8"
+    "@backstage/catalog-client": "npm:^1.15.1"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.2"
     "@backstage/config": "npm:^1.3.8"


### PR DESCRIPTION
  ## What & why

  The frontend response cache (#676) covered the OpenChoreo BFF hooks but **not the
  Backstage catalog**. The catalog list, entity pages, and entity-header breadcrumb
  dropdowns all called `catalogApiRef` directly, so every visit re-fetched from
  scratch and flashed a loading skeleton — even for data loaded seconds earlier.

  This PR brings the catalog under the same shared `queryClient`, so revisited
  catalog surfaces paint instantly from cache and revalidate in the background.

  ## Changes

  **1. `CachingCatalogApi` — wrap `catalogApiRef`**
  A `CatalogApi` wrapper (in `@openchoreo/backstage-plugin-react`) that routes reads
  (`getEntities` / `queryEntities` / `getEntityByRef` / `getEntitiesByRefs`) through
  the shared `queryClient`, keyed per signed-in user (`['@user', ref, 'catalog', …]`,
  matching the existing hook convention). Writes (`refreshEntity`, location
  add/remove/update, `removeEntityByUid`) invalidate the user's catalog cache.
  Streams and rarely-hot reads pass through uncached. Wired by overriding the
  `api:catalog` extension in `customOverrides.tsx` — no `App.tsx` change.
                                                                                               
  - `getEntityByRef` caches a `null` sentinel: it returns `Promise<Entity | undefined>`,       
    and TanStack's `fetchQuery` rejects on a resolved `undefined` ("Query data cannot          
    be undefined"). Without this, a normal 404 threw and broke the entity page. Now a          
    not-found stays a graceful "Entity not found".                                             
                                                                                               
  **2. Cache policy → always-revalidate (`staleTime: 0`)**                                     
  The `queryClient` default changes from 30s to 0 (stale-while-revalidate): a                  
  revisited surface paints cached data instantly (via `gcTime`) and always runs a              
  background refresh, so nothing on screen is silently stale. The two hooks that set           
  an explicit 30s `staleTime` now inherit this default.                                        
                                                                                               
  **3. Header breadcrumb dropdowns — cached-first**
  The namespace/project/component sibling dropdowns fetched with an imperative
  `await catalogApi.getEntities(...)`, which blocked on the network every open.
  Routed through `useOpenChoreoQuery` (keyed by the open level's kind+namespace) so
  reopening a level renders the cached list instantly and only revalidates in the
  background. Drops the manual loading state and request-id guarding.
  
  **4. Catalog list — seed rows from cache**
  `useEntityList` awaits its own fetch on every mount and can't paint from cache
  synchronously, so returning to a list flashed a skeleton. `CatalogCardList` now
  seeds its first render from the warm `queryEntities` response in the shared
  `queryClient` (prefix-matched by kind, scoped per user via the newly exported
  `useUserScopedKey`); the skeleton shows only on a true cold-cache miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Catalog reads now show immediately from warm cache on revisit and silently revalidate in the background, including faster breadcrumb quick-navigation and catalog list loading.
  * Improved “stale-while-revalidate” behavior reduces unnecessary loading/skeleton flicker, especially when staying within the same kind view.
* **Bug Fixes**
  * Catalog write operations now invalidate the relevant cached catalog data so updates appear promptly.
  * Cached catalog results remain correctly isolated per identity, including safe handling for “not found” entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->