### PR TITLE
feat(catalog): show a refresh indicator on cached catalog list and breadcrumb dropdown

### DIFF
--- a/.changeset/cache-catalog-always-revalidate.md
+++ b/.changeset/cache-catalog-always-revalidate.md
@@ -31,3 +31,11 @@ response (via the newly exported `useUserScopedKey`), so returning to a
 previously viewed list paints instantly from cache instead of flashing a
 skeleton while `useEntityList` re-fetches. `useUserScopedKey` is now exported
 from `@openchoreo/backstage-plugin-react`.
+
+Both cached-first surfaces now show a quiet inline spinner next to their label
+(the "All Components (N)" count and the breadcrumb menu title) while their
+background revalidation runs, so a refresh is visible instead of the data
+swapping in silently. The spinner tracks the real network refetch on the shared
+`queryClient` (via `useIsFetching`), not the surface's own `loading` flag —
+which resolves the instant the cached read returns while the revalidation is
+still in flight.

--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useMemo } from 'react';
 import { Box, Chip, IconButton, Tooltip, Typography } from '@material-ui/core';
-import { PageLoader } from '@openchoreo/backstage-design-system';
+import { PageLoader, Spinner } from '@openchoreo/backstage-design-system';
 import { TablePagination } from '@material-ui/core';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import { useApp, useRouteRef } from '@backstage/core-plugin-api';
@@ -20,10 +20,12 @@ import {
   queryClient,
   useUserScopedKey,
 } from '@openchoreo/backstage-plugin-react';
+import { useIsFetching } from '@tanstack/react-query';
 import type { QueryEntitiesResponse } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import { useCardListStyles } from './styles';
 import { pickCatalogSeed, type CatalogSeedEntry } from './catalogSeed';
+import { deriveCatalogLoadState } from './catalogLoadState';
 import {
   StarredChip,
   TypeChip,
@@ -238,33 +240,50 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
     displayTotal !== undefined ? ` (${displayTotal})` : ''
   }`;
 
-  // Show the skeleton only on a COLD load — when there is nothing safe to keep
-  // on screen: no live entities, no cached seed. On a same-kind revisit,
-  // `useEntityList` keeps the previously resolved entities (or we paint the
-  // cached seed) while a background refetch runs, so we keep rows instead of
-  // wiping to a skeleton.
-  //
-  // A kind SWITCH is treated as cold even though `useEntityList` still holds
-  // the old kind's entities: the column set is derived from `selectedKind`, so
-  // rendering the previous kind's rows under the new kind's headers would
-  // misalign columns. Detect it by comparing the held entities' kind to the
-  // selected kind. (The seed is already kind-matched, so it never trips this.)
-  const heldKindMatches =
-    entities.length === 0 ||
-    !selectedKind ||
-    // A held entity with no kind can't be proven a mismatch — don't force a
-    // cold reload over it (that would wipe otherwise-valid rows to the loader).
-    !entities[0].kind ||
-    entities[0].kind.toLowerCase() === selectedKind;
-  const firstLoad =
-    loading &&
-    displayEntities.length === 0 &&
-    (entities.length === 0 || !heldKindMatches);
+  // The real background-revalidation signal comes from the shared queryClient,
+  // not `useEntityList().loading`: our CachingCatalogApi serves the cached page
+  // instantly and revalidates behind it, so `loading` flips false the moment the
+  // cached read resolves (tens of ms) while the network refetch runs on for the
+  // whole round-trip. `useIsFetching` on the catalog `queryEntities` key tracks
+  // that actual in-flight fetch, so the overlay stays up until it settles.
+  const queryFetching =
+    useIsFetching(
+      { queryKey: scopeKey(['catalog', 'queryEntities']) },
+      queryClient,
+    ) > 0;
+
+  // Cold load (nothing safe to show → PageLoader) vs. background refresh (rows
+  // on screen while the query revalidates → quiet inline spinner). A kind SWITCH
+  // counts as cold — the column set follows `selectedKind`, so held old-kind
+  // rows would misalign under new headers. Logic lives in the tested pure helper.
+  const { firstLoad, backgroundRefreshing } = deriveCatalogLoadState({
+    loading,
+    queryFetching,
+    entities,
+    displayEntities,
+    selectedKind,
+  });
 
   return (
     <Box>
       <Box className={classes.searchAndTitle}>
-        <Typography className={classes.titleText}>{titleText}</Typography>
+        <Box display="flex" alignItems="center" style={{ gap: 8 }}>
+          <Typography className={classes.titleText}>{titleText}</Typography>
+          {/* Quiet inline spinner next to the count while a background
+              revalidation runs behind the cached/held rows. role="status" +
+              aria-label so assistive tech announces the refresh. */}
+          {backgroundRefreshing && (
+            <Box
+              component="span"
+              role="status"
+              aria-label={`Refreshing ${pluralLabel.toLowerCase()}`}
+              display="inline-flex"
+              alignItems="center"
+            >
+              <Spinner size="chip" aria-hidden="true" />
+            </Box>
+          )}
+        </Box>
         <Box display="flex" alignItems="center" style={{ gap: 8 }}>
           <NamespaceChip />
           <ProjectChip />

--- a/packages/app/src/components/catalog/catalogLoadState.test.ts
+++ b/packages/app/src/components/catalog/catalogLoadState.test.ts
@@ -1,0 +1,132 @@
+import type { CatalogLoadStateInput } from './catalogLoadState';
+import { deriveCatalogLoadState } from './catalogLoadState';
+
+const rows = (n: number) => Array.from({ length: n }, () => ({}));
+
+// Sensible defaults; each test overrides the fields it exercises.
+const base: CatalogLoadStateInput = {
+  loading: false,
+  queryFetching: false,
+  entities: [],
+  displayEntities: [],
+  selectedKind: 'component',
+};
+
+describe('deriveCatalogLoadState', () => {
+  describe('firstLoad (cold-load skeleton)', () => {
+    it('is a cold first load when loading with nothing on screen', () => {
+      const s = deriveCatalogLoadState({ ...base, loading: true });
+      expect(s.firstLoad).toBe(true);
+      expect(s.backgroundRefreshing).toBe(false);
+    });
+
+    it('is not a cold load once rows are on screen (seed painted)', () => {
+      const s = deriveCatalogLoadState({
+        ...base,
+        loading: true,
+        displayEntities: rows(5),
+      });
+      expect(s.firstLoad).toBe(false);
+    });
+
+    it('treats a kind switch as a cold load (held rows are a different kind)', () => {
+      // Production state: `useEntityList` keeps the old Component `entities`
+      // while the new kind refetches, and CatalogCardList renders those held
+      // rows as `displayEntities` (entities take precedence over the seed). So
+      // the fixture must carry NONEMPTY held display rows — the kind mismatch
+      // has to force a cold load anyway, or they'd render under API headers.
+      const heldComponentRows = [{ kind: 'Component' }];
+      const s = deriveCatalogLoadState({
+        ...base,
+        loading: true,
+        entities: heldComponentRows,
+        displayEntities: heldComponentRows,
+        selectedKind: 'api',
+      });
+      expect(s.heldKindMatches).toBe(false);
+      expect(s.firstLoad).toBe(true);
+    });
+
+    it('does not force a cold reload over a held entity that has no kind', () => {
+      const s = deriveCatalogLoadState({
+        ...base,
+        loading: true,
+        // A held entity can arrive without a kind at runtime; the guard must not
+        // treat that as a mismatch. Cast past the typed `kind: string`.
+        entities: [{ kind: undefined as unknown as string }],
+        displayEntities: rows(1),
+      });
+      expect(s.heldKindMatches).toBe(true);
+    });
+
+    it('is a cold load before the kind resolves (no selectedKind, no rows)', () => {
+      const s = deriveCatalogLoadState({
+        ...base,
+        loading: true,
+        selectedKind: undefined,
+      });
+      expect(s.firstLoad).toBe(true);
+    });
+  });
+
+  describe('backgroundRefreshing (refresh overlay)', () => {
+    it('is refreshing when the query is fetching behind rows on screen', () => {
+      const s = deriveCatalogLoadState({
+        ...base,
+        queryFetching: true,
+        displayEntities: rows(5),
+      });
+      expect(s.backgroundRefreshing).toBe(true);
+    });
+
+    it('is NOT tied to useEntityList loading — loading true, query idle → no overlay', () => {
+      // The cached-first read has resolved (`loading` false soon after) but here
+      // even with loading still true, if the queryClient is not fetching there
+      // is no real refetch to show.
+      const s = deriveCatalogLoadState({
+        ...base,
+        loading: true,
+        queryFetching: false,
+        displayEntities: rows(5),
+      });
+      expect(s.backgroundRefreshing).toBe(false);
+    });
+
+    it('stays on while the query fetches even after loading has settled', () => {
+      // The real fix: loading already false (cached read done), but the network
+      // revalidation is still in flight — the overlay must remain.
+      const s = deriveCatalogLoadState({
+        ...base,
+        loading: false,
+        queryFetching: true,
+        entities: [{ kind: 'Component' }],
+        displayEntities: rows(3),
+      });
+      expect(s.firstLoad).toBe(false);
+      expect(s.backgroundRefreshing).toBe(true);
+    });
+
+    it('does not show the overlay during a cold load (no rows yet)', () => {
+      // firstLoad owns the screen; even if the query is fetching, there are no
+      // rows to overlay, so it's the PageLoader, not the refresh spinner.
+      const s = deriveCatalogLoadState({
+        ...base,
+        loading: true,
+        queryFetching: true,
+        displayEntities: [],
+      });
+      expect(s.firstLoad).toBe(true);
+      expect(s.backgroundRefreshing).toBe(false);
+    });
+
+    it('shows neither indicator once the fetch has settled', () => {
+      const s = deriveCatalogLoadState({
+        ...base,
+        entities: [{ kind: 'Component' }],
+        displayEntities: rows(3),
+      });
+      expect(s.firstLoad).toBe(false);
+      expect(s.backgroundRefreshing).toBe(false);
+    });
+  });
+});

--- a/packages/app/src/components/catalog/catalogLoadState.ts
+++ b/packages/app/src/components/catalog/catalogLoadState.ts
@@ -1,0 +1,88 @@
+import type { Entity } from '@backstage/catalog-model';
+
+/**
+ * The catalog list's loading inputs, reduced to what the load-state derivation
+ * needs.
+ *
+ * `useEntityList().loading` is NOT a reliable "background refetch in flight"
+ * signal: the catalog reads route through `CachingCatalogApi`, which serves the
+ * cached page immediately (`ensureQueryData` + `staleTime: 0`) and revalidates
+ * in the background — so `loading` flips false the instant the cached value
+ * resolves (~tens of ms), long before the network revalidation finishes. The
+ * actual in-flight state lives on the shared `queryClient`, passed here as
+ * `queryFetching` (from `useIsFetching` on the catalog `queryEntities` key).
+ */
+export interface CatalogLoadStateInput {
+  /** `useEntityList().loading` — true only until the cached-first read resolves. */
+  loading: boolean;
+  /**
+   * Whether the shared `queryClient` is currently fetching the catalog
+   * `queryEntities` query (the real background revalidation). Drives the
+   * refresh overlay so it stays up for the whole network round-trip, not just
+   * the cached-read tick.
+   */
+  queryFetching: boolean;
+  /** Live entities from `useEntityList` (may be held over during a refetch). */
+  entities: Pick<Entity, 'kind'>[];
+  /** Rows actually rendered: live entities, else the cached seed. */
+  displayEntities: unknown[];
+  /** Lowercased selected kind, or undefined before it resolves. */
+  selectedKind: string | undefined;
+}
+
+export interface CatalogLoadState {
+  /**
+   * True when the held live entities are a different kind than the selected
+   * one — a kind SWITCH, where showing the old rows under new-kind headers
+   * would misalign columns, so it must be treated as a cold load.
+   */
+  heldKindMatches: boolean;
+  /**
+   * Cold load: `loading` with nothing safe to keep on screen (no rows, or a
+   * kind switch). Drives the full-page skeleton/PageLoader.
+   */
+  firstLoad: boolean;
+  /**
+   * A background revalidation while rows are already on screen (held live
+   * entities or the painted cache seed). Drives the quiet inline spinner so a
+   * refresh is visible without wiping to the skeleton. Gated on the real
+   * `queryClient` fetch state so it stays up for the whole round-trip, and
+   * never true during a cold `firstLoad`.
+   */
+  backgroundRefreshing: boolean;
+}
+
+/**
+ * Derive the catalog list's load state from `useEntityList` output, the shared
+ * queryClient's fetch state, and the resolved display rows. Pure so the
+ * cold-load / background-refresh split is unit-testable without standing up the
+ * whole list component and its EntityListProvider context.
+ */
+export function deriveCatalogLoadState(
+  input: CatalogLoadStateInput,
+): CatalogLoadState {
+  const { loading, queryFetching, entities, displayEntities, selectedKind } =
+    input;
+
+  const heldKindMatches =
+    entities.length === 0 ||
+    !selectedKind ||
+    // A held entity with no kind can't be proven a mismatch — don't force a
+    // cold reload over it (that would wipe otherwise-valid rows to the loader).
+    !entities[0].kind ||
+    entities[0].kind.toLowerCase() === selectedKind;
+
+  // Cold load whenever we're loading and there is nothing safe to keep on
+  // screen: either no rows at all, OR the held live rows are a different kind
+  // than the selected one (a kind SWITCH). `useEntityList` keeps the previous
+  // kind's `entities` while the new kind refetches, so `displayEntities` is
+  // nonempty during a switch — the `!heldKindMatches` term must fire
+  // independently, or those old rows would render under the new kind's headers.
+  const firstLoad =
+    loading && (displayEntities.length === 0 || !heldKindMatches);
+
+  const backgroundRefreshing =
+    queryFetching && !firstLoad && displayEntities.length > 0;
+
+  return { heldKindMatches, firstLoad, backgroundRefreshing };
+}

--- a/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.test.tsx
+++ b/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, type Theme } from '@material-ui/core/styles';
+import { openChoreoTheme } from '@openchoreo/backstage-design-system';
+import type { Entity } from '@backstage/catalog-model';
+import { CompactEntityHeader } from './CompactEntityHeader';
+
+// The unified theme's `getTheme('v4')` is typed as a union of supported MUI
+// versions; the header's makeStyles needs the v4 shape (theme.page.fontColor),
+// so narrow it here for the provider.
+const v4Theme = openChoreoTheme.getTheme('v4') as unknown as Theme;
+
+// Drive the sibling-list query directly so we can supply cached data without a
+// real network/QueryClient. Each test overrides the return value.
+const useOpenChoreoQueryMock = jest.fn();
+jest.mock('../../hooks/useOpenChoreoQuery', () => ({
+  useOpenChoreoQuery: (...args: unknown[]) => useOpenChoreoQueryMock(...args),
+}));
+
+// The refresh spinner is gated on `useIsFetching` (the inner CachingCatalogApi
+// getEntities query), NOT the outer query's isRefetching — so drive that flag
+// directly. `useUserScopedKey` needs the provider context we don't mount, so
+// stub it to a plain prefixer.
+const useIsFetchingMock = jest.fn<number, unknown[]>(() => 0);
+jest.mock('@tanstack/react-query', () => ({
+  useIsFetching: (...args: unknown[]) => useIsFetchingMock(...args),
+}));
+jest.mock('../../query/OpenChoreoQueryProvider', () => ({
+  useUserScopedKey: () => (key: unknown[]) => ['@user', 'u', ...key],
+}));
+
+// The header pulls the catalog API and resolves parent/ancestor titles via
+// react-use's useAsync; stub both so no provider/network is needed.
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: () => ({ getEntityByRef: jest.fn().mockResolvedValue(undefined) }),
+}));
+jest.mock('react-use/esm/useAsync', () => ({
+  __esModule: true,
+  default: () => ({ value: undefined, loading: false }),
+}));
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+}));
+
+// Catalog-react display helpers need app/entity context we don't supply; render
+// simple stand-ins so the header itself is what's under test.
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  catalogApiRef: { id: 'catalog' },
+  EntityDisplayName: ({ entityRef }: { entityRef: Entity }) => (
+    <span>{entityRef.metadata.name}</span>
+  ),
+  FavoriteEntity: () => <span data-testid="favorite" />,
+}));
+
+const componentEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name: 'payment-service', namespace: 'default' },
+  spec: { type: 'service' },
+};
+
+const sibling = (name: string): Entity => ({
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name, namespace: 'default' },
+});
+
+const renderHeader = () =>
+  render(
+    <ThemeProvider theme={v4Theme}>
+      <CompactEntityHeader
+        entity={componentEntity}
+        headerTitle="payment-service"
+        kind="component"
+        entityName="payment-service"
+      />
+    </ThemeProvider>,
+  );
+
+/** Open the current level's sibling menu by clicking its caret button. */
+const openBreadcrumbMenu = () => {
+  fireEvent.click(screen.getByLabelText('Open breadcrumb quick navigation'));
+};
+
+describe('CompactEntityHeader breadcrumb refresh indicator', () => {
+  afterEach(() => {
+    useOpenChoreoQueryMock.mockReset();
+    useIsFetchingMock.mockReset();
+    useIsFetchingMock.mockReturnValue(0);
+  });
+
+  it('shows the refresh spinner while an already-cached sibling list revalidates', () => {
+    // Cached data present AND the inner getEntities query is fetching.
+    useOpenChoreoQueryMock.mockReturnValue({
+      data: { items: [sibling('payment-service'), sibling('order-service')] },
+      loading: false,
+    });
+    useIsFetchingMock.mockReturnValue(1);
+
+    renderHeader();
+    openBreadcrumbMenu();
+
+    // The inline spinner renders role="status" with the level's plural label.
+    const overlay = screen.getByRole('status');
+    expect(overlay).toHaveAttribute('aria-label', 'Refreshing components');
+    // The cached items stay visible next to the spinner.
+    expect(screen.getByText('order-service')).toBeInTheDocument();
+  });
+
+  it('does not show the spinner when the inner query is not fetching', () => {
+    useOpenChoreoQueryMock.mockReturnValue({
+      data: { items: [sibling('payment-service')] },
+      loading: false,
+    });
+    useIsFetchingMock.mockReturnValue(0);
+
+    renderHeader();
+    openBreadcrumbMenu();
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('shows the first-load item (not the spinner) on the initial fetch', () => {
+    // First load: no cached data yet, loading true. Even if a fetch is counted,
+    // the "Loading resources..." item owns the menu and there is no cached list
+    // to overlay a refresh spinner on.
+    useOpenChoreoQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+    });
+    useIsFetchingMock.mockReturnValue(0);
+
+    renderHeader();
+    openBreadcrumbMenu();
+
+    expect(screen.getByText('Loading resources...')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
+++ b/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
@@ -6,7 +6,9 @@ import {
   useState,
 } from 'react';
 import useAsync from 'react-use/esm/useAsync';
+import { useIsFetching } from '@tanstack/react-query';
 import { useOpenChoreoQuery } from '../../hooks/useOpenChoreoQuery';
+import { useUserScopedKey } from '../../query/OpenChoreoQueryProvider';
 import Box from '@material-ui/core/Box';
 import MaterialBreadcrumbs from '@material-ui/core/Breadcrumbs';
 import Chip from '@material-ui/core/Chip';
@@ -35,6 +37,7 @@ import {
   lightTokens,
   darkTokens,
   Skeleton,
+  Spinner,
 } from '@openchoreo/backstage-design-system';
 
 export interface CompactEntityHeaderProps {
@@ -539,6 +542,32 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
       { enabled: Boolean(openTargetNode) },
     );
 
+  // The real background revalidation happens one layer down: the fetcher above
+  // calls the *cached* catalogApi (CachingCatalogApi), which serves its own
+  // cached `getEntities` entry instantly and revalidates behind it. So the outer
+  // query's `isRefetching` settles in a few ms while the network refetch runs on
+  // in the inner cache — the same instant-resolve trap the catalog list hit.
+  // Track that inner `getEntities` query directly via `useIsFetching`, matched
+  // to the open level's kind+namespace, so the spinner reflects the actual fetch.
+  const scopeKey = useUserScopedKey();
+  const siblingsRefetching =
+    useIsFetching({
+      queryKey: scopeKey(['catalog', 'getEntities']),
+      predicate: query => {
+        // Key shape: ['@user', user, 'catalog', 'getEntities', request].
+        const request = query.queryKey[4] as
+          | { filter?: Array<Record<string, unknown>> }
+          | undefined;
+        const filter = request?.filter?.[0];
+        return (
+          !!openTargetNode &&
+          !!filter &&
+          filter.kind === openTargetNode.kind &&
+          filter['metadata.namespace'] === openTargetNode.namespace
+        );
+      },
+    }) > 0;
+
   // Derive the menu items from the fetched siblings, applying the same
   // relation-based sibling filtering, current-entity flagging, and alpha sort
   // the imperative version did. Falls back to just the current node until data
@@ -853,10 +882,32 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         transformOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
-        <Box px={2} pt={1.25} pb={0.5}>
+        <Box
+          px={2}
+          pt={1.25}
+          pb={0.5}
+          display="flex"
+          alignItems="center"
+          style={{ gap: 8 }}
+        >
           <Typography className={classes.breadcrumbMenuTitle}>
             {breadcrumbMenuTitle}
           </Typography>
+          {/* Quiet inline spinner next to the menu title while an already-cached
+              sibling list revalidates in the background — the first load still
+              shows the "Loading resources..." item below. role="status" mirrors
+              the other cached surfaces so assistive tech announces the refresh. */}
+          {siblingsRefetching && (
+            <Box
+              component="span"
+              role="status"
+              aria-label={`Refreshing ${breadcrumbMenuTitle.toLowerCase()}`}
+              display="inline-flex"
+              alignItems="center"
+            >
+              <Spinner size="chip" aria-hidden="true" />
+            </Box>
+          )}
         </Box>
         {isBreadcrumbMenuLoading && (
           <MenuItem disabled className={classes.breadcrumbMenuItem}>


### PR DESCRIPTION
Surface a quiet inline spinner next to the label on the two cached-first surfaces (the catalog list count and the breadcrumb menu title) so a background revalidation is visible instead of swapping in silently.

Both track the real network refetch via useIsFetching on the shared queryClient, not the surface's own loading/isRefetching flag — those settle the instant the cached read resolves while the revalidation is still in flight (the catalog list reads through CachingCatalogApi; the breadcrumb double-caches through it too).


https://github.com/user-attachments/assets/0f1bdca2-3cb7-4186-b94b-adef91ceff7a


https://github.com/user-attachments/assets/20d14ac9-9ba4-48e2-93bc-c2453f522649



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subtle refresh indicators to catalog list titles and breadcrumb menus while cached content updates in the background.
  * Cached catalog rows and breadcrumb items remain visible during refresh.
  * Preserved clear loading messaging for initial content loads.

* **Bug Fixes**
  * Refresh indicators now accurately reflect active background updates and disappear when fetching completes.

* **Tests**
  * Added coverage for initial loading, cached content, and background refresh states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->