### PR TITLE
fix(catalog): reflect the newly selected kind immediately on switch

### DIFF
--- a/.changeset/cache-catalog-always-revalidate.md
+++ b/.changeset/cache-catalog-always-revalidate.md
@@ -39,3 +39,8 @@ swapping in silently. The spinner tracks the real network refetch on the shared
 `queryClient` (via `useIsFetching`), not the surface's own `loading` flag —
 which resolves the instant the cached read returns while the revalidation is
 still in flight.
+
+Switching the catalog Kind filter now reflects the newly selected kind
+immediately: a cached kind's rows and title appear at once from the cache, and
+an uncached kind shows a clean full-page loader under the new kind's title
+instead of leaving the previous kind's rows on screen until the fetch resolves.

--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -26,6 +26,8 @@ import { Entity } from '@backstage/catalog-model';
 import { useCardListStyles } from './styles';
 import { pickCatalogSeed, type CatalogSeedEntry } from './catalogSeed';
 import { deriveCatalogLoadState } from './catalogLoadState';
+import { useSelectedKind } from './SelectedKindContext';
+import { kindDisplayNames } from '../../utils/kindUtils';
 import {
   StarredChip,
   TypeChip,
@@ -168,17 +170,34 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
     navigate(url);
   };
 
-  // Prefer the applied filter's kind, but fall back to the URL query param on a
-  // fresh mount: `filters.kind` is only populated once ChoreoEntityKindPicker's
-  // effect re-registers it (which waits on an async kind fetch), so for the
-  // instant-paint window `filters.kind` is undefined while the URL already
-  // carries the kind. The picker reads the same `queryParameters.kind` first.
+  // The authoritative selected kind. `filters.kind` (applied filter) and the URL
+  // both LAG during an in-app kind switch: the provider only sets `appliedFilters`
+  // and rewrites the URL AFTER the new kind's fetch resolves. So on a switch, both
+  // still read the OLD kind for the whole loading window — which would leave the
+  // old kind's title/columns on screen (and defeat the kind-switch cold-load
+  // detection). The `ChoreoEntityKindPicker` publishes the newly picked kind to
+  // `SelectedKindContext` synchronously on selection, so prefer that; fall back to
+  // `filters.kind`/the URL for the initial mount and deep-links (before any in-app
+  // selection), where the context is still empty.
+  const { selectedKind: contextKind } = useSelectedKind();
   const urlKind = (
     [queryParameters?.kind].flat()[0] as string | undefined
   )?.toLowerCase();
-  const selectedKind = filters.kind?.value?.toLowerCase() ?? urlKind;
+  const selectedKind =
+    contextKind ?? filters.kind?.value?.toLowerCase() ?? urlKind;
   const gridTemplateClass = classes[getGridTemplate(selectedKind)];
   const headerColumns = getHeaderColumns(selectedKind);
+
+  // Whether the held live entities are the currently selected kind. During a
+  // kind SWITCH `useEntityList` keeps the previous kind's `entities` while the
+  // new kind refetches, so they'd be the wrong kind for the selected view.
+  // Detect that so we neither render them (they'd misalign under the new
+  // headers) nor let them block a cached seed for the new kind.
+  const heldKindMatches =
+    entities.length === 0 ||
+    !selectedKind ||
+    !entities[0].kind ||
+    entities[0].kind.toLowerCase() === selectedKind;
 
   // On a fresh mount (navigating back to /catalog) `useEntityList` starts with
   // empty `entities` and re-runs its own async fetch, so it can't paint from
@@ -218,23 +237,44 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
       selectedKind,
       hasNarrowingFilter,
       offset,
-      hasLiveEntities: entities.length > 0,
+      // Only entities of the SELECTED kind count as "live" — during a kind
+      // switch the held entities are the previous kind, so they must not block
+      // a cached seed for the new kind (which lets a cached B paint instantly
+      // instead of flashing the loader).
+      hasLiveEntities: entities.length > 0 && heldKindMatches,
     });
-  }, [scopeKey, selectedKind, hasNarrowingFilter, offset, entities.length]);
+  }, [
+    scopeKey,
+    selectedKind,
+    hasNarrowingFilter,
+    offset,
+    entities.length,
+    heldKindMatches,
+  ]);
 
-  // Rows to render: the live list once it has resolved, else the cached seed.
-  const displayEntities = entities.length > 0 ? entities : seed?.items ?? [];
+  // Rows to render: the live list when it's the selected kind, else the cached
+  // seed. On a kind switch the held entities are the wrong kind, so the seed
+  // (kind-matched) wins — a cached new kind paints immediately; an uncached one
+  // has no seed, leaving nothing to show so the cold-load loader takes over.
+  const displayEntities =
+    entities.length > 0 && heldKindMatches ? entities : seed?.items ?? [];
   // Prefer the live count; fall back to the seed's while it loads.
   const displayTotal = totalItems ?? seed?.totalItems;
 
-  // Fall back to the URL-derived kind (capitalized to match kindPluralNames
-  // keys) while filters.kind is still catching up, so the title reads correctly
-  // during the seed window instead of the generic "Entity".
+  // Derive the display label from the authoritative `selectedKind` first (via the
+  // same `kindDisplayNames` map the picker uses, e.g. domain→Namespace), so the
+  // title reflects the newly picked kind immediately on a switch instead of the
+  // lagging `filters.kind?.label`. Fall back to the applied filter's label, then a
+  // capitalized kind, then the generic "Entity".
   const capitalizedKind = selectedKind
     ? selectedKind.charAt(0).toUpperCase() + selectedKind.slice(1)
     : undefined;
   const kindLabel =
-    filters.kind?.label || filters.kind?.value || capitalizedKind || 'Entity';
+    (selectedKind && kindDisplayNames[selectedKind]) ||
+    filters.kind?.label ||
+    filters.kind?.value ||
+    capitalizedKind ||
+    'Entity';
   const pluralLabel = kindPluralNames[kindLabel] || `${kindLabel}s`;
   const titleText = `All ${displayTotal === 1 ? kindLabel : pluralLabel}${
     displayTotal !== undefined ? ` (${displayTotal})` : ''

--- a/packages/app/src/components/catalog/ChoreoEntityKindPicker.tsx
+++ b/packages/app/src/components/catalog/ChoreoEntityKindPicker.tsx
@@ -13,6 +13,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { kindDisplayNames, kindCategories } from '../../utils/kindUtils';
 import { useAllKinds } from '../../hooks/useAllKinds';
+import { useSelectedKind } from './SelectedKindContext';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -145,6 +146,17 @@ export const ChoreoEntityKindPicker = (props: ChoreoEntityKindPickerProps) => {
     useEntityKindFilter({
       initialFilter: initialFilter,
     });
+
+  // Publish the selected kind to the shared context so CatalogCardList sees it
+  // synchronously (before `filters.kind`/the URL settle post-fetch). Only the
+  // visible picker writes it — the hidden mobile/desktop twin would otherwise
+  // fight over the context with its own lagging `selectedKind`.
+  const { setSelectedKind: publishSelectedKind } = useSelectedKind();
+  useEffect(() => {
+    if (!hidden) {
+      publishSelectedKind(selectedKind);
+    }
+  }, [hidden, selectedKind, publishSelectedKind]);
 
   useEffect(() => {
     if (error) {

--- a/packages/app/src/components/catalog/CustomCatalogPage.tsx
+++ b/packages/app/src/components/catalog/CustomCatalogPage.tsx
@@ -7,6 +7,7 @@ import { ChoreoEntityKindPicker } from './ChoreoEntityKindPicker';
 import { StarredFilter } from './CustomPersonalFilters';
 import { CatalogCardList } from './CatalogCardList';
 import { ContextAwareCreateButton } from './ContextAwareCreateButton';
+import { SelectedKindProvider } from './SelectedKindContext';
 import { useStyles } from './styles';
 
 export interface CustomCatalogPageProps {
@@ -23,55 +24,57 @@ export const CustomCatalogPage = ({
     <PageWithHeader title="Catalog" themeId="home">
       <Content>
         <EntityListProvider pagination={{ mode: 'offset', limit: 25 }}>
-          <Box className={classes.root}>
-            {/* Header with Filter button (mobile only) */}
-            <Box className={classes.header}>
-              <Box
-                className={classes.filterButton}
-                component="button"
-                onClick={() => setDrawerOpen(true)}
-                style={{
-                  gap: '8px',
-                }}
-              >
-                <FilterListIcon fontSize="small" />
-                <span className={classes.filterButtonText}>Filters</span>
-              </Box>
-            </Box>
-
-            {/* Filters at the top (desktop) */}
-            <Box className={classes.filterSection}>
-              <Grid container spacing={2} alignItems="center">
-                <Grid item sm={12} md={4} lg={3}>
-                  <ChoreoEntityKindPicker initialFilter={initialKind} />
-                </Grid>
-              </Grid>
-            </Box>
-
-            {/* Filter drawer for mobile */}
-            <Drawer
-              anchor="left"
-              open={drawerOpen}
-              onClose={() => setDrawerOpen(false)}
-              className={classes.filterDrawer}
-            >
-              <Box className={classes.filterDrawerContent}>
-                <Box className={classes.filterGrid}>
-                  <Box className={classes.filterItem}>
-                    <ChoreoEntityKindPicker initialFilter={initialKind} />
-                  </Box>
-                  <Box className={classes.filterItem}>
-                    <StarredFilter />
-                  </Box>
+          <SelectedKindProvider>
+            <Box className={classes.root}>
+              {/* Header with Filter button (mobile only) */}
+              <Box className={classes.header}>
+                <Box
+                  className={classes.filterButton}
+                  component="button"
+                  onClick={() => setDrawerOpen(true)}
+                  style={{
+                    gap: '8px',
+                  }}
+                >
+                  <FilterListIcon fontSize="small" />
+                  <span className={classes.filterButtonText}>Filters</span>
                 </Box>
               </Box>
-            </Drawer>
 
-            {/* Catalog card list */}
-            <Box className={classes.contentArea}>
-              <CatalogCardList actionButton={<ContextAwareCreateButton />} />
+              {/* Filters at the top (desktop) */}
+              <Box className={classes.filterSection}>
+                <Grid container spacing={2} alignItems="center">
+                  <Grid item sm={12} md={4} lg={3}>
+                    <ChoreoEntityKindPicker initialFilter={initialKind} />
+                  </Grid>
+                </Grid>
+              </Box>
+
+              {/* Filter drawer for mobile */}
+              <Drawer
+                anchor="left"
+                open={drawerOpen}
+                onClose={() => setDrawerOpen(false)}
+                className={classes.filterDrawer}
+              >
+                <Box className={classes.filterDrawerContent}>
+                  <Box className={classes.filterGrid}>
+                    <Box className={classes.filterItem}>
+                      <ChoreoEntityKindPicker initialFilter={initialKind} />
+                    </Box>
+                    <Box className={classes.filterItem}>
+                      <StarredFilter />
+                    </Box>
+                  </Box>
+                </Box>
+              </Drawer>
+
+              {/* Catalog card list */}
+              <Box className={classes.contentArea}>
+                <CatalogCardList actionButton={<ContextAwareCreateButton />} />
+              </Box>
             </Box>
-          </Box>
+          </SelectedKindProvider>
         </EntityListProvider>
       </Content>
     </PageWithHeader>

--- a/packages/app/src/components/catalog/SelectedKindContext.test.tsx
+++ b/packages/app/src/components/catalog/SelectedKindContext.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, act } from '@testing-library/react';
+import { SelectedKindProvider, useSelectedKind } from './SelectedKindContext';
+
+/** Reads the context and exposes a way to publish a new kind. */
+const Probe = () => {
+  const { selectedKind, setSelectedKind } = useSelectedKind();
+  return (
+    <div>
+      <span data-testid="kind">{selectedKind ?? 'undefined'}</span>
+      <button type="button" onClick={() => setSelectedKind('Environment')}>
+        set-env
+      </button>
+    </div>
+  );
+};
+
+describe('SelectedKindContext', () => {
+  it('starts undefined and publishes a lowercased kind on set', () => {
+    render(
+      <SelectedKindProvider>
+        <Probe />
+      </SelectedKindProvider>,
+    );
+
+    expect(screen.getByTestId('kind')).toHaveTextContent('undefined');
+
+    act(() => {
+      screen.getByText('set-env').click();
+    });
+
+    // Kind is lowercased so it composes with the lowercase kind keys elsewhere.
+    expect(screen.getByTestId('kind')).toHaveTextContent('environment');
+  });
+
+  it('degrades to an undefined kind and a no-op setter outside a provider', () => {
+    // No provider: the hook must not throw, and setSelectedKind is a safe no-op.
+    render(<Probe />);
+
+    expect(screen.getByTestId('kind')).toHaveTextContent('undefined');
+    act(() => {
+      screen.getByText('set-env').click();
+    });
+    // Still undefined — the no-op setter changed nothing.
+    expect(screen.getByTestId('kind')).toHaveTextContent('undefined');
+  });
+});

--- a/packages/app/src/components/catalog/SelectedKindContext.tsx
+++ b/packages/app/src/components/catalog/SelectedKindContext.tsx
@@ -1,0 +1,71 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+
+/**
+ * The catalog Kind selection, shared between the `ChoreoEntityKindPicker` and
+ * `CatalogCardList`.
+ *
+ * Why this exists: `useEntityList()` only exposes the *applied* kind
+ * (`filters.kind`), which the provider updates **after** the new kind's fetch
+ * resolves — and the URL is likewise rewritten (via `history.replaceState`)
+ * only post-fetch. So during an in-app kind switch, neither `filters.kind` nor
+ * `queryParameters.kind` reflects the newly picked kind synchronously. The
+ * picker's own `onChange` is the only place that knows the new kind on the same
+ * tick as the click. Publishing it here lets `CatalogCardList` detect a kind
+ * switch immediately (so an uncached switch shows the full-page loader instead
+ * of lingering on the previous kind's rows), rather than waiting a round-trip.
+ */
+export interface SelectedKindContextValue {
+  /** Lowercased selected kind, or `undefined` before any in-app selection. */
+  selectedKind: string | undefined;
+  /** Publish the kind the user just picked (called synchronously from onChange). */
+  setSelectedKind: (kind: string) => void;
+}
+
+const SelectedKindContext = createContext<SelectedKindContextValue | undefined>(
+  undefined,
+);
+
+/**
+ * Holds the synchronously-selected catalog kind. Mount inside the
+ * `EntityListProvider` so it wraps the picker(s) and the list.
+ */
+export const SelectedKindProvider = ({ children }: PropsWithChildren<{}>) => {
+  const [selectedKind, setSelectedKindState] = useState<string | undefined>(
+    undefined,
+  );
+
+  const value = useMemo<SelectedKindContextValue>(
+    () => ({
+      selectedKind,
+      setSelectedKind: (kind: string) =>
+        setSelectedKindState(kind.toLowerCase()),
+    }),
+    [selectedKind],
+  );
+
+  return (
+    <SelectedKindContext.Provider value={value}>
+      {children}
+    </SelectedKindContext.Provider>
+  );
+};
+
+/**
+ * Read the shared selected kind. Returns `undefined` for `selectedKind` (and a
+ * no-op setter) when used outside a `SelectedKindProvider`, so consumers degrade
+ * to their own kind derivation instead of throwing.
+ */
+export function useSelectedKind(): SelectedKindContextValue {
+  return (
+    useContext(SelectedKindContext) ?? {
+      selectedKind: undefined,
+      setSelectedKind: () => {},
+    }
+  );
+}

--- a/packages/app/src/components/catalog/catalogLoadState.test.ts
+++ b/packages/app/src/components/catalog/catalogLoadState.test.ts
@@ -29,25 +29,37 @@ describe('deriveCatalogLoadState', () => {
       expect(s.firstLoad).toBe(false);
     });
 
-    it('treats a kind switch as a cold load (held rows are a different kind)', () => {
-      // Production state: `useEntityList` keeps the old Component `entities`
-      // while the new kind refetches, and CatalogCardList renders those held
-      // rows as `displayEntities` (entities take precedence over the seed). So
-      // the fixture must carry NONEMPTY held display rows — the kind mismatch
-      // has to force a cold load anyway, or they'd render under API headers.
-      const heldComponentRows = [{ kind: 'Component' }];
+    it('is a cold load on a switch to an UNCACHED kind (no rows to show)', () => {
+      // The caller scopes `displayEntities` to the selected kind, so during a
+      // switch to a kind with no cache seed it is empty (the held previous-kind
+      // rows are excluded). With nothing valid to show, the full loader fires.
       const s = deriveCatalogLoadState({
         ...base,
         loading: true,
-        entities: heldComponentRows,
-        displayEntities: heldComponentRows,
+        entities: [{ kind: 'Component' }], // held previous kind, still lingering
+        displayEntities: [], // but nothing shown for the new (uncached) kind
         selectedKind: 'api',
       });
       expect(s.heldKindMatches).toBe(false);
       expect(s.firstLoad).toBe(true);
     });
 
-    it('does not force a cold reload over a held entity that has no kind', () => {
+    it('is NOT a cold load on a switch to a CACHED kind (seed fills the rows)', () => {
+      // A cached kind supplies a kind-matched seed, so the caller passes nonempty
+      // `displayEntities` even though the held `entities` are the previous kind.
+      // The new kind paints from the seed — no loader.
+      const s = deriveCatalogLoadState({
+        ...base,
+        loading: true,
+        entities: [{ kind: 'Component' }], // held previous kind
+        displayEntities: rows(5), // the new kind's cached seed rows
+        selectedKind: 'api',
+      });
+      expect(s.heldKindMatches).toBe(false);
+      expect(s.firstLoad).toBe(false);
+    });
+
+    it('reports heldKindMatches=true for a held entity with no kind (no forced reload)', () => {
       const s = deriveCatalogLoadState({
         ...base,
         loading: true,

--- a/packages/app/src/components/catalog/catalogLoadState.ts
+++ b/packages/app/src/components/catalog/catalogLoadState.ts
@@ -72,14 +72,13 @@ export function deriveCatalogLoadState(
     !entities[0].kind ||
     entities[0].kind.toLowerCase() === selectedKind;
 
-  // Cold load whenever we're loading and there is nothing safe to keep on
-  // screen: either no rows at all, OR the held live rows are a different kind
-  // than the selected one (a kind SWITCH). `useEntityList` keeps the previous
-  // kind's `entities` while the new kind refetches, so `displayEntities` is
-  // nonempty during a switch — the `!heldKindMatches` term must fire
-  // independently, or those old rows would render under the new kind's headers.
-  const firstLoad =
-    loading && (displayEntities.length === 0 || !heldKindMatches);
+  // Cold load whenever we're loading with nothing valid to show. `displayEntities`
+  // is already scoped to the SELECTED kind by the caller (matching live rows, or
+  // the kind-matched cache seed — never the previous kind's held rows during a
+  // switch), so an empty `displayEntities` genuinely means "nothing for this kind
+  // yet". On a kind switch to a cached kind the seed fills it (no loader); to an
+  // uncached kind it's empty, so the full loader shows under the new kind's title.
+  const firstLoad = loading && displayEntities.length === 0;
 
   const backgroundRefreshing =
     queryFetching && !firstLoad && displayEntities.length > 0;


### PR DESCRIPTION
Switching the Kind filter now updates the title, columns and rows to the picked kind at once instead of lingering on the previous kind while it loads. A cached kind paints instantly from the seed; an uncached kind clears the old rows and shows the full-page loader under the new kind's title.

The picker publishes its selection to a shared SelectedKindContext synchronously, since useEntityList's filters.kind and the URL only settle after the fetch resolves. CatalogCardList reads that context so a kind switch is detected right away, and prefers a kind-matched cache seed over the held previous-kind rows.

Before:


https://github.com/user-attachments/assets/1535038d-2701-4fb8-abb7-15758c5e2a6a




After:


https://github.com/user-attachments/assets/36dc4495-abe9-4337-82a9-8c8abc39e374


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Catalog pages now display cached results immediately and refresh in the background.
  - Returning to catalog pages reduces loading delays and skeleton flashes.
  - Breadcrumb entity lists reopen quickly using cached data while checking for updates.

- **Bug Fixes**
  - Catalog changes now appear immediately after write operations.
  - Switching catalog kinds updates titles and cached results instantly.
  - Uncached kinds show a clear loading state without displaying rows from the previous kind.
  - Background refresh activity is now represented with an inline spinner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->