### PR TITLE
feat: label and filter k8s resources pod logs by container

### DIFF
--- a/.changeset/pod-logs-container-filter.md
+++ b/.changeset/pod-logs-container-filter.md
@@ -1,0 +1,12 @@
+---
+'@openchoreo/backstage-plugin': patch
+'@openchoreo/openchoreo-client-node': patch
+---
+
+Show container names in the resource-tree pod logs tab and add a per-container
+filter. The pod logs API now returns logs aggregated across all of a pod's
+containers, each entry tagged with its container. For multi-container pods
+(for example an app container plus a Dapr sidecar) the logs viewer aligns
+each line into timestamp / container / message columns and adds a container
+dropdown ("All containers" plus one entry per container) to filter the view.
+Single-container pods are unchanged.

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -11061,6 +11061,7 @@ components:
       required:
         - timestamp
         - log
+        - container
       properties:
         timestamp:
           type: string

--- a/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-api.yaml
@@ -4398,6 +4398,14 @@ paths:
           description: Name of the pod
           schema:
             type: string
+        - name: container
+          in: query
+          required: false
+          description: >-
+            Name of the container to fetch logs from. If omitted, logs from all
+            containers in the pod are returned, with each entry tagged by container.
+          schema:
+            type: string
         - name: sinceSeconds
           in: query
           required: false
@@ -11063,6 +11071,10 @@ components:
           type: string
           description: Log message content
           example: 'Starting application server on port 8080'
+        container:
+          type: string
+          description: Name of the container that produced this log entry
+          example: 'main'
 
     ResourcePodLogsResponse:
       type: object

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -5505,6 +5505,11 @@ export interface components {
        * @example Starting application server on port 8080
        */
       log: string;
+      /**
+       * @description Name of the container that produced this log entry
+       * @example main
+       */
+      container?: string;
     };
     /** @description Response containing logs for a specific pod */
     ResourcePodLogsResponse: {
@@ -11663,6 +11668,8 @@ export interface operations {
       query: {
         /** @description Name of the pod */
         podName: string;
+        /** @description Name of the container to fetch logs from. If omitted, logs from all containers in the pod are returned, with each entry tagged by container. */
+        container?: string;
         /** @description Number of seconds since which to show logs */
         sinceSeconds?: number;
       };

--- a/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
+++ b/packages/openchoreo-client-node/src/generated/openchoreo/types.ts
@@ -5509,7 +5509,7 @@ export interface components {
        * @description Name of the container that produced this log entry
        * @example main
        */
-      container?: string;
+      container: string;
     };
     /** @description Response containing logs for a specific pod */
     ResourcePodLogsResponse: {

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -620,6 +620,7 @@ export interface ResourceEventsResponse {
 export interface PodLogEntry {
   timestamp: string;
   log: string;
+  container?: string;
 }
 
 /** Response from the pod-logs API */

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.test.tsx
@@ -52,6 +52,8 @@ describe('ResourcePodLogsViewer', () => {
     // Both containers' lines are visible initially.
     expect(await screen.findByText('main started')).toBeInTheDocument();
     expect(screen.getByText('sidecar heartbeat')).toBeInTheDocument();
+    // The collapsed dropdown shows the "All containers" default.
+    expect(screen.getByText('All containers')).toBeInTheDocument();
 
     // Open the container dropdown and pick a single container.
     await userEvent.click(screen.getByRole('button', { name: /container/i }));
@@ -83,5 +85,57 @@ describe('ResourcePodLogsViewer', () => {
     expect(
       screen.queryByRole('button', { name: /container/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it('can filter a container literally named "all"', async () => {
+    const mockClient = createMockOpenChoreoClient();
+    mockClient.fetchPodLogs.mockResolvedValue(
+      podLogs([
+        {
+          timestamp: '2026-01-01T00:00:00Z',
+          log: 'main line',
+          container: 'main',
+        },
+        {
+          timestamp: '2026-01-01T00:00:01Z',
+          log: 'all line',
+          container: 'all',
+        },
+      ]),
+    );
+
+    renderViewer(mockClient, podNode('pod-3', ['main', 'all']));
+
+    expect(await screen.findByText('main line')).toBeInTheDocument();
+    expect(screen.getByText('all line')).toBeInTheDocument();
+
+    // Selecting the container named "all" must filter to it, not show everything.
+    await userEvent.click(screen.getByRole('button', { name: /container/i }));
+    await userEvent.click(await screen.findByRole('option', { name: 'all' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('main line')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('all line')).toBeInTheDocument();
+  });
+
+  it('labels lines for a multi-container pod even when only one container logged', async () => {
+    const mockClient = createMockOpenChoreoClient();
+    mockClient.fetchPodLogs.mockResolvedValue(
+      podLogs([
+        {
+          timestamp: '2026-01-01T00:00:00Z',
+          log: 'only main so far',
+          container: 'main',
+        },
+      ]),
+    );
+
+    // Pod spec declares two containers; only "main" has produced logs.
+    renderViewer(mockClient, podNode('pod-4', ['main', 'sidecar']));
+
+    expect(await screen.findByText('only main so far')).toBeInTheDocument();
+    // The container column is shown, derived from the pod spec rather than logs.
+    expect(screen.getByText('main')).toBeInTheDocument();
   });
 });

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.test.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestApiProvider } from '@backstage/test-utils';
+import {
+  createMockOpenChoreoClient,
+  type MockOpenChoreoClient,
+} from '@openchoreo/test-utils';
+import { openChoreoClientApiRef } from '../../../../api/OpenChoreoClientApi';
+import type { PodLogEntry } from '../../../../api/OpenChoreoClientApi';
+import { ResourcePodLogsViewer } from './ResourcePodLogsViewer';
+import type { LayoutNode } from './treeTypes';
+
+const podNode = (name: string, containers: string[]) =>
+  ({
+    name,
+    specObject: { spec: { containers: containers.map(c => ({ name: c })) } },
+  } as unknown as LayoutNode);
+
+const renderViewer = (mockClient: MockOpenChoreoClient, node: LayoutNode) =>
+  render(
+    <TestApiProvider apis={[[openChoreoClientApiRef, mockClient]]}>
+      <ResourcePodLogsViewer
+        node={node}
+        namespaceName="ns-1"
+        releaseBindingName="rb-1"
+      />
+    </TestApiProvider>,
+  );
+
+const podLogs = (entries: PodLogEntry[]) => ({ logEntries: entries });
+
+describe('ResourcePodLogsViewer', () => {
+  it('shows a container dropdown and filters logs by container', async () => {
+    const mockClient = createMockOpenChoreoClient();
+    mockClient.fetchPodLogs.mockResolvedValue(
+      podLogs([
+        {
+          timestamp: '2026-01-01T00:00:00Z',
+          log: 'main started',
+          container: 'main',
+        },
+        {
+          timestamp: '2026-01-01T00:00:01Z',
+          log: 'sidecar heartbeat',
+          container: 'log-sidecar',
+        },
+      ]),
+    );
+
+    renderViewer(mockClient, podNode('pod-1', ['main', 'log-sidecar']));
+
+    // Both containers' lines are visible initially.
+    expect(await screen.findByText('main started')).toBeInTheDocument();
+    expect(screen.getByText('sidecar heartbeat')).toBeInTheDocument();
+
+    // Open the container dropdown and pick a single container.
+    await userEvent.click(screen.getByRole('button', { name: /container/i }));
+    await userEvent.click(
+      await screen.findByRole('option', { name: 'log-sidecar' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('main started')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('sidecar heartbeat')).toBeInTheDocument();
+  });
+
+  it('shows no container dropdown for a single-container pod', async () => {
+    const mockClient = createMockOpenChoreoClient();
+    mockClient.fetchPodLogs.mockResolvedValue(
+      podLogs([
+        {
+          timestamp: '2026-01-01T00:00:00Z',
+          log: 'solo log',
+          container: 'main',
+        },
+      ]),
+    );
+
+    renderViewer(mockClient, podNode('pod-2', ['main']));
+
+    expect(await screen.findByText('solo log')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /container/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.tsx
@@ -1,10 +1,19 @@
-import { useState, useEffect, useRef, type FC } from 'react';
-import { Box, Typography, CircularProgress } from '@material-ui/core';
+import { useState, useEffect, useRef, useMemo, type FC } from 'react';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { useApi } from '@backstage/core-plugin-api';
 import { openChoreoClientApiRef } from '../../../../api/OpenChoreoClientApi';
 import type { PodLogEntry } from '../../../../api/OpenChoreoClientApi';
 import type { LayoutNode } from './treeTypes';
+import { getPodContainerNames } from './podUtils';
 import { useTreeStyles } from './treeStyles';
 
 interface ResourcePodLogsViewerProps {
@@ -14,27 +23,59 @@ interface ResourcePodLogsViewerProps {
   refreshKey?: number;
 }
 
+const ALL_CONTAINERS = 'all';
+
 const useLogStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    gap: theme.spacing(1),
+  },
+  filterControl: {
+    minWidth: 200,
+    alignSelf: 'flex-start',
+  },
   container: {
-    maxHeight: '100%',
+    flex: 1,
+    minHeight: 0,
     overflow: 'auto',
     backgroundColor: theme.palette.type === 'dark' ? '#1e1e1e' : '#f5f5f5',
     borderRadius: 4,
     padding: theme.spacing(1.5),
   },
   logLine: {
+    display: 'flex',
     fontFamily:
       'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
     fontSize: 12,
     lineHeight: 1.6,
-    whiteSpace: 'pre-wrap',
-    wordBreak: 'break-all',
     color: theme.palette.type === 'dark' ? '#d4d4d4' : '#1e1e1e',
   },
   timestamp: {
+    flexShrink: 0,
     color: theme.palette.type === 'dark' ? '#6a9955' : '#098658',
     marginRight: theme.spacing(1),
     userSelect: 'none',
+  },
+  // Fixed-width column (set dynamically in `ch`) so message text lines up
+  // regardless of container-name length when viewing all containers.
+  containerTag: {
+    flexShrink: 0,
+    color: theme.palette.type === 'dark' ? '#569cd6' : '#0451a5',
+    fontWeight: 600,
+    marginRight: theme.spacing(1),
+    userSelect: 'none',
+    whiteSpace: 'pre',
+  },
+  message: {
+    flex: 1,
+    minWidth: 0,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-all',
+  },
+  emptyFilterHint: {
+    padding: theme.spacing(1),
   },
 }));
 
@@ -67,6 +108,45 @@ export const ResourcePodLogsViewer: FC<ResourcePodLogsViewerProps> = ({
   const [logEntries, setLogEntries] = useState<PodLogEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedContainer, setSelectedContainer] =
+    useState<string>(ALL_CONTAINERS);
+
+  // Distinct containers that actually produced log lines, in first-seen order —
+  // drives per-line labelling and the width of the container column.
+  const loggedContainers = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          logEntries.map(e => e.container).filter((c): c is string => !!c),
+        ),
+      ),
+    [logEntries],
+  );
+
+  // Dropdown options come from the pod spec; fall back to the containers seen in the logs.
+  const podContainers = useMemo(
+    () => getPodContainerNames(node.specObject),
+    [node.specObject],
+  );
+  const containerOptions =
+    podContainers.length > 0 ? podContainers : loggedContainers;
+
+  const containerColumnWidth = useMemo(
+    () => loggedContainers.reduce((max, name) => Math.max(max, name.length), 0),
+    [loggedContainers],
+  );
+
+  const visibleEntries = useMemo(
+    () =>
+      selectedContainer === ALL_CONTAINERS
+        ? logEntries
+        : logEntries.filter(e => e.container === selectedContainer),
+    [logEntries, selectedContainer],
+  );
+
+  // Label each line only when viewing all containers of a multi-container pod.
+  const showContainerLabel =
+    selectedContainer === ALL_CONTAINERS && loggedContainers.length > 1;
 
   useEffect(() => {
     let cancelled = false;
@@ -107,12 +187,16 @@ export const ResourcePodLogsViewer: FC<ResourcePodLogsViewerProps> = ({
     };
   }, [client, namespaceName, releaseBindingName, node.name, refreshKey]);
 
-  // Auto-scroll to bottom on initial load
   useEffect(() => {
-    if (!loading && logEntries.length > 0 && containerRef.current) {
+    setSelectedContainer(ALL_CONTAINERS);
+  }, [node.name]);
+
+  // Auto-scroll to bottom on load and whenever the visible set changes.
+  useEffect(() => {
+    if (!loading && visibleEntries.length > 0 && containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight;
     }
-  }, [loading, logEntries.length]);
+  }, [loading, visibleEntries.length, selectedContainer]);
 
   if (loading) {
     return (
@@ -143,15 +227,58 @@ export const ResourcePodLogsViewer: FC<ResourcePodLogsViewerProps> = ({
   }
 
   return (
-    <div ref={containerRef} className={classes.container}>
-      {logEntries.map((entry, index) => (
-        <div key={index} className={classes.logLine}>
-          <span className={classes.timestamp}>
-            {formatLogTimestamp(entry.timestamp)}
-          </span>
-          {entry.log}
-        </div>
-      ))}
-    </div>
+    <Box className={classes.root}>
+      {containerOptions.length > 1 && (
+        <FormControl
+          variant="outlined"
+          size="small"
+          className={classes.filterControl}
+        >
+          <InputLabel id="logs-container-label">Container</InputLabel>
+          <Select
+            labelId="logs-container-label"
+            value={selectedContainer}
+            label="Container"
+            onChange={e => setSelectedContainer(e.target.value as string)}
+          >
+            <MenuItem value={ALL_CONTAINERS}>All containers</MenuItem>
+            {containerOptions.map(name => (
+              <MenuItem key={name} value={name}>
+                {name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
+      <div ref={containerRef} className={classes.container}>
+        {visibleEntries.length === 0 ? (
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            className={classes.emptyFilterHint}
+          >
+            No logs for container "{selectedContainer}"
+          </Typography>
+        ) : (
+          visibleEntries.map((entry, index) => (
+            <div key={index} className={classes.logLine}>
+              <span className={classes.timestamp}>
+                {formatLogTimestamp(entry.timestamp)}
+              </span>
+              {showContainerLabel && (
+                <span
+                  className={classes.containerTag}
+                  style={{ width: `${containerColumnWidth}ch` }}
+                >
+                  {entry.container ?? ''}
+                </span>
+              )}
+              <span className={classes.message}>{entry.log}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </Box>
   );
 };

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourcePodLogsViewer.tsx
@@ -23,7 +23,9 @@ interface ResourcePodLogsViewerProps {
   refreshKey?: number;
 }
 
-const ALL_CONTAINERS = 'all';
+// Sentinel for the "All containers" option. Underscores are invalid in a
+// Kubernetes container name (DNS-1123), so it cannot collide with a real container
+const ALL_CONTAINERS = '__all__';
 
 const useLogStyles = makeStyles(theme => ({
   root: {
@@ -146,7 +148,7 @@ export const ResourcePodLogsViewer: FC<ResourcePodLogsViewerProps> = ({
 
   // Label each line only when viewing all containers of a multi-container pod.
   const showContainerLabel =
-    selectedContainer === ALL_CONTAINERS && loggedContainers.length > 1;
+    selectedContainer === ALL_CONTAINERS && containerOptions.length > 1;
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Purpose
The pod logs API now returns logs from all of a pod's containers, each entry tagged with its container. Surface that in the resource-tree logs tab: for multi-container pods, align each line into timestamp / container / message columns and add a container dropdown ("All containers" plus one entry per container, sourced from the pod spec like the terminal picker) to filter the view. Single-container pods are unchanged.

Also sync the openchoreo-client-node OpenAPI spec and regenerate the client for the new pod-logs `container` field and query parameter.

Refs openchoreo/openchoreo#4186
Backend PR: https://github.com/openchoreo/openchoreo/pull/4236

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach

https://github.com/user-attachments/assets/27a5c26f-3f23-4e86-8ec0-e35759625e96



## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Pod logs now aggregate entries across all containers, tagging each line with its container.
  * Added a container dropdown filter to switch between “all containers” and per-container views.
  * Enhanced the pod logs display to align timestamp, container, and message columns for multi-container pods.
* **Bug Fixes**
  * Improved auto-scrolling so it stays in sync when filtering logs by container.
  * Added UI handling for edge cases, including pods with only one container emitting logs and container names matching special terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->