### PR TITLE
feat: surface OTel span status in tracing views

### DIFF
--- a/.changeset/trace-span-status-object.md
+++ b/.changeset/trace-span-status-object.md
@@ -1,0 +1,13 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+'@openchoreo/openchoreo-client-node': patch
+---
+
+Adapt the tracing views to the OpenTelemetry span status model. The
+observability API now returns a span's `status` as a `SpanStatus` object
+(`code` of `ok`/`error`/`unset` plus an optional `message`) instead of a plain
+status string. The waterfall tooltip now shows the span's status code, the span
+details panel gains a dedicated Status section (alongside Attributes and Resource
+Attributes) that surfaces the status message, and error spans stay highlighted
+based on the status code. This also prevents the span tooltip from crashing when
+the status is an object.

--- a/.changeset/traces-table-error-stripe.md
+++ b/.changeset/traces-table-error-stripe.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+---
+
+Fix the error stripe not rendering on error rows in the traces table. The red
+"contains errors" indicator was drawn by CSS targeting table cells (`td`/`th`)
+that no longer exist after the table moved to a div-based virtualized layout,
+and the span that did render (the tooltip's hover target) had no fill colour.
+The stripe is now drawn on the rendered element, so error traces show the red
+stripe again.

--- a/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
@@ -1443,12 +1443,7 @@ components:
                 type: string
                 description: The parent span ID
               status:
-                type: string
-                enum:
-                  - ok
-                  - error
-                  - unset
-                description: The execution status of the span. One of "ok", "error", or "unset".
+                $ref: '#/components/schemas/SpanStatus'
               attributes:
                 type: object
                 description: The span attributes
@@ -1492,12 +1487,7 @@ components:
           type: string
           description: The parent span ID
         status:
-          type: string
-          enum:
-            - ok
-            - error
-            - unset
-          description: The execution status of the span. One of "ok", "error", or "unset".
+          $ref: '#/components/schemas/SpanStatus'
         attributes:
           type: array
           items:
@@ -1510,6 +1500,26 @@ components:
               value:
                 type: string
                 description: The value of the attribute
+
+    # OpenTelemetry span status (code + optional message)
+    SpanStatus:
+      type: object
+      description: >-
+        Execution status of the span, following the OpenTelemetry span Status
+        model.
+      properties:
+        code:
+          type: string
+          enum:
+            - ok
+            - error
+            - unset
+          description: The status code of the span. One of "ok", "error", or "unset".
+        message:
+          type: string
+          description: >-
+            Developer-facing human-readable status description. Typically set
+            only when code is "error".
 
     # Request schemas for alert rules
     AlertRuleRequest:

--- a/packages/openchoreo-client-node/src/generated/observability/types.ts
+++ b/packages/openchoreo-client-node/src/generated/observability/types.ts
@@ -794,11 +794,7 @@ export interface components {
         durationNs?: number;
         /** @description The parent span ID */
         parentSpanId?: string;
-        /**
-         * @description The execution status of the span. One of "ok", "error", or "unset".
-         * @enum {string}
-         */
-        status?: 'ok' | 'error' | 'unset';
+        status?: components['schemas']['SpanStatus'];
         /** @description The span attributes */
         attributes?: {
           [key: string]: unknown;
@@ -837,17 +833,23 @@ export interface components {
       durationNs?: number;
       /** @description The parent span ID */
       parentSpanId?: string;
-      /**
-       * @description The execution status of the span. One of "ok", "error", or "unset".
-       * @enum {string}
-       */
-      status?: 'ok' | 'error' | 'unset';
+      status?: components['schemas']['SpanStatus'];
       attributes?: {
         /** @description The key of the attribute */
         key?: string;
         /** @description The value of the attribute */
         value?: string;
       }[];
+    };
+    /** @description Execution status of the span, following the OpenTelemetry span Status model. */
+    SpanStatus: {
+      /**
+       * @description The status code of the span. One of "ok", "error", or "unset".
+       * @enum {string}
+       */
+      code?: 'ok' | 'error' | 'unset';
+      /** @description Developer-facing human-readable status description. Typically set only when code is "error". */
+      message?: string;
     };
     AlertRuleRequest: {
       metadata: {

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.test.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.test.ts
@@ -399,3 +399,80 @@ describe('ObservabilityClient.getRuntimeEvents', () => {
     ).rejects.toThrow('kaboom');
   });
 });
+
+describe('ObservabilityClient.getTraceSpans', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveUrls.mockResolvedValue({ observerUrl: 'http://observer' });
+  });
+
+  it('passes the OTel status object through unchanged', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce(
+      mockOkResponse({
+        spans: [
+          {
+            spanId: 'span-1',
+            spanName: 'root',
+            startTime: 's',
+            endTime: 'e',
+            durationNs: 100,
+            status: { code: 'error', message: 'boom' },
+          },
+        ],
+        total: 1,
+        tookMs: 3,
+      }),
+    );
+
+    const client = createClient();
+    const result = await client.getTraceSpans(
+      'trace-1',
+      'ns1',
+      'project-a',
+      'dev',
+      'component-a',
+    );
+
+    const [url] = mockFetchApi.fetch.mock.calls[0];
+    expect(url).toBe('http://observer/api/v1alpha1/traces/trace-1/spans/query');
+    expect(result.spans[0].status).toEqual({
+      code: 'error',
+      message: 'boom',
+    });
+  });
+});
+
+describe('ObservabilityClient.getSpanDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveUrls.mockResolvedValue({ observerUrl: 'http://observer' });
+  });
+
+  it('maps the status object into the span details', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce(
+      mockOkResponse({
+        spanId: 'span-1',
+        spanName: 'GET /api',
+        startTime: 's',
+        endTime: 'e',
+        durationNs: 100,
+        status: { code: 'ok' },
+        attributes: [{ key: 'http.method', value: 'GET' }],
+      }),
+    );
+
+    const client = createClient();
+    const result = await client.getSpanDetails(
+      'trace-1',
+      'span-1',
+      'ns1',
+      'dev',
+    );
+
+    const [url] = mockFetchApi.fetch.mock.calls[0];
+    expect(url).toBe(
+      'http://observer/api/v1alpha1/traces/trace-1/spans/span-1',
+    );
+    expect(result.status).toEqual({ code: 'ok' });
+  });
+});

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
@@ -469,6 +469,7 @@ export class ObservabilityClient implements ObservabilityApi {
       endTime: data.endTime ?? '',
       durationNs: data.durationNs ?? 0,
       parentSpanId: data.parentSpanId,
+      status: data.status,
       attributes: data.attributes,
       resourceAttributes: data.resourceAttributes,
     };

--- a/plugins/openchoreo-observability/src/components/Traces/TracesTable.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/TracesTable.test.tsx
@@ -141,4 +141,20 @@ describe('TracesTable', () => {
       screen.getByText('Failed to load spans: Network error'),
     ).toBeInTheDocument();
   });
+
+  it('renders the error stripe for traces with errors', () => {
+    const { container } = renderTable({
+      traces: [{ ...sampleTrace, hasErrors: true }],
+    });
+
+    expect(
+      container.querySelector('[class*="errorStripe"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the error stripe for traces without errors', () => {
+    const { container } = renderTable();
+
+    expect(container.querySelector('[class*="errorStripe"]')).toBeNull();
+  });
 });

--- a/plugins/openchoreo-observability/src/components/Traces/TracesTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/TracesTable.tsx
@@ -126,7 +126,7 @@ export const TracesTable: FC<TracesTableProps> = ({
       <Box
         className={`${classes.traceRow} ${
           isRowExpanded ? classes.expandedRow : ''
-        } ${trace.hasErrors ? classes.errorRow : ''}`}
+        }`}
         onClick={() => handleToggle(rowKey, trace.traceId)}
         role="row"
       >

--- a/plugins/openchoreo-observability/src/components/Traces/WaterfallView.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/WaterfallView.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WaterfallView } from './WaterfallView';
+import { Span, SpanDetails } from '../../types';
+
+// ---- Helpers ----
+
+const errorSpan: Span = {
+  spanId: 'span-1',
+  spanName: 'root-span',
+  spanKind: 'SERVER',
+  startTime: '2024-06-01T10:00:00.000000000Z',
+  endTime: '2024-06-01T10:00:01.500000000Z',
+  durationNs: 1500000000,
+  status: { code: 'error', message: 'boom' },
+};
+
+const okSpan: Span = {
+  ...errorSpan,
+  status: { code: 'ok' },
+};
+
+const detailsFor = (span: Span): SpanDetails => ({
+  ...span,
+  attributes: { 'http.method': 'GET' },
+  resourceAttributes: { 'service.name': 'svc' },
+});
+
+function renderWaterfall(
+  spans: Span[],
+  getDetails: () => SpanDetails | undefined = () => undefined,
+) {
+  const spanDetails = {
+    fetchSpanDetails: jest.fn(),
+    getDetails: jest.fn(getDetails),
+    isLoading: jest.fn().mockReturnValue(false),
+    getError: jest.fn().mockReturnValue(undefined),
+  };
+  render(
+    <WaterfallView traceId="trace-1" spans={spans} spanDetails={spanDetails} />,
+  );
+  return spanDetails;
+}
+
+// ---- Tests ----
+
+describe('WaterfallView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('colors error spans red', () => {
+    renderWaterfall([errorSpan]);
+    expect(screen.getByText('1.500s')).toHaveStyle('background-color: #FCA5A5');
+  });
+
+  it('does not apply the error color to ok spans', () => {
+    renderWaterfall([okSpan]);
+    expect(screen.getByText('1.500s')).not.toHaveStyle(
+      'background-color: #FCA5A5',
+    );
+  });
+
+  it('renders the object status as a Status Code in the tooltip without crashing', async () => {
+    const user = userEvent.setup();
+    renderWaterfall([errorSpan]);
+
+    await user.hover(screen.getByText('1.500s'));
+
+    expect(await screen.findByText('Status Code:')).toBeInTheDocument();
+    expect(screen.getByText('error')).toBeInTheDocument();
+    // The old string-status label is gone.
+    expect(screen.queryByText('Status:')).not.toBeInTheDocument();
+  });
+
+  it('shows a dedicated Status section in the span details panel', async () => {
+    const user = userEvent.setup();
+    const spanDetails = renderWaterfall([errorSpan], () =>
+      detailsFor(errorSpan),
+    );
+
+    await user.click(screen.getByText('1.500s'));
+
+    expect(spanDetails.fetchSpanDetails).toHaveBeenCalledWith(
+      'trace-1',
+      'span-1',
+    );
+    // Status section renders the flattened OTel status fields. (The status code
+    // also appears in the hover tooltip that the click opens, hence getAllByText.)
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('code')).toBeInTheDocument();
+    expect(screen.getAllByText('error').length).toBeGreaterThan(0);
+    expect(screen.getByText('message')).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/Traces/WaterfallView.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/WaterfallView.tsx
@@ -17,6 +17,8 @@ import {
   parseRfc3339NanoToNanoseconds,
   formatDuration,
   formatTimeFromString,
+  isSpanError,
+  getSpanStatusCode,
 } from './utils';
 
 interface SpanDetailsHook {
@@ -132,13 +134,6 @@ const SpanDetailsPanel = ({ details, traceId }: SpanDetailsPanelProps) => {
     { label: 'Duration', value: formatDuration(details.durationNs) },
   ];
 
-  let statusColor = '#94A3B8';
-  if (details.status === 'error') {
-    statusColor = '#EF4444';
-  } else if (details.status === 'ok') {
-    statusColor = '#10B981';
-  }
-
   return (
     <Box>
       {/* Core span fields */}
@@ -183,35 +178,9 @@ const SpanDetailsPanel = ({ details, traceId }: SpanDetailsPanelProps) => {
             </Typography>
           </Box>
         ))}
-        {details.status && (
-          <Box display="flex" style={{ gap: 8, marginBottom: 2 }}>
-            <Typography
-              variant="caption"
-              style={{
-                fontSize: '0.7rem',
-                fontFamily: 'monospace',
-                fontWeight: 600,
-                minWidth: 220,
-                flexShrink: 0,
-              }}
-            >
-              Status
-            </Typography>
-            <Typography
-              variant="caption"
-              style={{
-                fontSize: '0.7rem',
-                fontFamily: 'monospace',
-                fontWeight: 600,
-                color: statusColor,
-              }}
-            >
-              {details.status}
-            </Typography>
-          </Box>
-        )}
       </Box>
 
+      <AttributeSection label="Status" data={details.status} />
       <AttributeSection label="Attributes" data={details.attributes} />
       <AttributeSection
         label="Resource Attributes"
@@ -235,9 +204,9 @@ export const WaterfallView = ({
   const getSpanColor = (
     spanName: string,
     depth: number,
-    status?: string,
+    isError: boolean,
   ): string => {
-    if (status === 'error') return '#FCA5A5'; // light red
+    if (isError) return '#FCA5A5'; // light red
 
     const colors = [
       '#93C5FD', // blue-300
@@ -424,7 +393,11 @@ export const WaterfallView = ({
             calculateWidth(span.startTime, span.endTime),
             0.5,
           );
-          const color = getSpanColor(span.spanName, span.depth, span.status);
+          const color = getSpanColor(
+            span.spanName,
+            span.depth,
+            isSpanError(span.status),
+          );
           const indent = span.depth * 20;
           const hasChildren = span.children.length > 0;
           const isCollapsed = collapsedSpans.has(span.spanId);
@@ -446,7 +419,7 @@ export const WaterfallView = ({
                   </IconButton>
                 )}
                 {!hasChildren && <Box style={{ width: '20px' }} />}
-                {span.status === 'error' && (
+                {isSpanError(span.status) && (
                   <Tooltip title="Span error">
                     <ErrorOutlineIcon className={classes.spanErrorIcon} />
                   </Tooltip>
@@ -575,17 +548,17 @@ export const WaterfallView = ({
                           {formatDuration(span.durationNs)}
                         </Typography>
                       </Box>
-                      {span.status && (
+                      {getSpanStatusCode(span.status) && (
                         <Box className={classes.tooltipRow}>
                           <Typography
                             variant="caption"
                             component="span"
                             className={classes.tooltipLabel}
                           >
-                            Status:
+                            Status Code:
                           </Typography>
                           <Typography variant="caption">
-                            {span.status}
+                            {getSpanStatusCode(span.status)}
                           </Typography>
                         </Box>
                       )}

--- a/plugins/openchoreo-observability/src/components/Traces/styles.ts
+++ b/plugins/openchoreo-observability/src/components/Traces/styles.ts
@@ -69,6 +69,7 @@ export const useTracesTableStyles = makeStyles((theme: Theme) => ({
     textOverflow: 'ellipsis',
   },
   traceIdCell: {
+    position: 'relative',
     fontSize: '0.75rem',
     fontFamily: 'monospace',
     overflow: 'hidden',
@@ -86,22 +87,9 @@ export const useTracesTableStyles = makeStyles((theme: Theme) => ({
       fontSize: '1rem',
     },
   },
-  errorRow: {
-    '& > td:first-child, & > th:first-child': {
-      position: 'relative',
-      borderLeft: 'none !important',
-      '&::before': {
-        content: '""',
-        position: 'absolute',
-        left: 0,
-        top: '5%',
-        bottom: '5%',
-        width: '3px',
-        backgroundColor: '#EF4444',
-        borderRadius: '2px',
-      },
-    },
-  },
+  // Absolutely positioned inside the (relative) trace-name cell. The span itself
+  // is a wide, transparent hit-area so the "contains errors" tooltip is easy to
+  // hover; the visible 3px stripe is drawn by the ::before.
   errorStripe: {
     position: 'absolute',
     left: 0,
@@ -110,6 +98,16 @@ export const useTracesTableStyles = makeStyles((theme: Theme) => ({
     width: '8px',
     cursor: 'default',
     zIndex: 1,
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      width: '3px',
+      backgroundColor: theme.palette.error.main,
+      borderRadius: '2px',
+    },
   },
 }));
 

--- a/plugins/openchoreo-observability/src/components/Traces/utils.test.ts
+++ b/plugins/openchoreo-observability/src/components/Traces/utils.test.ts
@@ -4,6 +4,8 @@ import {
   formatDuration,
   formatTime,
   formatTimeFromString,
+  getSpanStatusCode,
+  isSpanError,
 } from './utils';
 import { calculateTimeRange } from '@openchoreo/backstage-plugin-react';
 
@@ -84,6 +86,34 @@ describe('formatTimeFromString', () => {
     expect(formatTimeFromString('2024-06-01T10:00:00')).toBe(
       '2024-06-01T10:00:00Z',
     );
+  });
+});
+
+describe('getSpanStatusCode', () => {
+  it('returns the status code', () => {
+    expect(getSpanStatusCode({ code: 'ok' })).toBe('ok');
+  });
+
+  it('returns undefined when status is missing', () => {
+    expect(getSpanStatusCode(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when code is absent', () => {
+    expect(getSpanStatusCode({ message: 'boom' })).toBeUndefined();
+  });
+});
+
+describe('isSpanError', () => {
+  it('is true only for the error code', () => {
+    expect(isSpanError({ code: 'error' })).toBe(true);
+    expect(isSpanError({ code: 'error', message: 'boom' })).toBe(true);
+  });
+
+  it('is false for ok/unset/missing status', () => {
+    expect(isSpanError({ code: 'ok' })).toBe(false);
+    expect(isSpanError({ code: 'unset' })).toBe(false);
+    expect(isSpanError(undefined)).toBe(false);
+    expect(isSpanError({})).toBe(false);
   });
 });
 

--- a/plugins/openchoreo-observability/src/components/Traces/utils.ts
+++ b/plugins/openchoreo-observability/src/components/Traces/utils.ts
@@ -1,3 +1,5 @@
+import { SpanStatus } from '../../types';
+
 export function parseRfc3339NanoToNanoseconds(rfc3339Nano: string): number {
   // Split timestamp into base and fractional parts and return nanoseconds
   const [base, fractional] = rfc3339Nano.replace('Z', '').split('.');
@@ -33,4 +35,14 @@ export function formatTime(nanoseconds: number): string {
 
 export function formatTimeFromString(rfc3339Nano: string): string {
   return rfc3339Nano.endsWith('Z') ? rfc3339Nano : `${rfc3339Nano}Z`;
+}
+
+/** The OTel status code (`ok` | `error` | `unset`) of a span, if present. */
+export function getSpanStatusCode(status?: SpanStatus): string | undefined {
+  return status?.code;
+}
+
+/** Whether a span carries an error status. */
+export function isSpanError(status?: SpanStatus): boolean {
+  return status?.code === 'error';
 }

--- a/plugins/openchoreo-observability/src/types.ts
+++ b/plugins/openchoreo-observability/src/types.ts
@@ -45,6 +45,9 @@ export type HttpMetrics = {
 
 export type MetricType = 'resource' | 'http';
 
+// OTel span status ({ code: 'ok' | 'error' | 'unset', message? }) from the spec.
+export type SpanStatus = ObservabilityComponents['schemas']['SpanStatus'];
+
 export interface Span {
   spanId: string;
   spanName: string;
@@ -53,7 +56,7 @@ export interface Span {
   endTime: string;
   durationNs: number;
   parentSpanId?: string;
-  status?: 'ok' | 'error' | 'unset';
+  status?: SpanStatus;
 }
 
 export interface SpanDetails extends Span {


### PR DESCRIPTION
## Purpose
Related: https://github.com/openchoreo/openchoreo/issues/4199

This pull request adapts the OpenChoreo observability plugin to use the OpenTelemetry span status model, which represents span status as an object with a `code` (`ok`/`error`/`unset`) and an optional `message`, instead of a plain string. The UI is updated to display this richer status information in tooltips and details panels, error highlighting is improved and made more robust, and tests are added to cover the new model. Additionally, the error indicator in the traces table is fixed to render correctly with the new layout.

**Tracing status model migration and UI improvements:**

* The OpenChoreo observability API now returns span status as a `SpanStatus` object (`code` and optional `message`), following the OpenTelemetry model, instead of a plain string. The OpenAPI spec and client code are updated to reflect this. [[1]](diffhunk://#diff-0c4372410788ab95be74aecbabc2382970cc1a23615c69e4b879d9b76f58e6ccL1446-R1446) [[2]](diffhunk://#diff-0c4372410788ab95be74aecbabc2382970cc1a23615c69e4b879d9b76f58e6ccL1495-R1490) [[3]](diffhunk://#diff-0c4372410788ab95be74aecbabc2382970cc1a23615c69e4b879d9b76f58e6ccR1504-R1523) [[4]](diffhunk://#diff-43173fad5383c591d9a99ccd5acbcdca8adc5453970ad94e689b3d81942ef0d0R472)
* The waterfall view and span details panel are updated to display the status code and message, with a dedicated Status section and improved error highlighting based on the status code. The tooltip now shows "Status Code" and is robust to the new object shape. [[1]](diffhunk://#diff-d1afcd0bf44ad374a7eb9e5302d964a9495c63ffbfe36b136c26a53ead06853cR1-R96) [[2]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164R20-R21) [[3]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L135-L141) [[4]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L186-R183) [[5]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L238-R209) [[6]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L427-R400) [[7]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L449-R422) [[8]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L578-R561) [[9]](diffhunk://#diff-36255b5b41f1649b91f0bd3c329ddb525002cb98e72276c940211fce829ffb1dR1-R2) [[10]](diffhunk://#diff-36255b5b41f1649b91f0bd3c329ddb525002cb98e72276c940211fce829ffb1dR39-R48)

**Error indicator fixes and improvements:**

* The error stripe in the traces table is fixed to render correctly with the new div-based layout and improved CSS, ensuring error traces are visually marked. [[1]](diffhunk://#diff-7d4732e526af4ab1e822c95e897456bdf6ddba71a5c9b34a5888b1e7cff7d1e9R1-R10) [[2]](diffhunk://#diff-83ef4c0c3f6bde03305a92bfbc126d118e49537b4a3f664ff360cf74cb6bd70fR72) [[3]](diffhunk://#diff-83ef4c0c3f6bde03305a92bfbc126d118e49537b4a3f664ff360cf74cb6bd70fL89-R92) [[4]](diffhunk://#diff-83ef4c0c3f6bde03305a92bfbc126d118e49537b4a3f664ff360cf74cb6bd70fR101-R110) [[5]](diffhunk://#diff-240a81754b3fb876465b0aeb410a372f854be1714893ba9286e16149a7fee44aR144-R159)
* The logic for error highlighting is refactored to use the new status object, ensuring error highlighting is based on the status code and is robust to future changes. [[1]](diffhunk://#diff-effb2e236b7af878063083693467d63aa1a3fdea69a4dbf525785df2f45f06b1L129-R129) [[2]](diffhunk://#diff-4e00bc8ea30befd6aaf7ff54eac2b56b37294f05f28505d35c2bdbbfbac8612aR7-R8) [[3]](diffhunk://#diff-4e00bc8ea30befd6aaf7ff54eac2b56b37294f05f28505d35c2bdbbfbac8612aR92-R119)

**Testing and type support:**

* Tests are added and updated to check that the status object is passed through and rendered correctly in both the API client and UI components. [[1]](diffhunk://#diff-703e77fcc90f27501b6cf06bb3a3e808e03d4b134ba62c4111a153f5d3d3bfe8R402-R478) [[2]](diffhunk://#diff-d1afcd0bf44ad374a7eb9e5302d964a9495c63ffbfe36b136c26a53ead06853cR1-R96) [[3]](diffhunk://#diff-4e00bc8ea30befd6aaf7ff54eac2b56b37294f05f28505d35c2bdbbfbac8612aR92-R119)
* Utility functions are added for extracting the status code and checking for error status, improving code clarity and maintainability. [[1]](diffhunk://#diff-36255b5b41f1649b91f0bd3c329ddb525002cb98e72276c940211fce829ffb1dR39-R48) [[2]](diffhunk://#diff-4e00bc8ea30befd6aaf7ff54eac2b56b37294f05f28505d35c2bdbbfbac8612aR7-R8) [[3]](diffhunk://#diff-4e00bc8ea30befd6aaf7ff54eac2b56b37294f05f28505d35c2bdbbfbac8612aR92-R119)

(References: [[1]](diffhunk://#diff-6f30fdf624623eaa25a0cb28b43b3a1fde18da31e1e2e2a4d0c4a80117574562R1-R13) [[2]](diffhunk://#diff-0c4372410788ab95be74aecbabc2382970cc1a23615c69e4b879d9b76f58e6ccL1446-R1446) [[3]](diffhunk://#diff-0c4372410788ab95be74aecbabc2382970cc1a23615c69e4b879d9b76f58e6ccL1495-R1490) [[4]](diffhunk://#diff-0c4372410788ab95be74aecbabc2382970cc1a23615c69e4b879d9b76f58e6ccR1504-R1523) [[5]](diffhunk://#diff-43173fad5383c591d9a99ccd5acbcdca8adc5453970ad94e689b3d81942ef0d0R472) [[6]](diffhunk://#diff-d1afcd0bf44ad374a7eb9e5302d964a9495c63ffbfe36b136c26a53ead06853cR1-R96) [[7]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164R20-R21) [[8]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L135-L141) [[9]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L186-R183) [[10]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L238-R209) [[11]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L427-R400) [[12]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L449-R422) [[13]](diffhunk://#diff-60899be0f007b32dd35bcb4749d299e6528a24f1d48ff73da7367a7e3600b164L578-R561) [[14]](diffhunk://#diff-36255b5b41f1649b91f0bd3c329ddb525002cb98e72276c940211fce829ffb1dR1-R2) [[15]](diffhunk://#diff-36255b5b41f1649b91f0bd3c329ddb525002cb98e72276c940211fce829ffb1dR39-R48) [[16]](diffhunk://#diff-7d4732e526af4ab1e822c95e897456bdf6ddba71a5c9b34a5888b1e7cff7d1e9R1-R10) [[17]](diffhunk://#diff-83ef4c0c3f6bde03305a92bfbc126d118e49537b4a3f664ff360cf74cb6bd70fR72) [[18]](diffhunk://#diff-83ef4c0c3f6bde03305a92bfbc126d118e49537b4a3f664ff360cf74cb6bd70fL89-R92) [[19]](diffhunk://#diff-83ef4c0c3f6bde03305a92bfbc126d118e49537b4a3f664ff360cf74cb6bd70fR101-R110) [[20]](diffhunk://#diff-240a81754b3fb876465b0aeb410a372f854be1714893ba9286e16149a7fee44aR144-R159) [[21]](diffhunk://#diff-effb2e236b7af878063083693467d63aa1a3fdea69a4dbf525785df2f45f06b1L129-R129) [[22]](diffhunk://#diff-4e00bc8ea30befd6aaf7ff54eac2b56b37294f05f28505d35c2bdbbfbac8612aR7-R8) [[23]](diffhunk://#diff-4e00bc8ea30befd6aaf7ff54eac2b56b37294f05f28505d35c2bdbbfbac8612aR92-R119) [[24]](diffhunk://#diff-703e77fcc90f27501b6cf06bb3a3e808e03d4b134ba62c4111a153f5d3d3bfe8R402-R478)

## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
- Sync the observer OpenAPI spec and generated client to the new SpanStatus schema (code plus optional message)
- Show the status code in the waterfall tooltip and add a dedicated Status section to the span details panel
- Key error-span highlighting off status.code and stop the span tooltip from crashing when status is an object
- fix: render the error stripe in the traces table

Screen recording

https://github.com/user-attachments/assets/85e518e3-854e-4c90-80f4-77955f3b79d0


## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trace error indicators so red stripes appear correctly on traces containing errors.
  * Prevented span tooltips from crashing when status details are provided as structured data.

* **Improvements**
  * Updated span status displays to show status codes and optional messages.
  * Added a dedicated Status section to span details.
  * Error spans continue to be highlighted consistently in waterfall views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->