### PR TITLE
fix(caching): await stale catalog reads instead of serving them

### DIFF
--- a/.changeset/lazy-donkeys-repeat.md
+++ b/.changeset/lazy-donkeys-repeat.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin-react': patch
+'@openchoreo/backstage-plugin': patch
+---
+
+Fix cached catalog data not refreshing after a change. Creating a component or project
+left the project contents table, the namespace projects card and the catalog list showing
+the previous contents until you navigated away and back. Cached catalog reads are now
+refreshed before they are handed to the page, and the namespace cards update in place when
+newer data arrives.

--- a/.changeset/lazy-donkeys-repeat.md
+++ b/.changeset/lazy-donkeys-repeat.md
@@ -1,5 +1,5 @@
 ---
-'@openchoreo/backstage-plugin-react': patch
+'@openchoreo/backstage-plugin-react': minor
 '@openchoreo/backstage-plugin': patch
 ---
 

--- a/packages/app/src/components/catalog/CatalogCardList.tsx
+++ b/packages/app/src/components/catalog/CatalogCardList.tsx
@@ -280,12 +280,12 @@ export const CatalogCardList = ({ actionButton }: CatalogCardListProps) => {
     displayTotal !== undefined ? ` (${displayTotal})` : ''
   }`;
 
-  // The real background-revalidation signal comes from the shared queryClient,
-  // not `useEntityList().loading`: our CachingCatalogApi serves the cached page
-  // instantly and revalidates behind it, so `loading` flips false the moment the
-  // cached read resolves (tens of ms) while the network refetch runs on for the
-  // whole round-trip. `useIsFetching` on the catalog `queryEntities` key tracks
-  // that actual in-flight fetch, so the overlay stays up until it settles.
+  // The in-flight signal comes from the shared queryClient, not
+  // `useEntityList().loading`: CachingCatalogApi serves an entry inside its short
+  // freshness window without any network call, so `loading` covers a cache hit
+  // and a real round-trip alike and can't distinguish them. `useIsFetching` on
+  // the catalog `queryEntities` key is true for exactly the network fetch, so the
+  // spinner appears only when something is actually being fetched.
   const queryFetching =
     useIsFetching(
       { queryKey: scopeKey(['catalog', 'queryEntities']) },

--- a/packages/app/src/components/catalog/catalogLoadState.ts
+++ b/packages/app/src/components/catalog/catalogLoadState.ts
@@ -4,22 +4,22 @@ import type { Entity } from '@backstage/catalog-model';
  * The catalog list's loading inputs, reduced to what the load-state derivation
  * needs.
  *
- * `useEntityList().loading` is NOT a reliable "background refetch in flight"
- * signal: the catalog reads route through `CachingCatalogApi`, which serves the
- * cached page immediately (`ensureQueryData` + `staleTime: 0`) and revalidates
- * in the background — so `loading` flips false the instant the cached value
- * resolves (~tens of ms), long before the network revalidation finishes. The
- * actual in-flight state lives on the shared `queryClient`, passed here as
- * `queryFetching` (from `useIsFetching` on the catalog `queryEntities` key).
+ * `useEntityList().loading` alone is NOT enough to drive the refresh state.
+ * Catalog reads route through `CachingCatalogApi`, which serves an entry within
+ * its short freshness window without touching the network — so a cache-hit mount
+ * resolves in ~a tick with `loading` barely flipping, while a stale one awaits
+ * the full round-trip. Neither case tells you whether a fetch is actually in
+ * flight. That lives on the shared `queryClient`, passed here as `queryFetching`
+ * (from `useIsFetching` on the catalog `queryEntities` key), which is true for
+ * exactly the network round-trip and nothing else.
  */
 export interface CatalogLoadStateInput {
-  /** `useEntityList().loading` — true only until the cached-first read resolves. */
+  /** `useEntityList().loading` — spans the catalog read, cached or networked. */
   loading: boolean;
   /**
    * Whether the shared `queryClient` is currently fetching the catalog
-   * `queryEntities` query (the real background revalidation). Drives the
-   * refresh overlay so it stays up for the whole network round-trip, not just
-   * the cached-read tick.
+   * `queryEntities` query. Drives the refresh overlay so it covers the network
+   * round-trip and stays down on a cache hit.
    */
   queryFetching: boolean;
   /** Live entities from `useEntityList` (may be held over during a refetch). */

--- a/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
+++ b/plugins/openchoreo-react/src/components/OpenChoreoEntityLayout/CompactEntityHeader.tsx
@@ -523,10 +523,10 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
       : 'Resources';
 
   // Sibling entities for the open level, fetched through the cached catalog API
-  // via useQuery. Keyed by kind+namespace so reopening the same level renders
-  // the cached list instantly (cached-first) and only revalidates in the
-  // background — the imperative await-before-render version always blocked on
-  // the network, even for a list loaded moments earlier.
+  // via useQuery. Keyed by kind+namespace so reopening the same level paints the
+  // previous list instantly from this query's own cache entry and re-renders when
+  // the refetch lands — the imperative await-before-render version always blocked
+  // on the network, even for a list loaded moments earlier.
   const { data: siblingEntities, loading: siblingsLoading } =
     useOpenChoreoQuery(
       ['breadcrumb-siblings', openTargetNode?.kind, openTargetNode?.namespace],
@@ -542,13 +542,12 @@ export function CompactEntityHeader(props: CompactEntityHeaderProps) {
       { enabled: Boolean(openTargetNode) },
     );
 
-  // The real background revalidation happens one layer down: the fetcher above
-  // calls the *cached* catalogApi (CachingCatalogApi), which serves its own
-  // cached `getEntities` entry instantly and revalidates behind it. So the outer
-  // query's `isRefetching` settles in a few ms while the network refetch runs on
-  // in the inner cache — the same instant-resolve trap the catalog list hit.
-  // Track that inner `getEntities` query directly via `useIsFetching`, matched
-  // to the open level's kind+namespace, so the spinner reflects the actual fetch.
+  // Two cache layers sit under this: the outer query above, and the inner
+  // `getEntities` entry inside CachingCatalogApi. When the inner entry is still
+  // within its freshness window the outer fetcher resolves without any network
+  // call, so the outer `isRefetching` is not a reliable "fetching now" signal.
+  // Track the inner `getEntities` query directly via `useIsFetching`, matched to
+  // the open level's kind+namespace, so the spinner reflects the actual fetch.
   const scopeKey = useUserScopedKey();
   const siblingsRefetching =
     useIsFetching({

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoQuery.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoQuery.ts
@@ -1,5 +1,4 @@
 import {
-  keepPreviousData as keepPreviousDataFn,
   useQuery,
   type QueryKey,
   type UseQueryOptions,
@@ -49,22 +48,6 @@ export interface UseOpenChoreoQueryOptions<T> {
    * retry doesn't double it.
    */
   retry?: boolean | number;
-  /**
-   * Hold the PREVIOUS key's data while the new key's first fetch is in flight,
-   * instead of dropping to `loading` with no data.
-   *
-   * For queries whose key encodes an input that changes with the data itself
-   * (a page cursor, a filter, a resolved list of refs), a key change is exactly
-   * the moment the user must not see a skeleton: there are perfectly good rows
-   * on screen and only their contents are about to change. Without this, every
-   * such change is a cold entry — `data` undefined, `loading` true — which
-   * defeats the point of caching for the one transition that matters.
-   *
-   * While the placeholder is showing, `loading` stays false and `isRefetching`
-   * is true, so callers can render the old rows under a quiet refresh spinner.
-   * @default false
-   */
-  keepPreviousData?: boolean;
 }
 
 /**
@@ -149,9 +132,6 @@ export function useOpenChoreoQuery<T>(
       : {}),
     ...(options.enabled !== undefined ? { enabled: options.enabled } : {}),
     ...(options.retry !== undefined ? { retry: options.retry } : {}),
-    ...(options.keepPreviousData
-      ? { placeholderData: keepPreviousDataFn }
-      : {}),
   });
 
   // `enabled: false` leaves a query in a "pending but not fetching" state

--- a/plugins/openchoreo-react/src/hooks/useOpenChoreoQuery.ts
+++ b/plugins/openchoreo-react/src/hooks/useOpenChoreoQuery.ts
@@ -1,4 +1,5 @@
 import {
+  keepPreviousData as keepPreviousDataFn,
   useQuery,
   type QueryKey,
   type UseQueryOptions,
@@ -48,6 +49,22 @@ export interface UseOpenChoreoQueryOptions<T> {
    * retry doesn't double it.
    */
   retry?: boolean | number;
+  /**
+   * Hold the PREVIOUS key's data while the new key's first fetch is in flight,
+   * instead of dropping to `loading` with no data.
+   *
+   * For queries whose key encodes an input that changes with the data itself
+   * (a page cursor, a filter, a resolved list of refs), a key change is exactly
+   * the moment the user must not see a skeleton: there are perfectly good rows
+   * on screen and only their contents are about to change. Without this, every
+   * such change is a cold entry — `data` undefined, `loading` true — which
+   * defeats the point of caching for the one transition that matters.
+   *
+   * While the placeholder is showing, `loading` stays false and `isRefetching`
+   * is true, so callers can render the old rows under a quiet refresh spinner.
+   * @default false
+   */
+  keepPreviousData?: boolean;
 }
 
 /**
@@ -132,6 +149,9 @@ export function useOpenChoreoQuery<T>(
       : {}),
     ...(options.enabled !== undefined ? { enabled: options.enabled } : {}),
     ...(options.retry !== undefined ? { retry: options.retry } : {}),
+    ...(options.keepPreviousData
+      ? { placeholderData: keepPreviousDataFn }
+      : {}),
   });
 
   // `enabled: false` leaves a query in a "pending but not fetching" state

--- a/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.test.tsx
+++ b/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.test.tsx
@@ -122,6 +122,56 @@ describe('useRelatedEntitiesQuery', () => {
     ]);
   });
 
+  it('keeps the previous rows on screen while a changed relation set refetches', async () => {
+    // The regression this hook exists to prevent. The refs are part of the
+    // cache key, so creating a project moves the query to a fresh key — which
+    // without keepPreviousData means data: undefined, loading: true, and the
+    // card renders skeleton rows for the whole round-trip. That is exactly the
+    // "created a project, came back, saw a skeleton" case, so the meaningful
+    // assertion is that `loading` NEVER goes true and rows are never empty.
+    let release: (() => void) | undefined;
+    const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => {
+      if (entityRefs.length === 3) {
+        await new Promise<void>(resolve => {
+          release = resolve;
+        });
+      }
+      return { items: entityRefs.map(entityFor) };
+    });
+    const wrapper = createQueryWrapper([
+      [catalogApiRef, makeCatalogApi(getEntitiesByRefs)],
+    ]);
+
+    const withThirdProject: Entity = {
+      ...namespace,
+      relations: [
+        ...(namespace.relations ?? []),
+        { type: RELATION_HAS_PART, targetRef: 'system:default/new-project' },
+      ],
+    };
+
+    const { result, rerender } = renderHook(
+      ({ entity }) =>
+        useRelatedEntitiesQuery(entity, { type: RELATION_HAS_PART }),
+      { wrapper, initialProps: { entity: namespace } },
+    );
+
+    await waitFor(() => expect(result.current.entities).toHaveLength(2));
+
+    // Relations grow by one → new cache key → fetch starts and is held open.
+    rerender({ entity: withThirdProject });
+    await waitFor(() => expect(getEntitiesByRefs).toHaveBeenCalledTimes(2));
+
+    // Mid-flight: the previous two rows are still rendered, not a skeleton.
+    expect(result.current.loading).toBe(false);
+    expect(result.current.entities).toHaveLength(2);
+
+    release?.();
+
+    await waitFor(() => expect(result.current.entities).toHaveLength(3));
+    expect(result.current.loading).toBe(false);
+  });
+
   it('reuses the cache entry when re-rendered with an equal but not identical entity', async () => {
     // Backstage's useRelatedEntities keys its useAsync on the `entity` object,
     // so a new instance with identical relations refetches. Keying on the

--- a/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.test.tsx
+++ b/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.test.tsx
@@ -59,6 +59,58 @@ describe('useRelatedEntitiesQuery', () => {
     ]);
   });
 
+  it('sends the same sorted refs it keys on, so row order is deterministic', async () => {
+    // getEntitiesByRefs returns items positionally aligned to the refs given.
+    // If the key were sorted but the request were not, two callers with the
+    // same ref set in different orders would share one cache entry whose row
+    // order came from whichever ran first.
+    const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => ({
+      items: entityRefs.map(entityFor),
+    }));
+
+    const reversed: Entity = {
+      ...namespace,
+      relations: [...(namespace.relations ?? [])].reverse(),
+    };
+
+    const { result } = renderHook(
+      () => useRelatedEntitiesQuery(reversed, { type: RELATION_HAS_PART }),
+      {
+        wrapper: createQueryWrapper([
+          [catalogApiRef, makeCatalogApi(getEntitiesByRefs)],
+        ]),
+      },
+    );
+
+    await waitFor(() => expect(result.current.entities).toHaveLength(2));
+
+    // Relation order reversed on the source entity, request still sorted.
+    expect(getEntitiesByRefs).toHaveBeenCalledWith({
+      entityRefs: ['component:default/api', 'system:default/billing'],
+    });
+  });
+
+  it('returns a stable empty array across renders when nothing matches', async () => {
+    // A fresh [] per render would change the identity of the `data` prop the
+    // cards pass to MUI's Table, re-rendering it (and resetting page/sort) on
+    // every unrelated render.
+    const { result, rerender } = renderHook(
+      () => useRelatedEntitiesQuery(namespace, { kind: 'Template' }),
+      {
+        wrapper: createQueryWrapper([
+          [catalogApiRef, makeCatalogApi(jest.fn())],
+        ]),
+      },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const first = result.current.entities;
+
+    rerender();
+
+    expect(result.current.entities).toBe(first);
+  });
+
   it('filters by relation type alone when no kind is given', async () => {
     const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => ({
       items: entityRefs.map(entityFor),
@@ -75,8 +127,9 @@ describe('useRelatedEntitiesQuery', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
+    // Refs are sorted before being keyed and sent (see the ordering test above).
     expect(getEntitiesByRefs).toHaveBeenCalledWith({
-      entityRefs: ['system:default/billing', 'component:default/api'],
+      entityRefs: ['component:default/api', 'system:default/billing'],
     });
     expect(result.current.entities).toHaveLength(2);
   });

--- a/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.test.tsx
+++ b/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.test.tsx
@@ -1,0 +1,151 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { Entity, RELATION_HAS_PART } from '@backstage/catalog-model';
+import { createQueryWrapper } from '@openchoreo/test-utils';
+import { useRelatedEntitiesQuery } from './useRelatedEntitiesQuery';
+
+const namespace: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Domain',
+  metadata: { name: 'acme', namespace: 'default' },
+  relations: [
+    { type: RELATION_HAS_PART, targetRef: 'system:default/billing' },
+    { type: RELATION_HAS_PART, targetRef: 'component:default/api' },
+    { type: 'ownedBy', targetRef: 'group:default/team-a' },
+  ],
+};
+
+const entityFor = (ref: string): Entity => {
+  const [kind, rest] = ref.split(':');
+  const [ns, name] = rest.split('/');
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: kind.charAt(0).toUpperCase() + kind.slice(1),
+    metadata: { name, namespace: ns },
+  };
+};
+
+function makeCatalogApi(getEntitiesByRefs: jest.Mock) {
+  return { getEntitiesByRefs } as any;
+}
+
+describe('useRelatedEntitiesQuery', () => {
+  it('fetches only the refs matching the relation type and kind filter', async () => {
+    const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => ({
+      items: entityRefs.map(entityFor),
+    }));
+
+    const { result } = renderHook(
+      () =>
+        useRelatedEntitiesQuery(namespace, {
+          type: RELATION_HAS_PART,
+          kind: 'System',
+        }),
+      {
+        wrapper: createQueryWrapper([
+          [catalogApiRef, makeCatalogApi(getEntitiesByRefs)],
+        ]),
+      },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // The ownedBy relation and the non-System hasPart are both excluded.
+    expect(getEntitiesByRefs).toHaveBeenCalledWith({
+      entityRefs: ['system:default/billing'],
+    });
+    expect(result.current.entities).toEqual([
+      entityFor('system:default/billing'),
+    ]);
+  });
+
+  it('filters by relation type alone when no kind is given', async () => {
+    const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => ({
+      items: entityRefs.map(entityFor),
+    }));
+
+    const { result } = renderHook(
+      () => useRelatedEntitiesQuery(namespace, { type: RELATION_HAS_PART }),
+      {
+        wrapper: createQueryWrapper([
+          [catalogApiRef, makeCatalogApi(getEntitiesByRefs)],
+        ]),
+      },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(getEntitiesByRefs).toHaveBeenCalledWith({
+      entityRefs: ['system:default/billing', 'component:default/api'],
+    });
+    expect(result.current.entities).toHaveLength(2);
+  });
+
+  it('resolves to an empty list without querying when no relation matches', async () => {
+    const getEntitiesByRefs = jest.fn();
+
+    const { result } = renderHook(
+      () => useRelatedEntitiesQuery(namespace, { kind: 'Template' }),
+      {
+        wrapper: createQueryWrapper([
+          [catalogApiRef, makeCatalogApi(getEntitiesByRefs)],
+        ]),
+      },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // No refs → the query stays disabled, and callers get a resolved empty
+    // list rather than an undefined that never settles.
+    expect(getEntitiesByRefs).not.toHaveBeenCalled();
+    expect(result.current.entities).toEqual([]);
+  });
+
+  it('drops nulls for refs the catalog cannot resolve', async () => {
+    const getEntitiesByRefs = jest.fn(async () => ({
+      items: [entityFor('system:default/billing'), null],
+    }));
+
+    const { result } = renderHook(
+      () => useRelatedEntitiesQuery(namespace, { type: RELATION_HAS_PART }),
+      {
+        wrapper: createQueryWrapper([
+          [catalogApiRef, makeCatalogApi(getEntitiesByRefs)],
+        ]),
+      },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.entities).toEqual([
+      entityFor('system:default/billing'),
+    ]);
+  });
+
+  it('reuses the cache entry when re-rendered with an equal but not identical entity', async () => {
+    // Backstage's useRelatedEntities keys its useAsync on the `entity` object,
+    // so a new instance with identical relations refetches. Keying on the
+    // resolved refs is what lets a revisit paint from cache instead.
+    const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => ({
+      items: entityRefs.map(entityFor),
+    }));
+    const wrapper = createQueryWrapper([
+      [catalogApiRef, makeCatalogApi(getEntitiesByRefs)],
+    ]);
+
+    const { result, rerender } = renderHook(
+      ({ entity }) =>
+        useRelatedEntitiesQuery(entity, { type: RELATION_HAS_PART }),
+      { wrapper, initialProps: { entity: namespace } },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(getEntitiesByRefs).toHaveBeenCalledTimes(1);
+
+    // A structurally equal clone — what a re-fetched entity page hands down.
+    rerender({ entity: JSON.parse(JSON.stringify(namespace)) });
+
+    await waitFor(() => expect(result.current.entities).toHaveLength(2));
+    expect(getEntitiesByRefs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.test.tsx
+++ b/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.test.tsx
@@ -59,11 +59,10 @@ describe('useRelatedEntitiesQuery', () => {
     ]);
   });
 
-  it('sends the same sorted refs it keys on, so row order is deterministic', async () => {
-    // getEntitiesByRefs returns items positionally aligned to the refs given.
-    // If the key were sorted but the request were not, two callers with the
-    // same ref set in different orders would share one cache entry whose row
-    // order came from whichever ran first.
+  it('sorts the refs it requests, so row order is deterministic', async () => {
+    // getEntitiesByRefs returns items positionally aligned to the refs given,
+    // so unsorted refs would let rows follow whatever order the catalog
+    // provider emitted relations in — and reshuffle between refreshes.
     const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => ({
       items: entityRefs.map(entityFor),
     }));
@@ -127,7 +126,7 @@ describe('useRelatedEntitiesQuery', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // Refs are sorted before being keyed and sent (see the ordering test above).
+    // Refs are sorted before being sent (see the ordering test above).
     expect(getEntitiesByRefs).toHaveBeenCalledWith({
       entityRefs: ['component:default/api', 'system:default/billing'],
     });
@@ -175,27 +174,23 @@ describe('useRelatedEntitiesQuery', () => {
     ]);
   });
 
-  it('keeps the previous rows on screen while a changed relation set refetches', async () => {
-    // The regression this hook exists to prevent. The refs are part of the
-    // cache key, so creating a project moves the query to a fresh key — which
-    // without keepPreviousData means data: undefined, loading: true, and the
-    // card renders skeleton rows for the whole round-trip. That is exactly the
-    // "created a project, came back, saw a skeleton" case, so the meaningful
-    // assertion is that `loading` NEVER goes true and rows are never empty.
-    let release: (() => void) | undefined;
-    const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => {
-      if (entityRefs.length === 3) {
-        await new Promise<void>(resolve => {
-          release = resolve;
-        });
-      }
-      return { items: entityRefs.map(entityFor) };
-    });
+  it('paints previous rows without a skeleton and refetches when revisited', async () => {
+    // The regression this hook exists to prevent, in its real shape: navigating
+    // away and back is an UNMOUNT + REMOUNT, not an in-place rerender.
+    //
+    // The key is the question (entity + type + kind), not the resolved refs, so
+    // a project created in between lands on the same warm entry: rows paint
+    // immediately with loading false, and refetchOnMount brings the new set in.
+    // Were the refs in the key, this remount would hit a cold entry and the card
+    // would render skeleton rows for the whole round-trip.
+    const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => ({
+      items: entityRefs.map(entityFor),
+    }));
     const wrapper = createQueryWrapper([
       [catalogApiRef, makeCatalogApi(getEntitiesByRefs)],
     ]);
 
-    const withThirdProject: Entity = {
+    const withNewProject: Entity = {
       ...namespace,
       relations: [
         ...(namespace.relations ?? []),
@@ -203,26 +198,34 @@ describe('useRelatedEntitiesQuery', () => {
       ],
     };
 
-    const { result, rerender } = renderHook(
-      ({ entity }) =>
-        useRelatedEntitiesQuery(entity, { type: RELATION_HAS_PART }),
-      { wrapper, initialProps: { entity: namespace } },
+    const first = renderHook(
+      () => useRelatedEntitiesQuery(namespace, { type: RELATION_HAS_PART }),
+      { wrapper },
+    );
+    await waitFor(() => expect(first.result.current.entities).toHaveLength(2));
+    first.unmount();
+
+    // Revisit, now that a project has been created.
+    const second = renderHook(
+      () =>
+        useRelatedEntitiesQuery(withNewProject, { type: RELATION_HAS_PART }),
+      { wrapper },
     );
 
-    await waitFor(() => expect(result.current.entities).toHaveLength(2));
+    // Instant paint: the previous rows, never a loading state.
+    expect(second.result.current.loading).toBe(false);
+    expect(second.result.current.entities).toHaveLength(2);
 
-    // Relations grow by one → new cache key → fetch starts and is held open.
-    rerender({ entity: withThirdProject });
-    await waitFor(() => expect(getEntitiesByRefs).toHaveBeenCalledTimes(2));
-
-    // Mid-flight: the previous two rows are still rendered, not a skeleton.
-    expect(result.current.loading).toBe(false);
-    expect(result.current.entities).toHaveLength(2);
-
-    release?.();
-
-    await waitFor(() => expect(result.current.entities).toHaveLength(3));
-    expect(result.current.loading).toBe(false);
+    // ...and the refetch lands with the new relation set.
+    await waitFor(() => expect(second.result.current.entities).toHaveLength(3));
+    expect(second.result.current.loading).toBe(false);
+    expect(getEntitiesByRefs).toHaveBeenLastCalledWith({
+      entityRefs: [
+        'component:default/api',
+        'system:default/billing',
+        'system:default/new-project',
+      ],
+    });
   });
 
   it('reuses the cache entry when re-rendered with an equal but not identical entity', async () => {

--- a/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.ts
+++ b/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   Entity,
   parseEntityRef,
@@ -6,6 +7,13 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { useOpenChoreoQuery } from './useOpenChoreoQuery';
+
+/**
+ * Shared empty result. Returning a fresh `[]` per render would change the
+ * identity of the `data` prop the cards hand to MUI's Table on every unrelated
+ * re-render, re-rendering it (and resetting page/sort state) for no reason.
+ */
+const NO_ENTITIES: Entity[] = [];
 
 /** Relation filter, matching Backstage's `useRelatedEntities` options. */
 export interface RelatedEntitiesFilter {
@@ -21,8 +29,14 @@ export interface RelatedEntitiesQueryResult {
 
 /**
  * Fetches the entities an entity's relations point at, optionally filtered by
- * relation type and target kind — the same contract as Backstage's
+ * relation type and target kind — the same call signature as Backstage's
  * `useRelatedEntities`, but as a `useOpenChoreoQuery` observer.
+ *
+ * One deliberate difference from Backstage's result shape: `error` is
+ * `Error | null`, not `Error | undefined`, matching every other hook in this
+ * package (`UseOpenChoreoQueryResult`). Consistency inside the package beats
+ * drop-in parity with the hook being replaced — but it means a migrating call
+ * site that tests `error === undefined` must be updated to a truthiness check.
  *
  * Why not Backstage's version: it is a one-shot `useAsync`, so it resolves once
  * and can never be told about newer data. Our `CachingCatalogApi` is honest
@@ -52,20 +66,28 @@ export function useRelatedEntitiesQuery(
   const filterByTypeLower = relationFilter.type?.toLocaleLowerCase('en-US');
   const filterByKindLower = relationFilter.kind?.toLocaleLowerCase('en-US');
 
-  const targetRefs = (entity.relations ?? [])
-    .filter(
-      r =>
-        (!filterByTypeLower ||
-          r.type.toLocaleLowerCase('en-US') === filterByTypeLower) &&
-        (!filterByKindLower ||
-          parseEntityRef(r.targetRef).kind === filterByKindLower),
-    )
-    .map(r => r.targetRef);
+  // Sorted, so relation ordering churn on the source entity neither fragments
+  // the cache nor reshuffles the rows. The SAME sorted array is both hashed into
+  // the key and sent as the request: `getEntitiesByRefs` returns items
+  // positionally aligned to the refs it was given, so a key built from a
+  // different order than the request would let two callers share one entry whose
+  // row order came from whichever ran first.
+  const targetRefs = useMemo(
+    () =>
+      (entity.relations ?? [])
+        .filter(
+          r =>
+            (!filterByTypeLower ||
+              r.type.toLocaleLowerCase('en-US') === filterByTypeLower) &&
+            (!filterByKindLower ||
+              parseEntityRef(r.targetRef).kind === filterByKindLower),
+        )
+        .map(r => r.targetRef)
+        .sort(),
+    [entity.relations, filterByTypeLower, filterByKindLower],
+  );
 
-  // Sorted so relation ordering churn on the source entity can't fragment the
-  // cache; the request itself keeps the unsorted refs (order is irrelevant to
-  // getEntitiesByRefs, and callers sort their own rows).
-  const refsKey = [...targetRefs].sort().join(',');
+  const refsKey = targetRefs.join(',');
   const hasRefs = targetRefs.length > 0;
 
   const { data, loading, error } = useOpenChoreoQuery<Entity[]>(
@@ -88,7 +110,7 @@ export function useRelatedEntitiesQuery(
   return {
     // No relations is a resolved empty result, not a pending one — the query is
     // disabled in that case and would otherwise leave `data` undefined forever.
-    entities: hasRefs ? data : [],
+    entities: hasRefs ? data : NO_ENTITIES,
     loading,
     error,
   };

--- a/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.ts
+++ b/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.ts
@@ -35,6 +35,13 @@ export interface RelatedEntitiesQueryResult {
  * object (which is what Backstage's `useAsync` dep list keys on): two renders
  * holding different `Entity` instances with identical relations should share one
  * cache entry, not refetch.
+ *
+ * Because the refs are IN the key, adding or removing a relation moves the query
+ * to a fresh key — which, on its own, would mean an empty cache entry and a
+ * skeleton for exactly the case this hook exists to smooth (a project was just
+ * created). `keepPreviousData` closes that: the prior ref set's rows stay on
+ * screen while the new set is fetched, so the table only ever changes contents,
+ * never blanks. Callers can show a quiet spinner off `isRefetching`.
  */
 export function useRelatedEntitiesQuery(
   entity: Entity,
@@ -75,7 +82,7 @@ export function useRelatedEntitiesQuery(
       });
       return items.filter((x): x is Entity => Boolean(x));
     },
-    { enabled: hasRefs },
+    { enabled: hasRefs, keepPreviousData: true },
   );
 
   return {

--- a/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.ts
+++ b/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.ts
@@ -1,0 +1,88 @@
+import {
+  Entity,
+  parseEntityRef,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { useOpenChoreoQuery } from './useOpenChoreoQuery';
+
+/** Relation filter, matching Backstage's `useRelatedEntities` options. */
+export interface RelatedEntitiesFilter {
+  type?: string;
+  kind?: string;
+}
+
+export interface RelatedEntitiesQueryResult {
+  entities: Entity[] | undefined;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Fetches the entities an entity's relations point at, optionally filtered by
+ * relation type and target kind — the same contract as Backstage's
+ * `useRelatedEntities`, but as a `useOpenChoreoQuery` observer.
+ *
+ * Why not Backstage's version: it is a one-shot `useAsync`, so it resolves once
+ * and can never be told about newer data. Our `CachingCatalogApi` is honest
+ * about staleness, so a revisit refetches — but with `useAsync` that means
+ * skeleton rows for the whole round-trip. As an observer, the previous result
+ * paints instantly from the query cache and the row set re-renders when the
+ * refetch lands.
+ *
+ * The cache key is built from the RESOLVED target refs rather than the entity
+ * object (which is what Backstage's `useAsync` dep list keys on): two renders
+ * holding different `Entity` instances with identical relations should share one
+ * cache entry, not refetch.
+ */
+export function useRelatedEntitiesQuery(
+  entity: Entity,
+  relationFilter: RelatedEntitiesFilter = {},
+): RelatedEntitiesQueryResult {
+  const catalogApi = useApi(catalogApiRef);
+
+  const filterByTypeLower = relationFilter.type?.toLocaleLowerCase('en-US');
+  const filterByKindLower = relationFilter.kind?.toLocaleLowerCase('en-US');
+
+  const targetRefs = (entity.relations ?? [])
+    .filter(
+      r =>
+        (!filterByTypeLower ||
+          r.type.toLocaleLowerCase('en-US') === filterByTypeLower) &&
+        (!filterByKindLower ||
+          parseEntityRef(r.targetRef).kind === filterByKindLower),
+    )
+    .map(r => r.targetRef);
+
+  // Sorted so relation ordering churn on the source entity can't fragment the
+  // cache; the request itself keeps the unsorted refs (order is irrelevant to
+  // getEntitiesByRefs, and callers sort their own rows).
+  const refsKey = [...targetRefs].sort().join(',');
+  const hasRefs = targetRefs.length > 0;
+
+  const { data, loading, error } = useOpenChoreoQuery<Entity[]>(
+    [
+      'related-entities',
+      stringifyEntityRef(entity),
+      filterByTypeLower ?? '*',
+      filterByKindLower ?? '*',
+      refsKey,
+    ],
+    async () => {
+      const { items } = await catalogApi.getEntitiesByRefs({
+        entityRefs: targetRefs,
+      });
+      return items.filter((x): x is Entity => Boolean(x));
+    },
+    { enabled: hasRefs },
+  );
+
+  return {
+    // No relations is a resolved empty result, not a pending one — the query is
+    // disabled in that case and would otherwise leave `data` undefined forever.
+    entities: hasRefs ? data : [],
+    loading,
+    error,
+  };
+}

--- a/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.ts
+++ b/plugins/openchoreo-react/src/hooks/useRelatedEntitiesQuery.ts
@@ -45,17 +45,20 @@ export interface RelatedEntitiesQueryResult {
  * paints instantly from the query cache and the row set re-renders when the
  * refetch lands.
  *
- * The cache key is built from the RESOLVED target refs rather than the entity
- * object (which is what Backstage's `useAsync` dep list keys on): two renders
- * holding different `Entity` instances with identical relations should share one
- * cache entry, not refetch.
+ * The key is the QUESTION — this entity, this relation type, this target kind —
+ * and deliberately NOT the resolved refs, even though the refs are what gets
+ * fetched. The refs are derived from the entity that is already in the key, so
+ * including them would conflate "what am I asking" with "what was the answer
+ * last time": adding a project would look like a different query, land on a cold
+ * entry, and render skeletons for precisely the transition this hook exists to
+ * smooth (to say nothing of orphaning the old entry until `gcTime`).
  *
- * Because the refs are IN the key, adding or removing a relation moves the query
- * to a fresh key — which, on its own, would mean an empty cache entry and a
- * skeleton for exactly the case this hook exists to smooth (a project was just
- * created). `keepPreviousData` closes that: the prior ref set's rows stay on
- * screen while the new set is fetched, so the table only ever changes contents,
- * never blanks. Callers can show a quiet spinner off `isRefetching`.
+ * With a stable key, a revisit is a remount: TanStack hands back the previous
+ * answer immediately (`loading` false, rows on screen) and `refetchOnMount` +
+ * `staleTime: 0` refetch with the CURRENT refs behind it, so the table changes
+ * contents without ever blanking. Relations cannot change without a remount here
+ * — `useEntity` is fed by `useEntityFromUrl`'s `useAsync`, which is keyed on the
+ * URL and never refreshes in place.
  */
 export function useRelatedEntitiesQuery(
   entity: Entity,
@@ -66,12 +69,10 @@ export function useRelatedEntitiesQuery(
   const filterByTypeLower = relationFilter.type?.toLocaleLowerCase('en-US');
   const filterByKindLower = relationFilter.kind?.toLocaleLowerCase('en-US');
 
-  // Sorted, so relation ordering churn on the source entity neither fragments
-  // the cache nor reshuffles the rows. The SAME sorted array is both hashed into
-  // the key and sent as the request: `getEntitiesByRefs` returns items
-  // positionally aligned to the refs it was given, so a key built from a
-  // different order than the request would let two callers share one entry whose
-  // row order came from whichever ran first.
+  // Sorted so row order is deterministic: `getEntitiesByRefs` returns items
+  // positionally aligned to the refs it was given, so without this the rows
+  // would follow whatever order the catalog provider happened to emit relations
+  // in, and could reshuffle between refreshes.
   const targetRefs = useMemo(
     () =>
       (entity.relations ?? [])
@@ -87,7 +88,6 @@ export function useRelatedEntitiesQuery(
     [entity.relations, filterByTypeLower, filterByKindLower],
   );
 
-  const refsKey = targetRefs.join(',');
   const hasRefs = targetRefs.length > 0;
 
   const { data, loading, error } = useOpenChoreoQuery<Entity[]>(
@@ -96,7 +96,6 @@ export function useRelatedEntitiesQuery(
       stringifyEntityRef(entity),
       filterByTypeLower ?? '*',
       filterByKindLower ?? '*',
-      refsKey,
     ],
     async () => {
       const { items } = await catalogApi.getEntitiesByRefs({
@@ -104,7 +103,7 @@ export function useRelatedEntitiesQuery(
       });
       return items.filter((x): x is Entity => Boolean(x));
     },
-    { enabled: hasRefs, keepPreviousData: true },
+    { enabled: hasRefs },
   );
 
   return {

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -175,6 +175,11 @@ export { makeColumnStyle } from './components/VirtualizedLogList/columnStyle';
 
 // Hooks
 export {
+  useRelatedEntitiesQuery,
+  type RelatedEntitiesFilter,
+  type RelatedEntitiesQueryResult,
+} from './hooks/useRelatedEntitiesQuery';
+export {
   useRowExpansion,
   type UseRowExpansionResult,
 } from './hooks/useRowExpansion';

--- a/plugins/openchoreo-react/src/query/CachingCatalogApi.test.ts
+++ b/plugins/openchoreo-react/src/query/CachingCatalogApi.test.ts
@@ -35,10 +35,28 @@ function makeDelegate(overrides: Partial<CatalogApi> = {}): CatalogApi {
 const userA = () => Promise.resolve('user:default/alice');
 const userB = () => Promise.resolve('user:default/bob');
 
+// TanStack decides staleness from `Date.now()` (via `timeUntilStale`), so we
+// simulate elapsed time by offsetting it rather than with jest fake timers —
+// the shared client retries once on failure, and that backoff needs a real
+// `setTimeout` to fire.
+const realDateNow = Date.now.bind(Date);
+let timeOffset = 0;
+const advanceTime = (ms: number) => {
+  timeOffset += ms;
+};
+
 describe('CachingCatalogApi', () => {
   beforeEach(() => {
     // The wrapper uses the shared singleton; isolate each test.
     queryClient.clear();
+    timeOffset = 0;
+    jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => realDateNow() + timeOffset);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('dedupes concurrent identical reads to a single delegate call', async () => {
@@ -103,6 +121,97 @@ describe('CachingCatalogApi', () => {
         'component:default/missing',
       ]),
     ).toBeNull();
+  });
+
+  describe('freshness (the promise must never resolve with data we cannot correct)', () => {
+    // These lock in the fix for the bug where creating a component left the
+    // Project Contents table, the namespace Projects card and /catalog showing
+    // the pre-create list. `ensureQueryData({ revalidateIfStale: true })` served
+    // the stale value and discarded the revalidation; CatalogApi's consumers are
+    // one-shot awaits with no way to receive it. Nothing here was covered before,
+    // which is exactly why the bug shipped green.
+    it('serves a cached read within the freshness window without hitting the delegate', async () => {
+      const delegate = makeDelegate();
+      const api = new CachingCatalogApi(delegate, userA);
+
+      await api.getEntities({ filter: { kind: 'component' } });
+      await api.getEntities({ filter: { kind: 'component' } });
+
+      expect(delegate.getEntities).toHaveBeenCalledTimes(1);
+    });
+
+    it('AWAITS the refetch on a stale entry and resolves with the NEW value', async () => {
+      const getEntities = jest
+        .fn()
+        .mockResolvedValueOnce({ items: [{ metadata: { name: 'old' } }] })
+        .mockResolvedValueOnce({ items: [{ metadata: { name: 'new' } }] });
+      const api = new CachingCatalogApi(makeDelegate({ getEntities }), userA);
+
+      const first = await api.getEntities({ filter: { kind: 'component' } });
+      expect(first.items[0].metadata.name).toBe('old');
+
+      // Past the freshness window — as any create-then-navigate-back is.
+      advanceTime(10_000);
+
+      // The resolved VALUE is what matters: serving 'old' here while refetching
+      // in the background is the bug, because nothing would ever deliver 'new'.
+      const second = await api.getEntities({ filter: { kind: 'component' } });
+      expect(second.items[0].metadata.name).toBe('new');
+      expect(getEntities).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to the last good value when a refetch over a warm entry fails', async () => {
+      const getEntities = jest
+        .fn()
+        .mockResolvedValueOnce({ items: [{ metadata: { name: 'good' } }] });
+      const api = new CachingCatalogApi(makeDelegate({ getEntities }), userA);
+
+      await api.getEntities({ filter: { kind: 'component' } });
+
+      // Persistent rejection so the client's single retry fails too.
+      getEntities.mockRejectedValue(new Error('502 Bad Gateway'));
+      advanceTime(10_000);
+
+      // A transient blip must not blank a page that previously rode it out.
+      const result = await api.getEntities({ filter: { kind: 'component' } });
+      expect(result.items[0].metadata.name).toBe('good');
+    });
+
+    it('rejects when the very first read fails (no last good value to serve)', async () => {
+      const api = new CachingCatalogApi(
+        makeDelegate({
+          getEntities: jest.fn().mockRejectedValue(new Error('boom')),
+        }),
+        userA,
+      );
+
+      await expect(
+        api.getEntities({ filter: { kind: 'component' } }),
+      ).rejects.toThrow('boom');
+    });
+
+    it('awaits past a stale null sentinel so a since-created entity is returned', async () => {
+      // The create-then-return case for getEntityByRef: the first read 404s and
+      // caches `null`; the entity now exists and the second read must find it.
+      const getEntityByRef = jest
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ kind: 'Component' });
+      const api = new CachingCatalogApi(
+        makeDelegate({ getEntityByRef }),
+        userA,
+      );
+
+      await expect(
+        api.getEntityByRef('component:default/svc'),
+      ).resolves.toBeUndefined();
+
+      advanceTime(10_000);
+
+      await expect(
+        api.getEntityByRef('component:default/svc'),
+      ).resolves.toEqual({ kind: 'Component' });
+    });
   });
 
   it('keys reads by the request, so different requests do not collide', async () => {

--- a/plugins/openchoreo-react/src/query/CachingCatalogApi.test.ts
+++ b/plugins/openchoreo-react/src/query/CachingCatalogApi.test.ts
@@ -177,6 +177,49 @@ describe('CachingCatalogApi', () => {
       expect(result.items[0].metadata.name).toBe('good');
     });
 
+    it('does NOT serve invalidated data when the refresh fails', async () => {
+      // A write said this entry is wrong; if the follow-up read fails we must
+      // surface the error rather than resurrect the value the write discarded
+      // (for removeEntityByUid, that value is an entity the user just deleted).
+      //
+      // The flag has to be captured BEFORE the fetch: TanStack's `error` action
+      // sets isInvalidated=true unconditionally, so a post-failure read of it
+      // cannot tell "a write invalidated this" from "the refresh failed" — and
+      // a guard written that way would never fall back at all.
+      const getEntities = jest
+        .fn()
+        .mockResolvedValueOnce({ items: [{ metadata: { name: 'deleted' } }] });
+      const api = new CachingCatalogApi(makeDelegate({ getEntities }), userA);
+
+      await api.getEntities({ filter: { kind: 'component' } });
+
+      await api.refreshEntity('component:default/svc');
+      getEntities.mockRejectedValue(new Error('502 Bad Gateway'));
+
+      await expect(
+        api.getEntities({ filter: { kind: 'component' } }),
+      ).rejects.toThrow('502 Bad Gateway');
+    });
+
+    it('does not retry a failed read (the caller is awaiting it)', async () => {
+      // The app default is retry: 1. Because these reads are awaited, that
+      // backoff lands directly in a page load — two round-trips before the
+      // fallback. Exactly one delegate call per read.
+      const getEntities = jest
+        .fn()
+        .mockResolvedValueOnce({ items: [{ metadata: { name: 'good' } }] });
+      const api = new CachingCatalogApi(makeDelegate({ getEntities }), userA);
+
+      await api.getEntities({ filter: { kind: 'component' } });
+      expect(getEntities).toHaveBeenCalledTimes(1);
+
+      getEntities.mockRejectedValue(new Error('502 Bad Gateway'));
+      advanceTime(10_000);
+      await api.getEntities({ filter: { kind: 'component' } });
+
+      expect(getEntities).toHaveBeenCalledTimes(2);
+    });
+
     it('rejects when the very first read fails (no last good value to serve)', async () => {
       const api = new CachingCatalogApi(
         makeDelegate({

--- a/plugins/openchoreo-react/src/query/CachingCatalogApi.ts
+++ b/plugins/openchoreo-react/src/query/CachingCatalogApi.ts
@@ -40,15 +40,40 @@ export type GetUserRef = () => Promise<string | undefined>;
 const PENDING_USER = '@openchoreo/pending-user';
 
 /**
+ * Freshness window for cached catalog reads.
+ *
+ * Deliberately short. `CatalogApi` is a PROMISE API with no subscribers, so a
+ * stale entry must be AWAITED — we can never notify the caller about a
+ * revalidation that lands after the promise resolved. This window therefore
+ * exists only to collapse the sequential repeat-calls of a single
+ * render/navigation burst (unmount/remount, tab switch, StrictMode's double
+ * mount in dev). Concurrent callers already dedupe on the in-flight promise,
+ * independent of `staleTime`.
+ *
+ * Any value long enough for a human to perceive would reintroduce the bug this
+ * constant exists to prevent: create a component, navigate back, and see the
+ * pre-create list with no way to be told otherwise.
+ */
+const CATALOG_STALE_TIME_MS = 5_000;
+
+/**
  * A {@link CatalogApi} that routes catalog READS through the shared OpenChoreo
- * `queryClient`, so a revisited catalog list or entity page paints instantly
- * from cache (and revalidates in the background per the client's `staleTime: 0`
- * policy) instead of re-fetching from scratch and flashing a skeleton.
+ * `queryClient`, so the repeat reads of a single navigation collapse to one
+ * request instead of re-fetching from scratch.
  *
  * Backstage's own catalog hooks (`useEntityList` → `getEntities`/`queryEntities`,
  * the entity page → `getEntityByRef`) call this API directly, so wrapping it is
  * the only way to bring the catalog under the same cache as the OpenChoreo BFF
  * hooks. All other methods delegate straight through to the real client.
+ *
+ * IMPORTANT — this layer does NOT do stale-while-revalidate, and must not. SWR
+ * requires a subscriber to receive the revalidation, and every consumer of this
+ * API is a one-shot `await` (`useEffect`, `useAsync`, `EntityListProvider`),
+ * never a TanStack observer. A promise resolves exactly once, so anything served
+ * stale here can never be corrected on screen. Instant-paint belongs one layer
+ * up, in React, where a component can re-render: our own surfaces get it from
+ * `useOpenChoreoQuery`, and Backstage-owned surfaces from a cache seed (see
+ * `pickCatalogSeed` in the app's catalog list).
  *
  * Keys mirror the hook convention exactly (`['@user', userEntityRef, ...]`, see
  * `useUserScopedKey`) so per-user isolation is structural: a different user
@@ -79,31 +104,49 @@ export class CachingCatalogApi implements CatalogApi {
   }
 
   /**
-   * Read-through cache: serve the warm entry immediately and revalidate in the
-   * background. Uses `ensureQueryData({ revalidateIfStale: true })` rather than
-   * `fetchQuery`: with the client default `staleTime: 0` every entry is stale,
-   * and `fetchQuery` would AWAIT the network on a stale entry (never painting
-   * cached-first). `ensureQueryData` returns the cached value synchronously when
-   * present and kicks a background refetch, which is the actual instant-paint +
-   * stale-while-revalidate behavior an already-warm revisit wants. Concurrent
-   * callers still dedupe on the shared key.
+   * Read-through cache with an honest promise: a fresh entry (within
+   * {@link CATALOG_STALE_TIME_MS}) resolves instantly with no network, a stale
+   * one AWAITS the refetch and resolves with the new data.
+   *
+   * Uses `fetchQuery` rather than `ensureQueryData({ revalidateIfStale: true })`.
+   * `ensureQueryData` resolves with the STALE value and kicks a background
+   * refetch whose result it discards (`void this.prefetchQuery(...)`) — correct
+   * only when a TanStack observer is watching the cache and will re-render. No
+   * consumer of `CatalogApi` is one, so that fresh data was never reaching the
+   * screen. See the class doc.
+   *
+   * Concurrent callers still dedupe: `fetchQuery` returns the in-flight promise
+   * when one exists, regardless of `staleTime`.
    */
   private async cachedRead<T>(
     method: string,
     args: unknown[],
     fetch: () => Promise<T>,
   ): Promise<T> {
-    return queryClient.ensureQueryData({
-      queryKey: await this.keyFor(method, args),
-      queryFn: fetch,
-      revalidateIfStale: true,
-    });
+    const queryKey = await this.keyFor(method, args);
+    try {
+      return await queryClient.fetchQuery({
+        queryKey,
+        queryFn: fetch,
+        staleTime: CATALOG_STALE_TIME_MS,
+      });
+    } catch (err) {
+      // `ensureQueryData` used to swallow a failed revalidation and keep serving
+      // the last good value; `fetchQuery` rejects. Without this fallback a
+      // transient 502 would blank a page that currently rides it out. A cold
+      // entry has nothing to fall back to, so the error surfaces as before.
+      const lastGood = queryClient.getQueryData<T>(queryKey);
+      if (lastGood !== undefined) {
+        return lastGood;
+      }
+      throw err;
+    }
   }
 
   /**
    * Read-through cache for a method that may resolve to `undefined` (e.g.
-   * `getEntityByRef` on a missing/404 entity). TanStack's `ensureQueryData`
-   * (like `fetchQuery`) REJECTS when the queryFn resolves to `undefined`
+   * `getEntityByRef` on a missing/404 entity). TanStack's `fetchQuery`
+   * REJECTS when the queryFn resolves to `undefined`
    * ("Query data cannot be undefined"), which would turn a normal not-found into
    * a thrown error and break callers (the entity page and header breadcrumb
    * tolerate `undefined`). Cache a `null` sentinel instead (which TanStack does
@@ -114,11 +157,22 @@ export class CachingCatalogApi implements CatalogApi {
     args: unknown[],
     fetch: () => Promise<T | undefined>,
   ): Promise<T | undefined> {
-    const value = await queryClient.ensureQueryData<T | null>({
-      queryKey: await this.keyFor(method, args),
-      queryFn: async () => (await fetch()) ?? null,
-      revalidateIfStale: true,
-    });
+    const queryKey = await this.keyFor(method, args);
+    let value: T | null | undefined;
+    try {
+      value = await queryClient.fetchQuery<T | null>({
+        queryKey,
+        queryFn: async () => (await fetch()) ?? null,
+        staleTime: CATALOG_STALE_TIME_MS,
+      });
+    } catch (err) {
+      // Same last-good fallback as cachedRead. `undefined` here means "no cache
+      // entry at all" (the sentinel is `null`), so a cold miss still throws.
+      value = queryClient.getQueryData<T | null>(queryKey);
+      if (value === undefined) {
+        throw err;
+      }
+    }
     return value ?? undefined;
   }
 

--- a/plugins/openchoreo-react/src/query/CachingCatalogApi.ts
+++ b/plugins/openchoreo-react/src/query/CachingCatalogApi.ts
@@ -57,6 +57,18 @@ const PENDING_USER = '@openchoreo/pending-user';
 const CATALOG_STALE_TIME_MS = 5_000;
 
 /**
+ * No retry on catalog reads.
+ *
+ * These reads are AWAITED by the caller (see `cachedRead`), so the app-level
+ * `retry: 1` would put its ~1s backoff directly into a page load: a failing
+ * backend would make every navigation wait for two round-trips before falling
+ * back to cached data. The retry bought little anyway — the fallback below
+ * already rides out a transient blip, and the 5s window means the next
+ * navigation re-attempts almost immediately.
+ */
+const CATALOG_RETRY = 0;
+
+/**
  * A {@link CatalogApi} that routes catalog READS through the shared OpenChoreo
  * `queryClient`, so the repeat reads of a single navigation collapse to one
  * request instead of re-fetching from scratch.
@@ -123,18 +135,41 @@ export class CachingCatalogApi implements CatalogApi {
     args: unknown[],
     fetch: () => Promise<T>,
   ): Promise<T> {
-    const queryKey = await this.keyFor(method, args);
+    return this.readThrough(await this.keyFor(method, args), fetch);
+  }
+
+  /**
+   * The single read path: fetch honestly, and on failure fall back to the last
+   * good value only when that value is still trustworthy.
+   *
+   * `ensureQueryData` used to swallow a failed revalidation and keep serving the
+   * cached value; `fetchQuery` rejects, which would blank a page that today
+   * rides out a transient 502. The fallback restores that resilience — but NOT
+   * for an entry a write already invalidated, whose cached value is known-wrong
+   * (e.g. an entity `removeEntityByUid` just deleted).
+   *
+   * The invalidation flag must be read BEFORE the fetch: TanStack's `error`
+   * action sets `isInvalidated: true` unconditionally ("flag existing data as
+   * invalidated if we get a background error"), so after a failure the flag can
+   * no longer distinguish "a write invalidated this" from "the refresh failed".
+   */
+  private async readThrough<T>(
+    queryKey: QueryKey,
+    queryFn: () => Promise<T>,
+  ): Promise<T> {
+    const wasInvalidated =
+      queryClient.getQueryState<T>(queryKey)?.isInvalidated === true;
     try {
       return await queryClient.fetchQuery({
         queryKey,
-        queryFn: fetch,
+        queryFn,
         staleTime: CATALOG_STALE_TIME_MS,
+        retry: CATALOG_RETRY,
       });
     } catch (err) {
-      // `ensureQueryData` used to swallow a failed revalidation and keep serving
-      // the last good value; `fetchQuery` rejects. Without this fallback a
-      // transient 502 would blank a page that currently rides it out. A cold
-      // entry has nothing to fall back to, so the error surfaces as before.
+      if (wasInvalidated) {
+        throw err;
+      }
       const lastGood = queryClient.getQueryData<T>(queryKey);
       if (lastGood !== undefined) {
         return lastGood;
@@ -157,22 +192,14 @@ export class CachingCatalogApi implements CatalogApi {
     args: unknown[],
     fetch: () => Promise<T | undefined>,
   ): Promise<T | undefined> {
-    const queryKey = await this.keyFor(method, args);
-    let value: T | null | undefined;
-    try {
-      value = await queryClient.fetchQuery<T | null>({
-        queryKey,
-        queryFn: async () => (await fetch()) ?? null,
-        staleTime: CATALOG_STALE_TIME_MS,
-      });
-    } catch (err) {
-      // Same last-good fallback as cachedRead. `undefined` here means "no cache
-      // entry at all" (the sentinel is `null`), so a cold miss still throws.
-      value = queryClient.getQueryData<T | null>(queryKey);
-      if (value === undefined) {
-        throw err;
-      }
-    }
+    // Shares `readThrough`, so the freshness window, retry policy and
+    // invalidation-aware fallback can never drift from the non-nullable path.
+    // `undefined` never reaches the cache (the sentinel is `null`), so a cold
+    // miss still surfaces the error there.
+    const value = await this.readThrough<T | null>(
+      await this.keyFor(method, args),
+      async () => (await fetch()) ?? null,
+    );
     return value ?? undefined;
   }
 

--- a/plugins/openchoreo-react/src/query/queryClient.ts
+++ b/plugins/openchoreo-react/src/query/queryClient.ts
@@ -13,13 +13,20 @@ import { QueryClient } from '@tanstack/react-query';
  * "No QueryClient set" crash from a missing provider.
  *
  * Rationale for the defaults:
- * - `staleTime: 0` — stale-while-revalidate: a revisited surface paints cached
- *   data instantly (from the still-warm `gcTime` entry) AND always kicks a
- *   background revalidation, so data on screen is never left silently stale.
- *   Data is fresh cluster/BFF state, so we prefer an always-up-to-date view
- *   over suppressing refetches within a freshness window. Concurrent callers
- *   still dedupe to one request; an explicit `refetch()`/invalidate is
- *   immediate regardless. Pollers set their own `refetchInterval`.
+ * - `staleTime: 0` — stale-while-revalidate for OBSERVERS: a hook built on
+ *   `useOpenChoreoQuery` paints cached data instantly (from the still-warm
+ *   `gcTime` entry) AND always kicks a background revalidation, then RE-RENDERS
+ *   when it lands, so data on screen is never left silently stale. Data is fresh
+ *   cluster/BFF state, so we prefer an always-up-to-date view over suppressing
+ *   refetches within a freshness window. Concurrent callers still dedupe to one
+ *   request; an explicit `refetch()`/invalidate is immediate regardless. Pollers
+ *   set their own `refetchInterval`.
+ *
+ *   This is the right policy only where a subscriber exists to receive the
+ *   revalidation. {@link CachingCatalogApi} deliberately overrides it with its
+ *   own short `staleTime`, because it serves a promise API whose callers can
+ *   never be notified after the fact — see the rationale there before copying
+ *   this default into another non-React seam.
  * - `gcTime: 5m` — how long an unused cache entry survives after its last
  *   observer unmounts, so navigating away and back still hits warm cache. With
  *   `staleTime: 0` this is what carries the instant-paint on revisit.

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.test.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.test.tsx
@@ -1,0 +1,157 @@
+import { screen } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import type { Entity } from '@backstage/catalog-model';
+import { NamespaceProjectsCard } from './NamespaceProjectsCard';
+
+const useRelatedEntitiesQuery = jest.fn();
+const useScopedProjectCreatePermission = jest.fn();
+
+// The card is the integration under test; the data hook has its own suite.
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useRelatedEntitiesQuery: (...args: unknown[]) =>
+    useRelatedEntitiesQuery(...args),
+  useScopedProjectCreatePermission: () => useScopedProjectCreatePermission(),
+}));
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  Skeleton: () => <span data-testid="skeleton" />,
+}));
+
+// Mocked so the real stylesheet (which reads design-system colour tokens the
+// mock above does not provide) never loads.
+jest.mock('./styles', () => ({
+  useNamespaceProjectsCardStyles: () => ({
+    cardWrapper: '',
+    createProjectButton: '',
+  }),
+}));
+
+const namespace = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Domain',
+  metadata: { name: 'acme', namespace: 'default' },
+} as Entity;
+
+const project = (name: string, description?: string): Entity =>
+  ({
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'System',
+    metadata: { name, namespace: 'default', description },
+  } as Entity);
+
+function renderCard() {
+  return renderInTestApp(
+    <EntityProvider entity={namespace}>
+      <NamespaceProjectsCard />
+    </EntityProvider>,
+  );
+}
+
+describe('NamespaceProjectsCard', () => {
+  beforeEach(() => {
+    useRelatedEntitiesQuery.mockReset();
+    useScopedProjectCreatePermission.mockReset();
+    useScopedProjectCreatePermission.mockReturnValue({
+      canCreate: true,
+      loading: false,
+      createDeniedTooltip: '',
+    });
+  });
+
+  it('requests the namespace’s System hasPart relations', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [],
+      loading: false,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(useRelatedEntitiesQuery).toHaveBeenCalledWith(namespace, {
+      type: 'hasPart',
+      kind: 'System',
+    });
+  });
+
+  it('renders a row per project once loaded', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [project('billing', 'Billing stack'), project('checkout')],
+      loading: false,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(await screen.findByText('billing')).toBeInTheDocument();
+    expect(screen.getByText('checkout')).toBeInTheDocument();
+    expect(screen.getByText('Billing stack')).toBeInTheDocument();
+    expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+    // Name cell links to the project's entity page.
+    expect(screen.getByRole('link', { name: 'billing' })).toHaveAttribute(
+      'href',
+      '/catalog/default/system/billing',
+    );
+  });
+
+  it('shows skeleton rows instead of project rows while loading', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: undefined,
+      loading: true,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('keeps rendering rows when a refetch is in flight (no skeleton flash)', async () => {
+    // The regression the caching fix exists to prevent: `useRelatedEntitiesQuery`
+    // holds the previous rows (loading false) while the new ref set is fetched,
+    // so the card must render them rather than falling back to skeletons.
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [project('billing')],
+      loading: false,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(await screen.findByText('billing')).toBeInTheDocument();
+    expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when the namespace has no projects', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [],
+      loading: false,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(
+      await screen.findByText('No projects found in this namespace'),
+    ).toBeInTheDocument();
+  });
+
+  it('disables Create Project when the user lacks permission', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [],
+      loading: false,
+      error: null,
+    });
+    useScopedProjectCreatePermission.mockReturnValue({
+      canCreate: false,
+      loading: false,
+      createDeniedTooltip: 'You do not have permission',
+    });
+
+    await renderCard();
+
+    expect(
+      await screen.findByRole('button', { name: /create project/i }),
+    ).toBeDisabled();
+  });
+});

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceProjectsCard/NamespaceProjectsCard.tsx
@@ -1,13 +1,16 @@
 import { Link, Table, TableColumn } from '@backstage/core-components';
 import { useApp } from '@backstage/core-plugin-api';
 import { Entity, RELATION_HAS_PART } from '@backstage/catalog-model';
-import { useEntity, useRelatedEntities } from '@backstage/plugin-catalog-react';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import { Box, Button, Tooltip, Typography } from '@material-ui/core';
 import { Skeleton } from '@openchoreo/backstage-design-system';
 import AddIcon from '@material-ui/icons/Add';
 import { useNavigate } from 'react-router-dom';
 import { isMarkedForDeletion, DeletionBadge } from '../../DeleteEntity';
-import { useScopedProjectCreatePermission } from '@openchoreo/backstage-plugin-react';
+import {
+  useRelatedEntitiesQuery,
+  useScopedProjectCreatePermission,
+} from '@openchoreo/backstage-plugin-react';
 import { shouldNavigateOnRowClick } from '../../../utils/shouldNavigateOnRowClick';
 import { useNamespaceProjectsCardStyles } from './styles';
 
@@ -16,7 +19,7 @@ export const NamespaceProjectsCard = () => {
   const Icon = app.getSystemIcon('kind:system');
   const classes = useNamespaceProjectsCardStyles();
   const { entity } = useEntity();
-  const { entities: systems, loading } = useRelatedEntities(entity, {
+  const { entities: systems, loading } = useRelatedEntitiesQuery(entity, {
     type: RELATION_HAS_PART,
     kind: 'System',
   });

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceResourcesCard/NamespaceResourcesCard.test.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceResourcesCard/NamespaceResourcesCard.test.tsx
@@ -1,0 +1,127 @@
+import { screen } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import type { Entity } from '@backstage/catalog-model';
+import { NamespaceResourcesCard } from './NamespaceResourcesCard';
+
+const useRelatedEntitiesQuery = jest.fn();
+
+// The card is the integration under test; the data hook has its own suite.
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useRelatedEntitiesQuery: (...args: unknown[]) =>
+    useRelatedEntitiesQuery(...args),
+}));
+
+jest.mock('@openchoreo/backstage-design-system', () => ({
+  Skeleton: () => <span data-testid="skeleton" />,
+}));
+
+// Mocked so the real stylesheet (which reads design-system colour tokens the
+// mock above does not provide) never loads.
+jest.mock('./styles', () => ({
+  useNamespaceResourcesCardStyles: () => ({ cardWrapper: '' }),
+}));
+
+const namespace = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Domain',
+  metadata: { name: 'acme', namespace: 'default' },
+} as Entity;
+
+const related = (kind: string, name: string): Entity =>
+  ({
+    apiVersion: 'backstage.io/v1alpha1',
+    kind,
+    metadata: { name, namespace: 'default' },
+  } as Entity);
+
+function renderCard() {
+  return renderInTestApp(
+    <EntityProvider entity={namespace}>
+      <NamespaceResourcesCard />
+    </EntityProvider>,
+  );
+}
+
+describe('NamespaceResourcesCard', () => {
+  beforeEach(() => {
+    useRelatedEntitiesQuery.mockReset();
+  });
+
+  it('requests hasPart relations of every kind (no kind filter)', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [],
+      loading: false,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(useRelatedEntitiesQuery).toHaveBeenCalledWith(namespace, {
+      type: 'hasPart',
+    });
+  });
+
+  it('lists non-System related entities and excludes Systems', async () => {
+    // Systems are the namespace's projects and belong to the sibling card;
+    // this one shows everything else in the namespace.
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [
+        related('System', 'billing'),
+        related('Environment', 'production'),
+        related('Resource', 'redis'),
+      ],
+      loading: false,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(await screen.findByText('production')).toBeInTheDocument();
+    expect(screen.getByText('redis')).toBeInTheDocument();
+    expect(screen.queryByText('billing')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'redis' })).toHaveAttribute(
+      'href',
+      '/catalog/default/resource/redis',
+    );
+  });
+
+  it('shows skeleton rows while loading', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: undefined,
+      loading: true,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('keeps rendering rows when a refetch is in flight (no skeleton flash)', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [related('Resource', 'redis')],
+      loading: false,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(await screen.findByText('redis')).toBeInTheDocument();
+    expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when only Systems are related', async () => {
+    useRelatedEntitiesQuery.mockReturnValue({
+      entities: [related('System', 'billing')],
+      loading: false,
+      error: null,
+    });
+
+    await renderCard();
+
+    expect(
+      await screen.findByText('No resources found in this namespace'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/Namespaces/NamespaceResourcesCard/NamespaceResourcesCard.tsx
+++ b/plugins/openchoreo/src/components/Namespaces/NamespaceResourcesCard/NamespaceResourcesCard.tsx
@@ -1,9 +1,10 @@
 import { Link, Table, TableColumn } from '@backstage/core-components';
 import { useApp } from '@backstage/core-plugin-api';
 import { Entity, RELATION_HAS_PART } from '@backstage/catalog-model';
-import { useEntity, useRelatedEntities } from '@backstage/plugin-catalog-react';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import { Box, Typography } from '@material-ui/core';
 import { Skeleton } from '@openchoreo/backstage-design-system';
+import { useRelatedEntitiesQuery } from '@openchoreo/backstage-plugin-react';
 import { useNavigate } from 'react-router-dom';
 import { shouldNavigateOnRowClick } from '../../../utils/shouldNavigateOnRowClick';
 import { useNamespaceResourcesCardStyles } from './styles';
@@ -23,7 +24,7 @@ export const NamespaceResourcesCard = () => {
   const classes = useNamespaceResourcesCardStyles();
   const { entity } = useEntity();
   const navigate = useNavigate();
-  const { entities, loading } = useRelatedEntities(entity, {
+  const { entities, loading } = useRelatedEntitiesQuery(entity, {
     type: RELATION_HAS_PART,
   });
 


### PR DESCRIPTION
CachingCatalogApi used ensureQueryData({ revalidateIfStale: true }), which resolves with the stale value and discards the revalidation. CatalogApi's consumers are one-shot awaits with no way to receive it, so newly created entities never appeared until a second navigation. Use fetchQuery with a short freshness window, and subscribe the namespace cards so they keep instant paint.


https://github.com/user-attachments/assets/08657b12-3406-4993-be7c-29de31472e14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Catalog namespace project cards and catalog lists now update in place after component/project create or update, avoiding stale cached reads.
  - Cached catalog reads now refresh correctly within a freshness window and fall back to the last known good data when refresh fails.
  - UI loading states now reflect only active network fetches, preventing unwanted skeleton/flash during background revalidation.

- **New Features**
  - Added a new related-entities query hook that supports filtering by relationship type and target entity kind, returning consistent results and improved ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->