### PR TITLE
feat: prioritize HTTPS endpoint URLs in release binding transform

### DIFF
--- a/.changeset/https-priority-endpoint-urls.md
+++ b/.changeset/https-priority-endpoint-urls.md
@@ -1,0 +1,13 @@
+---
+'@openchoreo/backstage-plugin-backend': patch
+---
+
+Prefer HTTPS over HTTP for endpoint URLs surfaced in the API test console. When
+a ReleaseBinding endpoint exposes both an `http` and an `https` URL, the console
+could show either one, since the frontend selects the first entry of each URL
+map and is otherwise scheme-blind — which URL came first was decided by the
+upstream control-plane response ordering. The `ReleaseBinding` transformer now
+reorders each endpoint's `externalURLs`/`internalURLs` so `https` entries come
+first (relative order otherwise preserved), making the existing frontend
+selection land on the secure URL with no frontend change. http-only endpoints
+and endpoints without URL maps are unaffected.

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
@@ -2,6 +2,7 @@ import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
 import {
   deriveBindingStatus,
   deriveBindingStatusDetailed,
+  transformReleaseBinding,
 } from './release-binding';
 
 type ReleaseBinding = OpenChoreoComponents['schemas']['ReleaseBinding'];
@@ -270,5 +271,54 @@ describe('deriveBindingStatusDetailed', () => {
     const binding = makeBinding([]);
     const result = deriveBindingStatusDetailed(binding);
     expect(result).toEqual({ status: 'NotReady' });
+  });
+});
+
+describe('transformReleaseBinding endpoint https prioritization', () => {
+  const http = { host: 'api.example.com', port: 80, scheme: 'http' };
+  const https = { host: 'api.example.com', port: 443, scheme: 'https' };
+
+  function makeBindingWithEndpoints(endpoints: unknown[]): ReleaseBinding {
+    return {
+      status: { conditions: [], endpoints },
+    } as unknown as ReleaseBinding;
+  }
+
+  it('orders https before http in externalURLs', () => {
+    const result = transformReleaseBinding(
+      makeBindingWithEndpoints([
+        { name: 'ep', externalURLs: { plain: http, secure: https } },
+      ]),
+    );
+    const urls = Object.values(result.endpoints![0].externalURLs!);
+    expect(urls[0].scheme).toBe('https');
+    expect(urls[1].scheme).toBe('http');
+  });
+
+  it('orders https before http in internalURLs', () => {
+    const result = transformReleaseBinding(
+      makeBindingWithEndpoints([
+        { name: 'ep', internalURLs: { plain: http, secure: https } },
+      ]),
+    );
+    const urls = Object.values(result.endpoints![0].internalURLs!);
+    expect(urls[0].scheme).toBe('https');
+  });
+
+  it('preserves order when only http is present', () => {
+    const result = transformReleaseBinding(
+      makeBindingWithEndpoints([
+        { name: 'ep', externalURLs: { a: http, b: { ...http, port: 8080 } } },
+      ]),
+    );
+    const urls = Object.values(result.endpoints![0].externalURLs!);
+    expect(urls.map(u => u.port)).toEqual([80, 8080]);
+  });
+
+  it('leaves endpoints without URL maps untouched', () => {
+    const result = transformReleaseBinding(
+      makeBindingWithEndpoints([{ name: 'ep' }]),
+    );
+    expect(result.endpoints![0]).toEqual({ name: 'ep' });
   });
 });

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -2,6 +2,7 @@ import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
 import type {
   ReleaseBindingResponse,
   ReleaseBindingEndpoint,
+  ReleaseBindingEndpointURLDetails,
   ReleaseBindingCondition,
 } from '@openchoreo/backstage-plugin-common';
 import { getName, getNamespace, getCreatedAt } from './common';
@@ -142,6 +143,48 @@ export function deriveBindingStatusDetailed(
 }
 
 /**
+ * Reorders a URL map so that HTTPS entries come first.
+ *
+ * The frontend selects an endpoint's primary URL with `Object.values(urls)[0]`
+ * — the first entry in iteration order — and is otherwise scheme-blind. When an
+ * endpoint exposes both an http and an https URL we want the secure one to win,
+ * so we surface https entries first here while keeping the relative order of
+ * everything else stable. Object iteration order follows insertion order for the
+ * string keys used here, so rebuilding the record is enough to influence the
+ * frontend's choice without any frontend change.
+ */
+function prioritizeHttpsUrls(
+  urls: Record<string, ReleaseBindingEndpointURLDetails>,
+): Record<string, ReleaseBindingEndpointURLDetails> {
+  const isHttps = (d: ReleaseBindingEndpointURLDetails | undefined) =>
+    d?.scheme?.toLowerCase() === 'https';
+  const entries = Object.entries(urls);
+  const ordered = [
+    ...entries.filter(([, d]) => isHttps(d)),
+    ...entries.filter(([, d]) => !isHttps(d)),
+  ];
+  return Object.fromEntries(ordered);
+}
+
+/**
+ * Returns a copy of the endpoint with its external/internal URL maps reordered
+ * so https URLs take precedence over http when both are present.
+ */
+function prioritizeEndpointHttps(
+  endpoint: ReleaseBindingEndpoint,
+): ReleaseBindingEndpoint {
+  return {
+    ...endpoint,
+    ...(endpoint.externalURLs
+      ? { externalURLs: prioritizeHttpsUrls(endpoint.externalURLs) }
+      : {}),
+    ...(endpoint.internalURLs
+      ? { internalURLs: prioritizeHttpsUrls(endpoint.internalURLs) }
+      : {}),
+  };
+}
+
+/**
  * Transforms a K8s-style ReleaseBinding resource into the flat
  * ReleaseBindingResponse shape expected by the frontend.
  */
@@ -172,10 +215,12 @@ export function transformReleaseBinding(
     endpoints: (() => {
       const raw = (binding.status as any)?.endpoints;
       if (!Array.isArray(raw)) return undefined;
-      return raw.filter(
-        (e): e is ReleaseBindingEndpoint =>
-          e !== null && typeof e === 'object' && typeof e.name === 'string',
-      );
+      return raw
+        .filter(
+          (e): e is ReleaseBindingEndpoint =>
+            e !== null && typeof e === 'object' && typeof e.name === 'string',
+        )
+        .map(prioritizeEndpointHttps);
     })(),
     conditions: (() => {
       const raw = binding.status?.conditions;


### PR DESCRIPTION
## Purpose

When a ReleaseBinding endpoint exposes both an http and an https URL, the API test console (ApiTryOut) could pick either one. The frontend's derivePrimaryUrl selects an endpoint's primary URL via Object.values(urls)[0] — the first entry in iteration order — and is otherwise scheme-blind. Which URL ended up first was determined entirely by the upstream control-plane response ordering, so the console could surface an http URL even when a secure https one was available. The user cannot switch URLs in the UI, so whatever gets selected is what they're stuck with.

## Approach

Reorder each endpoint's externalURLs/internalURLs maps in the backend transformer (transformReleaseBinding) so that https entries come first, while keeping the relative order of everything else stable. Because the frontend already selects Object.values(urls)[0], this makes its existing selection land on the https URL with no frontend change — the console's displayed URL, copy link, and SwaggerUI server URL all inherit it automatically.

  Two small helpers added:
  - prioritizeHttpsUrls(urls) — stable reorder of a URL record, https first.
  - prioritizeEndpointHttps(endpoint) — applies it to both URL maps on an endpoint.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prioritized secure HTTPS endpoint URLs before HTTP URLs in both external and internal endpoint listings.
  * Preserved the existing relative order of URLs within each scheme.
  * Left endpoints without URL mappings unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->