### PR TITLE
feat: surface deployed OpenChoreo version in the console

### DIFF
--- a/.changeset/platform-version-display.md
+++ b/.changeset/platform-version-display.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin': minor
+'@openchoreo/backstage-plugin-backend': minor
+---
+
+Surface the deployed OpenChoreo platform version in the Console. The backend
+gains a `GET /platform-version` route proxying the OpenChoreo API server's
+public `/version` endpoint; the frontend gains `getPlatformVersion()` on the
+client and a `PlatformAboutCard` component. The stock portal shows the card
+in Settings → General next to the stock user-settings cards.

--- a/packages/portal-app/src/createPortalApp.tsx
+++ b/packages/portal-app/src/createPortalApp.tsx
@@ -1,4 +1,5 @@
 import { Route } from 'react-router-dom';
+import Grid from '@material-ui/core/Grid';
 import { catalogPlugin } from '@backstage/plugin-catalog';
 import { catalogImportPlugin } from '@backstage/plugin-catalog-import';
 import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
@@ -70,13 +71,16 @@ import { appThemes } from './themes';
 import { LEGACY_KIND_ICONS } from './kindIcons';
 import {
   AccessControlContent,
+  PlatformAboutCard,
   SecretsContent,
   ExecTerminalWindowPage,
 } from '@openchoreo/backstage-plugin';
 import {
   UserSettingsPage,
   SettingsLayout,
-  UserSettingsGeneral,
+  UserSettingsProfileCard,
+  UserSettingsAppearanceCard,
+  UserSettingsIdentityCard,
 } from '@backstage/plugin-user-settings';
 import { VisitListener } from '@backstage/plugin-home';
 
@@ -131,7 +135,22 @@ const routes = (
     <Route path="/settings" element={<UserSettingsPage />}>
       <SettingsLayout>
         <SettingsLayout.Route path="general" title="General">
-          <UserSettingsGeneral />
+          {/* The stock <UserSettingsGeneral /> grid, recomposed to append the
+              OpenChoreo platform version card (openchoreo/openchoreo#4344). */}
+          <Grid container direction="row" spacing={3}>
+            <Grid item xs={12} md={6}>
+              <UserSettingsProfileCard />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <UserSettingsAppearanceCard />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <UserSettingsIdentityCard />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <PlatformAboutCard />
+            </Grid>
+          </Grid>
         </SettingsLayout.Route>
         <SettingsLayout.Route path="access-control" title="Access Control">
           <AccessControlContent />

--- a/plugins/openchoreo-backend/src/plugin.ts
+++ b/plugins/openchoreo-backend/src/plugin.ts
@@ -27,6 +27,7 @@ import { DataPlaneInfoService } from './services/DataPlaneService/DataPlaneInfoS
 import { ClusterDataPlaneInfoService } from './services/ClusterDataPlaneService/ClusterDataPlaneInfoService';
 import { PlatformResourceService } from './services/PlatformResourceService/PlatformResourceService';
 import { WirelogsInfoService } from './services/WirelogsService/WirelogsInfoService';
+import { VersionService } from './services/VersionService/VersionService';
 import { openChoreoTokenServiceRef } from '@openchoreo/openchoreo-auth';
 import { openchoreoPermissions } from '@openchoreo/backstage-plugin-common';
 import {
@@ -170,6 +171,8 @@ export const choreoPlugin = createBackendPlugin({
 
         const wirelogsInfoService = new WirelogsInfoService(logger, baseUrl);
 
+        const versionService = new VersionService(logger, baseUrl);
+
         // Register OpenChoreo component permissions with the permissions registry
         // This enables CONDITIONAL permission checks against catalog entities
         const namespacedResourcePermissions = openchoreoPermissions.filter(
@@ -244,6 +247,7 @@ export const choreoPlugin = createBackendPlugin({
             clusterDataPlaneInfoService,
             platformResourceService,
             wirelogsInfoService,
+            versionService,
             annotationStore,
             catalogService: catalog,
             auth,

--- a/plugins/openchoreo-backend/src/router.test.ts
+++ b/plugins/openchoreo-backend/src/router.test.ts
@@ -120,6 +120,9 @@ function createMockServices() {
     wirelogsInfoService: {
       openStream: jest.fn(),
     },
+    versionService: {
+      fetchPlatformVersion: jest.fn(),
+    },
     annotationStore: {
       getAnnotations: jest.fn(),
       setAnnotations: jest.fn(),
@@ -164,6 +167,38 @@ describe('createRouter', () => {
     app = express();
     app.use(router);
     app.use(mockErrorHandler());
+  });
+
+  describe('GET /platform-version', () => {
+    it('should return the platform version on success', async () => {
+      const mockVersion = {
+        name: 'openchoreo-api',
+        version: 'v1.2.0',
+        gitRevision: 'abc12345',
+        buildTime: '2025-01-06T10:00:00Z',
+        goOS: 'linux',
+        goArch: 'amd64',
+        goVersion: 'go1.24.2',
+      };
+      services.versionService.fetchPlatformVersion.mockResolvedValue(
+        mockVersion,
+      );
+
+      const response = await request(app).get('/platform-version');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(mockVersion);
+    });
+
+    it('should return 500 when the upstream call fails', async () => {
+      services.versionService.fetchPlatformVersion.mockRejectedValue(
+        new Error('upstream unavailable'),
+      );
+
+      const response = await request(app).get('/platform-version');
+
+      expect(response.status).toBe(500);
+    });
   });
 
   describe('GET /deploy', () => {

--- a/plugins/openchoreo-backend/src/router.ts
+++ b/plugins/openchoreo-backend/src/router.ts
@@ -33,6 +33,7 @@ import {
 } from './services/ProjectReleaseService/ProjectReleaseInfoService';
 import { PlatformResourceService } from './services/PlatformResourceService/PlatformResourceService';
 import { WirelogsInfoService } from './services/WirelogsService/WirelogsInfoService';
+import { VersionService } from './services/VersionService/VersionService';
 import { AuthzService } from './services/AuthzService/AuthzService';
 import { DataPlaneInfoService } from './services/DataPlaneService/DataPlaneInfoService';
 import { ClusterDataPlaneInfoService } from './services/ClusterDataPlaneService/ClusterDataPlaneInfoService';
@@ -108,6 +109,7 @@ export async function createRouter({
   clusterDataPlaneInfoService,
   platformResourceService,
   wirelogsInfoService,
+  versionService,
   annotationStore,
   catalogService,
   auth,
@@ -137,6 +139,7 @@ export async function createRouter({
   clusterDataPlaneInfoService: ClusterDataPlaneInfoService;
   platformResourceService: PlatformResourceService;
   wirelogsInfoService: WirelogsInfoService;
+  versionService: VersionService;
   annotationStore: AnnotationStore;
   catalogService: CatalogService;
   auth: AuthService;
@@ -155,6 +158,12 @@ export async function createRouter({
   // Middleware to require authentication for mutating operations
   // When auth is enabled, POST/PUT/PATCH/DELETE operations require a valid user token
   const requireAuth = createRequireAuthMiddleware(tokenService, authEnabled);
+
+  // Deployed OpenChoreo platform version — upstream endpoint is public
+  // (`security: []`), so no auth middleware here.
+  router.get('/platform-version', async (_req, res) => {
+    res.json(await versionService.fetchPlatformVersion());
+  });
 
   router.get('/deploy', async (req, res) => {
     const { componentName, projectName, namespaceName } = req.query;

--- a/plugins/openchoreo-backend/src/services/VersionService/VersionService.test.ts
+++ b/plugins/openchoreo-backend/src/services/VersionService/VersionService.test.ts
@@ -1,0 +1,53 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { createOkResponse, createErrorResponse } from '@openchoreo/test-utils';
+import { VersionService } from './VersionService';
+
+const mockGET = jest.fn();
+
+jest.mock('@openchoreo/openchoreo-client-node', () => ({
+  ...jest.requireActual('@openchoreo/openchoreo-client-node'),
+  createOpenChoreoApiClient: jest.fn(() => ({
+    GET: mockGET,
+  })),
+}));
+
+const versionResponse = {
+  name: 'openchoreo-api',
+  version: 'v1.2.0',
+  gitRevision: 'abc12345',
+  buildTime: '2025-01-06T10:00:00Z',
+  goOS: 'linux',
+  goArch: 'amd64',
+  goVersion: 'go1.24.2',
+};
+
+const mockLogger = mockServices.logger.mock();
+
+function createService() {
+  return new VersionService(mockLogger, 'http://test:8080');
+}
+
+describe('VersionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchPlatformVersion', () => {
+    it('fetches the platform version', async () => {
+      mockGET.mockResolvedValueOnce(createOkResponse(versionResponse));
+
+      const service = createService();
+      const result = await service.fetchPlatformVersion();
+
+      expect(mockGET).toHaveBeenCalledWith('/version');
+      expect(result).toEqual(versionResponse);
+    });
+
+    it('throws on API error', async () => {
+      mockGET.mockResolvedValueOnce(createErrorResponse());
+
+      const service = createService();
+      await expect(service.fetchPlatformVersion()).rejects.toThrow();
+    });
+  });
+});

--- a/plugins/openchoreo-backend/src/services/VersionService/VersionService.ts
+++ b/plugins/openchoreo-backend/src/services/VersionService/VersionService.ts
@@ -1,0 +1,43 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  createOpenChoreoApiClient,
+  assertApiResponse,
+  type OpenChoreoComponents,
+} from '@openchoreo/openchoreo-client-node';
+
+export type PlatformVersion =
+  OpenChoreoComponents['schemas']['VersionResponse'];
+
+/**
+ * Service for retrieving the deployed OpenChoreo platform version.
+ * Calls the OpenChoreo API server's public, unauthenticated `/version`
+ * endpoint (served at the API root, outside `/api/v1`).
+ */
+export class VersionService {
+  private readonly logger: LoggerService;
+  private readonly baseUrl: string;
+
+  public constructor(logger: LoggerService, baseUrl: string) {
+    this.logger = logger;
+    this.baseUrl = baseUrl;
+  }
+
+  async fetchPlatformVersion(): Promise<PlatformVersion> {
+    try {
+      this.logger.debug('Fetching platform version');
+
+      const client = createOpenChoreoApiClient({
+        baseUrl: this.baseUrl,
+        logger: this.logger,
+      });
+
+      const { data, error, response } = await client.GET('/version');
+      assertApiResponse({ data, error, response }, 'fetch platform version');
+
+      return data!;
+    } catch (error: unknown) {
+      this.logger.error('Error fetching platform version:', error as Error);
+      throw error;
+    }
+  }
+}

--- a/plugins/openchoreo/src/api/OpenChoreoClient.test.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.test.ts
@@ -503,3 +503,44 @@ describe('OpenChoreoClient — fetchProjectReleaseSchema', () => {
     expect(opts.method ?? 'GET').toBe('GET');
   });
 });
+
+describe('OpenChoreoClient — platform version', () => {
+  const fetchMock = jest.fn();
+  const discovery = { getBaseUrl: jest.fn().mockResolvedValue(BASE_URL) };
+  const fetchApi = { fetch: fetchMock };
+  let client: OpenChoreoClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    discovery.getBaseUrl.mockResolvedValue(BASE_URL);
+    client = new OpenChoreoClient(discovery as any, fetchApi as any);
+  });
+
+  it('GETs /platform-version and returns the version info', async () => {
+    const versionInfo = {
+      name: 'openchoreo-api',
+      version: 'v1.2.0',
+      gitRevision: 'abc12345',
+      buildTime: '2025-01-06T10:00:00Z',
+      goOS: 'linux',
+      goArch: 'amd64',
+      goVersion: 'go1.24.2',
+    };
+    fetchMock.mockResolvedValueOnce(makeJsonResponse(versionInfo));
+
+    const result = await client.getPlatformVersion();
+
+    expect(result).toEqual(versionInfo);
+    const [calledUrl, opts] = fetchMock.mock.calls[0];
+    expect(calledUrl).toContain('/platform-version');
+    expect(opts.method ?? 'GET').toBe('GET');
+  });
+
+  it('throws on a non-2xx response', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({ error: 'unavailable' }, 502),
+    );
+
+    await expect(client.getPlatformVersion()).rejects.toThrow();
+  });
+});

--- a/plugins/openchoreo/src/api/OpenChoreoClient.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClient.ts
@@ -25,6 +25,7 @@ import type {
   ComponentTrait,
   UserTypeConfig,
   NamespaceSummary,
+  PlatformVersion,
   ProjectSummary,
   ComponentSummary,
   Secret,
@@ -107,6 +108,8 @@ const API_ENDPOINTS = {
   USER_TYPES: '/user-types',
   // Secrets endpoints
   SECRETS: '/secrets',
+  // Platform endpoints
+  PLATFORM_VERSION: '/platform-version',
   // Hierarchy data endpoints
   NAMESPACES: '/namespaces',
   PROJECTS: '/projects', // GET /namespaces/{namespaceName}/projects
@@ -1197,6 +1200,14 @@ export class OpenChoreoClient implements OpenChoreoClientApi {
       API_ENDPOINTS.USER_TYPES,
     );
     return response.data || [];
+  }
+
+  // ============================================
+  // Platform Operations
+  // ============================================
+
+  async getPlatformVersion(): Promise<PlatformVersion> {
+    return this.apiFetch<PlatformVersion>(API_ENDPOINTS.PLATFORM_VERSION);
   }
 
   // ============================================

--- a/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
+++ b/plugins/openchoreo/src/api/OpenChoreoClientApi.ts
@@ -543,6 +543,17 @@ export interface ComponentSummary {
   displayName?: string;
 }
 
+/** Deployed OpenChoreo platform version info (from the API server's /version) */
+export interface PlatformVersion {
+  name: string;
+  version: string;
+  gitRevision: string;
+  buildTime: string;
+  goOS: string;
+  goArch: string;
+  goVersion: string;
+}
+
 /** Component trait response */
 export interface ComponentTrait {
   kind?: 'Trait' | 'ClusterTrait';
@@ -1020,6 +1031,11 @@ export interface OpenChoreoClientApi {
 
   /** List all user types */
   listUserTypes(): Promise<UserTypeConfig[]>;
+
+  // === Platform Operations ===
+
+  /** Fetch the deployed OpenChoreo platform version */
+  getPlatformVersion(): Promise<PlatformVersion>;
 
   // === Hierarchy Data Operations ===
 

--- a/plugins/openchoreo/src/components/About/PlatformAboutCard.test.tsx
+++ b/plugins/openchoreo/src/components/About/PlatformAboutCard.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '@openchoreo/test-utils';
+import { openChoreoClientApiRef } from '../../api/OpenChoreoClientApi';
+import { PlatformAboutCard } from './PlatformAboutCard';
+
+const versionInfo = {
+  name: 'openchoreo-api',
+  version: 'v1.2.0',
+  gitRevision: 'abc12345',
+  buildTime: '2025-01-06T10:00:00Z',
+  goOS: 'linux',
+  goArch: 'amd64',
+  goVersion: 'go1.24.2',
+};
+
+const mockClient = {
+  getPlatformVersion: jest.fn(),
+};
+
+function renderPlatformAboutCard() {
+  const Wrapper = createQueryWrapper([
+    [openChoreoClientApiRef, mockClient as any],
+  ]);
+  return render(
+    <Wrapper>
+      <PlatformAboutCard />
+    </Wrapper>,
+  );
+}
+
+describe('PlatformAboutCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the platform version details', async () => {
+    mockClient.getPlatformVersion.mockResolvedValue(versionInfo);
+
+    renderPlatformAboutCard();
+
+    await waitFor(() => {
+      expect(screen.getByText('v1.2.0')).toBeInTheDocument();
+    });
+    expect(screen.getByText('abc12345')).toBeInTheDocument();
+    expect(screen.getByText('openchoreo-api')).toBeInTheDocument();
+    expect(screen.getByText('linux/amd64')).toBeInTheDocument();
+    expect(screen.getByText('go1.24.2')).toBeInTheDocument();
+  });
+
+  it('renders "unknown" for not-set build values', async () => {
+    mockClient.getPlatformVersion.mockResolvedValue({
+      ...versionInfo,
+      version: 'not-set',
+      gitRevision: 'not-set',
+      buildTime: 'not-set',
+    });
+
+    renderPlatformAboutCard();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('unknown').length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it('renders an error state when the fetch fails', async () => {
+    mockClient.getPlatformVersion.mockRejectedValue(
+      new Error('upstream unavailable'),
+    );
+
+    renderPlatformAboutCard();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText('Failed to fetch platform version'),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    expect(screen.getByText('upstream unavailable')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo/src/components/About/PlatformAboutCard.tsx
+++ b/plugins/openchoreo/src/components/About/PlatformAboutCard.tsx
@@ -1,0 +1,97 @@
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { InfoCard, Progress } from '@backstage/core-components';
+import { ErrorState } from '@openchoreo/backstage-plugin-react';
+import { usePlatformVersion } from '../../hooks/usePlatformVersion';
+
+// Binaries built outside the release pipeline report this literal.
+const NOT_SET = 'not-set';
+
+const useStyles = makeStyles(theme => ({
+  list: {
+    display: 'grid',
+    gridTemplateColumns: 'max-content 1fr',
+    columnGap: theme.spacing(4),
+    rowGap: theme.spacing(1.5),
+    margin: 0,
+  },
+  label: {
+    color: theme.palette.text.secondary,
+  },
+  value: {
+    fontWeight: 500,
+    wordBreak: 'break-all',
+  },
+}));
+
+const displayValue = (value: string | undefined): string =>
+  !value || value === NOT_SET ? 'unknown' : value;
+
+const formatBuildTime = (buildTime: string | undefined): string => {
+  if (!buildTime || buildTime === NOT_SET) {
+    return 'unknown';
+  }
+  const parsed = new Date(buildTime);
+  return isNaN(parsed.getTime()) ? buildTime : parsed.toLocaleString();
+};
+
+/**
+ * Card showing the deployed OpenChoreo platform version and build details,
+ * fetched from the OpenChoreo API server. Composed into the Settings →
+ * General tab next to the stock user-settings cards.
+ */
+export const PlatformAboutCard = () => {
+  const classes = useStyles();
+  const { version, loading, error } = usePlatformVersion();
+
+  if (loading) {
+    return (
+      <InfoCard title="OpenChoreo Version" variant="gridItem">
+        <Progress />
+      </InfoCard>
+    );
+  }
+
+  if (error) {
+    return (
+      <InfoCard title="OpenChoreo Version" variant="gridItem">
+        <ErrorState
+          title="Failed to fetch platform version"
+          message={error.message}
+        />
+      </InfoCard>
+    );
+  }
+
+  const rows: Array<[string, string]> = [
+    ['Version', displayValue(version?.version)],
+    ['Git revision', displayValue(version?.gitRevision)],
+    ['Build time', formatBuildTime(version?.buildTime)],
+    ['API server', displayValue(version?.name)],
+    [
+      'Platform',
+      version?.goOS && version?.goArch
+        ? `${version.goOS}/${version.goArch}`
+        : 'unknown',
+    ],
+    ['Go version', displayValue(version?.goVersion)],
+  ];
+
+  return (
+    <InfoCard title="OpenChoreo Version" variant="gridItem">
+      <dl className={classes.list}>
+        {rows.map(([label, value]) => (
+          <Typography
+            key={label}
+            component="div"
+            variant="body2"
+            style={{ display: 'contents' }}
+          >
+            <dt className={classes.label}>{label}</dt>
+            <dd className={classes.value}>{value}</dd>
+          </Typography>
+        ))}
+      </dl>
+    </InfoCard>
+  );
+};

--- a/plugins/openchoreo/src/components/About/index.ts
+++ b/plugins/openchoreo/src/components/About/index.ts
@@ -1,0 +1,1 @@
+export { PlatformAboutCard } from './PlatformAboutCard';

--- a/plugins/openchoreo/src/hooks/index.ts
+++ b/plugins/openchoreo/src/hooks/index.ts
@@ -19,3 +19,4 @@ export {
   type AsyncState,
 } from '@openchoreo/backstage-plugin-react';
 export { useQueryParams } from './useQueryParams';
+export { usePlatformVersion } from './usePlatformVersion';

--- a/plugins/openchoreo/src/hooks/usePlatformVersion.ts
+++ b/plugins/openchoreo/src/hooks/usePlatformVersion.ts
@@ -1,0 +1,28 @@
+import { useApi } from '@backstage/core-plugin-api';
+import { useOpenChoreoQuery } from '@openchoreo/backstage-plugin-react';
+import {
+  openChoreoClientApiRef,
+  PlatformVersion,
+} from '../api/OpenChoreoClientApi';
+
+interface UsePlatformVersionResult {
+  version: PlatformVersion | undefined;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Fetches the deployed OpenChoreo platform version. The version is immutable
+ * for the lifetime of a deployment, so the result is cached for the session.
+ */
+export function usePlatformVersion(): UsePlatformVersionResult {
+  const client = useApi(openChoreoClientApiRef);
+
+  const { data, loading, error } = useOpenChoreoQuery(
+    ['platform', 'version'],
+    () => client.getPlatformVersion(),
+    { staleTime: Infinity, retry: 1 },
+  );
+
+  return { version: data, loading, error };
+}

--- a/plugins/openchoreo/src/index.ts
+++ b/plugins/openchoreo/src/index.ts
@@ -26,6 +26,7 @@ export {
 } from './plugin';
 export { AccessControlContent } from './components/AccessControl';
 export { SecretsContent } from './components/Secrets';
+export { PlatformAboutCard } from './components/About';
 export * from './components/HomePage/MyProjectsWidget';
 export * from './components/HomePage/QuickActionsSection';
 export { ProjectContentsCard } from './components/Projects/ProjectContentsCard';


### PR DESCRIPTION
<img width="1727" height="902" alt="image" src="https://github.com/user-attachments/assets/58a6bfc3-5052-491d-a306-b54e102a6d61" />

fixes [openchoreo/openchoreo#4344](https://github.com/openchoreo/openchoreo/issues/4344)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an OpenChoreo platform information card to **Settings → General**.
  * Display version, build, Git revision, build time, API server, platform, and Go version details.
  * Added loading and error states, with unavailable values shown as “unknown.”
  * Added platform version retrieval through the client and a public platform-version endpoint.
* **Style**
  * Updated the General settings page with a responsive card-based layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->