### PR TITLE
feat: add cost insights view

### DIFF
--- a/.changeset/cost-insights-view.md
+++ b/.changeset/cost-insights-view.md
@@ -1,0 +1,23 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': minor
+'@openchoreo/backstage-portal-app': minor
+---
+
+Add a **Cost Insights** sidebar page that visualises the observer's
+per-environment FinOps (cost + right-sizing) data. The view is
+breadcrumb-scope driven (Namespace → Project → Component) with summary cards
+and a Table/Graph toggle at each level.
+
+- **Data layer**: `ObservabilityClient` gains `getCosts` /
+  `getCostRecommendations` (resolving the observer URL per
+  namespace+environment) plus `CostItem` / `CostRecommendationItem` types.
+- **Aggregation**: costs are fetched once per selected environment, plus one
+  query over the previous equal-length window for deltas, then aggregated
+  client-side — totals, cost-weighted efficiency, `% vs previous window`, and a
+  current-month forecast by linear extrapolation. At the component level,
+  right-sizing recommendations ("Cost After Optimizing") are attached
+- **UI**: breadcrumb scope switcher, environment multi-select, Table/Graph
+  toggle, shared Time Range and graph-only granularity filters, summary cards, a
+  sortable cost table (catalog-style column sorting, costs shown to 5 decimals
+  so sub-cent values are visible), and a recharts stacked-bar graph over time.
+  Wired into the portal sidebar and the `/cost-insights` route.

--- a/packages/portal-app/src/components/Root/Root.tsx
+++ b/packages/portal-app/src/components/Root/Root.tsx
@@ -38,6 +38,7 @@ import GroupIcon from '@material-ui/icons/People';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 import CategoryIcon from '@material-ui/icons/Category';
 import BubbleChartIcon from '@material-ui/icons/BubbleChart';
+import MonetizationOnIcon from '@material-ui/icons/MonetizationOn';
 import { AssistantDrawerProvider } from '@openchoreo/backstage-plugin-openchoreo-portal-assistant';
 // This app composes some OpenChoreo entity tabs itself via legacy
 // `EntityLayout.Route` JSX (see EntityPage.tsx), so they render OUTSIDE the
@@ -230,6 +231,11 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
                   icon={BubbleChartIcon}
                   to="platform-overview"
                   text="Platform"
+                />
+                <SidebarItem
+                  icon={MonetizationOnIcon}
+                  to="cost-insights"
+                  text="Cost Insights"
                 />
                 <MyGroupsSidebarItem
                   singularTitle="My Group"

--- a/packages/portal-app/src/createPortalApp.tsx
+++ b/packages/portal-app/src/createPortalApp.tsx
@@ -19,6 +19,7 @@ import { HomePage } from './components/Home';
 import { CustomGraphNode } from '@openchoreo/backstage-plugin-react';
 import { PageLoader } from '@openchoreo/backstage-design-system';
 import { PlatformOverviewPage } from './components/platformOverview';
+import { CostInsightsPage } from '@openchoreo/backstage-plugin-openchoreo-observability';
 
 import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
 import { createApp } from '@backstage/frontend-defaults';
@@ -146,6 +147,7 @@ const routes = (
       element={<CatalogGraphPage renderNode={CustomGraphNode} />}
     />
     <Route path="/platform-overview" element={<PlatformOverviewPage />} />
+    <Route path="/cost-insights" element={<CostInsightsPage />} />
     {/*
       Standalone full-window exec terminal, opened in a new browser tab from the
       resource drawer. The page renders a fixed viewport overlay over the app

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.costs.test.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.costs.test.ts
@@ -1,0 +1,197 @@
+import { ObservabilityClient } from './ObservabilityApi';
+
+const resolveUrls = jest.fn();
+
+jest.mock('./ObserverUrlCache', () => ({
+  ObserverUrlCache: jest.fn().mockImplementation(() => ({
+    resolveUrls,
+  })),
+}));
+
+const mockFetchApi = { fetch: jest.fn() };
+const mockDiscoveryApi = { getBaseUrl: jest.fn() };
+
+function createClient() {
+  return new ObservabilityClient({
+    discoveryApi: mockDiscoveryApi as any,
+    fetchApi: mockFetchApi as any,
+  });
+}
+
+const okResponse = (data: Record<string, unknown>) => ({
+  ok: true,
+  json: () => Promise.resolve(data),
+});
+
+describe('ObservabilityClient cost APIs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveUrls.mockResolvedValue({ observerUrl: 'http://observer' });
+  });
+
+  it('builds the environment-scoped cost URL with query params', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce(
+      okResponse({ items: [{ component: 'c', cpuCost: 1, memoryCost: 2 }] }),
+    );
+
+    const client = createClient();
+    const result = await client.getCosts('ns1', 'dev', {
+      project: 'proj',
+      component: 'comp',
+      startTime: '2026-07-01T00:00:00.000Z',
+      endTime: '2026-07-01T01:00:00.000Z',
+      granularity: '1h',
+    });
+
+    expect(resolveUrls).toHaveBeenCalledWith('ns1', 'dev');
+    const [url, options] = mockFetchApi.fetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe(
+      '/api/v1alpha1/costs/namespaces/ns1/environments/dev',
+    );
+    expect(parsed.searchParams.get('project')).toBe('proj');
+    expect(parsed.searchParams.get('component')).toBe('comp');
+    expect(parsed.searchParams.get('startTime')).toBe(
+      '2026-07-01T00:00:00.000Z',
+    );
+    expect(parsed.searchParams.get('endTime')).toBe('2026-07-01T01:00:00.000Z');
+    expect(parsed.searchParams.get('granularity')).toBe('1h');
+    expect(options.headers['x-openchoreo-direct']).toBe('true');
+    expect(result.items).toHaveLength(1);
+  });
+
+  it('omits optional params when not provided', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce(okResponse({ items: [] }));
+
+    const client = createClient();
+    await client.getCosts('ns1', 'dev', {
+      startTime: 's',
+      endTime: 'e',
+    });
+
+    const [url] = mockFetchApi.fetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('project')).toBe(false);
+    expect(parsed.searchParams.has('granularity')).toBe(false);
+  });
+
+  it('builds the recommendations URL', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce(
+      okResponse({
+        items: [
+          {
+            component: 'comp',
+            environment: 'dev',
+            current: { cpuCost: 2, memoryCost: 3 },
+            recommendation: { cpuCost: 1, memoryCost: 1 },
+          },
+        ],
+      }),
+    );
+
+    const client = createClient();
+    const result = await client.getCostRecommendations('ns1', 'dev', {
+      project: 'proj',
+      component: 'comp',
+      startTime: 's',
+      endTime: 'e',
+    });
+
+    const [url] = mockFetchApi.fetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe(
+      '/api/v1alpha1/costs/namespaces/ns1/environments/dev/recommendations',
+    );
+    expect(parsed.searchParams.get('project')).toBe('proj');
+    expect(parsed.searchParams.get('component')).toBe('comp');
+    expect(parsed.searchParams.get('startTime')).toBe('s');
+    expect(parsed.searchParams.get('endTime')).toBe('e');
+    expect(result.items[0].recommendation.cpuCost).toBe(1);
+  });
+
+  it('surfaces the "not enabled" message on the observability error', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () =>
+        Promise.resolve({
+          error: 'Observability is not configured for component',
+        }),
+    });
+
+    const client = createClient();
+    await expect(client.getCosts('ns1', 'dev')).rejects.toThrow(
+      'Observability is not enabled for this component',
+    );
+  });
+
+  it('throws the parsed error for a generic cost failure', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ error: 'boom' }),
+    });
+
+    const client = createClient();
+    await expect(client.getCosts('ns1', 'dev')).rejects.toThrow('boom');
+  });
+
+  it('defaults cost items to an empty array when the body omits them', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce(okResponse({}));
+
+    const client = createClient();
+    const result = await client.getCosts('ns1', 'dev', {
+      startTime: 's',
+      endTime: 'e',
+    });
+    expect(result.items).toEqual([]);
+  });
+
+  it('omits optional params on the recommendations URL', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce(okResponse({ items: [] }));
+
+    const client = createClient();
+    await client.getCostRecommendations('ns1', 'dev', {
+      startTime: 's',
+      endTime: 'e',
+    });
+
+    const [url] = mockFetchApi.fetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('project')).toBe(false);
+    expect(parsed.searchParams.has('component')).toBe(false);
+  });
+
+  it('surfaces the "not enabled" message on a recommendations error', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () =>
+        Promise.resolve({
+          error: 'Observability is not configured for component',
+        }),
+    });
+
+    const client = createClient();
+    await expect(client.getCostRecommendations('ns1', 'dev')).rejects.toThrow(
+      'Observability is not enabled for this component',
+    );
+  });
+
+  it('throws the parsed error for a generic recommendations failure', async () => {
+    mockFetchApi.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ error: 'rec-boom' }),
+    });
+
+    const client = createClient();
+    await expect(client.getCostRecommendations('ns1', 'dev')).rejects.toThrow(
+      'rec-boom',
+    );
+  });
+});

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
@@ -16,6 +16,8 @@ import {
   IncidentSummary,
   FinOpsReportSummary,
   FinOpsReportDetailed,
+  CostItem,
+  CostRecommendationItem,
 } from '../types';
 import { LogsResponse } from '../components/RuntimeLogs/types';
 import { EventsResponse } from '../components/RuntimeEvents/types';
@@ -184,6 +186,29 @@ export interface ObservabilityApi {
     environmentName: string,
     namespaceName: string,
   ): Promise<FinOpsReportDetailed>;
+
+  getCosts(
+    namespaceName: string,
+    environmentName: string,
+    options?: {
+      project?: string;
+      component?: string;
+      startTime?: string;
+      endTime?: string;
+      granularity?: string;
+    },
+  ): Promise<{ items: CostItem[] }>;
+
+  getCostRecommendations(
+    namespaceName: string,
+    environmentName: string,
+    options?: {
+      project?: string;
+      component?: string;
+      startTime?: string;
+      endTime?: string;
+    },
+  ): Promise<{ items: CostRecommendationItem[] }>;
 }
 
 export const observabilityApiRef = createApiRef<ObservabilityApi>({
@@ -1005,6 +1030,115 @@ export class ObservabilityClient implements ObservabilityApi {
 
     const data = await response.json();
     return data;
+  }
+
+  async getCosts(
+    namespaceName: string,
+    environmentName: string,
+    options?: {
+      project?: string;
+      component?: string;
+      startTime?: string;
+      endTime?: string;
+      granularity?: string;
+    },
+  ): Promise<{ items: CostItem[] }> {
+    const { observerUrl } = await this.urlCache.resolveUrls(
+      namespaceName,
+      environmentName,
+    );
+
+    const url = new URL(
+      `${observerUrl}/api/v1alpha1/costs/namespaces/${encodeURIComponent(
+        namespaceName,
+      )}/environments/${encodeURIComponent(environmentName)}`,
+    );
+    if (options?.project) url.searchParams.set('project', options.project);
+    if (options?.component)
+      url.searchParams.set('component', options.component);
+    if (options?.startTime)
+      url.searchParams.set('startTime', options.startTime);
+    if (options?.endTime) url.searchParams.set('endTime', options.endTime);
+    if (options?.granularity)
+      url.searchParams.set('granularity', options.granularity);
+
+    const response = await this.fetchApi.fetch(url.toString(), {
+      headers: { ...DIRECT_HEADER },
+    });
+
+    if (!response.ok) {
+      const error = await this.parseError(response);
+      if (error.includes('Observability is not configured for component')) {
+        throw new Error('Observability is not enabled for this component');
+      }
+      throw new Error(error || `Failed to fetch costs: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return {
+      items: (data.items ?? []).map((item: any) => ({
+        ...item,
+        cpuCost: item.cpuCost ?? 0,
+        memoryCost: item.memoryCost ?? 0,
+        efficiency: item.efficiency ?? 0,
+      })),
+    };
+  }
+
+  async getCostRecommendations(
+    namespaceName: string,
+    environmentName: string,
+    options?: {
+      project?: string;
+      component?: string;
+      startTime?: string;
+      endTime?: string;
+    },
+  ): Promise<{ items: CostRecommendationItem[] }> {
+    const { observerUrl } = await this.urlCache.resolveUrls(
+      namespaceName,
+      environmentName,
+    );
+
+    const url = new URL(
+      `${observerUrl}/api/v1alpha1/costs/namespaces/${encodeURIComponent(
+        namespaceName,
+      )}/environments/${encodeURIComponent(environmentName)}/recommendations`,
+    );
+    if (options?.project) url.searchParams.set('project', options.project);
+    if (options?.component)
+      url.searchParams.set('component', options.component);
+    if (options?.startTime)
+      url.searchParams.set('startTime', options.startTime);
+    if (options?.endTime) url.searchParams.set('endTime', options.endTime);
+
+    const response = await this.fetchApi.fetch(url.toString(), {
+      headers: { ...DIRECT_HEADER },
+    });
+
+    if (!response.ok) {
+      const error = await this.parseError(response);
+      if (error.includes('Observability is not configured for component')) {
+        throw new Error('Observability is not enabled for this component');
+      }
+      throw new Error(
+        error || `Failed to fetch cost recommendations: ${response.statusText}`,
+      );
+    }
+
+    const data = await response.json();
+    const normalizeProfile = (p: any) => ({
+      ...p,
+      cpuCost: p?.cpuCost ?? 0,
+      memoryCost: p?.memoryCost ?? 0,
+    });
+    return {
+      items: (data.items ?? []).map((item: any) => ({
+        ...item,
+        current: normalizeProfile(item.current),
+        recommendation: normalizeProfile(item.recommendation),
+      })),
+    };
   }
 
   private async parseError(response: Response): Promise<string> {

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsBreadcrumb.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsBreadcrumb.test.tsx
@@ -1,0 +1,117 @@
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { createQueryWrapper } from '@openchoreo/test-utils';
+import { CostInsightsBreadcrumb } from './CostInsightsBreadcrumb';
+import type { CostScope } from './types';
+
+const entity = (
+  kind: string,
+  name: string,
+  title?: string,
+  annotations?: Record<string, string>,
+) => ({
+  apiVersion: 'backstage.io/v1alpha1',
+  kind,
+  metadata: { name, ...(title ? { title } : {}), annotations },
+});
+
+// Catalog entities keyed by kind: Domains = namespaces, Systems = projects,
+// Components carry namespace/project annotations.
+const getEntities = jest.fn(async ({ filter }: any) => {
+  switch (filter.kind) {
+    case 'Domain':
+      return { items: [entity('Domain', 'default', 'Default NS')] };
+    case 'System':
+      return {
+        items: [
+          entity('System', 'gcp', 'GCP Demo'),
+          entity('System', 'shop', 'Shop'),
+        ],
+      };
+    case 'Component':
+      return {
+        items: [
+          entity('Component', 'api', 'API Service', {
+            'openchoreo.io/namespace': 'default',
+            'openchoreo.io/project': 'gcp',
+          }),
+        ],
+      };
+    default:
+      return { items: [] };
+  }
+});
+
+async function renderBreadcrumb(scope: CostScope, onScopeChange = jest.fn()) {
+  // useOpenChoreoQuery needs a QueryClient; the breadcrumb styles read
+  // `theme.page.fontColor`, so it also needs a Backstage theme (renderInTestApp).
+  const QueryWrapper = createQueryWrapper();
+  await renderInTestApp(
+    <TestApiProvider apis={[[catalogApiRef, { getEntities } as any]]}>
+      <QueryWrapper>
+        <CostInsightsBreadcrumb scope={scope} onScopeChange={onScopeChange} />
+      </QueryWrapper>
+    </TestApiProvider>,
+  );
+  return { onScopeChange };
+}
+
+describe('CostInsightsBreadcrumb', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the namespace segment with its catalog title', async () => {
+    await renderBreadcrumb({ namespace: 'default' });
+    expect(await screen.findByText('Default NS')).toBeInTheDocument();
+    // Deeper segments are hidden until selected.
+    expect(screen.queryByText('GCP Demo')).not.toBeInTheDocument();
+  });
+
+  it('opens the namespace switcher and changes scope on selection', async () => {
+    const { onScopeChange } = await renderBreadcrumb({ namespace: 'default' });
+    await screen.findByText('Default NS');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch namespace' }));
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: 'Default NS' }),
+    );
+    expect(onScopeChange).toHaveBeenCalledWith({ namespace: 'default' });
+  });
+
+  it('renders project and component segments once the scope is deep enough', async () => {
+    await renderBreadcrumb({
+      namespace: 'default',
+      project: 'gcp',
+      component: 'api',
+    });
+    expect(await screen.findByText('GCP Demo')).toBeInTheDocument();
+    expect(await screen.findByText('API Service')).toBeInTheDocument();
+  });
+
+  it('navigates to a shallower scope when a segment name is clicked', async () => {
+    const { onScopeChange } = await renderBreadcrumb({
+      namespace: 'default',
+      project: 'gcp',
+    });
+    const nsLink = await screen.findByRole('button', { name: 'Default NS' });
+    fireEvent.click(nsLink);
+    // Clicking the namespace name drops the deeper project selection.
+    expect(onScopeChange).toHaveBeenCalledWith({ namespace: 'default' });
+  });
+
+  it('only queries deeper levels once their parent scope is set', async () => {
+    await renderBreadcrumb({ namespace: 'default' });
+    await screen.findByText('Default NS');
+    await waitFor(() =>
+      expect(
+        getEntities.mock.calls.some(([arg]) => arg.filter.kind === 'Domain'),
+      ).toBe(true),
+    );
+    // No project selected, so the Component query must stay disabled.
+    expect(
+      getEntities.mock.calls.some(([arg]) => arg.filter.kind === 'Component'),
+    ).toBe(false);
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsBreadcrumb.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsBreadcrumb.tsx
@@ -1,0 +1,292 @@
+import { FC, useRef, useState } from 'react';
+import {
+  Link,
+  Menu,
+  MenuItem,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import type { Entity } from '@backstage/catalog-model';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { useOpenChoreoQuery } from '@openchoreo/backstage-plugin-react';
+import { useGetComponentsByProject } from '../../hooks/useGetComponentsByProject';
+import type { CostScope } from './types';
+
+// Rendered inside the Backstage <Header> gradient bar (as the `subtitle`), so
+// text/border derive from `theme.page.fontColor` to stay legible on the purple
+// background — matching the entity CompactEntityHeader breadcrumb pills.
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.5),
+    marginTop: theme.spacing(1.5),
+  },
+  segment: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.page.fontColor,
+    border: `1px solid ${theme.page.fontColor}33`,
+    borderRadius: 6,
+    backgroundColor: `${theme.page.fontColor}0D`,
+    padding: theme.spacing(0.25, 0.5, 0.25, 0.75),
+    '&:hover': {
+      backgroundColor: `${theme.page.fontColor}1A`,
+    },
+  },
+  kind: {
+    color: theme.page.fontColor,
+    opacity: 0.75,
+    fontWeight: 500,
+    marginRight: theme.spacing(0.5),
+    fontSize: theme.typography.body2.fontSize,
+    textTransform: 'lowercase',
+  },
+  // The name is a hyperlink to that scope level: underline on hover, navigate
+  // on click. `component="button"` renders a real button, so reset its chrome.
+  value: {
+    color: theme.page.fontColor,
+    fontWeight: 700,
+    fontSize: theme.typography.body2.fontSize,
+    fontFamily: 'inherit',
+    background: 'transparent',
+    border: 0,
+    padding: 0,
+    cursor: 'pointer',
+    textDecoration: 'none',
+    '&:hover': {
+      color: theme.page.fontColor,
+      textDecoration: 'underline',
+    },
+  },
+  caretButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'transparent',
+    border: 0,
+    padding: 0,
+    marginLeft: theme.spacing(0.25),
+    cursor: 'pointer',
+    color: theme.page.fontColor,
+  },
+  caret: {
+    color: theme.page.fontColor,
+    opacity: 0.85,
+    display: 'block',
+  },
+}));
+
+interface Option {
+  name: string;
+  label: string;
+}
+
+interface ScopeSegmentProps {
+  kind: string;
+  value: string;
+  options: Option[];
+  loading?: boolean;
+  /** Switch to a sibling at this level (via the caret dropdown). */
+  onSelect: (name: string | undefined) => void;
+  /** Navigate to this scope level (clicking the name). */
+  onNavigate: () => void;
+}
+
+const ScopeSegment: FC<ScopeSegmentProps> = ({
+  kind,
+  value,
+  options,
+  loading,
+  onSelect,
+  onNavigate,
+}) => {
+  const classes = useStyles();
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <span className={classes.segment}>
+        <Typography component="span" className={classes.kind}>
+          {`${kind} /`}
+        </Typography>
+        <Link
+          component="button"
+          type="button"
+          className={classes.value}
+          onClick={onNavigate}
+        >
+          {value}
+        </Link>
+        <button
+          ref={anchorRef}
+          type="button"
+          className={classes.caretButton}
+          onClick={() => setOpen(true)}
+          aria-label={`Switch ${kind}`}
+        >
+          <ArrowDropDownIcon className={classes.caret} fontSize="small" />
+        </button>
+      </span>
+      <Menu
+        anchorEl={anchorRef.current}
+        open={open}
+        onClose={() => setOpen(false)}
+        getContentAnchorEl={null}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      >
+        {loading && <MenuItem disabled>Loading…</MenuItem>}
+        {!loading && options.length === 0 && (
+          <MenuItem disabled>No {kind}s found</MenuItem>
+        )}
+        {options.map(opt => (
+          <MenuItem
+            key={opt.name}
+            selected={opt.name === value}
+            onClick={() => {
+              onSelect(opt.name);
+              setOpen(false);
+            }}
+          >
+            {opt.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+export interface CostInsightsBreadcrumbProps {
+  scope: CostScope;
+  onScopeChange: (next: CostScope) => void;
+}
+
+export const CostInsightsBreadcrumb: FC<CostInsightsBreadcrumbProps> = ({
+  scope,
+  onScopeChange,
+}) => {
+  const classes = useStyles();
+  const catalogApi = useApi(catalogApiRef);
+
+  // Options carry the raw entity name (used for navigation + cost-API calls) and
+  // the catalog `metadata.title` as the display label, so the breadcrumb shows
+  // "GCP Microservice Demo" rather than "gcp-microservices-demo".
+  const toOptions = (
+    items: Array<{ metadata: Entity['metadata'] }>,
+  ): Option[] =>
+    items
+      .map(e => ({
+        name: e.metadata.name,
+        label: e.metadata.title || e.metadata.name,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+  const { data: namespaces = [], loading: nsLoading } = useOpenChoreoQuery<
+    Option[]
+  >(['cost-insights-namespaces'], async () => {
+    const { items } = await catalogApi.getEntities({
+      filter: { kind: 'Domain' },
+      fields: ['metadata.name', 'metadata.title'],
+    });
+    return toOptions(items);
+  });
+
+  const { data: projects = [], loading: projLoading } = useOpenChoreoQuery<
+    Option[]
+  >(
+    ['cost-insights-projects', scope.namespace ?? ''],
+    async () => {
+      const { items } = await catalogApi.getEntities({
+        filter: { kind: 'System', 'metadata.namespace': scope.namespace! },
+        fields: ['metadata.name', 'metadata.title'],
+      });
+      return toOptions(items);
+    },
+    { enabled: Boolean(scope.namespace) },
+  );
+
+  // Reuse the shared project-components hook (kind=Component + namespace/project
+  // annotation filter). It keys off a project entity, so synthesise one from the
+  // current scope; a missing namespace/project leaves the hook's guard disabled.
+  const projectEntity: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'System',
+    metadata: {
+      name: scope.project ?? '',
+      annotations: { [CHOREO_ANNOTATIONS.NAMESPACE]: scope.namespace ?? '' },
+    },
+  };
+  const { components: projectComponents, loading: compLoading } =
+    useGetComponentsByProject(projectEntity);
+  const components: Option[] = projectComponents
+    .map(c => ({ name: c.name, label: c.displayName || c.name }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  // Display the title for the selected name (falls back to the name until the
+  // options load, or when the entity has no title).
+  const labelFor = (options: Option[], name?: string): string =>
+    (name && options.find(o => o.name === name)?.label) || name || '';
+
+  return (
+    <div className={classes.root}>
+      <ScopeSegment
+        kind="namespace"
+        value={labelFor(namespaces, scope.namespace) || 'Select namespace'}
+        options={namespaces}
+        loading={nsLoading}
+        onSelect={name => onScopeChange({ namespace: name })}
+        onNavigate={() => onScopeChange({ namespace: scope.namespace })}
+      />
+
+      {/* Only show a level once it is actually selected; an absent deeper level
+          means "all" (aggregated). Clicking a name navigates to that level,
+          dropping any deeper selection. */}
+      {scope.project && (
+        <ScopeSegment
+          kind="project"
+          value={labelFor(projects, scope.project)}
+          options={projects}
+          loading={projLoading}
+          onSelect={name =>
+            onScopeChange({ namespace: scope.namespace, project: name })
+          }
+          onNavigate={() =>
+            onScopeChange({
+              namespace: scope.namespace,
+              project: scope.project,
+            })
+          }
+        />
+      )}
+
+      {scope.project && scope.component && (
+        <ScopeSegment
+          kind="component"
+          value={labelFor(components, scope.component)}
+          options={components}
+          loading={compLoading}
+          onSelect={name =>
+            onScopeChange({
+              namespace: scope.namespace,
+              project: scope.project,
+              component: name,
+            })
+          }
+          onNavigate={() =>
+            onScopeChange({
+              namespace: scope.namespace,
+              project: scope.project,
+              component: scope.component,
+            })
+          }
+        />
+      )}
+    </div>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CostInsightsFilters } from './CostInsightsFilters';
+import type { Environment } from '@openchoreo/backstage-plugin-react';
+
+const environments: Environment[] = [
+  { name: 'dev', namespace: 'default', displayName: 'Development' },
+];
+
+function renderFilters(
+  overrides: Partial<React.ComponentProps<typeof CostInsightsFilters>> = {},
+) {
+  const props = {
+    environments,
+    selectedEnvironments: ['dev'],
+    onEnvironmentsChange: jest.fn(),
+    view: 'table' as const,
+    onViewChange: jest.fn(),
+    timeRange: '1h',
+    onTimeRangeChange: jest.fn(),
+    granularity: '1d',
+    onGranularityChange: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<CostInsightsFilters {...props} />) };
+}
+
+describe('CostInsightsFilters', () => {
+  it('renders the view toggle, environments and time range', () => {
+    renderFilters();
+    expect(screen.getByRole('button', { name: 'Table' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Graph' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Environments' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Time Range' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the granularity selector in table view and shows it in graph view', () => {
+    const { rerender, props } = renderFilters({ view: 'table' });
+    expect(screen.queryByText('Time Granularity')).not.toBeInTheDocument();
+
+    rerender(<CostInsightsFilters {...props} view="graph" />);
+    expect(
+      screen.getAllByText('Time Granularity').length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits the selected view when a toggle is clicked', () => {
+    const { props } = renderFilters({ view: 'table' });
+    fireEvent.click(screen.getByRole('button', { name: 'Graph' }));
+    expect(props.onViewChange).toHaveBeenCalledWith('graph');
+  });
+
+  it('disables the view toggles when disabled', () => {
+    renderFilters({ disabled: true });
+    expect(screen.getByRole('button', { name: 'Table' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Graph' })).toBeDisabled();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.tsx
@@ -1,0 +1,147 @@
+import { FC } from 'react';
+import {
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  makeStyles,
+} from '@material-ui/core';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+import {
+  TimeRangeFilter,
+  type Environment,
+} from '@openchoreo/backstage-plugin-react';
+import { EnvironmentMultiSelect } from './EnvironmentMultiSelect';
+import type { CostViewMode } from './types';
+
+export const GRANULARITY_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '1h', label: '1 hour' },
+  { value: '6h', label: '6 hours' },
+  { value: '12h', label: '12 hours' },
+  { value: '1d', label: '1 day' },
+  { value: '7d', label: '1 week' },
+];
+
+export const DEFAULT_GRANULARITY = '1d';
+
+export interface CostInsightsFiltersProps {
+  environments: Environment[];
+  environmentsLoading?: boolean;
+  selectedEnvironments: string[];
+  onEnvironmentsChange: (names: string[]) => void;
+  view: CostViewMode;
+  onViewChange: (view: CostViewMode) => void;
+  timeRange: string;
+  customStartTime?: string;
+  customEndTime?: string;
+  onTimeRangeChange: (next: {
+    timeRange: string;
+    customStartTime?: string;
+    customEndTime?: string;
+  }) => void;
+  granularity: string;
+  onGranularityChange: (granularity: string) => void;
+  disabled?: boolean;
+}
+
+const useStyles = makeStyles(theme => ({
+  toggleGroup: { height: '100%' },
+  toggleButton: { textTransform: 'none', padding: theme.spacing(0, 2) },
+  spacer: { flexGrow: 1 },
+  control: { minWidth: 220 },
+}));
+
+export const CostInsightsFilters: FC<CostInsightsFiltersProps> = ({
+  environments,
+  environmentsLoading = false,
+  selectedEnvironments,
+  onEnvironmentsChange,
+  view,
+  onViewChange,
+  timeRange,
+  customStartTime,
+  customEndTime,
+  onTimeRangeChange,
+  granularity,
+  onGranularityChange,
+  disabled = false,
+}) => {
+  const classes = useStyles();
+  const isGraph = view === 'graph';
+
+  return (
+    <Grid container spacing={2} alignItems="center" wrap="nowrap">
+      <Grid item>
+        <ToggleButtonGroup
+          exclusive
+          size="medium"
+          value={view}
+          onChange={(_e, next) => next && onViewChange(next as CostViewMode)}
+          className={classes.toggleGroup}
+          aria-label="View mode"
+        >
+          <ToggleButton
+            value="table"
+            className={classes.toggleButton}
+            disabled={disabled}
+          >
+            Table
+          </ToggleButton>
+          <ToggleButton
+            value="graph"
+            className={classes.toggleButton}
+            disabled={disabled}
+          >
+            Graph
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Grid>
+
+      <Grid item className={classes.spacer} />
+
+      <Grid item className={classes.control}>
+        <EnvironmentMultiSelect
+          environments={environments}
+          loading={environmentsLoading}
+          value={selectedEnvironments}
+          onChange={onEnvironmentsChange}
+          disabled={disabled}
+        />
+      </Grid>
+
+      <Grid item className={classes.control}>
+        <TimeRangeFilter
+          value={timeRange}
+          customStartTime={customStartTime}
+          customEndTime={customEndTime}
+          onChange={onTimeRangeChange}
+          disabled={disabled}
+        />
+      </Grid>
+
+      {isGraph && (
+        <Grid item className={classes.control}>
+          <FormControl fullWidth variant="outlined" disabled={disabled}>
+            <InputLabel id="cost-granularity-label">
+              Time Granularity
+            </InputLabel>
+            <Select
+              labelId="cost-granularity-label"
+              label="Time Granularity"
+              value={granularity}
+              onChange={e => onGranularityChange(e.target.value as string)}
+            >
+              {GRANULARITY_OPTIONS.map(o => (
+                <MenuItem key={o.value} value={o.value}>
+                  {o.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+      )}
+    </Grid>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraph.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraph.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { CostInsightsGraph } from './CostInsightsGraph';
+import type { CostSeriesPoint } from './types';
+
+// recharts' ResponsiveContainer measures its parent, which is 0×0 in jsdom, so
+// the real chart renders nothing. Mock the primitives to expose the props we
+// care about (one <Bar> per stack key) as inspectable DOM.
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  BarChart: ({ children }: any) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: ({ dataKey }: any) => <div data-testid="bar" data-key={dataKey} />,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}));
+
+const series: CostSeriesPoint[] = [
+  { timestamp: '2026-07-01T00:00:00.000Z', gcp: 10, shop: 2 },
+  { timestamp: '2026-07-02T00:00:00.000Z', gcp: 6 },
+];
+
+describe('CostInsightsGraph', () => {
+  it('renders a stacked bar per series key', () => {
+    render(<CostInsightsGraph series={series} seriesKeys={['gcp', 'shop']} />);
+    const bars = screen.getAllByTestId('bar');
+    expect(bars.map(b => b.getAttribute('data-key'))).toEqual(['gcp', 'shop']);
+  });
+
+  it('renders an empty state when there is no series data', () => {
+    render(<CostInsightsGraph series={[]} seriesKeys={[]} />);
+    expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/No cost data to plot for the selected scope/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are points but no stack keys', () => {
+    render(<CostInsightsGraph series={series} seriesKeys={[]} />);
+    expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+    expect(screen.getByText(/No cost data to plot/i)).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraph.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraph.tsx
@@ -1,0 +1,273 @@
+import { FC, useMemo } from 'react';
+import { Paper, Typography, makeStyles, useTheme } from '@material-ui/core';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { CostSeriesPoint } from './types';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    padding: theme.spacing(2),
+    height: 420,
+  },
+  empty: {
+    height: 420,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Horizontal scroll kicks in only when the chart's min width exceeds the
+  // container (many buckets); otherwise it just fills the available space.
+  scroll: {
+    height: '100%',
+    overflowX: 'auto',
+    overflowY: 'hidden',
+  },
+}));
+
+// Curated categorical palettes for the stacked series. The colours are muted
+// mid-tones (calm rather than neon), yet each meets WCAG 2.2 AA / BITV 2.0
+const PALETTE_LIGHT = [
+  '#3f6cb0', // blue
+  '#2f8f7a', // teal
+  '#b06636', // rust
+  '#845bb0', // violet
+  '#a53f63', // rose
+  '#6f7a2f', // olive
+  '#2f8fae', // cyan
+  '#8a6a34', // brown
+  '#6f727a', // grey
+  '#993f8f', // magenta
+];
+const PALETTE_DARK = [
+  '#8fa8e0', // blue
+  '#4fc0a4', // teal
+  '#e0a074', // rust
+  '#bb9fe0', // violet
+  '#e07f9f', // rose
+  '#b6c470', // olive
+  '#5fc0e0', // cyan
+  '#a7adb8', // grey
+  '#d8c85f', // yellow
+  '#d98fd0', // magenta
+];
+
+const FILL_OPACITY = 0.9;
+
+// Cap each bar's width so a lone bucket doesn't stretch across the whole chart;
+// it stays this wide and centred regardless of how few bars there are.
+const MAX_BAR_SIZE = 64;
+// Minimum horizontal room per bucket. Once there are enough buckets to exceed
+// the container, the chart grows to this width per bucket and scrolls sideways
+const MIN_BUCKET_WIDTH = 48;
+
+// Costs are often sub-dollar; scale the decimal precision to the axis range so
+// small values don't all collapse to "$0".
+const formatAxisCost = (value: number): string => {
+  if (value === 0) return '$0';
+  const abs = Math.abs(value);
+  let digits = 0;
+  if (abs < 0.01) digits = 4;
+  else if (abs < 0.1) digits = 3;
+  else if (abs < 1) digits = 2;
+  else if (abs < 10) digits = 1;
+  return `$${value.toFixed(digits)}`;
+};
+
+const formatBucket = (iso: string): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+export interface CostInsightsGraphProps {
+  series: CostSeriesPoint[];
+  seriesKeys: string[];
+}
+
+export const CostInsightsGraph: FC<CostInsightsGraphProps> = ({
+  series,
+  seriesKeys,
+}) => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const dark = theme.palette.type === 'dark';
+
+  // Theme-aware categorical palette; flips with light/dark.
+  const palette = dark ? PALETTE_DARK : PALETTE_LIGHT;
+
+  // Deterministic per-key colour assignment so a series keeps its colour across
+  // re-renders. With more series than palette entries the colours wrap.
+  const colorFor = useMemo(() => {
+    const map = new Map<string, string>();
+    seriesKeys.forEach((key, i) => map.set(key, palette[i % palette.length]));
+    return map;
+  }, [seriesKeys, palette]);
+
+  if (series.length === 0 || seriesKeys.length === 0) {
+    return (
+      <Paper variant="outlined" className={classes.empty}>
+        <Typography color="textSecondary">
+          No cost data to plot for the selected scope, environments and time
+          range.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper variant="outlined" className={classes.container}>
+      <div className={classes.scroll}>
+        <div
+          style={{
+            height: '100%',
+            width: `max(100%, ${series.length * MIN_BUCKET_WIDTH}px)`,
+          }}
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={series}
+              margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={theme.palette.divider}
+              />
+              <XAxis
+                dataKey="timestamp"
+                tickFormatter={formatBucket}
+                tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+              />
+              <YAxis
+                tickFormatter={formatAxisCost}
+                width={64}
+                tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+              />
+              <Tooltip
+                cursor={{ fill: theme.palette.action.hover }}
+                content={({ active, payload, label }) => {
+                  if (!active || !payload?.length) return null;
+                  return (
+                    <div
+                      style={{
+                        backgroundColor: theme.palette.background.paper,
+                        border: `1px solid ${theme.palette.divider}`,
+                        borderRadius: 4,
+                        padding: theme.spacing(1, 1.5),
+                        color: theme.palette.text.primary,
+                        fontSize: 12,
+                      }}
+                    >
+                      <div style={{ marginBottom: 4, fontWeight: 500 }}>
+                        {formatBucket(String(label))}
+                      </div>
+                      {/* List top-to-bottom to mirror the stacked bar: the last
+                      series is drawn on top, so it appears first here. */}
+                      {[...payload].reverse().map(entry => {
+                        const colour = colorFor.get(String(entry.dataKey));
+                        return (
+                          <div
+                            key={String(entry.dataKey)}
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 6,
+                              lineHeight: 1.6,
+                            }}
+                          >
+                            {/* Colour swatch tying the row back to its stacked bar. */}
+                            <span
+                              style={{
+                                width: 10,
+                                height: 10,
+                                borderRadius: 2,
+                                backgroundColor: colour,
+                                opacity: FILL_OPACITY,
+                                flexShrink: 0,
+                              }}
+                            />
+                            <span>{entry.name}</span>
+                            <span
+                              style={{ marginLeft: 'auto', fontWeight: 500 }}
+                            >
+                              ${Number(entry.value).toFixed(2)}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                }}
+              />
+              <Legend
+                content={({ payload }) => (
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      justifyContent: 'center',
+                      gap: theme.spacing(0.5, 1.5),
+                      paddingTop: theme.spacing(1),
+                      color: theme.palette.text.primary,
+                      fontSize: 12,
+                    }}
+                  >
+                    {payload?.map(entry => {
+                      const key = String(entry.dataKey ?? entry.value);
+                      return (
+                        <span
+                          key={key}
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 6,
+                          }}
+                        >
+                          {/* Swatch at the same opacity as the bars. */}
+                          <span
+                            style={{
+                              width: 10,
+                              height: 10,
+                              borderRadius: 2,
+                              backgroundColor: colorFor.get(key),
+                              opacity: FILL_OPACITY,
+                              flexShrink: 0,
+                            }}
+                          />
+                          {String(entry.value)}
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+              />
+              {seriesKeys.map(key => (
+                <Bar
+                  key={key}
+                  dataKey={key}
+                  stackId="cost"
+                  fill={colorFor.get(key)}
+                  fillOpacity={FILL_OPACITY}
+                  name={key}
+                  maxBarSize={MAX_BAR_SIZE}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </Paper>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.test.tsx
@@ -1,0 +1,148 @@
+import { screen } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { CostInsightsPage } from './CostInsightsPage';
+
+// Child components are exercised by their own tests; stub them to lightweight
+// markers so this suite focuses on the page's state wiring.
+jest.mock('./CostInsightsBreadcrumb', () => ({
+  CostInsightsBreadcrumb: () => <div data-testid="breadcrumb" />,
+}));
+jest.mock('./CostInsightsFilters', () => ({
+  CostInsightsFilters: () => <div data-testid="filters" />,
+  DEFAULT_GRANULARITY: '1d',
+}));
+jest.mock('./CostSummaryCards', () => ({
+  CostSummaryCards: () => <div data-testid="summary-cards" />,
+}));
+jest.mock('./CostInsightsTable', () => ({
+  CostInsightsTable: () => <div data-testid="cost-table" />,
+}));
+jest.mock('./CostInsightsGraph', () => ({
+  CostInsightsGraph: () => <div data-testid="cost-graph" />,
+}));
+
+const mockUseNamespaceEnvironments = jest.fn();
+const mockUseDimensionTitles = jest.fn();
+const mockUseCostInsights = jest.fn();
+
+jest.mock('./useNamespaceEnvironments', () => ({
+  useNamespaceEnvironments: (...args: any[]) =>
+    mockUseNamespaceEnvironments(...args),
+}));
+jest.mock('./useDimensionTitles', () => ({
+  useDimensionTitles: (...args: any[]) => mockUseDimensionTitles(...args),
+}));
+jest.mock('./useCostInsights', () => ({
+  useCostInsights: (...args: any[]) => mockUseCostInsights(...args),
+}));
+
+const data = {
+  level: 'namespace' as const,
+  summary: {
+    totalCost: 22,
+    deltaPct: 10,
+    forecastThisMonth: 500,
+    efficiency: 0.3,
+  },
+  rows: [
+    {
+      key: 'gcp',
+      label: 'gcp',
+      cpuCost: 10,
+      memoryCost: 12,
+      total: 22,
+      efficiency: 0.3,
+      deltaPct: 10,
+    },
+  ],
+  series: [{ timestamp: '2026-07-01T00:00:00.000Z', gcp: 22 }],
+  seriesKeys: ['gcp'],
+};
+
+function setupDefaults() {
+  mockUseNamespaceEnvironments.mockReturnValue({
+    environments: [{ name: 'dev', namespace: 'default', displayName: 'Dev' }],
+    loading: false,
+    error: null,
+  });
+  mockUseDimensionTitles.mockReturnValue({});
+  mockUseCostInsights.mockReturnValue({
+    data,
+    loading: false,
+    isRefetching: false,
+    error: null,
+    refresh: jest.fn(),
+  });
+}
+
+const renderPage = (route = '/?namespace=default') =>
+  renderInTestApp(<CostInsightsPage />, { routeEntries: [route] });
+
+describe('CostInsightsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDefaults();
+  });
+
+  it('renders the filters, summary cards and table in table view', async () => {
+    await renderPage();
+    expect(screen.getByTestId('filters')).toBeInTheDocument();
+    expect(screen.getByTestId('summary-cards')).toBeInTheDocument();
+    expect(screen.getByTestId('cost-table')).toBeInTheDocument();
+    expect(screen.queryByTestId('cost-graph')).not.toBeInTheDocument();
+  });
+
+  it('renders the graph instead of the table in graph view', async () => {
+    await renderPage('/?namespace=default&view=graph');
+    expect(screen.getByTestId('cost-graph')).toBeInTheDocument();
+    expect(screen.queryByTestId('cost-table')).not.toBeInTheDocument();
+  });
+
+  it('shows a loader while cost data loads', async () => {
+    mockUseCostInsights.mockReturnValue({
+      data: undefined,
+      loading: true,
+      isRefetching: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    await renderPage();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByTestId('cost-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('summary-cards')).not.toBeInTheDocument();
+  });
+
+  it('shows an error alert when the cost query fails', async () => {
+    mockUseCostInsights.mockReturnValue({
+      data: undefined,
+      loading: false,
+      isRefetching: false,
+      error: 'Failed to load cost data',
+      refresh: jest.fn(),
+    });
+    await renderPage();
+    expect(screen.getByText('Failed to load cost data')).toBeInTheDocument();
+  });
+
+  it('prompts to pick another namespace when it has no environments', async () => {
+    mockUseNamespaceEnvironments.mockReturnValue({
+      environments: [],
+      loading: false,
+      error: null,
+    });
+    await renderPage();
+    expect(
+      screen.getByText(/No environments found for namespace/i),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces an environments-loading error', async () => {
+    mockUseNamespaceEnvironments.mockReturnValue({
+      environments: [],
+      loading: false,
+      error: 'catalog down',
+    });
+    await renderPage();
+    expect(screen.getByText('catalog down')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.tsx
@@ -1,0 +1,317 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useApp } from '@backstage/core-plugin-api';
+import { Page, Header, Content } from '@backstage/core-components';
+import { Box, Chip, Typography, makeStyles } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import {
+  PageLoader,
+  RefreshOverlay,
+} from '@openchoreo/backstage-design-system';
+import { parseUrlTimeRange, writeUrlTimeRange } from '../../utils/urlTimeRange';
+import { CostInsightsBreadcrumb } from './CostInsightsBreadcrumb';
+import { deriveLevel } from './costAggregation';
+import {
+  CostInsightsFilters,
+  DEFAULT_GRANULARITY,
+} from './CostInsightsFilters';
+import { CostSummaryCards } from './CostSummaryCards';
+import { CostInsightsTable } from './CostInsightsTable';
+import { CostInsightsGraph } from './CostInsightsGraph';
+import { useNamespaceEnvironments } from './useNamespaceEnvironments';
+import { useDimensionTitles } from './useDimensionTitles';
+import { useCostInsights } from './useCostInsights';
+import type { CostScope, CostViewMode } from './types';
+
+const DEFAULT_NAMESPACE = 'default';
+const COST_DEFAULT_TIME_RANGE = '1h';
+
+// The catalog kind each table row maps to, so we reuse the app's registered
+// kind icons (same symbols the catalog shows).
+const LEVEL_KIND: Record<string, string> = {
+  namespace: 'system', // rows are projects (Project = System)
+  project: 'component',
+  component: 'environment',
+};
+
+const useStyles = makeStyles(theme => ({
+  section: { marginTop: theme.spacing(2) },
+  titleRow: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+  },
+  // Mirrors the entity header's kind chip: legible on the gradient bar in both
+  // themes via `theme.page.fontColor`.
+  levelChip: {
+    color: theme.page.fontColor,
+    borderColor: `${theme.page.fontColor}80`,
+    fontSize: '0.7rem',
+    fontWeight: 600,
+    height: 24,
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+  },
+}));
+
+export const CostInsightsPage = () => {
+  const classes = useStyles();
+  const app = useApp();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // --- URL state ---
+  const namespace = searchParams.get('namespace') || DEFAULT_NAMESPACE;
+  const project = searchParams.get('project') || undefined;
+  // A component is only meaningful when a project is also selected.
+  const component = project
+    ? searchParams.get('component') || undefined
+    : undefined;
+  const scope: CostScope = useMemo(
+    () => ({ namespace, project, component }),
+    [namespace, project, component],
+  );
+  const level = deriveLevel(scope);
+  // Raw dimension name to catalog title, so rows read "GCP Microservice Demo".
+  const titles = useDimensionTitles(level, scope);
+
+  const view: CostViewMode =
+    searchParams.get('view') === 'graph' ? 'graph' : 'table';
+  const granularity = searchParams.get('granularity') || DEFAULT_GRANULARITY;
+  const { timeRange, customStartTime, customEndTime } = parseUrlTimeRange(
+    searchParams,
+    COST_DEFAULT_TIME_RANGE,
+  );
+  // `null` means the param is absent (default to all environments); a present
+  // value — even empty — is an explicit user selection we must preserve.
+  const envsRaw = searchParams.get('envs');
+  const envsParam = useMemo(
+    () => (envsRaw === null ? null : envsRaw.split(',').filter(Boolean)),
+    [envsRaw],
+  );
+
+  const update = useCallback(
+    (mutator: (params: URLSearchParams) => void) => {
+      const next = new URLSearchParams(searchParams);
+      mutator(next);
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const onScopeChange = useCallback(
+    (nextScope: CostScope) => {
+      update(params => {
+        const namespaceChanged = nextScope.namespace !== namespace;
+        if (nextScope.namespace) params.set('namespace', nextScope.namespace);
+        else params.delete('namespace');
+        if (nextScope.project) params.set('project', nextScope.project);
+        else params.delete('project');
+        if (nextScope.component) params.set('component', nextScope.component);
+        else params.delete('component');
+        // Environments belong to a namespace, so reset the selection when the
+        // namespace changes (the previous names may not exist in the new one).
+        if (namespaceChanged) params.delete('envs');
+      });
+    },
+    [update, namespace],
+  );
+
+  // --- Environments for the current namespace ---
+  const {
+    environments,
+    loading: envsLoading,
+    error: envsError,
+  } = useNamespaceEnvironments(namespace);
+
+  // Default to every environment until the user narrows the selection, so the
+  // page shows aggregated data immediately.
+  const allEnvNames = useMemo(
+    () => environments.map(e => e.name),
+    [environments],
+  );
+  // Absent param means default to all; a present selection (including an explicit
+  // empty one) is honored as-is.
+  const selectedEnvironments = envsParam === null ? allEnvNames : envsParam;
+
+  const onEnvironmentsChange = useCallback(
+    (names: string[]) => {
+      update(params => {
+        // An explicit "all selected" is stored as absent (the default), so the
+        // URL stays clean and keeps meaning "all". Selecting none serializes an
+        // explicit empty value so it survives a reload and the "select
+        // environments" alert can render.
+        const isAll = names.length > 0 && names.length === allEnvNames.length;
+        if (isAll) params.delete('envs');
+        else params.set('envs', names.join(','));
+      });
+    },
+    [update, allEnvNames.length],
+  );
+
+  const onViewChange = useCallback(
+    (nextView: CostViewMode) =>
+      update(params => {
+        if (nextView === 'table') params.delete('view');
+        else params.set('view', nextView);
+      }),
+    [update],
+  );
+
+  const onTimeRangeChange = useCallback(
+    (next: {
+      timeRange: string;
+      customStartTime?: string;
+      customEndTime?: string;
+    }) =>
+      update(params =>
+        writeUrlTimeRange(params, next, COST_DEFAULT_TIME_RANGE),
+      ),
+    [update],
+  );
+
+  const onGranularityChange = useCallback(
+    (next: string) =>
+      update(params => {
+        if (next === DEFAULT_GRANULARITY) params.delete('granularity');
+        else params.set('granularity', next);
+      }),
+    [update],
+  );
+
+  // Drill one level deeper by clicking a table row: namespace to project,
+  // project to component (component rows are leaf environments).
+  const onDrill = useCallback(
+    (key: string) => {
+      if (project) {
+        onScopeChange({ namespace, project, component: key });
+      } else {
+        onScopeChange({ namespace, project: key });
+      }
+    },
+    [namespace, project, onScopeChange],
+  );
+
+  // --- Cost data ---
+  const { data, loading, isRefetching, error } = useCostInsights({
+    scope,
+    environments: selectedEnvironments,
+    timeRange,
+    customStartTime,
+    customEndTime,
+    view,
+    granularity,
+  });
+
+  const noEnvironments =
+    !envsLoading && !envsError && environments.length === 0;
+
+  return (
+    <Page themeId="tool">
+      <Header
+        title={
+          <Box component="span" className={classes.titleRow}>
+            <span>Cost Insights</span>
+            <Chip
+              component="span"
+              label={level}
+              variant="outlined"
+              size="small"
+              className={classes.levelChip}
+            />
+          </Box>
+        }
+        pageTitleOverride="Cost Insights"
+        subtitle={
+          <CostInsightsBreadcrumb scope={scope} onScopeChange={onScopeChange} />
+        }
+      />
+      <Content>
+        <Box className={classes.section}>
+          <CostInsightsFilters
+            environments={environments}
+            environmentsLoading={envsLoading}
+            selectedEnvironments={selectedEnvironments}
+            onEnvironmentsChange={onEnvironmentsChange}
+            view={view}
+            onViewChange={onViewChange}
+            timeRange={timeRange}
+            customStartTime={customStartTime}
+            customEndTime={customEndTime}
+            onTimeRangeChange={onTimeRangeChange}
+            granularity={granularity}
+            onGranularityChange={onGranularityChange}
+          />
+        </Box>
+
+        {envsError && (
+          <Box className={classes.section}>
+            <Alert severity="error">{envsError}</Alert>
+          </Box>
+        )}
+
+        {noEnvironments && (
+          <Box className={classes.section}>
+            <Alert severity="info">
+              No environments found for namespace “{namespace}”. Select another
+              namespace from the breadcrumb.
+            </Alert>
+          </Box>
+        )}
+
+        {!noEnvironments &&
+          selectedEnvironments.length === 0 &&
+          !envsLoading && (
+            <Box className={classes.section}>
+              <Alert severity="info">
+                Select one or more environments to view cost insights.
+              </Alert>
+            </Box>
+          )}
+
+        {error && (
+          <Box className={classes.section}>
+            <Alert severity="error">{error}</Alert>
+          </Box>
+        )}
+
+        {loading && <PageLoader />}
+
+        {!loading && data && (
+          <Box position="relative">
+            <RefreshOverlay
+              active={isRefetching}
+              label="Refreshing cost data"
+            />
+            <Box className={classes.section}>
+              <CostSummaryCards summary={data.summary} />
+            </Box>
+            <Box className={classes.section}>
+              {view === 'graph' ? (
+                <CostInsightsGraph
+                  series={data.series}
+                  seriesKeys={data.seriesKeys}
+                />
+              ) : (
+                <CostInsightsTable
+                  level={data.level}
+                  rows={data.rows}
+                  onDrill={data.level === 'component' ? undefined : onDrill}
+                  icon={app.getSystemIcon(`kind:${LEVEL_KIND[data.level]}`)}
+                  titles={titles}
+                />
+              )}
+            </Box>
+          </Box>
+        )}
+
+        {!loading && !data && !error && !noEnvironments && (
+          <Box className={classes.section}>
+            <Typography color="textSecondary">
+              Select a scope and environments to view cost insights.
+            </Typography>
+          </Box>
+        )}
+      </Content>
+    </Page>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CostInsightsTable } from './CostInsightsTable';
+import type { CostRow } from './types';
+
+const rows: CostRow[] = [
+  {
+    key: 'gcp',
+    label: 'gcp',
+    cpuCost: 10,
+    memoryCost: 12,
+    total: 22,
+    efficiency: 0.3,
+    deltaPct: 10,
+  },
+  {
+    key: 'shop',
+    label: 'shop',
+    cpuCost: 2,
+    memoryCost: 4,
+    total: 6,
+    efficiency: 0.7,
+    deltaPct: null,
+  },
+];
+
+describe('CostInsightsTable', () => {
+  it('renders the standard columns for a namespace-level view', () => {
+    render(<CostInsightsTable level="namespace" rows={rows} />);
+    expect(screen.getByText('Project')).toBeInTheDocument();
+    expect(screen.getByText('gcp')).toBeInTheDocument();
+    expect(screen.getByText('22.00000')).toBeInTheDocument();
+    expect(screen.getByText('30%')).toBeInTheDocument(); // efficiency
+    expect(screen.getByText('+10%')).toBeInTheDocument(); // delta
+    expect(screen.getByText('—')).toBeInTheDocument(); // null delta for shop
+  });
+
+  it('renders an Environment table without optimizing columns at component level', () => {
+    const componentRows: CostRow[] = [
+      {
+        key: 'dev',
+        label: 'dev',
+        cpuCost: 2,
+        memoryCost: 3,
+        total: 5,
+        efficiency: 0.6,
+        deltaPct: null,
+      },
+    ];
+    render(<CostInsightsTable level="component" rows={componentRows} />);
+    expect(screen.getByText('Environment')).toBeInTheDocument();
+    expect(screen.queryByText('Cost After Optimizing')).not.toBeInTheDocument();
+    expect(screen.getByText('dev')).toBeInTheDocument();
+    expect(screen.getByText('5.00000')).toBeInTheDocument(); // total
+  });
+
+  it('drills into a row when onDrill is provided', () => {
+    const onDrill = jest.fn();
+    render(
+      <CostInsightsTable level="namespace" rows={rows} onDrill={onDrill} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'gcp' }));
+    expect(onDrill).toHaveBeenCalledWith('gcp');
+  });
+
+  it('renders the dimension as plain text without onDrill', () => {
+    render(<CostInsightsTable level="namespace" rows={rows} />);
+    expect(
+      screen.queryByRole('button', { name: 'gcp' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('gcp')).toBeInTheDocument();
+  });
+
+  it('sorts by total descending by default and toggles on header click', () => {
+    render(<CostInsightsTable level="namespace" rows={rows} />);
+
+    const dimensionCells = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1) // drop the header row
+        .map(row => row.querySelector('td')?.textContent);
+
+    // Default: highest total first (gcp 22 before shop 6).
+    expect(dimensionCells()).toEqual(['gcp', 'shop']);
+
+    // Clicking the active Total header toggles to ascending.
+    fireEvent.click(screen.getByRole('button', { name: /Total \(USD\)/ }));
+    expect(dimensionCells()).toEqual(['shop', 'gcp']);
+  });
+
+  it('renders an empty state when there are no rows', () => {
+    render(<CostInsightsTable level="namespace" rows={[]} />);
+    expect(
+      screen.getByText(/No cost data for the selected scope/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.tsx
@@ -1,0 +1,273 @@
+import { FC, useMemo, useState } from 'react';
+import {
+  Link,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Typography,
+  Paper,
+  makeStyles,
+} from '@material-ui/core';
+import type { IconComponent } from '@backstage/core-plugin-api';
+import type { CostRow, CostScopeLevel } from './types';
+import { formatCost, formatEfficiency, formatDelta } from './format';
+
+const useStyles = makeStyles(theme => ({
+  numeric: { textAlign: 'right', whiteSpace: 'nowrap' },
+  up: { color: theme.palette.error.main },
+  down: { color: theme.palette.success.main },
+  // Bold, link-coloured dimension names, matching the catalog table.
+  nameCell: { fontWeight: 600 },
+  nameWrap: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+  kindIcon: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.palette.text.secondary,
+    flexShrink: 0,
+    '& svg': { fontSize: 18, display: 'block' },
+  },
+  drillLink: {
+    textAlign: 'left',
+    font: 'inherit',
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+  empty: { padding: theme.spacing(4), textAlign: 'center' },
+}));
+
+const dimensionHeader = (level: CostScopeLevel): string => {
+  switch (level) {
+    case 'namespace':
+      return 'Project';
+    case 'project':
+      return 'Component';
+    case 'component':
+    default:
+      return 'Environment';
+  }
+};
+
+type SortId =
+  | 'name'
+  | 'cpuCost'
+  | 'memoryCost'
+  | 'efficiency'
+  | 'total'
+  | 'deltaPct';
+type SortOrder = 'asc' | 'desc';
+
+const DeltaCell: FC<{ deltaPct: number | null }> = ({ deltaPct }) => {
+  const classes = useStyles();
+  let cls = '';
+  // Only color finite deltas; non-finite values (e.g. Infinity) render as the
+  // neutral em dash, so leave them uncolored too.
+  if (deltaPct !== null && Number.isFinite(deltaPct)) {
+    if (deltaPct > 0) cls = classes.up;
+    else if (deltaPct < 0) cls = classes.down;
+  }
+  return <span className={cls}>{formatDelta(deltaPct)}</span>;
+};
+
+export interface CostInsightsTableProps {
+  level: CostScopeLevel;
+  rows: CostRow[];
+  /**
+   * Drill into a row's dimension (namespace to project, project to component). When
+   * omitted (component level, whose rows are leaf environments) the dimension
+   * renders as plain text.
+   */
+  onDrill?: (key: string) => void;
+  /** Entity-kind icon shown before each name (matches the catalog symbols). */
+  icon?: IconComponent;
+  /** Raw dimension name to catalog title, for display (keys stay raw names). */
+  titles?: Record<string, string>;
+}
+
+export const CostInsightsTable: FC<CostInsightsTableProps> = ({
+  level,
+  rows,
+  onDrill,
+  icon: KindIcon,
+  titles,
+}) => {
+  const classes = useStyles();
+
+  // Default sort: highest total cost first (like the catalog's default sort on
+  // Created). Clicking a header toggles asc/desc; the active column shows the
+  // arrow, and hovering any header reveals it.
+  const [orderBy, setOrderBy] = useState<SortId>('total');
+  const [order, setOrder] = useState<SortOrder>('desc');
+
+  const onSort = (id: SortId) => {
+    if (orderBy === id) {
+      setOrder(prev => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setOrderBy(id);
+      // Names read naturally ascending; costs are most useful highest-first.
+      setOrder(id === 'name' ? 'asc' : 'desc');
+    }
+  };
+
+  const sortedRows = useMemo(() => {
+    const decorated = rows.map(row => ({
+      row,
+      display: titles?.[row.key] ?? row.label,
+    }));
+    const factor = order === 'asc' ? 1 : -1;
+    return decorated.sort((a, b) => {
+      if (orderBy === 'name') {
+        return factor * a.display.localeCompare(b.display);
+      }
+      const av = a.row[orderBy];
+      const bv = b.row[orderBy];
+      // Unknown values (null deltas / efficiency) always sort last.
+      if (av === null && bv === null) return 0;
+      if (av === null) return 1;
+      if (bv === null) return -1;
+      return factor * (av - bv);
+    });
+  }, [rows, titles, order, orderBy]);
+
+  if (rows.length === 0) {
+    return (
+      <Paper variant="outlined">
+        <Typography className={classes.empty} color="textSecondary">
+          No cost data for the selected scope, environments and time range.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <TableContainer component={Paper} variant="outlined">
+      <Table size="small" aria-label="Cost insights">
+        <TableHead>
+          <TableRow>
+            <TableCell sortDirection={orderBy === 'name' ? order : false}>
+              <TableSortLabel
+                active={orderBy === 'name'}
+                direction={orderBy === 'name' ? order : 'asc'}
+                onClick={() => onSort('name')}
+              >
+                {dimensionHeader(level)}
+              </TableSortLabel>
+            </TableCell>
+            <TableCell
+              className={classes.numeric}
+              sortDirection={orderBy === 'cpuCost' ? order : false}
+            >
+              <TableSortLabel
+                active={orderBy === 'cpuCost'}
+                direction={orderBy === 'cpuCost' ? order : 'asc'}
+                onClick={() => onSort('cpuCost')}
+              >
+                CPU (USD)
+              </TableSortLabel>
+            </TableCell>
+            <TableCell
+              className={classes.numeric}
+              sortDirection={orderBy === 'memoryCost' ? order : false}
+            >
+              <TableSortLabel
+                active={orderBy === 'memoryCost'}
+                direction={orderBy === 'memoryCost' ? order : 'asc'}
+                onClick={() => onSort('memoryCost')}
+              >
+                Memory (USD)
+              </TableSortLabel>
+            </TableCell>
+            <TableCell
+              className={classes.numeric}
+              sortDirection={orderBy === 'efficiency' ? order : false}
+            >
+              <TableSortLabel
+                active={orderBy === 'efficiency'}
+                direction={orderBy === 'efficiency' ? order : 'asc'}
+                onClick={() => onSort('efficiency')}
+              >
+                Efficiency
+              </TableSortLabel>
+            </TableCell>
+            <TableCell
+              className={classes.numeric}
+              sortDirection={orderBy === 'total' ? order : false}
+            >
+              <TableSortLabel
+                active={orderBy === 'total'}
+                direction={orderBy === 'total' ? order : 'asc'}
+                onClick={() => onSort('total')}
+              >
+                Total (USD)
+              </TableSortLabel>
+            </TableCell>
+            <TableCell
+              className={classes.numeric}
+              sortDirection={orderBy === 'deltaPct' ? order : false}
+            >
+              <TableSortLabel
+                active={orderBy === 'deltaPct'}
+                direction={orderBy === 'deltaPct' ? order : 'asc'}
+                onClick={() => onSort('deltaPct')}
+              >
+                Inc/dec vs prev window
+              </TableSortLabel>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedRows.map(({ row, display }) => {
+            return (
+              <TableRow key={row.key}>
+                <TableCell className={classes.nameCell}>
+                  <span className={classes.nameWrap}>
+                    {KindIcon && (
+                      <span className={classes.kindIcon}>
+                        <KindIcon fontSize="small" />
+                      </span>
+                    )}
+                    {onDrill ? (
+                      <Link
+                        component="button"
+                        type="button"
+                        color="primary"
+                        className={classes.drillLink}
+                        onClick={() => onDrill(row.key)}
+                      >
+                        {display}
+                      </Link>
+                    ) : (
+                      display
+                    )}
+                  </span>
+                </TableCell>
+                <TableCell className={classes.numeric}>
+                  {formatCost(row.cpuCost)}
+                </TableCell>
+                <TableCell className={classes.numeric}>
+                  {formatCost(row.memoryCost)}
+                </TableCell>
+                <TableCell className={classes.numeric}>
+                  {formatEfficiency(row.efficiency)}
+                </TableCell>
+                <TableCell className={classes.numeric}>
+                  {formatCost(row.total)}
+                </TableCell>
+                <TableCell className={classes.numeric}>
+                  <DeltaCell deltaPct={row.deltaPct} />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { CostSummaryCards } from './CostSummaryCards';
+import type { CostSummary } from './types';
+
+const summary = (over: Partial<CostSummary> = {}): CostSummary => ({
+  totalCost: 22,
+  deltaPct: 10,
+  forecastThisMonth: 500,
+  efficiency: 0.3,
+  ...over,
+});
+
+describe('CostSummaryCards', () => {
+  it('renders the total, forecast and efficiency headlines', () => {
+    render(<CostSummaryCards summary={summary()} />);
+    expect(screen.getByText('Total Cost')).toBeInTheDocument();
+    expect(screen.getByText('USD 22.00')).toBeInTheDocument();
+    expect(screen.getByText('Forecast this month')).toBeInTheDocument();
+    expect(screen.getByText('USD 500.00')).toBeInTheDocument();
+    expect(screen.getByText('Efficiency')).toBeInTheDocument();
+    expect(screen.getByText('30%')).toBeInTheDocument();
+  });
+
+  it('shows an upward delta chip against the previous window', () => {
+    render(<CostSummaryCards summary={summary({ deltaPct: 10 })} />);
+    expect(screen.getByText('10% vs prev window')).toBeInTheDocument();
+  });
+
+  it('shows a downward delta with its magnitude only', () => {
+    render(<CostSummaryCards summary={summary({ deltaPct: -8 })} />);
+    expect(screen.getByText('8% vs prev window')).toBeInTheDocument();
+  });
+
+  it('falls back to a "No previous window" note when the delta is unknown', () => {
+    render(<CostSummaryCards summary={summary({ deltaPct: null })} />);
+    expect(screen.getByText('No previous window')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.tsx
@@ -1,0 +1,94 @@
+import { FC } from 'react';
+import { Grid, Typography, makeStyles } from '@material-ui/core';
+import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
+import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
+import { Card } from '@openchoreo/backstage-design-system';
+import type { CostSummary } from './types';
+import { formatUsd, formatEfficiency } from './format';
+
+const useStyles = makeStyles(theme => ({
+  card: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  },
+  label: {
+    fontWeight: 600,
+    fontSize: theme.typography.h6.fontSize,
+    color: theme.palette.text.primary,
+  },
+  value: { fontWeight: 700 },
+  delta: { display: 'inline-flex', alignItems: 'center', gap: 2 },
+  up: { color: theme.palette.error.main },
+  down: { color: theme.palette.success.main },
+  deltaIcon: { fontSize: 16 },
+  muted: { color: theme.palette.text.secondary },
+}));
+
+export interface CostSummaryCardsProps {
+  summary: CostSummary;
+}
+
+const DeltaChip: FC<{ deltaPct: number | null }> = ({ deltaPct }) => {
+  const classes = useStyles();
+  if (deltaPct === null || !Number.isFinite(deltaPct)) {
+    return (
+      <Typography variant="body2" className={classes.muted}>
+        No previous window
+      </Typography>
+    );
+  }
+  const rounded = Math.round(deltaPct);
+  const up = rounded > 0;
+  const down = rounded < 0;
+  return (
+    <Typography
+      variant="body2"
+      component="span"
+      className={`${classes.delta} ${up ? classes.up : ''} ${
+        down ? classes.down : ''
+      }`}
+    >
+      {up && <ArrowUpwardIcon className={classes.deltaIcon} />}
+      {down && <ArrowDownwardIcon className={classes.deltaIcon} />}
+      {`${Math.abs(rounded)}% vs prev window`}
+    </Typography>
+  );
+};
+
+export const CostSummaryCards: FC<CostSummaryCardsProps> = ({ summary }) => {
+  const classes = useStyles();
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12} sm={4}>
+        <Card padding={16} className={classes.card}>
+          <Typography className={classes.label}>Total Cost</Typography>
+          <Typography variant="h5" className={classes.value}>
+            {formatUsd(summary.totalCost)}
+          </Typography>
+          <DeltaChip deltaPct={summary.deltaPct} />
+        </Card>
+      </Grid>
+      <Grid item xs={12} sm={4}>
+        <Card padding={16} className={classes.card}>
+          <Typography className={classes.label}>Forecast this month</Typography>
+          <Typography variant="h5" className={classes.value}>
+            {formatUsd(summary.forecastThisMonth)}
+          </Typography>
+          <Typography variant="body2" className={classes.muted}>
+            at current rate
+          </Typography>
+        </Card>
+      </Grid>
+      <Grid item xs={12} sm={4}>
+        <Card padding={16} className={classes.card}>
+          <Typography className={classes.label}>Efficiency</Typography>
+          <Typography variant="h5" className={classes.value}>
+            {formatEfficiency(summary.efficiency)}
+          </Typography>
+        </Card>
+      </Grid>
+    </Grid>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/EnvironmentMultiSelect.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/EnvironmentMultiSelect.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { EnvironmentMultiSelect } from './EnvironmentMultiSelect';
+import type { Environment } from '@openchoreo/backstage-plugin-react';
+
+const environments: Environment[] = [
+  { name: 'dev', namespace: 'default', displayName: 'Development' },
+  { name: 'prod', namespace: 'default', displayName: 'Production' },
+];
+
+const getTrigger = () =>
+  screen.getByRole('textbox', { name: 'Environments' }) as HTMLInputElement;
+
+describe('EnvironmentMultiSelect', () => {
+  it('summarises the trigger label from the current selection', () => {
+    const { rerender } = render(
+      <EnvironmentMultiSelect
+        environments={environments}
+        value={[]}
+        onChange={jest.fn()}
+      />,
+    );
+    expect(getTrigger().value).toBe('Select environments');
+
+    rerender(
+      <EnvironmentMultiSelect
+        environments={environments}
+        value={['dev']}
+        onChange={jest.fn()}
+      />,
+    );
+    // A single selection shows the environment's display name.
+    expect(getTrigger().value).toBe('Development');
+
+    rerender(
+      <EnvironmentMultiSelect
+        environments={environments}
+        value={['dev', 'prod']}
+        onChange={jest.fn()}
+      />,
+    );
+    // Multiple selections list each environment's display name.
+    expect(getTrigger().value).toBe('Development, Production');
+  });
+
+  it('adds an unchecked environment to the selection on click', () => {
+    const onChange = jest.fn();
+    render(
+      <EnvironmentMultiSelect
+        environments={environments}
+        value={['dev']}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(getTrigger());
+    fireEvent.click(screen.getByText('Production'));
+    expect(onChange).toHaveBeenCalledWith(['dev', 'prod']);
+  });
+
+  it('removes an already-selected environment on click', () => {
+    const onChange = jest.fn();
+    render(
+      <EnvironmentMultiSelect
+        environments={environments}
+        value={['dev', 'prod']}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(getTrigger());
+    fireEvent.click(screen.getByText('Development'));
+    expect(onChange).toHaveBeenCalledWith(['prod']);
+  });
+
+  it('renders a skeleton instead of the control while loading', () => {
+    render(
+      <EnvironmentMultiSelect
+        environments={[]}
+        value={[]}
+        onChange={jest.fn()}
+        loading
+      />,
+    );
+    expect(
+      screen.queryByRole('textbox', { name: 'Environments' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a "No environments" note when the list is empty', () => {
+    render(
+      <EnvironmentMultiSelect
+        environments={[]}
+        value={[]}
+        onChange={jest.fn()}
+      />,
+    );
+    fireEvent.click(getTrigger());
+    // The popover is portalled; scope the query to the presentation menu.
+    const menu = screen.getByRole('presentation');
+    expect(within(menu).getByText('No environments')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/EnvironmentMultiSelect.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/EnvironmentMultiSelect.tsx
@@ -1,0 +1,130 @@
+import { FC, useRef, useState } from 'react';
+import {
+  Checkbox,
+  InputAdornment,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+  MenuList,
+  Popover,
+  TextField,
+  makeStyles,
+} from '@material-ui/core';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import { Skeleton } from '@openchoreo/backstage-design-system';
+import type { Environment } from '@openchoreo/backstage-plugin-react';
+
+export interface EnvironmentMultiSelectProps {
+  environments: Environment[];
+  /** Selected environment names. */
+  value: string[];
+  onChange: (names: string[]) => void;
+  loading?: boolean;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  size?: 'small' | 'medium';
+}
+
+const useStyles = makeStyles(theme => ({
+  trigger: {
+    cursor: 'pointer',
+    '& input': { cursor: 'pointer' },
+  },
+  list: {
+    minWidth: 220,
+    padding: theme.spacing(1, 0),
+  },
+  checkbox: { padding: theme.spacing(0.5) },
+}));
+
+/**
+ * Multi-select environment picker (checkbox popover). Observer cost data is
+ * per-environment; the page aggregates across every selected environment.
+ */
+export const EnvironmentMultiSelect: FC<EnvironmentMultiSelectProps> = ({
+  environments,
+  value,
+  onChange,
+  loading = false,
+  disabled = false,
+  fullWidth = true,
+  size = 'medium',
+}) => {
+  const classes = useStyles();
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const toggle = (name: string) => {
+    const next = value.includes(name)
+      ? value.filter(v => v !== name)
+      : [...value, name];
+    onChange(next);
+  };
+
+  const selectedSet = new Set(value);
+  const triggerLabel = (() => {
+    if (value.length === 0) return 'Select environments';
+    return value
+      .map(name => environments.find(e => e.name === name)?.displayName || name)
+      .join(', ');
+  })();
+
+  if (loading) {
+    return <Skeleton variant="rect" height={size === 'small' ? 40 : 56} />;
+  }
+
+  return (
+    <>
+      <div ref={anchorRef}>
+        <TextField
+          fullWidth={fullWidth}
+          size={size}
+          disabled={disabled}
+          variant="outlined"
+          label="Environments"
+          value={triggerLabel}
+          onClick={() => !disabled && setOpen(true)}
+          InputLabelProps={{ shrink: true }}
+          inputProps={{ 'aria-label': 'Environments' }}
+          InputProps={{
+            readOnly: true,
+            classes: { root: classes.trigger },
+            endAdornment: (
+              <InputAdornment position="end">
+                <ArrowDropDownIcon />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </div>
+      <Popover
+        open={open}
+        anchorEl={anchorRef.current}
+        onClose={() => setOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      >
+        <MenuList className={classes.list} disablePadding>
+          {environments.length === 0 && (
+            <MenuItem disabled>No environments</MenuItem>
+          )}
+          {environments.map(env => (
+            <MenuItem key={env.name} onClick={() => toggle(env.name)} dense>
+              <ListItemIcon>
+                <Checkbox
+                  edge="start"
+                  className={classes.checkbox}
+                  checked={selectedSet.has(env.name)}
+                  tabIndex={-1}
+                  disableRipple
+                  color="primary"
+                />
+              </ListItemIcon>
+              <ListItemText primary={env.displayName || env.name} />
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Popover>
+    </>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.test.ts
@@ -1,0 +1,255 @@
+import type { CostItem, CostRecommendationItem } from '../../types';
+import {
+  deriveLevel,
+  dimensionOf,
+  totalCost,
+  percentChange,
+  monthDurationMs,
+  forecastThisMonth,
+  aggregateRows,
+  computeSummary,
+  buildSeries,
+  buildCostInsightsData,
+} from './costAggregation';
+
+const costItem = (over: Partial<CostItem>): CostItem => ({
+  component: 'comp',
+  startTime: '2026-07-01T00:00:00.000Z',
+  endTime: '2026-07-01T01:00:00.000Z',
+  environment: 'dev',
+  project: 'proj',
+  namespace: 'default',
+  cpuCost: 0,
+  memoryCost: 0,
+  efficiency: 0,
+  ...over,
+});
+
+describe('deriveLevel', () => {
+  it('derives the level from breadcrumb depth', () => {
+    expect(deriveLevel({ namespace: 'ns' })).toBe('namespace');
+    expect(deriveLevel({ namespace: 'ns', project: 'p' })).toBe('project');
+    expect(deriveLevel({ namespace: 'ns', project: 'p', component: 'c' })).toBe(
+      'component',
+    );
+  });
+});
+
+describe('dimensionOf', () => {
+  const item = costItem({ project: 'p1', component: 'c1', environment: 'e1' });
+  it('groups by project / component / environment per level', () => {
+    expect(dimensionOf(item, 'namespace')).toBe('p1');
+    expect(dimensionOf(item, 'project')).toBe('c1');
+    expect(dimensionOf(item, 'component')).toBe('e1');
+  });
+});
+
+describe('totalCost & percentChange', () => {
+  it('sums cpu + memory across items', () => {
+    expect(
+      totalCost([
+        costItem({ cpuCost: 10, memoryCost: 12 }),
+        costItem({ cpuCost: 2, memoryCost: 4 }),
+      ]),
+    ).toBe(28);
+  });
+
+  it('computes percent change and guards divide-by-zero', () => {
+    expect(percentChange(110, 100)).toBeCloseTo(10);
+    expect(percentChange(90, 100)).toBeCloseTo(-10);
+    expect(percentChange(5, 0)).toBeNull();
+    expect(percentChange(5, undefined)).toBeNull();
+  });
+});
+
+describe('forecastThisMonth', () => {
+  it('extrapolates the window rate to the calendar month', () => {
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const monthMs = monthDurationMs(now); // July = 31 days
+    // 1-hour window costing $1 means rate $1/hour.
+    const forecast = forecastThisMonth(
+      1,
+      '2026-07-01T00:00:00.000Z',
+      '2026-07-01T01:00:00.000Z',
+      now,
+    );
+    expect(forecast).toBeCloseTo(monthMs / (60 * 60 * 1000));
+  });
+
+  it('falls back to the raw total for a non-positive window', () => {
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    expect(
+      forecastThisMonth(
+        42,
+        '2026-07-01T00:00:00Z',
+        '2026-07-01T00:00:00Z',
+        now,
+      ),
+    ).toBe(42);
+  });
+});
+
+describe('aggregateRows', () => {
+  it('aggregates across environments and cost-weights efficiency', () => {
+    // Same project "gcp" seen in two environments; efficiency should be
+    // weighted by spend: (0.3*22 + 0.7*6) / 28.
+    const current = [
+      costItem({
+        project: 'gcp',
+        cpuCost: 10,
+        memoryCost: 12,
+        efficiency: 0.3,
+      }),
+      costItem({
+        project: 'gcp',
+        environment: 'prod',
+        cpuCost: 2,
+        memoryCost: 4,
+        efficiency: 0.7,
+      }),
+      costItem({ project: 'shop', cpuCost: 1, memoryCost: 1, efficiency: 0.5 }),
+    ];
+    const previous = [
+      costItem({ project: 'gcp', cpuCost: 10, memoryCost: 10 }), // prev total 20
+    ];
+
+    const rows = aggregateRows(current, previous, 'namespace');
+    const gcp = rows.find(r => r.key === 'gcp')!;
+    expect(gcp.total).toBe(28);
+    expect(gcp.cpuCost).toBe(12);
+    expect(gcp.memoryCost).toBe(16);
+    expect(gcp.efficiency).toBeCloseTo((0.3 * 22 + 0.7 * 6) / 28);
+    expect(gcp.deltaPct).toBeCloseTo(((28 - 20) / 20) * 100);
+
+    const shop = rows.find(r => r.key === 'shop')!;
+    expect(shop.deltaPct).toBeNull(); // no previous data for shop
+
+    // Sorted by total descending.
+    expect(rows.map(r => r.key)).toEqual(['gcp', 'shop']);
+  });
+
+  it('attaches recommendations at the component level keyed by environment', () => {
+    const current = [
+      costItem({
+        environment: 'dev',
+        cpuCost: 2,
+        memoryCost: 3,
+        efficiency: 0.6,
+      }),
+    ];
+    const recommendations: CostRecommendationItem[] = [
+      {
+        component: 'comp',
+        environment: 'dev',
+        project: 'proj',
+        namespace: 'default',
+        current: { cpuCost: 2, memoryCost: 3 },
+        recommendation: {
+          cpuRequest: '100m',
+          memoryRequest: '128Mi',
+          cpuCost: 1,
+          memoryCost: 1,
+        },
+      },
+    ];
+
+    const rows = aggregateRows(current, [], 'component', recommendations);
+    const dev = rows.find(r => r.key === 'dev')!;
+    expect(dev.recommendation).toBeDefined();
+    expect(dev.recommendation!.total).toBe(2);
+    expect(dev.recommendation!.cpuRequest).toBe('100m');
+  });
+});
+
+describe('computeSummary', () => {
+  it('produces total, delta and efficiency', () => {
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const current = [
+      costItem({ cpuCost: 10, memoryCost: 12, efficiency: 0.3 }),
+    ];
+    const previous = [costItem({ cpuCost: 10, memoryCost: 10 })];
+    const summary = computeSummary(
+      current,
+      previous,
+      '2026-07-01T00:00:00.000Z',
+      '2026-07-01T01:00:00.000Z',
+      now,
+    );
+    expect(summary.totalCost).toBe(22);
+    expect(summary.deltaPct).toBeCloseTo(((22 - 20) / 20) * 100);
+    expect(summary.efficiency).toBeCloseTo(0.3);
+    expect(summary.forecastThisMonth).toBeGreaterThan(0);
+  });
+});
+
+describe('buildSeries', () => {
+  it('buckets by time and stacks by dimension across environments', () => {
+    const items = [
+      costItem({
+        startTime: '2026-07-01T00:00:00.000Z',
+        project: 'gcp',
+        cpuCost: 5,
+        memoryCost: 5,
+      }),
+      costItem({
+        startTime: '2026-07-01T00:00:00.000Z',
+        project: 'shop',
+        cpuCost: 1,
+        memoryCost: 1,
+      }),
+      costItem({
+        startTime: '2026-07-02T00:00:00.000Z',
+        project: 'gcp',
+        cpuCost: 3,
+        memoryCost: 3,
+      }),
+    ];
+    const { series, seriesKeys } = buildSeries(items, 'namespace');
+    expect(seriesKeys).toEqual(['gcp', 'shop']);
+    expect(series).toHaveLength(2);
+    expect(series[0]).toMatchObject({
+      timestamp: '2026-07-01T00:00:00.000Z',
+      gcp: 10,
+      shop: 2,
+    });
+    expect(series[1]).toMatchObject({
+      timestamp: '2026-07-02T00:00:00.000Z',
+      gcp: 6,
+    });
+  });
+});
+
+describe('buildCostInsightsData', () => {
+  it('assembles the level, summary, rows and series into one payload', () => {
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const data = buildCostInsightsData({
+      level: 'namespace',
+      currentItems: [
+        costItem({
+          project: 'gcp',
+          cpuCost: 10,
+          memoryCost: 12,
+          efficiency: 0.3,
+        }),
+        costItem({
+          project: 'shop',
+          cpuCost: 2,
+          memoryCost: 4,
+          efficiency: 0.7,
+        }),
+      ],
+      previousItems: [
+        costItem({ project: 'gcp', cpuCost: 10, memoryCost: 10 }),
+      ],
+      windowStart: '2026-07-01T00:00:00.000Z',
+      windowEnd: '2026-07-01T01:00:00.000Z',
+      now,
+    });
+
+    expect(data.level).toBe('namespace');
+    expect(data.summary.totalCost).toBe(28);
+    expect(data.rows.map(r => r.key)).toEqual(['gcp', 'shop']);
+    expect(data.seriesKeys).toEqual(['gcp', 'shop']);
+    expect(data.series).toHaveLength(1);
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.ts
@@ -1,0 +1,270 @@
+import type { CostItem, CostRecommendationItem } from '../../types';
+import type {
+  CostScope,
+  CostScopeLevel,
+  CostRow,
+  CostSummary,
+  CostSeriesPoint,
+  CostInsightsData,
+} from './types';
+
+/** Derive the scope level from the breadcrumb selection depth. */
+export function deriveLevel(scope: CostScope): CostScopeLevel {
+  if (scope.component) return 'component';
+  if (scope.project) return 'project';
+  return 'namespace';
+}
+
+/** The field a cost item is grouped by at the given level. */
+export function dimensionOf(item: CostItem, level: CostScopeLevel): string {
+  switch (level) {
+    case 'namespace':
+      return item.project;
+    case 'project':
+      return item.component;
+    case 'component':
+    default:
+      return item.environment;
+  }
+}
+
+const itemTotal = (item: CostItem): number =>
+  (item.cpuCost ?? 0) + (item.memoryCost ?? 0);
+
+/**
+ * Cost-weighted average efficiency across items. Efficiency of a bigger spend
+ * counts more; returns 0 when there is no spend to weight by.
+ */
+function weightedEfficiency(items: CostItem[]): number {
+  let weightSum = 0;
+  let effSum = 0;
+  for (const item of items) {
+    const weight = itemTotal(item);
+    weightSum += weight;
+    effSum += (item.efficiency ?? 0) * weight;
+  }
+  return weightSum > 0 ? effSum / weightSum : 0;
+}
+
+/** Sum of cpu + memory cost across every item. */
+export function totalCost(items: CostItem[]): number {
+  return items.reduce((sum, item) => sum + itemTotal(item), 0);
+}
+
+/** Percent change from `previous` to `current`; null when previous is 0/unknown. */
+export function percentChange(
+  current: number,
+  previous: number | undefined,
+): number | null {
+  if (previous === undefined || previous === 0) return null;
+  return ((current - previous) / previous) * 100;
+}
+
+/** Milliseconds in the calendar month that contains `now`. */
+export function monthDurationMs(now: Date): number {
+  const start = new Date(now.getFullYear(), now.getMonth(), 1);
+  const end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  return end.getTime() - start.getTime();
+}
+
+/**
+ * Forecast the current calendar month's spend by extrapolating the window's
+ * spend rate. `windowStart`/`windowEnd` bound the measured window.
+ */
+export function forecastThisMonth(
+  total: number,
+  windowStart: string,
+  windowEnd: string,
+  now: Date,
+): number {
+  const windowMs =
+    new Date(windowEnd).getTime() - new Date(windowStart).getTime();
+  if (!Number.isFinite(windowMs) || windowMs <= 0) return total;
+  const ratePerMs = total / windowMs;
+  return ratePerMs * monthDurationMs(now);
+}
+
+function groupBy<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const bucket = map.get(key);
+    if (bucket) bucket.push(item);
+    else map.set(key, [item]);
+  }
+  return map;
+}
+
+/** Previous-window totals keyed by dimension value, for delta computation. */
+function previousTotalsByDimension(
+  previousItems: CostItem[],
+  level: CostScopeLevel,
+): Map<string, number> {
+  const totals = new Map<string, number>();
+  for (const item of previousItems) {
+    const dim = dimensionOf(item, level);
+    totals.set(dim, (totals.get(dim) ?? 0) + itemTotal(item));
+  }
+  return totals;
+}
+
+/**
+ * Aggregate the flat, multi-environment cost items into one row per dimension
+ * value. At the component level, attaches the right-sizing recommendation
+ * ("Cost After Optimizing") keyed by environment.
+ */
+export function aggregateRows(
+  currentItems: CostItem[],
+  previousItems: CostItem[],
+  level: CostScopeLevel,
+  recommendations: CostRecommendationItem[] = [],
+): CostRow[] {
+  const prevTotals = previousTotalsByDimension(previousItems, level);
+  const grouped = groupBy(currentItems, item => dimensionOf(item, level));
+
+  // Recommendations are only meaningful at the component level, where rows are
+  // environments. Sum the recommended cost per environment.
+  const recByEnv = new Map<string, CostRecommendationItem[]>();
+  if (level === 'component') {
+    for (const rec of recommendations) {
+      const bucket = recByEnv.get(rec.environment);
+      if (bucket) bucket.push(rec);
+      else recByEnv.set(rec.environment, [rec]);
+    }
+  }
+
+  const rows: CostRow[] = [];
+  for (const [key, items] of grouped) {
+    const cpuCost = items.reduce((s, i) => s + (i.cpuCost ?? 0), 0);
+    const memoryCost = items.reduce((s, i) => s + (i.memoryCost ?? 0), 0);
+    const total = cpuCost + memoryCost;
+
+    let recommendation: CostRow['recommendation'];
+    if (level === 'component') {
+      const recs = recByEnv.get(key);
+      if (recs && recs.length > 0) {
+        const recCpu = recs.reduce(
+          (s, r) => s + (r.recommendation.cpuCost ?? 0),
+          0,
+        );
+        const recMem = recs.reduce(
+          (s, r) => s + (r.recommendation.memoryCost ?? 0),
+          0,
+        );
+        // Resource strings only make sense for a single component/env pair;
+        // surface the first recommendation's request/limit values.
+        const first = recs[0].recommendation;
+        recommendation = {
+          cpuRequest: first.cpuRequest,
+          cpuLimit: first.cpuLimit,
+          memoryRequest: first.memoryRequest,
+          memoryLimit: first.memoryLimit,
+          cpuCost: recCpu,
+          memoryCost: recMem,
+          total: recCpu + recMem,
+        };
+      }
+    }
+
+    rows.push({
+      key,
+      label: key,
+      cpuCost,
+      memoryCost,
+      total,
+      efficiency: weightedEfficiency(items),
+      deltaPct: percentChange(total, prevTotals.get(key)),
+      recommendation,
+    });
+  }
+
+  return rows.sort((a, b) => b.total - a.total);
+}
+
+/** Overall summary cards (total + delta + forecast + efficiency). */
+export function computeSummary(
+  currentItems: CostItem[],
+  previousItems: CostItem[],
+  windowStart: string,
+  windowEnd: string,
+  now: Date,
+): CostSummary {
+  const total = totalCost(currentItems);
+  const prevTotal = totalCost(previousItems);
+  return {
+    totalCost: total,
+    deltaPct: percentChange(total, prevTotal || undefined),
+    forecastThisMonth: forecastThisMonth(total, windowStart, windowEnd, now),
+    efficiency: weightedEfficiency(currentItems),
+  };
+}
+
+/**
+ * Build stacked-bar series: one point per time bucket (item.startTime), with a
+ * cost total for each dimension value in that bucket (summed across
+ * environments). Returns the points ordered by time plus the distinct
+ * dimension values used as stack keys.
+ */
+export function buildSeries(
+  items: CostItem[],
+  level: CostScopeLevel,
+): { series: CostSeriesPoint[]; seriesKeys: string[] } {
+  // Normalise to the parsed instant so equivalent timestamps in different
+  // textual forms (across per-environment responses) collapse into one bucket.
+  const bucketKey = (startTime: string): string => {
+    const t = new Date(startTime).getTime();
+    return Number.isNaN(t) ? startTime : new Date(t).toISOString();
+  };
+  const byBucket = groupBy(items, item => bucketKey(item.startTime));
+  const seriesKeys = new Set<string>();
+
+  const series: CostSeriesPoint[] = [...byBucket.entries()]
+    .sort(([a], [b]) => new Date(a).getTime() - new Date(b).getTime())
+    .map(([timestamp, bucketItems]) => {
+      const point: CostSeriesPoint = { timestamp };
+      for (const item of bucketItems) {
+        const dim = dimensionOf(item, level);
+        seriesKeys.add(dim);
+        point[dim] = ((point[dim] as number) ?? 0) + itemTotal(item);
+      }
+      return point;
+    });
+
+  return { series, seriesKeys: [...seriesKeys].sort() };
+}
+
+/** Assemble everything the view needs from the raw multi-env responses. */
+export function buildCostInsightsData(params: {
+  level: CostScopeLevel;
+  currentItems: CostItem[];
+  previousItems: CostItem[];
+  recommendations?: CostRecommendationItem[];
+  windowStart: string;
+  windowEnd: string;
+  now: Date;
+}): CostInsightsData {
+  const {
+    level,
+    currentItems,
+    previousItems,
+    recommendations = [],
+    windowStart,
+    windowEnd,
+    now,
+  } = params;
+
+  const { series, seriesKeys } = buildSeries(currentItems, level);
+  return {
+    level,
+    summary: computeSummary(
+      currentItems,
+      previousItems,
+      windowStart,
+      windowEnd,
+      now,
+    ),
+    rows: aggregateRows(currentItems, previousItems, level, recommendations),
+    series,
+    seriesKeys,
+  };
+}

--- a/plugins/openchoreo-observability/src/components/CostInsights/format.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/format.test.ts
@@ -1,0 +1,44 @@
+import { formatCost, formatUsd, formatEfficiency, formatDelta } from './format';
+
+describe('formatCost', () => {
+  it('renders costs with 5 decimal places so sub-cent values stay visible', () => {
+    expect(formatCost(0.00047)).toBe('0.00047');
+    expect(formatCost(0.00024)).toBe('0.00024');
+    expect(formatCost(22)).toBe('22.00000');
+    expect(formatCost(0)).toBe('0.00000');
+  });
+});
+
+describe('formatUsd', () => {
+  it('renders a card headline with a USD prefix and 2 decimals', () => {
+    expect(formatUsd(12)).toBe('USD 12.00');
+    expect(formatUsd(0.005)).toBe('USD 0.01');
+    expect(formatUsd(0)).toBe('USD 0.00');
+  });
+});
+
+describe('formatEfficiency', () => {
+  it('renders a 0..1 ratio as a rounded percentage', () => {
+    expect(formatEfficiency(0.3)).toBe('30%');
+    expect(formatEfficiency(0.456)).toBe('46%');
+    expect(formatEfficiency(1)).toBe('100%');
+    expect(formatEfficiency(0)).toBe('0%');
+  });
+});
+
+describe('formatDelta', () => {
+  it('prefixes positive deltas with a sign and rounds', () => {
+    expect(formatDelta(10)).toBe('+10%');
+    expect(formatDelta(10.4)).toBe('+10%');
+  });
+
+  it('renders negative deltas without an extra sign', () => {
+    expect(formatDelta(-3)).toBe('-3%');
+  });
+
+  it('renders an em dash for null / non-finite deltas', () => {
+    expect(formatDelta(null)).toBe('—');
+    expect(formatDelta(Infinity)).toBe('—');
+    expect(formatDelta(NaN)).toBe('—');
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/format.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/format.ts
@@ -1,0 +1,22 @@
+/** Format a cost number for a table cell, e.g. `0.00047`. */
+export function formatCost(value: number): string {
+  return value.toFixed(5);
+}
+
+/** Format a cost as a card headline, e.g. `USD 12.00`. */
+export function formatUsd(value: number): string {
+  return `USD ${value.toFixed(2)}`;
+}
+
+/** Format an efficiency ratio (0..1) as a percentage, e.g. `45%`. */
+export function formatEfficiency(ratio: number): string {
+  return `${Math.round(ratio * 100)}%`;
+}
+
+/** Format a signed delta percentage, e.g. `+10%` / `-3%` / `—`. */
+export function formatDelta(deltaPct: number | null): string {
+  if (deltaPct === null || !Number.isFinite(deltaPct)) return '—';
+  const rounded = Math.round(deltaPct);
+  const sign = rounded > 0 ? '+' : '';
+  return `${sign}${rounded}%`;
+}

--- a/plugins/openchoreo-observability/src/components/CostInsights/index.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/index.ts
@@ -1,0 +1,1 @@
+export { CostInsightsPage } from './CostInsightsPage';

--- a/plugins/openchoreo-observability/src/components/CostInsights/types.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/types.ts
@@ -1,0 +1,58 @@
+import type { CostResourceProfile } from '../../types';
+
+export type CostViewMode = 'table' | 'graph';
+
+/**
+ * The scope level is derived from how deep the breadcrumb selection goes:
+ * - `namespace`: rows are projects
+ * - `project`:   rows are components
+ * - `component`: rows are environments (with right-sizing recommendations)
+ */
+export type CostScopeLevel = 'namespace' | 'project' | 'component';
+
+export interface CostScope {
+  namespace?: string;
+  project?: string;
+  component?: string;
+}
+
+/** Recommendation ("Cost After Optimizing") shown only at the component level. */
+export interface CostRowRecommendation extends CostResourceProfile {
+  total: number;
+}
+
+export interface CostRow {
+  /** Dimension value: project / component / environment name. */
+  key: string;
+  label: string;
+  cpuCost: number;
+  memoryCost: number;
+  total: number;
+  /** Cost-weighted average efficiency in 0..1. */
+  efficiency: number;
+  /** Percent change vs the previous equal-length window (null if unknown). */
+  deltaPct: number | null;
+  recommendation?: CostRowRecommendation;
+}
+
+export interface CostSummary {
+  totalCost: number;
+  deltaPct: number | null;
+  /** Linear extrapolation of the window's spend to the current calendar month. */
+  forecastThisMonth: number;
+  efficiency: number;
+}
+
+/** One stacked-bar time bucket: `{ timestamp, [dimensionValue]: cost }`. */
+export type CostSeriesPoint = {
+  timestamp: string;
+} & Record<string, number | string>;
+
+export interface CostInsightsData {
+  level: CostScopeLevel;
+  summary: CostSummary;
+  rows: CostRow[];
+  series: CostSeriesPoint[];
+  /** Distinct dimension values used as stack keys in the graph. */
+  seriesKeys: string[];
+}

--- a/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.test.ts
@@ -1,0 +1,163 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useApi } from '@backstage/core-plugin-api';
+import { createQueryWrapper } from '@openchoreo/test-utils';
+import { useCostInsights } from './useCostInsights';
+import type { UseCostInsightsParams } from './useCostInsights';
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return { ...actual, useApi: jest.fn() };
+});
+
+// Keep the real caching wrapper; only pin the window so previous-window maths
+// and the per-env call args are deterministic.
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  ...jest.requireActual('@openchoreo/backstage-plugin-react'),
+  calculateTimeRange: jest.fn().mockReturnValue({
+    startTime: '2026-07-02T00:00:00.000Z',
+    endTime: '2026-07-02T01:00:00.000Z',
+  }),
+}));
+
+const costItem = (over: Record<string, unknown> = {}) => ({
+  component: 'comp',
+  startTime: '2026-07-02T00:00:00.000Z',
+  endTime: '2026-07-02T01:00:00.000Z',
+  environment: 'dev',
+  project: 'gcp',
+  namespace: 'default',
+  cpuCost: 10,
+  memoryCost: 12,
+  efficiency: 0.3,
+  ...over,
+});
+
+const baseParams = (
+  over: Partial<UseCostInsightsParams> = {},
+): UseCostInsightsParams => ({
+  scope: { namespace: 'default' },
+  environments: ['dev'],
+  timeRange: '1h',
+  view: 'table',
+  granularity: '1d',
+  ...over,
+});
+
+describe('useCostInsights', () => {
+  const getCosts = jest.fn();
+  const getCostRecommendations = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useApi as jest.Mock).mockReturnValue({ getCosts, getCostRecommendations });
+    getCosts.mockResolvedValue({ items: [costItem()] });
+    getCostRecommendations.mockResolvedValue({ items: [] });
+  });
+
+  it('fetches a current and previous window per environment and aggregates', async () => {
+    const { result } = renderHook(
+      () => useCostInsights(baseParams({ environments: ['dev', 'prod'] })),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 2 envs × (current + previous) = 4 cost calls; recommendations only at the
+    // component level, so none here.
+    expect(getCosts).toHaveBeenCalledTimes(4);
+    expect(getCostRecommendations).not.toHaveBeenCalled();
+    expect(result.current.data?.level).toBe('namespace');
+    expect(result.current.data?.rows.map(r => r.key)).toContain('gcp');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('requests recommendations at the component level', async () => {
+    getCostRecommendations.mockResolvedValue({
+      items: [
+        {
+          component: 'comp',
+          environment: 'dev',
+          project: 'gcp',
+          namespace: 'default',
+          current: { cpuCost: 22, memoryCost: 0 },
+          recommendation: { cpuCost: 5, memoryCost: 3 },
+        },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCostInsights(
+          baseParams({
+            scope: { namespace: 'default', project: 'gcp', component: 'comp' },
+            environments: ['dev'],
+          }),
+        ),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(getCostRecommendations).toHaveBeenCalledTimes(1);
+    const devRow = result.current.data?.rows.find(r => r.key === 'dev');
+    expect(devRow?.recommendation?.total).toBe(8);
+  });
+
+  it('passes the granularity only in graph view', async () => {
+    const { result } = renderHook(
+      () => useCostInsights(baseParams({ view: 'graph', granularity: '6h' })),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // The first call is the current window and carries the granularity.
+    expect(getCosts.mock.calls[0][2]).toEqual(
+      expect.objectContaining({ granularity: '6h' }),
+    );
+  });
+
+  it('is disabled without a namespace or environments', async () => {
+    const { result: noNs } = renderHook(
+      () => useCostInsights(baseParams({ scope: {} })),
+      { wrapper: createQueryWrapper() },
+    );
+    const { result: noEnvs } = renderHook(
+      () => useCostInsights(baseParams({ environments: [] })),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(noNs.current.loading).toBe(false));
+    await waitFor(() => expect(noEnvs.current.loading).toBe(false));
+    expect(getCosts).not.toHaveBeenCalled();
+  });
+
+  it('keeps resolved environments when only some fail', async () => {
+    getCosts.mockImplementation((_ns: string, env: string) =>
+      env === 'bad'
+        ? Promise.reject(new Error('env disabled'))
+        : Promise.resolve({ items: [costItem({ environment: env })] }),
+    );
+
+    const { result } = renderHook(
+      () => useCostInsights(baseParams({ environments: ['dev', 'bad'] })),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.data?.rows.length).toBeGreaterThan(0);
+  });
+
+  it('errors only when every environment fails', async () => {
+    getCosts.mockRejectedValue(new Error('all down'));
+
+    const { result } = renderHook(
+      () => useCostInsights(baseParams({ environments: ['dev', 'prod'] })),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.error).toBe('all down'));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.ts
@@ -1,0 +1,156 @@
+import { useApi } from '@backstage/core-plugin-api';
+import {
+  useOpenChoreoQuery,
+  calculateTimeRange,
+} from '@openchoreo/backstage-plugin-react';
+import { observabilityApiRef } from '../../api/ObservabilityApi';
+import type { CostItem, CostRecommendationItem } from '../../types';
+import { buildCostInsightsData, deriveLevel } from './costAggregation';
+import type { CostInsightsData, CostScope, CostViewMode } from './types';
+
+export interface UseCostInsightsParams {
+  scope: CostScope;
+  /** Selected environment names (multi-select). */
+  environments: string[];
+  timeRange: string;
+  customStartTime?: string;
+  customEndTime?: string;
+  view: CostViewMode;
+  /** Cost-API granularity (e.g. `1h`, `1d`), only used in graph view. */
+  granularity: string;
+}
+
+export interface UseCostInsightsResult {
+  data: CostInsightsData | undefined;
+  loading: boolean;
+  isRefetching: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Fetches cost (and, at the component level, right-sizing recommendations) for
+ * every selected environment and aggregates them client-side — the observer
+ * cost APIs are per-environment, so multi-environment totals are summed here.
+ * A second query over the previous equal-length window drives the deltas.
+ */
+export function useCostInsights(
+  params: UseCostInsightsParams,
+): UseCostInsightsResult {
+  const api = useApi(observabilityApiRef);
+  const { scope, environments, timeRange, view, granularity } = params;
+  const namespace = scope.namespace;
+  const level = deriveLevel(scope);
+  const sortedEnvs = [...environments].sort();
+
+  const enabled = Boolean(namespace) && sortedEnvs.length > 0;
+
+  const { data, loading, isRefetching, error, refetch } =
+    useOpenChoreoQuery<CostInsightsData>(
+      [
+        'cost-insights',
+        namespace ?? '',
+        scope.project ?? '',
+        scope.component ?? '',
+        sortedEnvs.join(','),
+        timeRange,
+        params.customStartTime ?? '',
+        params.customEndTime ?? '',
+        view,
+        granularity,
+      ],
+      async () => {
+        const { startTime, endTime } = calculateTimeRange(timeRange, {
+          startTime: params.customStartTime,
+          endTime: params.customEndTime,
+        });
+        // Previous equal-length window, immediately before the current one.
+        const windowMs =
+          new Date(endTime).getTime() - new Date(startTime).getTime();
+        const prevStart = new Date(
+          new Date(startTime).getTime() - windowMs,
+        ).toISOString();
+        const prevEnd = startTime;
+
+        const scopeOpts = {
+          project: scope.project,
+          component: scope.component,
+        };
+
+        const perEnv = await Promise.allSettled(
+          sortedEnvs.map(async env => {
+            const current = await api.getCosts(namespace!, env, {
+              ...scopeOpts,
+              startTime,
+              endTime,
+              granularity: view === 'graph' ? granularity : undefined,
+            });
+            const previous = await api.getCosts(namespace!, env, {
+              ...scopeOpts,
+              startTime: prevStart,
+              endTime: prevEnd,
+            });
+            const recommendations =
+              level === 'component'
+                ? await api.getCostRecommendations(namespace!, env, {
+                    ...scopeOpts,
+                    startTime,
+                    endTime,
+                  })
+                : { items: [] as CostRecommendationItem[] };
+            return {
+              current: current.items,
+              previous: previous.items,
+              recommendations: recommendations.items,
+            };
+          }),
+        );
+
+        const fulfilled = perEnv.filter(
+          (
+            r,
+          ): r is PromiseFulfilledResult<{
+            current: CostItem[];
+            previous: CostItem[];
+            recommendations: CostRecommendationItem[];
+          }> => r.status === 'fulfilled',
+        );
+
+        // Only fail outright when *every* environment failed; otherwise show
+        // the environments that resolved (a single disabled env shouldn't blank
+        // the whole page).
+        if (fulfilled.length === 0) {
+          const firstRejected = perEnv.find(r => r.status === 'rejected') as
+            | PromiseRejectedResult
+            | undefined;
+          const reason = firstRejected?.reason;
+          throw reason instanceof Error
+            ? reason
+            : new Error('Failed to load cost data');
+        }
+
+        const currentItems = fulfilled.flatMap(r => r.value.current);
+        const previousItems = fulfilled.flatMap(r => r.value.previous);
+        const recommendations = fulfilled.flatMap(r => r.value.recommendations);
+
+        return buildCostInsightsData({
+          level,
+          currentItems,
+          previousItems,
+          recommendations,
+          windowStart: startTime,
+          windowEnd: endTime,
+          now: new Date(),
+        });
+      },
+      { enabled, keepPreviousData: true },
+    );
+
+  return {
+    data,
+    loading,
+    isRefetching,
+    error: error ? error.message || 'Failed to load cost data' : null,
+    refresh: refetch,
+  };
+}

--- a/plugins/openchoreo-observability/src/components/CostInsights/useDimensionTitles.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useDimensionTitles.test.ts
@@ -1,0 +1,93 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useApi } from '@backstage/core-plugin-api';
+import { createQueryWrapper } from '@openchoreo/test-utils';
+import { useDimensionTitles } from './useDimensionTitles';
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return { ...actual, useApi: jest.fn() };
+});
+
+describe('useDimensionTitles', () => {
+  const getEntities = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useApi as jest.Mock).mockReturnValue({ getEntities });
+  });
+
+  it('maps System names to titles at the namespace level', async () => {
+    getEntities.mockResolvedValueOnce({
+      items: [
+        { metadata: { name: 'gcp', title: 'GCP Demo' } },
+        { metadata: { name: 'shop' } }, // no title, so absent from the map
+      ],
+    });
+
+    const { result } = renderHook(
+      () => useDimensionTitles('namespace', { namespace: 'default' }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current).toEqual({ gcp: 'GCP Demo' }));
+    expect(getEntities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: { kind: 'System', 'metadata.namespace': 'default' },
+      }),
+    );
+  });
+
+  it('filters Components by namespace + project annotations at the project level', async () => {
+    getEntities.mockResolvedValueOnce({
+      items: [
+        {
+          metadata: {
+            name: 'api',
+            title: 'API Service',
+            annotations: {
+              'openchoreo.io/namespace': 'default',
+              'openchoreo.io/project': 'gcp',
+            },
+          },
+        },
+        {
+          metadata: {
+            name: 'other',
+            title: 'Other',
+            annotations: {
+              'openchoreo.io/namespace': 'default',
+              'openchoreo.io/project': 'shop',
+            },
+          },
+        },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useDimensionTitles('project', { namespace: 'default', project: 'gcp' }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current).toEqual({ api: 'API Service' }));
+    // Components are namespace/project-scoped via annotations in the filter.
+    expect(getEntities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          kind: 'Component',
+          'metadata.annotations.openchoreo.io/namespace': 'default',
+          'metadata.annotations.openchoreo.io/project': 'gcp',
+        },
+      }),
+    );
+  });
+
+  it('returns an empty map without a namespace', async () => {
+    const { result } = renderHook(() => useDimensionTitles('namespace', {}), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(getEntities).not.toHaveBeenCalled());
+    expect(result.current).toEqual({});
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/useDimensionTitles.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useDimensionTitles.ts
@@ -1,0 +1,76 @@
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { useOpenChoreoQuery } from '@openchoreo/backstage-plugin-react';
+import type { CostScope, CostScopeLevel } from './types';
+
+// The catalog kind whose entities back each level's table rows.
+const KIND_BY_LEVEL: Record<CostScopeLevel, string> = {
+  namespace: 'System', // rows are projects (Project = System)
+  project: 'Component',
+  component: 'Environment',
+};
+
+/**
+ * Maps the raw dimension names the cost API returns (project / component /
+ * environment) to their catalog `metadata.title`, so table rows read "GCP
+ * Microservice Demo" instead of "gcp-microservices-demo". Names without a
+ * title are simply absent from the map (callers fall back to the name).
+ *
+ * The dimension entity kind depends on the level: at the namespace level rows
+ * are projects (System), at the project level components (Component), and at
+ * the component level environments (Environment).
+ */
+export function useDimensionTitles(
+  level: CostScopeLevel,
+  scope: CostScope,
+): Record<string, string> {
+  const catalogApi = useApi(catalogApiRef);
+
+  const { data } = useOpenChoreoQuery<Record<string, string>>(
+    [
+      'cost-insights-dimension-titles',
+      level,
+      scope.namespace ?? '',
+      scope.project ?? '',
+    ],
+    async () => {
+      const kind = KIND_BY_LEVEL[level];
+
+      // Components are namespace-scoped via annotations, not `metadata.namespace`.
+      const { items } = await catalogApi.getEntities({
+        filter:
+          kind === 'Component'
+            ? {
+                kind,
+                [`metadata.annotations.${CHOREO_ANNOTATIONS.NAMESPACE}`]:
+                  scope.namespace!,
+                [`metadata.annotations.${CHOREO_ANNOTATIONS.PROJECT}`]:
+                  scope.project!,
+              }
+            : { kind, 'metadata.namespace': scope.namespace! },
+        fields: ['metadata.name', 'metadata.title', 'metadata.annotations'],
+      });
+
+      const map: Record<string, string> = {};
+      for (const entity of items) {
+        if (kind === 'Component') {
+          const ann = entity.metadata.annotations ?? {};
+          if (
+            ann[CHOREO_ANNOTATIONS.NAMESPACE] !== scope.namespace ||
+            ann[CHOREO_ANNOTATIONS.PROJECT] !== scope.project
+          ) {
+            continue;
+          }
+        }
+        if (entity.metadata.title) {
+          map[entity.metadata.name] = entity.metadata.title;
+        }
+      }
+      return map;
+    },
+    { enabled: Boolean(scope.namespace) },
+  );
+
+  return data ?? {};
+}

--- a/plugins/openchoreo-observability/src/components/CostInsights/useNamespaceEnvironments.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useNamespaceEnvironments.test.ts
@@ -1,0 +1,85 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useApi } from '@backstage/core-plugin-api';
+import { createQueryWrapper } from '@openchoreo/test-utils';
+import { useNamespaceEnvironments } from './useNamespaceEnvironments';
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return { ...actual, useApi: jest.fn() };
+});
+
+describe('useNamespaceEnvironments', () => {
+  const getEntities = jest.fn();
+
+  const envEntity = (name: string, title?: string) => ({
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Environment',
+    metadata: {
+      name,
+      ...(title ? { title } : {}),
+      annotations: { 'openchoreo.io/namespace': 'default' },
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useApi as jest.Mock).mockReturnValue({ getEntities });
+  });
+
+  it('lists the namespace environments sorted by name', async () => {
+    getEntities.mockResolvedValueOnce({
+      items: [envEntity('prod', 'Production'), envEntity('dev', 'Development')],
+    });
+
+    const { result } = renderHook(() => useNamespaceEnvironments('default'), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(getEntities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: { kind: 'Environment', 'metadata.namespace': 'default' },
+      }),
+    );
+    expect(result.current.environments.map(e => e.name)).toEqual([
+      'dev',
+      'prod',
+    ]);
+    // Display name falls back to the catalog title.
+    expect(result.current.environments[0].displayName).toBe('Development');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('falls back to the entity name when no title is set', async () => {
+    getEntities.mockResolvedValueOnce({ items: [envEntity('dev')] });
+
+    const { result } = renderHook(() => useNamespaceEnvironments('default'), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.environments[0].displayName).toBe('dev');
+  });
+
+  it('does not query the catalog without a namespace', async () => {
+    const { result } = renderHook(() => useNamespaceEnvironments(undefined), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(getEntities).not.toHaveBeenCalled();
+    expect(result.current.environments).toEqual([]);
+  });
+
+  it('surfaces the error message on failure', async () => {
+    getEntities.mockRejectedValueOnce(new Error('catalog down'));
+
+    const { result } = renderHook(() => useNamespaceEnvironments('default'), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('catalog down'));
+    expect(result.current.environments).toEqual([]);
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/useNamespaceEnvironments.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useNamespaceEnvironments.ts
@@ -1,0 +1,62 @@
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import {
+  useOpenChoreoQuery,
+  type Environment,
+} from '@openchoreo/backstage-plugin-react';
+
+export interface UseNamespaceEnvironmentsResult {
+  environments: Environment[];
+  loading: boolean;
+  isRefetching: boolean;
+  error: string | null;
+}
+
+/**
+ * Lists the environments belonging to a namespace, straight from the catalog
+ * (`kind: Environment`). Unlike `useProjectEnvironments` this needs no project,
+ * so it works at every Cost Insights scope level — including the namespace view
+ * where no project is selected yet.
+ */
+export const useNamespaceEnvironments = (
+  namespace: string | undefined,
+): UseNamespaceEnvironmentsResult => {
+  const catalogApi = useApi(catalogApiRef);
+
+  const { data, loading, isRefetching, error } = useOpenChoreoQuery<
+    Environment[]
+  >(
+    ['cost-insights-namespace-environments', namespace ?? ''],
+    async () => {
+      if (!namespace) return [];
+      const { items } = await catalogApi.getEntities({
+        filter: { kind: 'Environment', 'metadata.namespace': namespace },
+        fields: [
+          'metadata.name',
+          'metadata.namespace',
+          'metadata.title',
+          'metadata.annotations',
+        ],
+      });
+      return items
+        .map(entry => {
+          const ann = entry.metadata.annotations ?? {};
+          return {
+            name: entry.metadata.name,
+            displayName: entry.metadata.title ?? entry.metadata.name,
+            namespace: ann[CHOREO_ANNOTATIONS.NAMESPACE] ?? namespace,
+          } as Environment;
+        })
+        .sort((a, b) => a.name.localeCompare(b.name));
+    },
+    { enabled: Boolean(namespace) },
+  );
+
+  return {
+    environments: data ?? [],
+    loading,
+    isRefetching,
+    error: error ? error.message || 'Failed to load environments' : null,
+  };
+};

--- a/plugins/openchoreo-observability/src/index.ts
+++ b/plugins/openchoreo-observability/src/index.ts
@@ -12,6 +12,16 @@ export {
   ObservabilityCostAnalysis,
 } from './plugin';
 export type { RenderLogRowAction } from './components/RuntimeLogs/LogEntry';
+export {
+  observabilityApiRef,
+  type ObservabilityApi,
+} from './api/ObservabilityApi';
+export type {
+  CostItem,
+  CostRecommendationItem,
+  CostResourceProfile,
+} from './types';
+export { CostInsightsPage } from './components/CostInsights/CostInsightsPage';
 export { useComponentHasAnyCiliumEnabledEnvironment } from './hooks';
 export {
   logRowActionRendererApiRef,

--- a/plugins/openchoreo-observability/src/types.ts
+++ b/plugins/openchoreo-observability/src/types.ts
@@ -243,3 +243,50 @@ export interface InvestigationStep {
   outcome: string;
   rationale?: string | null;
 }
+
+// -- Cost Insights types (from the observer FinOps cost/recommendation APIs) --
+
+/**
+ * A single cost data point from the observer cost endpoint. When a
+ * `granularity` is requested the endpoint returns one item per component per
+ * time bucket (so `startTime`/`endTime` describe the bucket); otherwise a
+ * single item per component spanning the whole window.
+ */
+export interface CostItem {
+  componentUid?: string;
+  component: string;
+  startTime: string;
+  endTime: string;
+  environmentUid?: string;
+  environment: string;
+  projectUid?: string;
+  project: string;
+  namespace: string;
+  cpuCost: number;
+  memoryCost: number;
+  /** Resource efficiency ratio in the range 0..1. */
+  efficiency: number;
+}
+
+/** Current or recommended resource allocation + its cost, from the observer. */
+export interface CostResourceProfile {
+  cpuRequest?: string;
+  cpuLimit?: string;
+  memoryRequest?: string;
+  memoryLimit?: string;
+  cpuCost: number;
+  memoryCost: number;
+}
+
+/** A right-sizing recommendation for a component in a given environment. */
+export interface CostRecommendationItem {
+  componentUid?: string;
+  component: string;
+  environmentUid?: string;
+  environment: string;
+  projectUid?: string;
+  project: string;
+  namespace: string;
+  current: CostResourceProfile;
+  recommendation: CostResourceProfile;
+}

--- a/plugins/openchoreo-observability/src/utils/urlTimeRange.ts
+++ b/plugins/openchoreo-observability/src/utils/urlTimeRange.ts
@@ -15,11 +15,21 @@ export interface UrlTimeRange {
 /**
  * Parse `timeRange` + `from`/`to` query params with validation.
  * If `timeRange === 'custom'` but `from`/`to` are missing or unparseable,
- * falls back to the default preset.
+ * falls back to `defaultTimeRange`.
+ *
+ * `defaultTimeRange` lets a view pick its own landing window — e.g. Cost
+ * Insights defaults to a day-scale window because OpenCost cost allocation is
+ * day-grained and a sub-hour window yields an empty accumulation.
  */
-export function parseUrlTimeRange(searchParams: URLSearchParams): UrlTimeRange {
-  const raw = searchParams.get('timeRange') || DEFAULT_TIME_RANGE;
-  let timeRange = VALID_TIME_RANGES.has(raw) ? raw : DEFAULT_TIME_RANGE;
+export function parseUrlTimeRange(
+  searchParams: URLSearchParams,
+  defaultTimeRange: string = DEFAULT_TIME_RANGE,
+): UrlTimeRange {
+  const fallback = VALID_TIME_RANGES.has(defaultTimeRange)
+    ? defaultTimeRange
+    : DEFAULT_TIME_RANGE;
+  const raw = searchParams.get('timeRange') || fallback;
+  let timeRange = VALID_TIME_RANGES.has(raw) ? raw : fallback;
   let customStartTime: string | undefined;
   let customEndTime: string | undefined;
   if (timeRange === 'custom') {
@@ -29,7 +39,7 @@ export function parseUrlTimeRange(searchParams: URLSearchParams): UrlTimeRange {
       customStartTime = from;
       customEndTime = to;
     } else {
-      timeRange = DEFAULT_TIME_RANGE;
+      timeRange = fallback;
     }
   }
   return { timeRange, customStartTime, customEndTime };
@@ -37,15 +47,17 @@ export function parseUrlTimeRange(searchParams: URLSearchParams): UrlTimeRange {
 
 /**
  * Apply a partial time-range update to a URLSearchParams instance in place.
- * Switching away from `custom` clears stale `from`/`to`. Default preset is
- * elided from the URL so it stays clean.
+ * Switching away from `custom` clears stale `from`/`to`. The `defaultTimeRange`
+ * preset is elided from the URL so it stays clean — pass the same value the
+ * view gives {@link parseUrlTimeRange} so the two stay in sync.
  */
 export function writeUrlTimeRange(
   params: URLSearchParams,
   next: Partial<UrlTimeRange>,
+  defaultTimeRange: string = DEFAULT_TIME_RANGE,
 ): void {
   if (next.timeRange !== undefined) {
-    if (next.timeRange === DEFAULT_TIME_RANGE) {
+    if (next.timeRange === defaultTimeRange) {
       params.delete('timeRange');
     } else {
       params.set('timeRange', next.timeRange);


### PR DESCRIPTION
## Purpose

Implement a cost insights view in the Backstage portal
https://github.com/openchoreo/openchoreo/issues/4381

## Goals

Provide cost information about OpenChoreo resources

## Approach
- Data layer (openchoreo-observability plugin): added getCosts / getCostRecommendations to ObservabilityClient (resolving the observer URL per namespace+environment) plus CostItem / CostRecommendationItem types.
- Aggregation (costAggregation.ts, useCostInsights): fetches costs once per selected environment (plus one extra query over the previous equal-length window for deltas), then aggregates client-side - totals, cost-weighted efficiency, % vs previous window, and a current-month forecast by linear extrapolation.
- UI: CostInsightsPage (URL-state driven), CostInsightsBreadcrumb (scope switcher mirroring the catalog compact header), CostInsightsFilters (env multi-select + Table/Graph toggle + shared Time Range + graph-only granularity), CostSummaryCards, CostInsightsTable (sortable columns, catalog-style hover/active arrows; costs shown to 5 decimals so sub-cent values are visible), and CostInsightsGraph (recharts stacked bars over time). Wired into the sidebar and /cost-insights route.
- Tests: unit tests for the aggregation logic, table (sorting + formatting), summary cards, graph, filters, environment multi-select, breadcrumb, and cost API client.

Note - Recommendations are not shown in the cost insights page yet. They will be added through a future PR


## Samples

### Namespace view
Tabular
<img width="1726" height="1025" alt="Screenshot 2026-07-31 at 16 52 44" src="https://github.com/user-attachments/assets/a830bde3-7718-46cd-903c-4fb341a4f8e6" />

Graphical
<img width="1722" height="1029" alt="Screenshot 2026-07-31 at 17 18 06" src="https://github.com/user-attachments/assets/fdc13cdd-3126-4875-85e9-744d9b6519ac" />


### Project view 
Tabular
<img width="1725" height="1029" alt="Screenshot 2026-07-31 at 16 53 04" src="https://github.com/user-attachments/assets/32b230c2-36ba-4f88-94a2-7d7cc5fe5ebd" />

Graphical
<img width="1724" height="1028" alt="Screenshot 2026-07-31 at 17 09 20" src="https://github.com/user-attachments/assets/b8c0ba27-f5d1-47a0-a244-f14a3b50bc37" />

### Component view
Tabular
<img width="1728" height="1032" alt="Screenshot 2026-07-31 at 16 56 56" src="https://github.com/user-attachments/assets/9ee7d70a-7207-4a4c-82d6-983c673253a3" />

Graphical
<img width="1724" height="1028" alt="Screenshot 2026-07-31 at 17 19 17" src="https://github.com/user-attachments/assets/2f1d5cce-067c-4bec-a33f-0ec9a0652bbc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added a Cost Insights page accessible from the portal sidebar.
- View cost summaries, forecasts, efficiency metrics, and changes over time.
- Filter insights by environment, time range, view, and graph granularity.
- Explore costs by namespace, project, and component using interactive breadcrumbs.
- Switch between visual charts and sortable tables, with optimization recommendations where available.
- Added loading, error, empty-state, and refresh feedback for cost data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->