### PR TITLE
fix: authenticate backend inter-plugin calls under auth policy

### DIFF
--- a/.changeset/authenticate-backend-inter-plugin-calls.md
+++ b/.changeset/authenticate-backend-inter-plugin-calls.md
@@ -1,0 +1,8 @@
+---
+'@openchoreo/backstage-plugin-scaffolder-backend-module': patch
+'@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth': patch
+---
+
+Authenticate backend-to-backend calls (scaffolder catalog reads and the
+sign-in `cache-capabilities` hook) with a service identity so they no longer
+return `401` once the default auth policy is enforced.

--- a/plugins/auth-backend-module-openchoreo-auth/src/auth.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/auth.ts
@@ -54,8 +54,9 @@ export const OpenChoreoAuthModule = createBackendModule({
         logger: coreServices.logger,
         config: coreServices.rootConfig,
         discovery: coreServices.discovery,
+        auth: coreServices.auth,
       },
-      async init({ providers, logger, config, discovery }) {
+      async init({ providers, logger, config, discovery, auth }) {
         // Check if auth feature is enabled (defaults to true)
         const authEnabled =
           config.getOptionalBoolean('openchoreo.features.auth.enabled') ?? true;
@@ -132,11 +133,22 @@ export const OpenChoreoAuthModule = createBackendModule({
                   const permissionBaseUrl = await discovery.getBaseUrl(
                     'permission',
                   );
+                  // Authenticate this inter-plugin call with a service token:
+                  // with the default auth policy enforced, an unauthenticated
+                  // POST is rejected with 401 and the pre-cache silently fails.
+                  const { token: serviceToken } =
+                    await auth.getPluginRequestToken({
+                      onBehalfOf: await auth.getOwnServiceCredentials(),
+                      targetPluginId: 'permission',
+                    });
                   const response = await fetch(
                     `${permissionBaseUrl}/cache-capabilities`,
                     {
                       method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
+                      headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${serviceToken}`,
+                      },
                       body: JSON.stringify({ userEntityRef, accessToken }),
                     },
                   );

--- a/plugins/scaffolder-backend-module-openchoreo/package.json
+++ b/plugins/scaffolder-backend-module-openchoreo/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.9.1",
-    "@backstage/catalog-client": "^1.15.1",
     "@backstage/config": "^1.3.8",
+    "@backstage/plugin-catalog-node": "^2.2.1",
     "@backstage/plugin-scaffolder-node": "^0.13.3",
     "@openchoreo/backstage-plugin-catalog-backend-module": "workspace:^",
     "@openchoreo/backstage-plugin-common": "workspace:^",

--- a/plugins/scaffolder-backend-module-openchoreo/src/actions/component.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/actions/component.ts
@@ -10,7 +10,7 @@ import {
   buildWorkloadResource,
   type WorkflowParameterMapping,
 } from './componentResourceBuilder';
-import { CatalogClient } from '@backstage/catalog-client';
+import { CatalogService } from '@backstage/plugin-catalog-node';
 import {
   CHOREO_ANNOTATIONS,
   ComponentTypeUtils,
@@ -21,7 +21,7 @@ import {
   type AnnotationStore,
   translateComponentToEntity,
 } from '@openchoreo/backstage-plugin-catalog-backend-module';
-import type { DiscoveryService } from '@backstage/backend-plugin-api';
+import type { AuthService } from '@backstage/backend-plugin-api';
 
 /**
  * Namespace used for cluster-scoped resources such as ClusterWorkflows.
@@ -53,7 +53,8 @@ const MAX_NAME_LENGTH = 253;
 
 export const createComponentAction = (
   config: Config,
-  discovery: DiscoveryService,
+  catalog: CatalogService,
+  auth: AuthService,
   immediateCatalog: ImmediateCatalogService,
   annotationStore: AnnotationStore,
 ) => {
@@ -239,16 +240,21 @@ export const createComponentAction = (
         `Extracted project name: ${projectName} from ${ctx.input.projectName}`,
       );
 
-      const catalogApi = new CatalogClient({
-        discoveryApi: discovery,
-      });
+      // Backend-to-backend catalog reads run under a service identity: the
+      // CatalogService attaches the service token the enforced default auth
+      // policy requires (unauthenticated inter-plugin calls are rejected with
+      // 401), and service credentials keep these lookups unaffected by catalog
+      // visibility policies.
+      const credentials = await auth.getOwnServiceCredentials();
 
       // Resolve namespace from project entity to prevent cross-namespace mismatch
       try {
         const projectRef = ctx.input.projectName.includes(':')
           ? ctx.input.projectName
           : `system:${namespaceName}/${projectName}`;
-        const projectEntity = await catalogApi.getEntityByRef(projectRef);
+        const projectEntity = await catalog.getEntityByRef(projectRef, {
+          credentials,
+        });
         if (projectEntity) {
           const projectNs =
             projectEntity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE];
@@ -267,11 +273,14 @@ export const createComponentAction = (
       // Note: This requires catalog-backend to be accessible
       try {
         // Get all components from catalog
-        const { items } = await catalogApi.getEntities({
-          filter: {
-            kind: 'Component',
+        const { items } = await catalog.getEntities(
+          {
+            filter: {
+              kind: 'Component',
+            },
           },
-        });
+          { credentials },
+        );
 
         // Filter components by namespace annotation and check if name exists
         const existsInNamespace = items.some(
@@ -411,13 +420,16 @@ export const createComponentAction = (
               namespaceFilter = { 'metadata.namespace': namespaceName };
             }
 
-            const workflowEntities = await catalogApi.getEntities({
-              filter: {
-                kind: isClusterWorkflow ? 'ClusterWorkflow' : 'Workflow',
-                'metadata.name': lookupName,
-                ...namespaceFilter,
+            const workflowEntities = await catalog.getEntities(
+              {
+                filter: {
+                  kind: isClusterWorkflow ? 'ClusterWorkflow' : 'Workflow',
+                  'metadata.name': lookupName,
+                  ...namespaceFilter,
+                },
               },
-            });
+              { credentials },
+            );
             const workflowEntity = workflowEntities.items[0];
             const annotation =
               workflowEntity?.metadata?.annotations?.[

--- a/plugins/scaffolder-backend-module-openchoreo/src/module.ts
+++ b/plugins/scaffolder-backend-module-openchoreo/src/module.ts
@@ -7,6 +7,7 @@ import {
   immediateCatalogServiceRef,
   annotationStoreRef,
 } from '@openchoreo/backstage-plugin-catalog-backend-module';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import { createComponentTypeDefinitionAction } from './actions/componentType';
 import { createResourceTypeDefinitionAction } from './actions/resourceType';
 import { createProjectTypeDefinitionAction } from './actions/projectType';
@@ -33,14 +34,16 @@ export const scaffolderModule = createBackendModule({
       deps: {
         scaffolderActions: scaffolderActionsExtensionPoint,
         config: coreServices.rootConfig,
-        discovery: coreServices.discovery,
+        auth: coreServices.auth,
+        catalog: catalogServiceRef,
         immediateCatalog: immediateCatalogServiceRef,
         annotationStore: annotationStoreRef,
       },
       async init({
         scaffolderActions,
         config,
-        discovery,
+        auth,
+        catalog,
         immediateCatalog,
         annotationStore,
       }) {
@@ -48,7 +51,8 @@ export const scaffolderModule = createBackendModule({
           createProjectAction(config, immediateCatalog),
           createComponentAction(
             config,
-            discovery,
+            catalog,
+            auth,
             immediateCatalog,
             annotationStore,
           ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10222,9 +10222,9 @@ __metadata:
   resolution: "@openchoreo/backstage-plugin-scaffolder-backend-module@workspace:plugins/scaffolder-backend-module-openchoreo"
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.9.1"
-    "@backstage/catalog-client": "npm:^1.15.1"
     "@backstage/cli": "npm:^0.36.2"
     "@backstage/config": "npm:^1.3.8"
+    "@backstage/plugin-catalog-node": "npm:^2.2.1"
     "@backstage/plugin-scaffolder-node": "npm:^0.13.3"
     "@backstage/plugin-scaffolder-node-test-utils": "npm:^0.3.11"
     "@openchoreo/backstage-plugin-catalog-backend-module": "workspace:^"


### PR DESCRIPTION
## Purpose

After the change that enforced Backstage's default auth policy (deriving the dangerouslyDisableDefaultAuthPolicy flag from the auth feature flag instead of hardcoding it to true), several backend-to-backend calls that carried no service credentials started failing with 401 Unauthorized. These calls worked in 1.2.0 only because the policy was disabled, which left the entire backend API unauthenticated. Once the policy is enforced (any auth-enabled deployment, i.e. 1.2.1+), the calls break.

Two user-visible symptoms:
  - Component creation — the scaffolder logs Failed to resolve project namespace / check for duplicate component name / fetch Workflow entity … 401 Unauthorized.
  - Permission pre-cache — the sign-in hook's POST /api/permission/cache-capabilities returns 401, so users' capability profiles are never warmed at login (leading to denied permissions / empty catalog until the profile is lazily re-fetched).

## Goals

Keep the default auth policy enforced (external unauthenticated requests stay blocked) while allowing legitimate internal backend-to-backend calls to succeed by giving them a service identity — without re-opening the security hole the flag change closed.

## Approach

Authenticated the two backend call sites that were missing a service token, using Backstage's standard service-auth mechanism:

**1. Scaffolder — scaffolder-backend-module-openchoreo**

  - Replaced the raw CatalogClient in the openchoreo:component:create action with the framework's CatalogService (catalogServiceRef), which attaches the service token automatically.
  - The three catalog reads (namespace resolution, duplicate-name check, workflow-annotation lookup) now pass { credentials } from auth.getOwnServiceCredentials() — a service identity, so lookups are unaffected by catalog visibility policies.
  - Wired coreServices.auth + catalogServiceRef into the module; dropped the now-unused discovery dependency and swapped @backstage/catalog-client for @backstage/plugin-catalog-node.

**2. Auth module — auth-backend-module-openchoreo-auth**

  - The POST /api/permission/cache-capabilities call is a custom route with no typed service client, so it can't use a CatalogService-style wrapper. Instead, the sign-in resolver now mints a service token via auth.getPluginRequestToken({ 
  -   onBehalfOf: await auth.getOwnServiceCredentials(), targetPluginId: 'permission' }) and sends it as an Authorization: Bearer <token> header on the request.
  - Wired coreServices.auth into the module's dependencies so the resolver has access to the AuthService.
  - This restores the sign-in capability pre-cache: the profile is fetched and cached at login/refresh instead of silently failing, which also fixes the downstream "new grant not visible until backend restart" behavior.

## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Backend-to-backend requests now use authenticated service identities and authorization tokens.
  * Catalog access and capability caching are protected by service authentication.

* **Reliability**
  * Improved authentication for project lookups, duplicate component checks, and workflow metadata retrieval.
  * Sign-in continues successfully even when capability caching is temporarily unavailable.

* **Maintenance**
  * Updated backend catalog integration to use the current service-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->