### PR TITLE
Reduce About and Relations card height on entity overview pages

### DIFF
--- a/.changeset/tiny-lands-draw.md
+++ b/.changeset/tiny-lands-draw.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-portal-app': patch
+---
+
+Reduce EntityCatalogGraphCard height from 400px to 300px on entity overview pages.

--- a/packages/portal-app/src/components/catalog/EntityPage.tsx
+++ b/packages/portal-app/src/components/catalog/EntityPage.tsx
@@ -325,7 +325,7 @@ function OverviewContent() {
         </EntitySwitch.Case>
       </EntitySwitch>
       <Grid item md={6} xs={12}>
-        <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+        <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
       </Grid>
     </Grid>
   );
@@ -651,7 +651,7 @@ const apiPage = (
           <EntityAboutCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
       </Grid>
     </EntityLayout.Route>
@@ -733,7 +733,7 @@ const systemPage = (
 
         {/* Row 3: Catalog Relations, full width */}
         <Grid item xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
       </Grid>
     </EntityLayout.Route>
@@ -838,7 +838,7 @@ const defaultResourcePage = (
           <EntityAboutCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={4} xs={12}>
           <EntityLinksCard />
@@ -874,7 +874,7 @@ const openchoreoResourcePage = (
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
       </Grid>
     </EntityLayout.Route>
@@ -925,7 +925,7 @@ const environmentPage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[
               RELATION_PART_OF,
               RELATION_HAS_PART,
@@ -963,7 +963,7 @@ const notificationChannelPage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[RELATION_NOTIFIES, RELATION_NOTIFIED_BY]}
             renderNode={CustomGraphNode}
           />
@@ -1001,7 +1001,7 @@ const dataplanePage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[
               RELATION_PART_OF,
               RELATION_HAS_PART,
@@ -1043,7 +1043,7 @@ const clusterDataplanePage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[
               RELATION_HOSTED_ON,
               RELATION_HOSTS,
@@ -1075,7 +1075,7 @@ const workflowPlanePage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[
               RELATION_PART_OF,
               RELATION_HAS_PART,
@@ -1109,7 +1109,7 @@ const clusterWorkflowPlanePage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[
               RELATION_OBSERVED_BY,
               RELATION_OBSERVES,
@@ -1151,7 +1151,7 @@ const observabilityPlanePage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[
               RELATION_PART_OF,
               RELATION_HAS_PART,
@@ -1188,7 +1188,7 @@ const clusterObservabilityPlanePage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[RELATION_OBSERVED_BY, RELATION_OBSERVES]}
             renderNode={CustomGraphNode}
           />
@@ -1222,7 +1222,7 @@ const deploymentPipelinePage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[
               RELATION_PART_OF,
               RELATION_HAS_PART,
@@ -1254,7 +1254,7 @@ const componentTypePage = (
           <ComponentTypeOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1276,7 +1276,7 @@ const resourceTypePage = (
           <ResourceTypeOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1301,7 +1301,7 @@ const traitTypePage = (
           <TraitTypeOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1323,7 +1323,7 @@ const clusterComponentTypePage = (
           <ComponentTypeOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1345,7 +1345,7 @@ const clusterResourceTypePage = (
           <ResourceTypeOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1367,7 +1367,7 @@ const projectTypePage = (
           <ProjectTypeOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1389,7 +1389,7 @@ const clusterProjectTypePage = (
           <ProjectTypeOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1411,7 +1411,7 @@ const clusterTraitTypePage = (
           <TraitTypeOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1436,7 +1436,7 @@ const workflowPage = (
           <WorkflowOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1467,7 +1467,7 @@ const clusterWorkflowPage = (
           <WorkflowOverviewCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityCatalogGraphCard height={400} renderNode={CustomGraphNode} />
+          <EntityCatalogGraphCard height={300} renderNode={CustomGraphNode} />
         </Grid>
         <Grid item md={12} xs={12}>
           <OpenChoreoAboutCard variant="gridItem" showEditIcon />
@@ -1502,7 +1502,7 @@ const componentWorkflowPage = (
         </Grid>
         <Grid item md={6} xs={12}>
           <EntityCatalogGraphCard
-            height={400}
+            height={300}
             relations={[
               RELATION_PART_OF,
               RELATION_HAS_PART,


### PR DESCRIPTION
## Purpose

Related to openchoreo/openchoreo#3906

Reduce the height of the About and Relations cards on entity overview pages by lowering the `EntityCatalogGraphCard` height from `400px` to `300px`.

## Goals

- Reduce the vertical size of the About and Relations cards by approximately 25%.
- Maintain the existing layout and responsiveness.

## Approach

- Updated all `EntityCatalogGraphCard` instances in `packages/portal-app/src/components/catalog/EntityPage.tsx` to use `height={300}` instead of `height={400}`.
- The About card continues to resize automatically through the existing grid layout.


## User stories

- As a user, I can view more information on entity overview pages with reduced card height while keeping the relations graph readable.

## Release note

Reduced the height of the About and Relations cards on entity overview pages.

## Documentation

N/A – This is a UI layout adjustment and does not require documentation changes.

## Training

N/A

## Certification

N/A – No certification impact.

## Marketing

N/A

## Automation tests

- Unit tests
  - N/A
- Integration tests
  - N/A

## Security checks

- Followed secure coding standards? **Yes**
- Ran FindSecurityBugs plugin? **No** (not applicable for this UI-only change)
- Confirmed no secrets were committed? **Yes**

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

- Code reviewed locally.
- UI could not be verified due to local environment setup issues.

## Learning

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the catalog relationship graph height from 400px to 300px on entity overview pages.
  * Applied the updated sizing consistently across components, APIs, systems, resources, platforms, types, and workflows.
  * Graph relationships and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->