### PR TITLE
fix(portal-app): register the Jenkins frontend plugin

### DIFF
--- a/.changeset/register-jenkins-frontend-plugin.md
+++ b/.changeset/register-jenkins-frontend-plugin.md
@@ -1,0 +1,16 @@
+---
+'@openchoreo/backstage-portal-app': patch
+'@openchoreo/backstage-plugin-catalog-backend-module': patch
+---
+
+Register the Jenkins frontend plugin so the build-status card and tab work.
+`EntityLatestJenkinsRunCard` and `EntityJenkinsContent` are entity cards and
+tabs rather than routes, so `convertLegacyAppRoot` never discovered the plugin
+and `jenkinsApiRef` had no factory — the entity page threw
+`NotImplementedError: No implementation available for apiRef{plugin.jenkins.service2}`.
+Same fix already applied for api-docs and kubernetes.
+
+Also clarifies the scaffolder's CI identifier field: it takes a Jenkins job
+**full name** (`my-folder/my-job`), not a `/job/...` URL path. The plugin adds
+the `/job/` segments itself, so a URL-style value resolves to a folder literally
+named `job` and 404s.

--- a/packages/portal-app/src/createPortalApp.tsx
+++ b/packages/portal-app/src/createPortalApp.tsx
@@ -65,6 +65,11 @@ import catalogImportPluginAlpha from '@backstage/plugin-catalog-import/alpha';
 // they depend on are absent and the tabs throw `NotImplementedError`.
 import apiDocsPluginAlpha from '@backstage/plugin-api-docs/alpha';
 import kubernetesPluginAlpha from '@backstage/plugin-kubernetes/alpha';
+// Same reasoning for Jenkins: we reuse `EntityLatestJenkinsRunCard` and
+// `EntityJenkinsContent` on the entity page, but those are cards/tabs rather
+// than routes, so `convertLegacyAppRoot` never discovers the plugin and
+// `jenkinsApiRef` (`plugin.jenkins.service2`) has no factory.
+import jenkinsPluginAlpha from '@backstage-community/plugin-jenkins/alpha';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
@@ -220,6 +225,7 @@ export function createPortalApp(options?: PortalAppOptions) {
       catalogImportPluginAlpha,
       apiDocsPluginAlpha,
       kubernetesPluginAlpha,
+      jenkinsPluginAlpha,
       openchoreoPluginAlpha,
       openchoreoCiPluginAlpha,
       openchoreoObservabilityPluginAlpha,

--- a/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/converters/CtdToTemplateConverter.ts
@@ -368,7 +368,8 @@ export class CtdToTemplateConverter {
           title: 'CI Job / Project Identifier',
           type: 'string',
           description:
-            'Identifier for the external CI job (e.g., Jenkins job path, GitHub repo slug, or GitLab project ID).',
+            'Identifier for the external CI job (e.g., Jenkins job full name such as ' +
+            '`my-folder/my-job`, GitHub repo slug, or GitLab project ID).',
         },
       },
     };


### PR DESCRIPTION
Entity cards and tabs are not routes, so convertLegacyAppRoot never discovers the Jenkins plugin and jenkinsApiRef has no factory. Same fix already applied for api-docs and kubernetes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jenkins integration support to the portal app.
  * Jenkins entity cards and tabs can now access the required Jenkins API functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->