### PR TITLE
fix: map WorkflowRun UI status from WorkflowCompleted reasons

### DIFF
--- a/.changeset/workflowrun-completed-status.md
+++ b/.changeset/workflowrun-completed-status.md
@@ -1,0 +1,10 @@
+---
+'@openchoreo/backstage-plugin-common': patch
+'@openchoreo/backstage-plugin-openchoreo-workflows-backend': patch
+'@openchoreo/backstage-plugin-openchoreo-ci-backend': patch
+'@openchoreo/backstage-plugin-backend': patch
+---
+
+Map WorkflowRun UI status from `WorkflowCompleted` condition reasons (and typed
+`WorkflowFailed`/`WorkflowSucceeded`), so completed failures no longer show as
+Pending when only the aggregate condition is present.

--- a/plugins/openchoreo-backend/src/services/transformers/transformers.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/transformers.test.ts
@@ -447,7 +447,7 @@ describe('transformComponentWorkflowRun', () => {
     expect(result.workflow?.name).toBe('docker-build');
   });
 
-  it('derives status from Ready condition reason', () => {
+  it('derives status as Failed from Ready condition failure reason', () => {
     const withReason: OpenChoreoComponents['schemas']['WorkflowRun'] = {
       ...run,
       status: {
@@ -461,8 +461,39 @@ describe('transformComponentWorkflowRun', () => {
         ],
       },
     };
-    expect(transformComponentWorkflowRun(withReason).status).toBe(
-      'BuildFailed',
+    expect(transformComponentWorkflowRun(withReason).status).toBe('Failed');
+  });
+
+  it('derives status as Failed from WorkflowCompleted reason WorkflowFailed', () => {
+    const completedFailed: OpenChoreoComponents['schemas']['WorkflowRun'] = {
+      ...run,
+      status: {
+        completedAt: '2026-08-04T10:26:02Z',
+        conditions: [
+          {
+            type: 'WorkflowCompleted',
+            status: 'True',
+            reason: 'WorkflowFailed',
+            lastTransitionTime: '2026-08-04T10:26:02Z',
+          },
+          {
+            type: 'WorkflowRunning',
+            status: 'False',
+            reason: 'WorkflowRunning',
+            lastTransitionTime: '2026-08-04T10:26:02Z',
+          },
+        ],
+        tasks: [
+          {
+            name: 'verify-prerequisites',
+            phase: 'Pending',
+            startedAt: '2026-08-04T09:55:40Z',
+          },
+        ],
+      },
+    };
+    expect(transformComponentWorkflowRun(completedFailed).status).toBe(
+      'Failed',
     );
   });
 

--- a/plugins/openchoreo-backend/src/services/transformers/workflow-run.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/workflow-run.ts
@@ -1,6 +1,9 @@
 import type { OpenChoreoComponents } from '@openchoreo/openchoreo-client-node';
 import type { ComponentWorkflowRunResponse } from '@openchoreo/backstage-plugin-common';
-import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
+import {
+  CHOREO_LABELS,
+  deriveWorkflowRunDisplayStatus,
+} from '@openchoreo/backstage-plugin-common';
 
 // New K8s-style WorkflowRun (metadata + spec + status)
 type WorkflowRun = OpenChoreoComponents['schemas']['WorkflowRun'];
@@ -16,49 +19,13 @@ export function transformComponentWorkflowRun(
   const labels = run.metadata?.labels ?? {};
   const annotations = run.metadata?.annotations ?? {};
 
-  // Derive overall status.
-  // completedAt is the strongest signal — if set, the run is definitively done
-  // and we never return an in-progress status even if K8s conditions are stale.
-  const readyCondition = run.status?.conditions?.find(c => c.type === 'Ready');
-  const tasks = (run.status?.tasks ?? []) as Array<{
-    phase?: string;
-    completedAt?: string;
-  }>;
-
-  let status: string;
-  if (run.status?.completedAt) {
-    if (tasks.some(t => t.phase === 'Failed' || t.phase === 'Error')) {
-      status = 'Failed';
-    } else {
-      const reason = readyCondition?.reason;
-      status =
-        reason && reason !== 'Running' && reason !== 'Pending'
-          ? reason
-          : 'Succeeded';
-    }
-  } else if (readyCondition) {
-    status =
-      readyCondition.reason ||
-      (readyCondition.status === 'True' ? 'Succeeded' : 'Running');
-  } else if (tasks.some(t => t.phase === 'Failed' || t.phase === 'Error')) {
-    status = 'Failed';
-  } else if (tasks.length > 0 && tasks.every(t => t.phase === 'Succeeded')) {
-    status = 'Succeeded';
-  } else if (tasks.some(t => t.phase === 'Running')) {
-    status = 'Running';
-  } else if (run.status?.startedAt) {
-    status = 'Running';
-  } else {
-    status = 'Pending';
-  }
-
   return {
     name: run.metadata?.name ?? '',
     uuid: run.metadata?.uid ?? '',
     componentName: labels[CHOREO_LABELS.WORKFLOW_COMPONENT] ?? '',
     projectName: labels[CHOREO_LABELS.WORKFLOW_PROJECT] ?? '',
     namespaceName: run.metadata?.namespace ?? '',
-    status,
+    status: deriveWorkflowRunDisplayStatus(run),
     commit: annotations['openchoreo.dev/commit'],
     image: annotations['openchoreo.dev/image'],
     createdAt: run.metadata?.creationTimestamp,

--- a/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
+++ b/plugins/openchoreo-ci-backend/src/services/WorkflowService.ts
@@ -8,6 +8,7 @@ import {
 } from '@openchoreo/openchoreo-client-node';
 import {
   CHOREO_LABELS,
+  deriveWorkflowRunDisplayStatus,
   type ComponentWorkflowRunResponse,
   type ComponentWorkflowRunStatusResponse,
   type WorkflowResponse,
@@ -23,51 +24,9 @@ type ModelsBuild = ComponentWorkflowRunResponse;
 
 type WorkflowRunStatusResponse = ComponentWorkflowRunStatusResponse;
 
-/**
- * Derive a string status from a raw K8s WorkflowRun.
- *
- * completedAt is treated as the strongest signal: if set, the run is
- * definitively done and we never return an in-progress status, even if
- * the K8s conditions are stale (e.g. controller hasn't reconciled yet).
- */
+/** @see deriveWorkflowRunDisplayStatus */
 function deriveWorkflowRunStatus(run: any): string {
-  const readyCondition = (run.status?.conditions ?? []).find(
-    (c: any) => c.type === 'Ready',
-  );
-  const tasks = (run.status?.tasks ?? []) as any[];
-
-  // completedAt is the strongest completion signal — takes priority
-  if (run.status?.completedAt) {
-    if (tasks.some((t: any) => t.phase === 'Failed' || t.phase === 'Error')) {
-      return 'Failed';
-    }
-    const reason = readyCondition?.reason;
-    if (reason && reason !== 'Running' && reason !== 'Pending') {
-      return reason;
-    }
-    return 'Succeeded';
-  }
-
-  // Trust the Ready condition when the run has not yet completed
-  if (readyCondition) {
-    return (
-      readyCondition.reason ||
-      (readyCondition.status === 'True' ? 'Succeeded' : 'Running')
-    );
-  }
-
-  // No conditions — fall back to tasks then timing
-  if (tasks.some((t: any) => t.phase === 'Failed' || t.phase === 'Error')) {
-    return 'Failed';
-  }
-  if (tasks.every((t: any) => t.phase === 'Succeeded') && tasks.length > 0) {
-    return 'Succeeded';
-  }
-  if (tasks.some((t: any) => t.phase === 'Running')) {
-    return 'Running';
-  }
-  if (run.status?.startedAt) return 'Running';
-  return 'Pending';
+  return deriveWorkflowRunDisplayStatus(run);
 }
 
 /** Transform a raw K8s-style WorkflowRun object into the flat ModelsBuild shape. */

--- a/plugins/openchoreo-common/src/index.ts
+++ b/plugins/openchoreo-common/src/index.ts
@@ -298,6 +298,12 @@ export type {
 
 // Workflow status helpers (shared by build/workflow log + event tabs)
 export { isTerminalStatus, isStepLive } from './workflowStatus';
+export {
+  deriveWorkflowRunDisplayStatus,
+  type WorkflowRunStatusCondition,
+  type WorkflowRunStatusSource,
+  type WorkflowRunStatusTask,
+} from './workflowRunStatus';
 
 // Observability types — aligned with /api/v1/logs/query response schema
 import type { ObservabilityComponents } from '@openchoreo/openchoreo-client-node';

--- a/plugins/openchoreo-common/src/workflowRunStatus.test.ts
+++ b/plugins/openchoreo-common/src/workflowRunStatus.test.ts
@@ -152,9 +152,7 @@ describe('deriveWorkflowRunDisplayStatus', () => {
     expect(
       deriveWorkflowRunDisplayStatus({
         status: {
-          conditions: [
-            { type: 'WorkloadUpdated', status: 'True', reason: '' },
-          ],
+          conditions: [{ type: 'WorkloadUpdated', status: 'True', reason: '' }],
         },
       }),
     ).toBe('Completed');

--- a/plugins/openchoreo-common/src/workflowRunStatus.test.ts
+++ b/plugins/openchoreo-common/src/workflowRunStatus.test.ts
@@ -1,0 +1,199 @@
+import { deriveWorkflowRunDisplayStatus } from './workflowRunStatus';
+
+describe('deriveWorkflowRunDisplayStatus', () => {
+  it('returns Pending when status is absent', () => {
+    expect(deriveWorkflowRunDisplayStatus({})).toBe('Pending');
+  });
+
+  it('returns Failed for typed WorkflowFailed condition', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          conditions: [
+            { type: 'WorkflowFailed', status: 'True', reason: 'Failed' },
+          ],
+        },
+      }),
+    ).toBe('Failed');
+  });
+
+  it('returns Succeeded for typed WorkflowSucceeded condition', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          conditions: [
+            { type: 'WorkflowSucceeded', status: 'True', reason: 'Succeeded' },
+          ],
+        },
+      }),
+    ).toBe('Succeeded');
+  });
+
+  it('returns Failed for WorkflowCompleted=True reason WorkflowFailed', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:26:02Z',
+          conditions: [
+            {
+              type: 'WorkflowCompleted',
+              status: 'True',
+              reason: 'WorkflowFailed',
+              message: 'Workflow has been deleted from the cluster',
+            },
+            {
+              type: 'WorkflowRunning',
+              status: 'False',
+              reason: 'WorkflowRunning',
+            },
+          ],
+          tasks: [{ phase: 'Pending' }],
+        },
+      }),
+    ).toBe('Failed');
+  });
+
+  it('returns Failed for WorkflowCompleted ComponentValidationFailed', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [
+            {
+              type: 'WorkflowCompleted',
+              status: 'True',
+              reason: 'ComponentValidationFailed',
+            },
+          ],
+        },
+      }),
+    ).toBe('Failed');
+  });
+
+  it('returns Succeeded for WorkflowCompleted=True reason WorkflowSucceeded', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [
+            {
+              type: 'WorkflowCompleted',
+              status: 'True',
+              reason: 'WorkflowSucceeded',
+            },
+          ],
+        },
+      }),
+    ).toBe('Succeeded');
+  });
+
+  it('prefers WorkflowCompleted failure over typed WorkflowSucceeded', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [
+            {
+              type: 'WorkflowSucceeded',
+              status: 'True',
+              reason: 'WorkflowSucceeded',
+            },
+            {
+              type: 'WorkflowCompleted',
+              status: 'True',
+              reason: 'WorkflowFailed',
+            },
+          ],
+        },
+      }),
+    ).toBe('Failed');
+  });
+
+  it('normalizes unrecognized terminal WorkflowCompleted reason to Completed', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [
+            {
+              type: 'WorkflowCompleted',
+              status: 'True',
+              reason: 'Cancelled',
+            },
+          ],
+        },
+      }),
+    ).toBe('Completed');
+  });
+
+  it('does not treat WorkflowCompleted=False WorkflowPending as terminal Failed', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          startedAt: '2026-08-04T10:00:00Z',
+          conditions: [
+            {
+              type: 'WorkflowCompleted',
+              status: 'False',
+              reason: 'WorkflowPending',
+            },
+            {
+              type: 'WorkflowRunning',
+              status: 'True',
+              reason: 'WorkflowRunning',
+            },
+          ],
+        },
+      }),
+    ).toBe('Running');
+  });
+
+  it('returns Completed for WorkloadUpdated', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          conditions: [
+            { type: 'WorkloadUpdated', status: 'True', reason: '' },
+          ],
+        },
+      }),
+    ).toBe('Completed');
+  });
+
+  it('returns Failed from completedAt when a task phase is Failed', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [],
+          tasks: [{ phase: 'Failed' }],
+        },
+      }),
+    ).toBe('Failed');
+  });
+
+  it('returns Succeeded from completedAt when no failure signal', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'False',
+              reason: 'Running',
+            },
+          ],
+        },
+      }),
+    ).toBe('Succeeded');
+  });
+
+  it('returns Running from startedAt when no conditions', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: { startedAt: '2026-08-04T10:00:00Z', conditions: [] },
+      }),
+    ).toBe('Running');
+  });
+});

--- a/plugins/openchoreo-common/src/workflowRunStatus.test.ts
+++ b/plugins/openchoreo-common/src/workflowRunStatus.test.ts
@@ -194,4 +194,146 @@ describe('deriveWorkflowRunDisplayStatus', () => {
       }),
     ).toBe('Running');
   });
+
+  it('returns Failed from completedAt when WorkflowCompleted is False but reason is failed', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [
+            {
+              type: 'WorkflowCompleted',
+              status: 'False',
+              reason: 'WorkflowFailed',
+            },
+          ],
+          tasks: [{ phase: 'Pending' }],
+        },
+      }),
+    ).toBe('Failed');
+  });
+
+  it('returns Ready reason from completedAt when it is not a failure signal', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [{ type: 'Ready', status: 'True', reason: 'Completed' }],
+        },
+      }),
+    ).toBe('Completed');
+  });
+
+  it('returns Failed from Ready condition reason without completedAt', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          conditions: [
+            { type: 'Ready', status: 'False', reason: 'ValidationFailed' },
+          ],
+        },
+      }),
+    ).toBe('Failed');
+  });
+
+  it('returns Ready reason when present without completedAt', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          conditions: [{ type: 'Ready', status: 'False', reason: 'Running' }],
+        },
+      }),
+    ).toBe('Running');
+  });
+
+  it('returns Succeeded when Ready is True without reason', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          conditions: [{ type: 'Ready', status: 'True' }],
+        },
+      }),
+    ).toBe('Succeeded');
+  });
+
+  it('returns Running when Ready is False without reason', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          conditions: [{ type: 'Ready', status: 'False' }],
+        },
+      }),
+    ).toBe('Running');
+  });
+
+  it('returns Failed from task phase without completedAt', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: { tasks: [{ phase: 'Failed' }] },
+      }),
+    ).toBe('Failed');
+  });
+
+  it('returns Succeeded when all tasks succeeded without completedAt', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          tasks: [{ phase: 'Succeeded' }, { phase: 'Succeeded' }],
+        },
+      }),
+    ).toBe('Succeeded');
+  });
+
+  it('returns Running from task phase without timestamps', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: { tasks: [{ phase: 'Running' }] },
+      }),
+    ).toBe('Running');
+  });
+
+  it('does not treat WorkflowPending as failure in Ready reason', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          conditions: [
+            { type: 'Ready', status: 'False', reason: 'WorkflowPending' },
+          ],
+        },
+      }),
+    ).toBe('WorkflowPending');
+  });
+
+  it('returns Succeeded from completedAt when Ready reason is Running', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [{ type: 'Ready', status: 'False', reason: 'Running' }],
+        },
+      }),
+    ).toBe('Succeeded');
+  });
+
+  it('returns Succeeded from completedAt when Ready reason is Pending', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [{ type: 'Ready', status: 'False', reason: 'Pending' }],
+        },
+      }),
+    ).toBe('Succeeded');
+  });
+
+  it('returns Succeeded from completedAt when WorkflowCompleted has no reason', () => {
+    expect(
+      deriveWorkflowRunDisplayStatus({
+        status: {
+          completedAt: '2026-08-04T10:00:00Z',
+          conditions: [{ type: 'WorkflowCompleted', status: 'False' }],
+        },
+      }),
+    ).toBe('Succeeded');
+  });
 });

--- a/plugins/openchoreo-common/src/workflowRunStatus.ts
+++ b/plugins/openchoreo-common/src/workflowRunStatus.ts
@@ -40,6 +40,7 @@ export type WorkflowRunStatusSource = {
 
 const FAILURE_REASON_RE = /Fail|Error|Invalid|Denied|Timeout/i;
 
+/** True when a condition reason indicates terminal or in-progress failure. */
 function isFailureReason(reason?: string): boolean {
   if (!reason) return false;
   if (
@@ -52,6 +53,7 @@ function isFailureReason(reason?: string): boolean {
   return FAILURE_REASON_RE.test(reason);
 }
 
+/** True when a WorkflowCompleted (or similar) reason denotes success. */
 function isSuccessReason(reason?: string): boolean {
   return (
     reason === 'WorkflowSucceeded' ||

--- a/plugins/openchoreo-common/src/workflowRunStatus.ts
+++ b/plugins/openchoreo-common/src/workflowRunStatus.ts
@@ -1,0 +1,163 @@
+/**
+ * Derive a UI-facing WorkflowRun status from the raw K8s-style CR.
+ *
+ * OpenChoreo controllers expose two overlapping condition vocabularies:
+ *   - typed: WorkflowFailed / WorkflowSucceeded / WorkflowRunning
+ *   - completed: WorkflowCompleted=True with reason WorkflowFailed|WorkflowSucceeded|…
+ *
+ * UI that only checks typed conditions mis-labels completed failures as Pending.
+ * completedAt is a terminal signal, but must not map to Succeeded when
+ * WorkflowCompleted reason indicates failure — status.tasks can lag
+ * (e.g. stuck Pending while Argo already Failed).
+ *
+ * Failure from `WorkflowCompleted` takes precedence over typed
+ * `WorkflowSucceeded` when both are present.
+ *
+ * See also openchoreo/openchoreo#3877 (controller sets typed WorkflowFailed on
+ * some validation paths) and the WorkflowRun API condition docs.
+ */
+
+export type WorkflowRunStatusCondition = {
+  type?: string;
+  status?: string;
+  reason?: string;
+  message?: string;
+};
+
+export type WorkflowRunStatusTask = {
+  phase?: string;
+  completedAt?: string;
+};
+
+export type WorkflowRunStatusSource = {
+  status?: {
+    conditions?: WorkflowRunStatusCondition[];
+    tasks?: WorkflowRunStatusTask[];
+    startedAt?: string;
+    completedAt?: string;
+  };
+};
+
+const FAILURE_REASON_RE = /Fail|Error|Invalid|Denied|Timeout/i;
+
+function isFailureReason(reason?: string): boolean {
+  if (!reason) return false;
+  if (
+    reason === 'Running' ||
+    reason === 'Pending' ||
+    reason === 'WorkflowPending'
+  ) {
+    return false;
+  }
+  return FAILURE_REASON_RE.test(reason);
+}
+
+function isSuccessReason(reason?: string): boolean {
+  return (
+    reason === 'WorkflowSucceeded' ||
+    reason === 'Succeeded' ||
+    reason === 'Completed'
+  );
+}
+
+/**
+ * Returns a display status string used by portal CI/Workflows UIs:
+ * Pending | Running | Succeeded | Failed | Completed.
+ */
+export function deriveWorkflowRunDisplayStatus(
+  run: WorkflowRunStatusSource,
+): string {
+  const conditions = run.status?.conditions ?? [];
+  const tasks = (run.status?.tasks ?? []) as WorkflowRunStatusTask[];
+
+  if (
+    conditions.some(c => c.type === 'WorkflowFailed' && c.status === 'True')
+  ) {
+    return 'Failed';
+  }
+
+  const workflowCompleted = conditions.find(
+    c => c.type === 'WorkflowCompleted',
+  );
+  // Prefer aggregate completion failure over typed success when both exist.
+  if (
+    workflowCompleted?.status === 'True' &&
+    isFailureReason(workflowCompleted.reason)
+  ) {
+    return 'Failed';
+  }
+
+  if (
+    conditions.some(c => c.type === 'WorkflowSucceeded' && c.status === 'True')
+  ) {
+    return 'Succeeded';
+  }
+
+  if (workflowCompleted?.status === 'True') {
+    const reason = workflowCompleted.reason;
+    if (isSuccessReason(reason) || !reason) {
+      return 'Succeeded';
+    }
+    // Unrecognized terminal reasons stay within the documented status set.
+    if (
+      reason !== 'Running' &&
+      reason !== 'Pending' &&
+      reason !== 'WorkflowPending'
+    ) {
+      return 'Completed';
+    }
+  }
+
+  if (
+    conditions.some(c => c.type === 'WorkloadUpdated' && c.status === 'True')
+  ) {
+    return 'Completed';
+  }
+
+  const readyCondition = conditions.find(c => c.type === 'Ready');
+
+  if (run.status?.completedAt) {
+    if (tasks.some(t => t.phase === 'Failed' || t.phase === 'Error')) {
+      return 'Failed';
+    }
+    // Stale tasks may still say Pending while the run is done — prefer
+    // WorkflowCompleted reason over inventing Succeeded.
+    if (workflowCompleted && isFailureReason(workflowCompleted.reason)) {
+      return 'Failed';
+    }
+    const reason = readyCondition?.reason;
+    if (reason && reason !== 'Running' && reason !== 'Pending') {
+      return isFailureReason(reason) ? 'Failed' : reason;
+    }
+    return 'Succeeded';
+  }
+
+  if (readyCondition) {
+    const reason = readyCondition.reason;
+    if (reason) {
+      if (isFailureReason(reason)) return 'Failed';
+      return reason;
+    }
+    return readyCondition.status === 'True' ? 'Succeeded' : 'Running';
+  }
+
+  if (
+    conditions.some(c => c.type === 'WorkflowRunning' && c.status === 'True')
+  ) {
+    return 'Running';
+  }
+
+  if (tasks.some(t => t.phase === 'Failed' || t.phase === 'Error')) {
+    return 'Failed';
+  }
+  if (tasks.length > 0 && tasks.every(t => t.phase === 'Succeeded')) {
+    return 'Succeeded';
+  }
+  if (tasks.some(t => t.phase === 'Running')) {
+    return 'Running';
+  }
+  if (run.status?.startedAt) {
+    return 'Running';
+  }
+  return 'Pending';
+}

--- a/plugins/openchoreo-workflows-backend/package.json
+++ b/plugins/openchoreo-workflows-backend/package.json
@@ -34,6 +34,7 @@
     "@backstage/backend-defaults": "^0.17.1",
     "@backstage/backend-plugin-api": "^1.9.1",
     "@backstage/errors": "^1.3.1",
+    "@openchoreo/backstage-plugin-common": "workspace:^",
     "@openchoreo/openchoreo-auth": "workspace:^",
     "@openchoreo/openchoreo-client-node": "workspace:^",
     "express": "4.21.1",

--- a/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
+++ b/plugins/openchoreo-workflows-backend/src/services/GenericWorkflowService.ts
@@ -6,7 +6,10 @@ import {
   fetchAllPages,
   ObservabilityUrlResolver,
 } from '@openchoreo/openchoreo-client-node';
-import { CHOREO_LABELS } from '@openchoreo/backstage-plugin-common';
+import {
+  CHOREO_LABELS,
+  deriveWorkflowRunDisplayStatus,
+} from '@openchoreo/backstage-plugin-common';
 import {
   Workflow,
   WorkflowRun,
@@ -17,49 +20,9 @@ import {
   WorkflowRunEventEntry,
 } from '../types';
 
-/**
- * Derive a display status from a raw K8s-style WorkflowRun object.
- *
- * Checks conditions in priority order, matching the Go-side
- * getComponentWorkflowStatus logic:
- *   1. WorkloadUpdated + True → Completed
- *   2. WorkflowFailed  + True → Failed
- *   3. WorkflowSucceeded + True → Succeeded
- *   4. WorkflowRunning + True → Running
- *   5. Default → Pending
- */
+/** @see deriveWorkflowRunDisplayStatus */
 function deriveWorkflowRunStatus(run: any): string {
-  const conditions = (run.status?.conditions ?? []) as any[];
-
-  if (conditions.length === 0) {
-    return 'Pending';
-  }
-
-  if (
-    conditions.some(c => c.type === 'WorkloadUpdated' && c.status === 'True')
-  ) {
-    return 'Completed';
-  }
-
-  if (
-    conditions.some(c => c.type === 'WorkflowFailed' && c.status === 'True')
-  ) {
-    return 'Failed';
-  }
-
-  if (
-    conditions.some(c => c.type === 'WorkflowSucceeded' && c.status === 'True')
-  ) {
-    return 'Succeeded';
-  }
-
-  if (
-    conditions.some(c => c.type === 'WorkflowRunning' && c.status === 'True')
-  ) {
-    return 'Running';
-  }
-
-  return 'Pending';
+  return deriveWorkflowRunDisplayStatus(run);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -10030,6 +10030,7 @@ __metadata:
     "@backstage/backend-test-utils": "npm:^1.11.3"
     "@backstage/cli": "npm:^0.36.2"
     "@backstage/errors": "npm:^1.3.1"
+    "@openchoreo/backstage-plugin-common": "workspace:^"
     "@openchoreo/openchoreo-auth": "workspace:^"
     "@openchoreo/openchoreo-client-node": "workspace:^"
     "@types/express": "npm:4.17.21"


### PR DESCRIPTION
## Summary

- Add shared `deriveWorkflowRunDisplayStatus` that understands both typed conditions (`WorkflowFailed` / `WorkflowSucceeded`) and aggregate `WorkflowCompleted=True` + reason (`WorkflowFailed`, `ComponentValidationFailed`, `WorkflowSucceeded`, …).
- Use it from Workflows backend, CI backend, and `transformComponentWorkflowRun` so completed failures no longer show as **Pending** (or false **Succeeded** when `tasks[]` lag).

Fixes openchoreo/openchoreo#4442  
Related: https://github.com/openchoreo/openchoreo/issues/4419  
Related controller fix class: https://github.com/openchoreo/openchoreo/pull/3877

## Context

On some terminal failure paths the WorkflowRun CR has:

- `completedAt` set
- `WorkflowCompleted=True reason=WorkflowFailed`
- **no** typed `WorkflowFailed=True`
- stale `tasks[].phase: Pending`

`GenericWorkflowService.deriveWorkflowRunStatus` previously only checked typed conditions → default **Pending**. CI/`completedAt` paths could even report **Succeeded** when tasks were not Failed.

## Test plan

- [x] Unit tests for `deriveWorkflowRunDisplayStatus` (`workflowRunStatus.test.ts`)
- [x] Transformer test for `WorkflowCompleted` + stale Pending task → Failed
- [ ] Manual: failed WorkflowRun with only `WorkflowCompleted/WorkflowFailed` → Workflows + CI chips show **Failed**
- [ ] Manual: succeeded run with `WorkflowCompleted/WorkflowSucceeded` still shows **Succeeded**
- [ ] Manual: running run with `WorkflowRunning=True` still shows **Running**


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WorkflowRun status display across workflow views for completed, failed, succeeded, running, and pending workflows.
  * Failed runs now consistently appear as **Failed**, rather than showing an underlying failure reason.
  * Completed workflows are correctly prioritized over stale task statuses and accurately reflect completion outcomes.
  * Status handling is now consistent across all workflow views.

* **Tests**
  * Added comprehensive coverage for workflow status mapping, completion details, pending tasks, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->