### PR TITLE
fix: treat more ReleaseBinding Ready reasons as progressing

### DIFF
--- a/.changeset/releasebinding-progressing-reasons.md
+++ b/.changeset/releasebinding-progressing-reasons.md
@@ -1,0 +1,6 @@
+---
+'@openchoreo/backstage-plugin-backend': patch
+---
+
+Treat ReleaseBinding Ready reasons `ReleaseSynced`, `ResourceDependenciesPending`,
+and `ResourcesNotReady` as progressing (NotReady) instead of Failed.

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
@@ -44,6 +44,42 @@ describe('deriveBindingStatus', () => {
     expect(deriveBindingStatus(binding)).toBe('Ready');
   });
 
+  it('returns NotReady for ReleaseSynced reason while release is not synced', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'ReleaseSynced',
+        message: 'Release is not synced',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns NotReady for ResourceDependenciesPending reason on Ready', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'ResourceDependenciesPending',
+        message: '1 resource dependencies pending, 0 resolved',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
+  it('returns NotReady for ResourcesNotReady reason', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'ResourcesNotReady',
+        message: 'Deployment has unavailable replicas',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
+
   it('returns NotReady for ResourcesProgressing reason', () => {
     const binding = makeBinding([
       {

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -9,8 +9,16 @@ import { getName, getNamespace, getCreatedAt } from './common';
 
 type NewReleaseBinding = OpenChoreoComponents['schemas']['ReleaseBinding'];
 
-/** Reasons on the Ready condition that indicate transient progress, not an error. */
+/**
+ * Reasons on the Ready condition that indicate transient progress, not an error.
+ * Keep aligned with ReleaseBinding controller condition reasons
+ * (internal/controller/releasebinding/controller_conditions.go).
+ */
 const PROGRESSING_REASONS = [
+  // Sync / dependency / rollout phases commonly seen right after deploy.
+  'ReleaseSynced',
+  'ResourceDependenciesPending',
+  'ResourcesNotReady',
   'ResourcesProgressing',
   'JobRunning',
   'ConnectionsPending',


### PR DESCRIPTION
## Summary

- Extend `PROGRESSING_REASONS` with `ReleaseSynced`, `ResourceDependenciesPending`, and `ResourcesNotReady`.
- Keep existing upstream reasons (`ResourcesProgressing`, `JobRunning`, `ConnectionsPending`, `ResourcesUnknown`, `ProjectReleaseNotSet`).
- Add unit coverage for the new reasons.

Fixes openchoreo/openchoreo#4441

## Context

Right after deploy the controller commonly sets `Ready=False` with sync/dependency reasons. Without them in `PROGRESSING_REASONS`, the portal shows **Failed** during normal rollout.

## Test plan

- [x] Unit tests for `ReleaseSynced`, `ResourceDependenciesPending`, `ResourcesNotReady` → NotReady
- [x] Existing progressing/failure reason tests still pass
- [ ] Manual: deploy component → binding status stays NotReady/Pending during sync, becomes Ready (or real Failed) only on terminal outcome


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release status reporting by classifying synchronization and dependency-related conditions as progressing rather than failed.
  * Release bindings now remain marked as **Not Ready** while required resources are still syncing, pending, or becoming available.

* **Tests**
  * Added coverage for the updated release-binding status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->