### PR TITLE
feat: show recommendations that lead to cost savings and provide a mechanism to update the releaseBinding to apply them

### DIFF
--- a/.changeset/cost-insights-recommendations-apply.md
+++ b/.changeset/cost-insights-recommendations-apply.md
@@ -1,0 +1,23 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': minor
+'@openchoreo/backstage-plugin-react': patch
+---
+
+Extend the component-level **Cost Insights** table to show right-sizing
+recommendations and apply them in one click.
+
+- **Recommendation table**: per-environment rows show the current cost (with
+  cpu/memory breakdown), an efficiency bar, the recommended resource-request
+  change (e.g. `cpu 100m → 12m`), the resulting saving (with percentage), and an
+  **Apply** button.
+- **Apply action**: resolves the environment's ReleaseBinding, shows a
+  confirm-diff dialog, and applies the recommended CPU/memory. Gated on the
+  env-scoped `releasebinding:update` permission; the button is disabled when
+  there is nothing to apply.
+- **Stale-recommendation guard**: recommendations are withheld (with an
+  explanatory notice showing the spec update time) when the binding was updated
+  after the selected window started, plus a 5-minute settling buffer, so
+  pre-change usage can't produce misleading recommendations.
+- **Polish**: costs rounded to 2 decimals, more prominent summary-card values,
+  gap-filling for missing graph buckets, and a full loader (no stale data) when
+  the window/scope changes.

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.tsx
@@ -192,7 +192,7 @@ export const CostInsightsPage = () => {
   );
 
   // --- Cost data ---
-  const { data, loading, isRefetching, error } = useCostInsights({
+  const { data, loading, isRefetching, error, refresh } = useCostInsights({
     scope,
     environments: selectedEnvironments,
     timeRange,
@@ -298,6 +298,8 @@ export const CostInsightsPage = () => {
                   onDrill={data.level === 'component' ? undefined : onDrill}
                   icon={app.getSystemIcon(`kind:${LEVEL_KIND[data.level]}`)}
                   titles={titles}
+                  scope={scope}
+                  onOptimized={refresh}
                 />
               )}
             </Box>

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CostInsightsTable } from './CostInsightsTable';
-import type { CostRow } from './types';
+import type { CostRow, CostScope } from './types';
+
+// The Apply button pulls in Backstage APIs (discovery, catalog, permission);
+// stub it so the table test stays a pure rendering test.
+jest.mock('./CostOptimizeButton', () => ({
+  CostOptimizeButton: ({ env }: { env: string }) => (
+    <button type="button">Apply {env}</button>
+  ),
+}));
 
 const rows: CostRow[] = [
   {
@@ -23,18 +31,198 @@ const rows: CostRow[] = [
   },
 ];
 
+const scope: CostScope = {
+  namespace: 'default',
+  project: 'demo',
+  component: 'ad',
+};
+
 describe('CostInsightsTable', () => {
   it('renders the standard columns for a namespace-level view', () => {
     render(<CostInsightsTable level="namespace" rows={rows} />);
     expect(screen.getByText('Project')).toBeInTheDocument();
     expect(screen.getByText('gcp')).toBeInTheDocument();
-    expect(screen.getByText('22.00000')).toBeInTheDocument();
+    expect(screen.getByText('22.00')).toBeInTheDocument();
     expect(screen.getByText('30%')).toBeInTheDocument(); // efficiency
     expect(screen.getByText('+10%')).toBeInTheDocument(); // delta
     expect(screen.getByText('—')).toBeInTheDocument(); // null delta for shop
   });
 
-  it('renders an Environment table without optimizing columns at component level', () => {
+  it('renders the recommendation columns, the resource change and saving, and an Apply button at component level', () => {
+    const componentRows: CostRow[] = [
+      {
+        key: 'dev',
+        label: 'dev',
+        cpuCost: 2,
+        memoryCost: 3,
+        total: 5,
+        efficiency: 0.6,
+        deltaPct: null,
+        recommendation: {
+          cpuRequest: '50m',
+          cpuLimit: '100m',
+          memoryRequest: '64Mi',
+          memoryLimit: '128Mi',
+          cpuCost: 1,
+          memoryCost: 1.5,
+          total: 2.5,
+          current: {
+            cpuRequest: '100m',
+            memoryRequest: '128Mi',
+          },
+        },
+      },
+    ];
+    render(
+      <CostInsightsTable
+        level="component"
+        rows={componentRows}
+        scope={scope}
+        onOptimized={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Environment')).toBeInTheDocument();
+    expect(screen.getByText('Current cost (USD)')).toBeInTheDocument();
+    expect(screen.getByText('Recommended change')).toBeInTheDocument();
+    expect(screen.getByText('Saving (USD)')).toBeInTheDocument();
+    // Saving = current total − recommended total: 5 − 2.5.
+    expect(screen.getByText('2.50')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument(); // saving percentage
+    // The resource-request changes driving the saving.
+    expect(screen.getByText('→ 50m')).toBeInTheDocument();
+    expect(screen.getByText('→ 64Mi')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Apply dev' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the stale-recommendation notice with the spec update time', () => {
+    const componentRows: CostRow[] = [
+      {
+        key: 'dev',
+        label: 'dev',
+        cpuCost: 2,
+        memoryCost: 3,
+        total: 5,
+        efficiency: 0.6,
+        deltaPct: null,
+        recommendationStale: true,
+        recommendationStaleSince: '2026-08-01T10:30:00.000Z',
+      },
+    ];
+    render(
+      <CostInsightsTable
+        level="component"
+        rows={componentRows}
+        scope={scope}
+        onOptimized={jest.fn()}
+      />,
+    );
+    expect(screen.getByText(/release binding was updated/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/after this time window started/),
+    ).toBeInTheDocument();
+    // No Apply button while the recommendation is withheld.
+    expect(
+      screen.queryByRole('button', { name: /Apply/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a dash for a non-positive saving (recommended cost not lower)', () => {
+    const componentRows: CostRow[] = [
+      {
+        key: 'dev',
+        label: 'dev',
+        cpuCost: 2,
+        memoryCost: 3,
+        total: 5,
+        efficiency: 0.6,
+        deltaPct: null,
+        recommendation: {
+          cpuRequest: '200m',
+          cpuCost: 4,
+          memoryCost: 4,
+          total: 8, // higher than current 5 -> saving is negative
+          current: { cpuRequest: '100m' },
+        },
+      },
+    ];
+    render(
+      <CostInsightsTable
+        level="component"
+        rows={componentRows}
+        scope={scope}
+        onOptimized={jest.fn()}
+      />,
+    );
+    // The recommended change still renders, but the saving is dashed.
+    expect(screen.getByText('→ 200m')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('sorts component rows by saving and toggles other columns', () => {
+    const componentRows: CostRow[] = [
+      {
+        key: 'dev',
+        label: 'dev',
+        cpuCost: 2,
+        memoryCost: 3,
+        total: 5,
+        efficiency: 0.6,
+        deltaPct: null,
+        recommendation: {
+          cpuRequest: '50m',
+          cpuCost: 1,
+          memoryCost: 1,
+          total: 2, // saving 3
+          current: { cpuRequest: '100m' },
+        },
+      },
+      {
+        key: 'prod',
+        label: 'prod',
+        cpuCost: 4,
+        memoryCost: 4,
+        total: 8,
+        efficiency: 0.9,
+        deltaPct: null,
+        recommendation: {
+          cpuRequest: '70m',
+          cpuCost: 3,
+          memoryCost: 3,
+          total: 6, // saving 2
+          current: { cpuRequest: '100m' },
+        },
+      },
+    ];
+    render(
+      <CostInsightsTable
+        level="component"
+        rows={componentRows}
+        scope={scope}
+        onOptimized={jest.fn()}
+      />,
+    );
+
+    const envCells = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1)
+        .map(row => row.querySelector('td')?.textContent);
+
+    // Default: highest saving first (dev 3 before prod 2).
+    expect(envCells()).toEqual(['dev', 'prod']);
+
+    // Sorting by Environment ascending orders alphabetically.
+    fireEvent.click(screen.getByRole('button', { name: /Environment/ }));
+    expect(envCells()).toEqual(['dev', 'prod']);
+
+    // Sorting by Efficiency descending puts prod (0.9) first.
+    fireEvent.click(screen.getByRole('button', { name: /Efficiency/ }));
+    expect(envCells()).toEqual(['prod', 'dev']);
+  });
+
+  it('shows dashes and no Apply button when a row has no recommendation', () => {
     const componentRows: CostRow[] = [
       {
         key: 'dev',
@@ -46,11 +234,18 @@ describe('CostInsightsTable', () => {
         deltaPct: null,
       },
     ];
-    render(<CostInsightsTable level="component" rows={componentRows} />);
-    expect(screen.getByText('Environment')).toBeInTheDocument();
-    expect(screen.queryByText('Cost After Optimizing')).not.toBeInTheDocument();
-    expect(screen.getByText('dev')).toBeInTheDocument();
-    expect(screen.getByText('5.00000')).toBeInTheDocument(); // total
+    render(
+      <CostInsightsTable
+        level="component"
+        rows={componentRows}
+        scope={scope}
+        onOptimized={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Recommended change')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Apply/ }),
+    ).not.toBeInTheDocument();
   });
 
   it('drills into a row when onDrill is provided', () => {

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.tsx
@@ -1,6 +1,7 @@
 import { FC, useMemo, useState } from 'react';
 import {
   Link,
+  LinearProgress,
   Table,
   TableBody,
   TableCell,
@@ -13,13 +14,34 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import type { IconComponent } from '@backstage/core-plugin-api';
-import type { CostRow, CostScopeLevel } from './types';
+import type {
+  CostRow,
+  CostRowRecommendation,
+  CostScope,
+  CostScopeLevel,
+} from './types';
 import { formatCost, formatEfficiency, formatDelta } from './format';
+import { CostOptimizeButton } from './CostOptimizeButton';
+import { hasApplyableRecommendation } from './optimizeChange';
+
+/** Human-readable local time for the binding's spec update, shown in the notice. */
+function formatSpecUpdateTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
 
 const useStyles = makeStyles(theme => ({
   numeric: { textAlign: 'right', whiteSpace: 'nowrap' },
   up: { color: theme.palette.error.main },
   down: { color: theme.palette.success.main },
+  savings: { color: theme.palette.success.main, fontWeight: 600 },
   // Bold, link-coloured dimension names, matching the catalog table.
   nameCell: { fontWeight: 600 },
   nameWrap: {
@@ -41,6 +63,63 @@ const useStyles = makeStyles(theme => ({
     cursor: 'pointer',
   },
   empty: { padding: theme.spacing(4), textAlign: 'center' },
+  // Extra vertical room for the stacked cell content.
+  recRow: {
+    '& > td': {
+      paddingTop: theme.spacing(2),
+      paddingBottom: theme.spacing(2),
+    },
+  },
+
+  // Component-level recommendation table
+  envCell: { whiteSpace: 'nowrap' },
+  envWrap: { display: 'flex', alignItems: 'center', gap: theme.spacing(1.5) },
+  envDot: {
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    backgroundColor: theme.palette.primary.main,
+    flexShrink: 0,
+  },
+  envName: { fontWeight: 700, fontSize: '1rem' },
+  costMain: { fontWeight: 600 },
+  subText: {
+    color: theme.palette.text.secondary,
+    fontSize: '0.75rem',
+    whiteSpace: 'nowrap',
+  },
+  effWrap: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+  },
+  effBar: {
+    flexGrow: 1,
+    minWidth: 80,
+    maxWidth: 160,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: theme.palette.divider,
+  },
+  effValue: { minWidth: 40, whiteSpace: 'nowrap' },
+  change: {
+    fontFamily: 'monospace',
+    fontSize: '0.8rem',
+    whiteSpace: 'nowrap',
+  },
+  staleNotice: {
+    color: theme.palette.text.secondary,
+    fontStyle: 'italic',
+    fontSize: '0.8rem',
+  },
+  changeNew: { color: theme.palette.success.main },
+  changeEmpty: { color: theme.palette.text.secondary },
+  savingMain: {
+    color: theme.palette.success.main,
+    fontWeight: 700,
+    fontSize: '1.1rem',
+  },
+  actionCell: { textAlign: 'right', whiteSpace: 'nowrap' },
 }));
 
 const dimensionHeader = (level: CostScopeLevel): string => {
@@ -89,9 +168,260 @@ export interface CostInsightsTableProps {
   icon?: IconComponent;
   /** Raw dimension name to catalog title, for display (keys stay raw names). */
   titles?: Record<string, string>;
+  /** Current scope, needed to apply a recommendation (component level only). */
+  scope?: CostScope;
+  /** Called after an Optimize apply succeeds, so the page can refetch. */
+  onOptimized?: () => void;
 }
 
-export const CostInsightsTable: FC<CostInsightsTableProps> = ({
+const EmptyState: FC = () => {
+  const classes = useStyles();
+  return (
+    <Paper variant="outlined">
+      <Typography className={classes.empty} color="textSecondary">
+        No cost data for the selected scope, environments and time range.
+      </Typography>
+    </Paper>
+  );
+};
+
+/** The recommendation's total saving over the current spend (null if unknown). */
+const savingOf = (row: CostRow): number | null =>
+  row.recommendation ? row.total - row.recommendation.total : null;
+
+/** Percent of current spend the recommendation saves (0 when no current spend). */
+const savingPctOf = (row: CostRow): number | null => {
+  const saving = savingOf(row);
+  if (saving === null) return null;
+  return row.total > 0 ? (saving / row.total) * 100 : 0;
+};
+
+/** One resource-request change (e.g. `cpu 100m → 12m`) driving the saving. */
+interface ReqChange {
+  label: string;
+  from: string;
+  to: string;
+}
+
+/** The request changes a recommendation applies, for the "Recommended change" column. */
+function recommendedChanges(
+  rec: CostRowRecommendation | undefined,
+): ReqChange[] {
+  if (!rec) return [];
+  const current = rec.current ?? {};
+  const changes: ReqChange[] = [];
+  if (
+    rec.cpuRequest &&
+    current.cpuRequest &&
+    rec.cpuRequest !== current.cpuRequest
+  ) {
+    changes.push({
+      label: 'cpu',
+      from: current.cpuRequest,
+      to: rec.cpuRequest,
+    });
+  }
+  if (
+    rec.memoryRequest &&
+    current.memoryRequest &&
+    rec.memoryRequest !== current.memoryRequest
+  ) {
+    changes.push({
+      label: 'memory',
+      from: current.memoryRequest,
+      to: rec.memoryRequest,
+    });
+  }
+  return changes;
+}
+
+/**
+ * Component-level cost table: one row per environment, surfacing the right-sizing
+ * recommendation. current cost breakdown, efficiency bar, the resource change
+ * that drives the saving, the saving itself, and an Apply button. Sorted by
+ * saving (highest first) by default.
+ */
+const RecommendationCostTable: FC<CostInsightsTableProps> = ({
+  rows,
+  titles,
+  scope,
+  onOptimized,
+}) => {
+  const classes = useStyles();
+  const [orderBy, setOrderBy] = useState<
+    'name' | 'total' | 'efficiency' | 'saving'
+  >('saving');
+  const [order, setOrder] = useState<SortOrder>('desc');
+
+  const onSort = (id: typeof orderBy) => {
+    if (orderBy === id) {
+      setOrder(prev => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setOrderBy(id);
+      setOrder(id === 'name' ? 'asc' : 'desc');
+    }
+  };
+
+  const sortedRows = useMemo(() => {
+    const decorated = rows.map(row => ({
+      row,
+      display: titles?.[row.key] ?? row.label,
+    }));
+    const factor = order === 'asc' ? 1 : -1;
+    const valueOf = (row: CostRow): number | null => {
+      switch (orderBy) {
+        case 'total':
+          return row.total;
+        case 'efficiency':
+          return row.efficiency;
+        case 'saving':
+        default:
+          return savingOf(row);
+      }
+    };
+    return decorated.sort((a, b) => {
+      if (orderBy === 'name')
+        return factor * a.display.localeCompare(b.display);
+      const av = valueOf(a.row);
+      const bv = valueOf(b.row);
+      // Rows without a recommendation (null saving) always sort last.
+      if (av === null && bv === null) return 0;
+      if (av === null) return 1;
+      if (bv === null) return -1;
+      return factor * (av - bv);
+    });
+  }, [rows, titles, order, orderBy]);
+
+  const sortLabel = (id: typeof orderBy, label: string) => (
+    <TableSortLabel
+      active={orderBy === id}
+      direction={orderBy === id ? order : 'asc'}
+      onClick={() => onSort(id)}
+    >
+      {label}
+    </TableSortLabel>
+  );
+
+  return (
+    <TableContainer component={Paper} variant="outlined">
+      <Table aria-label="Cost insights">
+        <TableHead>
+          <TableRow>
+            <TableCell>{sortLabel('name', 'Environment')}</TableCell>
+            <TableCell className={classes.numeric}>
+              {sortLabel('total', 'Current cost (USD)')}
+            </TableCell>
+            <TableCell>{sortLabel('efficiency', 'Efficiency')}</TableCell>
+            <TableCell>Recommended change</TableCell>
+            <TableCell className={classes.numeric}>
+              {sortLabel('saving', 'Saving (USD)')}
+            </TableCell>
+            <TableCell className={classes.actionCell} />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedRows.map(({ row, display }) => {
+            const changes = recommendedChanges(row.recommendation);
+            const saving = savingOf(row);
+            const savingPct = savingPctOf(row);
+            return (
+              <TableRow key={row.key} className={classes.recRow}>
+                <TableCell className={classes.envCell}>
+                  <span className={classes.envWrap}>
+                    <span className={classes.envDot} />
+                    <span className={classes.envName}>{display}</span>
+                  </span>
+                </TableCell>
+                <TableCell className={classes.numeric}>
+                  <div className={classes.costMain}>
+                    {formatCost(row.total)}
+                  </div>
+                  <div className={classes.subText}>
+                    cpu {formatCost(row.cpuCost)} · mem{' '}
+                    {formatCost(row.memoryCost)}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <span className={classes.effWrap}>
+                    <LinearProgress
+                      variant="determinate"
+                      value={Math.min(100, Math.max(0, row.efficiency * 100))}
+                      className={classes.effBar}
+                    />
+                    <span className={classes.effValue}>
+                      {formatEfficiency(row.efficiency)}
+                    </span>
+                  </span>
+                </TableCell>
+                {row.recommendationStale ? (
+                  <TableCell colSpan={3} className={classes.staleNotice}>
+                    The component's release binding was updated
+                    {row.recommendationStaleSince
+                      ? ` on ${formatSpecUpdateTime(
+                          row.recommendationStaleSince,
+                        )}`
+                      : ''}
+                    , after this time window started, so recommendations can't
+                    be shown. Select a time range that starts at least 5 minutes
+                    after that time. The buffer lets fresh cost data be
+                    collected for the updated spec.
+                  </TableCell>
+                ) : (
+                  <>
+                    <TableCell>
+                      {changes.length === 0 ? (
+                        <span className={classes.changeEmpty}>—</span>
+                      ) : (
+                        changes.map(c => (
+                          <div key={c.label} className={classes.change}>
+                            {c.label} {c.from}{' '}
+                            <span className={classes.changeNew}>→ {c.to}</span>
+                          </div>
+                        ))
+                      )}
+                    </TableCell>
+                    <TableCell className={classes.numeric}>
+                      {saving === null || saving <= 0 ? (
+                        '—'
+                      ) : (
+                        <>
+                          <div className={classes.savingMain}>
+                            {formatCost(saving)}
+                          </div>
+                          {savingPct !== null && (
+                            <div className={classes.subText}>
+                              {Math.round(savingPct)}%
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </TableCell>
+                    <TableCell className={classes.actionCell}>
+                      {scope &&
+                        onOptimized &&
+                        hasApplyableRecommendation(row.recommendation) && (
+                          <CostOptimizeButton
+                            env={row.key}
+                            recommendation={row.recommendation}
+                            scope={scope}
+                            onOptimized={onOptimized}
+                            disabled={changes.length === 0}
+                          />
+                        )}
+                    </TableCell>
+                  </>
+                )}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+/** Namespace / project level table: cost breakdown per dimension, drillable. */
+const StandardCostTable: FC<CostInsightsTableProps> = ({
   level,
   rows,
   onDrill,
@@ -99,10 +429,6 @@ export const CostInsightsTable: FC<CostInsightsTableProps> = ({
   titles,
 }) => {
   const classes = useStyles();
-
-  // Default sort: highest total cost first (like the catalog's default sort on
-  // Created). Clicking a header toggles asc/desc; the active column shows the
-  // arrow, and hovering any header reveals it.
   const [orderBy, setOrderBy] = useState<SortId>('total');
   const [order, setOrder] = useState<SortOrder>('desc');
 
@@ -111,7 +437,6 @@ export const CostInsightsTable: FC<CostInsightsTableProps> = ({
       setOrder(prev => (prev === 'asc' ? 'desc' : 'asc'));
     } else {
       setOrderBy(id);
-      // Names read naturally ascending; costs are most useful highest-first.
       setOrder(id === 'name' ? 'asc' : 'desc');
     }
   };
@@ -128,7 +453,6 @@ export const CostInsightsTable: FC<CostInsightsTableProps> = ({
       }
       const av = a.row[orderBy];
       const bv = b.row[orderBy];
-      // Unknown values (null deltas / efficiency) always sort last.
       if (av === null && bv === null) return 0;
       if (av === null) return 1;
       if (bv === null) return -1;
@@ -136,15 +460,15 @@ export const CostInsightsTable: FC<CostInsightsTableProps> = ({
     });
   }, [rows, titles, order, orderBy]);
 
-  if (rows.length === 0) {
-    return (
-      <Paper variant="outlined">
-        <Typography className={classes.empty} color="textSecondary">
-          No cost data for the selected scope, environments and time range.
-        </Typography>
-      </Paper>
-    );
-  }
+  const sortLabel = (id: SortId, label: string) => (
+    <TableSortLabel
+      active={orderBy === id}
+      direction={orderBy === id ? order : 'asc'}
+      onClick={() => onSort(id)}
+    >
+      {label}
+    </TableSortLabel>
+  );
 
   return (
     <TableContainer component={Paper} variant="outlined">
@@ -152,122 +476,95 @@ export const CostInsightsTable: FC<CostInsightsTableProps> = ({
         <TableHead>
           <TableRow>
             <TableCell sortDirection={orderBy === 'name' ? order : false}>
-              <TableSortLabel
-                active={orderBy === 'name'}
-                direction={orderBy === 'name' ? order : 'asc'}
-                onClick={() => onSort('name')}
-              >
-                {dimensionHeader(level)}
-              </TableSortLabel>
+              {sortLabel('name', dimensionHeader(level))}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'cpuCost' ? order : false}
             >
-              <TableSortLabel
-                active={orderBy === 'cpuCost'}
-                direction={orderBy === 'cpuCost' ? order : 'asc'}
-                onClick={() => onSort('cpuCost')}
-              >
-                CPU (USD)
-              </TableSortLabel>
+              {sortLabel('cpuCost', 'CPU (USD)')}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'memoryCost' ? order : false}
             >
-              <TableSortLabel
-                active={orderBy === 'memoryCost'}
-                direction={orderBy === 'memoryCost' ? order : 'asc'}
-                onClick={() => onSort('memoryCost')}
-              >
-                Memory (USD)
-              </TableSortLabel>
+              {sortLabel('memoryCost', 'Memory (USD)')}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'efficiency' ? order : false}
             >
-              <TableSortLabel
-                active={orderBy === 'efficiency'}
-                direction={orderBy === 'efficiency' ? order : 'asc'}
-                onClick={() => onSort('efficiency')}
-              >
-                Efficiency
-              </TableSortLabel>
+              {sortLabel('efficiency', 'Efficiency')}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'total' ? order : false}
             >
-              <TableSortLabel
-                active={orderBy === 'total'}
-                direction={orderBy === 'total' ? order : 'asc'}
-                onClick={() => onSort('total')}
-              >
-                Total (USD)
-              </TableSortLabel>
+              {sortLabel('total', 'Total (USD)')}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'deltaPct' ? order : false}
             >
-              <TableSortLabel
-                active={orderBy === 'deltaPct'}
-                direction={orderBy === 'deltaPct' ? order : 'asc'}
-                onClick={() => onSort('deltaPct')}
-              >
-                Inc/dec vs prev window
-              </TableSortLabel>
+              {sortLabel('deltaPct', 'Inc/dec vs prev window')}
             </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {sortedRows.map(({ row, display }) => {
-            return (
-              <TableRow key={row.key}>
-                <TableCell className={classes.nameCell}>
-                  <span className={classes.nameWrap}>
-                    {KindIcon && (
-                      <span className={classes.kindIcon}>
-                        <KindIcon fontSize="small" />
-                      </span>
-                    )}
-                    {onDrill ? (
-                      <Link
-                        component="button"
-                        type="button"
-                        color="primary"
-                        className={classes.drillLink}
-                        onClick={() => onDrill(row.key)}
-                      >
-                        {display}
-                      </Link>
-                    ) : (
-                      display
-                    )}
-                  </span>
-                </TableCell>
-                <TableCell className={classes.numeric}>
-                  {formatCost(row.cpuCost)}
-                </TableCell>
-                <TableCell className={classes.numeric}>
-                  {formatCost(row.memoryCost)}
-                </TableCell>
-                <TableCell className={classes.numeric}>
-                  {formatEfficiency(row.efficiency)}
-                </TableCell>
-                <TableCell className={classes.numeric}>
-                  {formatCost(row.total)}
-                </TableCell>
-                <TableCell className={classes.numeric}>
-                  <DeltaCell deltaPct={row.deltaPct} />
-                </TableCell>
-              </TableRow>
-            );
-          })}
+          {sortedRows.map(({ row, display }) => (
+            <TableRow key={row.key}>
+              <TableCell className={classes.nameCell}>
+                <span className={classes.nameWrap}>
+                  {KindIcon && (
+                    <span className={classes.kindIcon}>
+                      <KindIcon fontSize="small" />
+                    </span>
+                  )}
+                  {onDrill ? (
+                    <Link
+                      component="button"
+                      type="button"
+                      color="primary"
+                      className={classes.drillLink}
+                      onClick={() => onDrill(row.key)}
+                    >
+                      {display}
+                    </Link>
+                  ) : (
+                    display
+                  )}
+                </span>
+              </TableCell>
+              <TableCell className={classes.numeric}>
+                {formatCost(row.cpuCost)}
+              </TableCell>
+              <TableCell className={classes.numeric}>
+                {formatCost(row.memoryCost)}
+              </TableCell>
+              <TableCell className={classes.numeric}>
+                {formatEfficiency(row.efficiency)}
+              </TableCell>
+              <TableCell className={classes.numeric}>
+                {formatCost(row.total)}
+              </TableCell>
+              <TableCell className={classes.numeric}>
+                <DeltaCell deltaPct={row.deltaPct} />
+              </TableCell>
+            </TableRow>
+          ))}
         </TableBody>
       </Table>
     </TableContainer>
+  );
+};
+
+export const CostInsightsTable: FC<CostInsightsTableProps> = props => {
+  if (props.rows.length === 0) return <EmptyState />;
+  // The component level shows environments with right-sizing recommendations in
+  // a dedicated layout; other levels use the standard drillable cost breakdown.
+  return props.level === 'component' ? (
+    <RecommendationCostTable {...props} />
+  ) : (
+    <StandardCostTable {...props} />
   );
 };

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostOptimizeButton.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostOptimizeButton.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CostOptimizeButton } from './CostOptimizeButton';
+import type { CostRowRecommendation, CostScope } from './types';
+
+jest.mock('../../utils/applyResourceChange', () => ({
+  applyResourceChange: jest.fn(),
+}));
+import { applyResourceChange } from '../../utils/applyResourceChange';
+
+const mockApply = applyResourceChange as jest.MockedFunction<
+  typeof applyResourceChange
+>;
+
+jest.mock('./optimizeChange', () => {
+  const actual = jest.requireActual('./optimizeChange');
+  return {
+    ...actual,
+    resolveReleaseBindingName: jest.fn(),
+    buildOptimizeChange: jest.fn(() => ({
+      release_binding: 'ad-dev',
+      fields: [{ json_pointer: '/spec/x', value: '50m' }],
+    })),
+  };
+});
+import {
+  resolveReleaseBindingName,
+  buildOptimizeChange,
+} from './optimizeChange';
+
+const mockResolve = resolveReleaseBindingName as jest.MockedFunction<
+  typeof resolveReleaseBindingName
+>;
+
+const mockPermission = jest.fn();
+const mockUseOpenChoreoQuery = jest.fn();
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  useEnvScopedPermission: (opts: unknown) => mockPermission(opts),
+  useOpenChoreoQuery: () => mockUseOpenChoreoQuery(),
+  // Lightweight stand-in for the real ChangesList diff renderer.
+  ChangesList: ({
+    sections,
+  }: {
+    sections: Array<{
+      title: string;
+      changes: Array<{ path: string; oldValue?: string; newValue?: string }>;
+    }>;
+  }) => (
+    <div>
+      {sections.map(s => (
+        <div key={s.title}>
+          <div>
+            {s.title} ({s.changes.length} changes)
+          </div>
+          {s.changes.map(c => (
+            <div key={c.path}>
+              {c.path}: {c.oldValue ? `"${c.oldValue}" → ` : '[New] '}"
+              {c.newValue}"
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('@openchoreo/backstage-plugin-common', () => ({
+  CHOREO_ANNOTATIONS: { NAMESPACE: 'ns', PROJECT: 'proj' },
+  openchoreoReleaseBindingUpdatePermission: { name: 'releasebinding.update' },
+}));
+
+const mockGetBaseUrl = jest.fn(async (id: string) => `http://backend/${id}`);
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: () => ({ fetch: jest.fn(), getBaseUrl: mockGetBaseUrl }),
+  fetchApiRef: {},
+  discoveryApiRef: {},
+}));
+jest.mock('@backstage/plugin-catalog-react', () => ({ catalogApiRef: {} }));
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: () => 'component:default/ad',
+}));
+
+const recommendation: CostRowRecommendation = {
+  cpuRequest: '50m',
+  cpuLimit: '100m',
+  memoryRequest: '64Mi',
+  memoryLimit: '128Mi',
+  cpuCost: 1,
+  memoryCost: 1,
+  total: 2,
+};
+
+const scope: CostScope = {
+  namespace: 'default',
+  project: 'demo',
+  component: 'ad',
+};
+
+function renderButton() {
+  return render(
+    <CostOptimizeButton
+      env="dev"
+      recommendation={recommendation}
+      scope={scope}
+      onOptimized={jest.fn()}
+    />,
+  );
+}
+
+describe('CostOptimizeButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPermission.mockReturnValue({ allowed: true, loading: false });
+    mockUseOpenChoreoQuery.mockReturnValue({ data: 'component:default/ad' });
+    mockResolve.mockResolvedValue('ad-dev');
+    mockApply.mockResolvedValue(undefined);
+  });
+
+  it('disables the Apply button when permission is denied', () => {
+    mockPermission.mockReturnValue({ allowed: false, loading: false });
+    renderButton();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
+
+  it('disables the Apply button with a tooltip when there is nothing to apply', () => {
+    render(
+      <CostOptimizeButton
+        env="dev"
+        recommendation={recommendation}
+        scope={scope}
+        onOptimized={jest.fn()}
+        disabled
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Apply' }).closest('span'),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the Apply button until the component entity ref resolves', () => {
+    mockUseOpenChoreoQuery.mockReturnValue({ data: undefined });
+    renderButton();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
+
+  it('checks the releasebinding:update permission scoped to the environment', () => {
+    renderButton();
+    expect(mockPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environment: 'dev',
+        resourceRef: 'component:default/ad',
+      }),
+    );
+  });
+
+  it('opens a confirmation dialog showing the changes and redeploy note', () => {
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(screen.getByText(/Confirm Save Changes/)).toBeInTheDocument();
+    expect(
+      screen.getByText('Component Overrides (4 changes)'),
+    ).toBeInTheDocument();
+    // Recommended values render as diff entries (quoted quantity strings).
+    expect(screen.getByText(/"50m"/)).toBeInTheDocument();
+    expect(screen.getByText(/"128Mi"/)).toBeInTheDocument();
+    expect(screen.getByText(/trigger a redeployment/)).toBeInTheDocument();
+  });
+
+  it('resolves the binding and applies the change on confirm', async () => {
+    const onOptimized = jest.fn();
+    render(
+      <CostOptimizeButton
+        env="dev"
+        recommendation={recommendation}
+        scope={scope}
+        onOptimized={onOptimized}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Save' }));
+
+    await waitFor(() =>
+      expect(mockResolve).toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespaceName: 'default',
+          projectName: 'demo',
+          componentName: 'ad',
+          environment: 'dev',
+        }),
+      ),
+    );
+    expect(buildOptimizeChange).toHaveBeenCalledWith('ad-dev', recommendation);
+    await waitFor(() =>
+      expect(mockApply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespaceName: 'default',
+          change: { release_binding: 'ad-dev', fields: [expect.anything()] },
+        }),
+      ),
+    );
+    await waitFor(() => expect(onOptimized).toHaveBeenCalledTimes(1));
+    expect(
+      screen.getByRole('button', { name: /applied/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an error and a Retry action when apply fails', async () => {
+    mockApply.mockRejectedValue(new Error('binding not found'));
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Save' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/binding not found/)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostOptimizeButton.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostOptimizeButton.tsx
@@ -1,0 +1,234 @@
+import { useCallback, useState } from 'react';
+import {
+  Button,
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import CheckIcon from '@material-ui/icons/Check';
+import { Alert } from '@material-ui/lab';
+import {
+  useApi,
+  fetchApiRef,
+  discoveryApiRef,
+} from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import {
+  ChangesList,
+  useEnvScopedPermission,
+  useOpenChoreoQuery,
+} from '@openchoreo/backstage-plugin-react';
+import {
+  CHOREO_ANNOTATIONS,
+  openchoreoReleaseBindingUpdatePermission,
+} from '@openchoreo/backstage-plugin-common';
+import { applyResourceChange } from '../../utils/applyResourceChange';
+import {
+  buildOptimizeChange,
+  buildRecommendationChanges,
+  resolveReleaseBindingName,
+} from './optimizeChange';
+import type { CostRowRecommendation, CostScope } from './types';
+
+interface CostOptimizeButtonProps {
+  /** Environment name (the component-level row key). */
+  env: string;
+  recommendation: CostRowRecommendation;
+  scope: CostScope;
+  /** Called after a successful apply so the page can refetch cost data. */
+  onOptimized: () => void;
+  /** Disable the button (e.g. when the recommendation makes no change). */
+  disabled?: boolean;
+}
+
+type ApplyStatus = 'idle' | 'applying' | 'success' | 'failed';
+
+/** Resolve the component's catalog entity ref, for env-scoped permission checks. */
+function useComponentEntityRef(scope: CostScope): string | undefined {
+  const catalogApi = useApi(catalogApiRef);
+  const { data } = useOpenChoreoQuery<string | null>(
+    [
+      'cost-insights-component-ref',
+      scope.namespace ?? '',
+      scope.project ?? '',
+      scope.component ?? '',
+    ],
+    async () => {
+      const { items } = await catalogApi.getEntities({
+        filter: {
+          kind: 'Component',
+          'metadata.name': scope.component!,
+          [`metadata.annotations.${CHOREO_ANNOTATIONS.NAMESPACE}`]:
+            scope.namespace!,
+          [`metadata.annotations.${CHOREO_ANNOTATIONS.PROJECT}`]:
+            scope.project!,
+        },
+        fields: ['kind', 'metadata.name', 'metadata.namespace'],
+      });
+      const entity = items[0];
+      return entity ? stringifyEntityRef(entity) : null;
+    },
+    {
+      enabled: Boolean(scope.namespace && scope.project && scope.component),
+    },
+  );
+  return data ?? undefined;
+}
+
+export const CostOptimizeButton = ({
+  env,
+  recommendation,
+  scope,
+  onOptimized,
+  disabled: disabledProp,
+}: CostOptimizeButtonProps) => {
+  const fetchApi = useApi(fetchApiRef);
+  const discovery = useApi(discoveryApiRef);
+
+  const resourceRef = useComponentEntityRef(scope);
+  const { allowed, loading: permissionLoading } = useEnvScopedPermission({
+    permission: openchoreoReleaseBindingUpdatePermission,
+    resourceRef: resourceRef ?? '',
+    environment: env,
+  });
+
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<ApplyStatus>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleApply = useCallback(async () => {
+    setStatus('applying');
+    setErrorMsg('');
+    try {
+      const [observabilityBaseUrl, openchoreoBaseUrl] = await Promise.all([
+        discovery.getBaseUrl('openchoreo-observability-backend'),
+        discovery.getBaseUrl('openchoreo'),
+      ]);
+
+      const releaseBinding = await resolveReleaseBindingName({
+        openchoreoBaseUrl,
+        fetchApi,
+        namespaceName: scope.namespace!,
+        projectName: scope.project!,
+        componentName: scope.component!,
+        environment: env,
+      });
+
+      await applyResourceChange({
+        backendBaseUrl: observabilityBaseUrl,
+        fetchApi,
+        namespaceName: scope.namespace!,
+        change: buildOptimizeChange(releaseBinding, recommendation),
+      });
+
+      setStatus('success');
+      setOpen(false);
+      onOptimized();
+    } catch (err) {
+      setErrorMsg(
+        err instanceof Error ? err.message : 'Failed to apply recommendation',
+      );
+      setStatus('failed');
+    }
+  }, [discovery, fetchApi, scope, env, recommendation, onOptimized]);
+
+  if (status === 'success') {
+    return (
+      <Button
+        variant="outlined"
+        size="small"
+        disabled
+        startIcon={<CheckIcon />}
+      >
+        Applied
+      </Button>
+    );
+  }
+
+  const disabled =
+    permissionLoading || !allowed || !resourceRef || Boolean(disabledProp);
+  let tooltipTitle = '';
+  if (disabledProp) tooltipTitle = 'No recommendations to apply';
+  else if (!allowed)
+    tooltipTitle = `You do not have permission to modify the deployment in ${env}`;
+  const changes = buildRecommendationChanges(recommendation);
+
+  let confirmLabel = 'Confirm Save';
+  if (status === 'applying') confirmLabel = 'Saving...';
+  else if (status === 'failed') confirmLabel = 'Retry';
+
+  return (
+    <>
+      <Tooltip title={tooltipTitle}>
+        <span>
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            onClick={() => {
+              setStatus('idle');
+              setErrorMsg('');
+              setOpen(true);
+            }}
+            disabled={disabled}
+          >
+            Apply
+          </Button>
+        </span>
+      </Tooltip>
+
+      <Dialog
+        open={open}
+        onClose={() => status !== 'applying' && setOpen(false)}
+        maxWidth="md"
+        fullWidth
+        aria-labelledby="cost-optimize-dialog-title"
+      >
+        <DialogTitle id="cost-optimize-dialog-title">
+          Confirm Save Changes ({changes.length}{' '}
+          {changes.length === 1 ? 'change' : 'changes'})
+        </DialogTitle>
+        <DialogContent dividers>
+          <ChangesList
+            sections={[{ title: 'Component Overrides', changes }]}
+            emptyMessage="No changes to apply"
+          />
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            style={{ marginTop: 16 }}
+          >
+            This will trigger a redeployment of the <strong>{env}</strong>{' '}
+            environment.
+          </Typography>
+          {status === 'failed' && (
+            <Box mt={2}>
+              <Alert severity="error">{errorMsg}</Alert>
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setOpen(false)}
+            disabled={status === 'applying'}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleApply}
+            disabled={status === 'applying'}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.tsx
@@ -15,10 +15,17 @@ const useStyles = makeStyles(theme => ({
   },
   label: {
     fontWeight: 600,
-    fontSize: theme.typography.h6.fontSize,
+    fontSize: '0.75rem',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: theme.palette.text.secondary,
+  },
+  value: {
+    fontWeight: 700,
+    fontSize: '1.5rem',
+    lineHeight: 1.1,
     color: theme.palette.text.primary,
   },
-  value: { fontWeight: 700 },
   delta: { display: 'inline-flex', alignItems: 'center', gap: 2 },
   up: { color: theme.palette.error.main },
   down: { color: theme.palette.success.main },
@@ -64,7 +71,7 @@ export const CostSummaryCards: FC<CostSummaryCardsProps> = ({ summary }) => {
       <Grid item xs={12} sm={4}>
         <Card padding={16} className={classes.card}>
           <Typography className={classes.label}>Total Cost</Typography>
-          <Typography variant="h5" className={classes.value}>
+          <Typography component="div" className={classes.value}>
             {formatUsd(summary.totalCost)}
           </Typography>
           <DeltaChip deltaPct={summary.deltaPct} />
@@ -73,7 +80,7 @@ export const CostSummaryCards: FC<CostSummaryCardsProps> = ({ summary }) => {
       <Grid item xs={12} sm={4}>
         <Card padding={16} className={classes.card}>
           <Typography className={classes.label}>Forecast this month</Typography>
-          <Typography variant="h5" className={classes.value}>
+          <Typography component="div" className={classes.value}>
             {formatUsd(summary.forecastThisMonth)}
           </Typography>
           <Typography variant="body2" className={classes.muted}>
@@ -84,7 +91,7 @@ export const CostSummaryCards: FC<CostSummaryCardsProps> = ({ summary }) => {
       <Grid item xs={12} sm={4}>
         <Card padding={16} className={classes.card}>
           <Typography className={classes.label}>Efficiency</Typography>
-          <Typography variant="h5" className={classes.value}>
+          <Typography component="div" className={classes.value}>
             {formatEfficiency(summary.efficiency)}
           </Typography>
         </Card>

--- a/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.ts
@@ -118,6 +118,7 @@ export function aggregateRows(
   previousItems: CostItem[],
   level: CostScopeLevel,
   recommendations: CostRecommendationItem[] = [],
+  staleRecommendationEnvs: Map<string, string> = new Map(),
 ): CostRow[] {
   const prevTotals = previousTotalsByDimension(previousItems, level);
   const grouped = groupBy(currentItems, item => dimensionOf(item, level));
@@ -139,8 +140,14 @@ export function aggregateRows(
     const memoryCost = items.reduce((s, i) => s + (i.memoryCost ?? 0), 0);
     const total = cpuCost + memoryCost;
 
+    const recommendationStale =
+      level === 'component' && staleRecommendationEnvs.has(key);
+    const recommendationStaleSince = recommendationStale
+      ? staleRecommendationEnvs.get(key)
+      : undefined;
+
     let recommendation: CostRow['recommendation'];
-    if (level === 'component') {
+    if (level === 'component' && !recommendationStale) {
       const recs = recByEnv.get(key);
       if (recs && recs.length > 0) {
         const recCpu = recs.reduce(
@@ -152,8 +159,10 @@ export function aggregateRows(
           0,
         );
         // Resource strings only make sense for a single component/env pair;
-        // surface the first recommendation's request/limit values.
+        // surface the first recommendation's request/limit values (and its
+        // current values, for the confirm-diff dialog).
         const first = recs[0].recommendation;
+        const firstCurrent = recs[0].current;
         recommendation = {
           cpuRequest: first.cpuRequest,
           cpuLimit: first.cpuLimit,
@@ -162,6 +171,12 @@ export function aggregateRows(
           cpuCost: recCpu,
           memoryCost: recMem,
           total: recCpu + recMem,
+          current: {
+            cpuRequest: firstCurrent.cpuRequest,
+            cpuLimit: firstCurrent.cpuLimit,
+            memoryRequest: firstCurrent.memoryRequest,
+            memoryLimit: firstCurrent.memoryLimit,
+          },
         };
       }
     }
@@ -175,6 +190,8 @@ export function aggregateRows(
       efficiency: weightedEfficiency(items),
       deltaPct: percentChange(total, prevTotals.get(key)),
       recommendation,
+      recommendationStale,
+      recommendationStaleSince,
     });
   }
 
@@ -230,7 +247,45 @@ export function buildSeries(
       return point;
     });
 
-  return { series, seriesKeys: [...seriesKeys].sort() };
+  return {
+    series: fillMissingBuckets(series),
+    seriesKeys: [...seriesKeys].sort(),
+  };
+}
+
+/**
+ * The cost API can omit empty buckets, which then collapse together on the
+ * chart and hide the gap. Infer the interval from the smallest gap between
+ * buckets and insert empty points for every skipped interval.
+ */
+function fillMissingBuckets(series: CostSeriesPoint[]): CostSeriesPoint[] {
+  if (series.length < 2) return series;
+
+  const times = series.map(p => new Date(p.timestamp).getTime());
+  if (times.some(t => Number.isNaN(t))) return series;
+
+  let interval = Infinity;
+  for (let i = 1; i < times.length; i++) {
+    const gap = times[i] - times[i - 1];
+    if (gap > 0 && gap < interval) interval = gap;
+  }
+  if (!Number.isFinite(interval) || interval <= 0) return series;
+
+  const MAX_POINTS = 2000;
+
+  const filled: CostSeriesPoint[] = [series[0]];
+  for (let i = 1; i < series.length; i++) {
+    const prev = times[i - 1];
+    const curr = times[i];
+    const steps = Math.round((curr - prev) / interval);
+    for (let s = 1; s < steps && filled.length < MAX_POINTS; s++) {
+      filled.push({
+        timestamp: new Date(prev + s * interval).toISOString(),
+      });
+    }
+    filled.push(series[i]);
+  }
+  return filled;
 }
 
 /** Assemble everything the view needs from the raw multi-env responses. */
@@ -239,6 +294,8 @@ export function buildCostInsightsData(params: {
   currentItems: CostItem[];
   previousItems: CostItem[];
   recommendations?: CostRecommendationItem[];
+  /** Withheld-recommendation envs mapped to the binding's spec update time. */
+  staleRecommendationEnvs?: Map<string, string>;
   windowStart: string;
   windowEnd: string;
   now: Date;
@@ -248,6 +305,7 @@ export function buildCostInsightsData(params: {
     currentItems,
     previousItems,
     recommendations = [],
+    staleRecommendationEnvs = new Map<string, string>(),
     windowStart,
     windowEnd,
     now,
@@ -263,7 +321,13 @@ export function buildCostInsightsData(params: {
       windowEnd,
       now,
     ),
-    rows: aggregateRows(currentItems, previousItems, level, recommendations),
+    rows: aggregateRows(
+      currentItems,
+      previousItems,
+      level,
+      recommendations,
+      staleRecommendationEnvs,
+    ),
     series,
     seriesKeys,
   };

--- a/plugins/openchoreo-observability/src/components/CostInsights/format.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/format.test.ts
@@ -1,11 +1,11 @@
 import { formatCost, formatUsd, formatEfficiency, formatDelta } from './format';
 
 describe('formatCost', () => {
-  it('renders costs with 5 decimal places so sub-cent values stay visible', () => {
-    expect(formatCost(0.00047)).toBe('0.00047');
-    expect(formatCost(0.00024)).toBe('0.00024');
-    expect(formatCost(22)).toBe('22.00000');
-    expect(formatCost(0)).toBe('0.00000');
+  it('renders costs rounded to 2 decimal places', () => {
+    expect(formatCost(0.00047)).toBe('0.00');
+    expect(formatCost(1.235)).toBe('1.24');
+    expect(formatCost(22)).toBe('22.00');
+    expect(formatCost(0)).toBe('0.00');
   });
 });
 

--- a/plugins/openchoreo-observability/src/components/CostInsights/format.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/format.ts
@@ -1,6 +1,6 @@
-/** Format a cost number for a table cell, e.g. `0.00047`. */
+/** Format a cost number for a table cell, rounded to 2 decimals, e.g. `3.04`. */
 export function formatCost(value: number): string {
-  return value.toFixed(5);
+  return value.toFixed(2);
 }
 
 /** Format a cost as a card headline, e.g. `USD 12.00`. */

--- a/plugins/openchoreo-observability/src/components/CostInsights/optimizeChange.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/optimizeChange.test.ts
@@ -1,0 +1,277 @@
+import type { FetchApi } from '@backstage/core-plugin-api';
+import {
+  buildOptimizeChange,
+  buildRecommendationChanges,
+  fetchBindingInfoByEnv,
+  hasApplyableRecommendation,
+  normalizeEnv,
+  resolveReleaseBindingName,
+} from './optimizeChange';
+import type { CostRowRecommendation } from './types';
+
+const makeFetchApi = (impl: jest.Mock): FetchApi =>
+  ({ fetch: impl } as unknown as FetchApi);
+
+const okResponse = (body: unknown) =>
+  ({ ok: true, json: async () => body } as Response);
+
+describe('resolveReleaseBindingName', () => {
+  const base = {
+    openchoreoBaseUrl: 'http://backend/api/openchoreo',
+    namespaceName: 'default',
+    projectName: 'demo',
+    componentName: 'ad',
+  };
+
+  it('matches the binding by environment and returns its name', async () => {
+    const fetch = jest.fn().mockResolvedValue(
+      okResponse({
+        data: {
+          items: [
+            { name: 'ad-dev', environment: 'dev' },
+            { name: 'ad-prod', environment: 'prod' },
+          ],
+        },
+      }),
+    );
+    const name = await resolveReleaseBindingName({
+      ...base,
+      fetchApi: makeFetchApi(fetch),
+      environment: 'prod',
+    });
+    expect(name).toBe('ad-prod');
+    // The query targets the component's bindings.
+    expect(fetch.mock.calls[0][0]).toContain('componentName=ad');
+    expect(fetch.mock.calls[0][0]).toContain('projectName=demo');
+    expect(fetch.mock.calls[0][0]).toContain('namespaceName=default');
+  });
+
+  it('falls back to a case-insensitive environment match', async () => {
+    const fetch = jest.fn().mockResolvedValue(
+      okResponse({
+        data: { items: [{ name: 'ad-dev', environment: 'Dev' }] },
+      }),
+    );
+    const name = await resolveReleaseBindingName({
+      ...base,
+      fetchApi: makeFetchApi(fetch),
+      environment: 'dev',
+    });
+    expect(name).toBe('ad-dev');
+  });
+
+  it('throws when no binding matches the environment', async () => {
+    const fetch = jest.fn().mockResolvedValue(
+      okResponse({
+        data: { items: [{ name: 'ad-dev', environment: 'dev' }] },
+      }),
+    );
+    await expect(
+      resolveReleaseBindingName({
+        ...base,
+        fetchApi: makeFetchApi(fetch),
+        environment: 'staging',
+      }),
+    ).rejects.toThrow(/No release binding found/);
+  });
+
+  it('throws when the lookup request fails', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, statusText: 'Bad Gateway' } as Response);
+    await expect(
+      resolveReleaseBindingName({
+        ...base,
+        fetchApi: makeFetchApi(fetch),
+        environment: 'dev',
+      }),
+    ).rejects.toThrow(/Failed to look up release bindings/);
+  });
+});
+
+describe('buildOptimizeChange', () => {
+  it('builds field patches for every present resource value', () => {
+    const rec: CostRowRecommendation = {
+      cpuRequest: '50m',
+      cpuLimit: '100m',
+      memoryRequest: '64Mi',
+      memoryLimit: '128Mi',
+      cpuCost: 1,
+      memoryCost: 1,
+      total: 2,
+    };
+    const change = buildOptimizeChange('ad-dev', rec);
+    expect(change.release_binding).toBe('ad-dev');
+    expect(change.fields).toEqual([
+      {
+        json_pointer:
+          '/spec/componentTypeEnvironmentConfigs/resources/requests/cpu',
+        value: '50m',
+      },
+      {
+        json_pointer:
+          '/spec/componentTypeEnvironmentConfigs/resources/limits/cpu',
+        value: '100m',
+      },
+      {
+        json_pointer:
+          '/spec/componentTypeEnvironmentConfigs/resources/requests/memory',
+        value: '64Mi',
+      },
+      {
+        json_pointer:
+          '/spec/componentTypeEnvironmentConfigs/resources/limits/memory',
+        value: '128Mi',
+      },
+    ]);
+  });
+
+  it('omits absent resource values', () => {
+    const rec: CostRowRecommendation = {
+      cpuRequest: '50m',
+      cpuCost: 1,
+      memoryCost: 1,
+      total: 2,
+    };
+    const change = buildOptimizeChange('ad-dev', rec);
+    expect(change.fields).toEqual([
+      {
+        json_pointer:
+          '/spec/componentTypeEnvironmentConfigs/resources/requests/cpu',
+        value: '50m',
+      },
+    ]);
+  });
+});
+
+describe('fetchBindingInfoByEnv', () => {
+  const base = {
+    openchoreoBaseUrl: 'http://backend/api/openchoreo',
+    namespaceName: 'default',
+    projectName: 'demo',
+    componentName: 'ad',
+  };
+
+  it('maps each binding by normalized environment with its live resources', async () => {
+    const fetch = jest.fn().mockResolvedValue(
+      okResponse({
+        data: {
+          items: [
+            {
+              name: 'ad-dev',
+              environment: 'Dev',
+              lastSpecUpdateTime: '2026-08-01T00:00:00.000Z',
+              componentTypeEnvironmentConfigs: {
+                resources: {
+                  requests: { cpu: '100m', memory: '128Mi' },
+                  limits: { cpu: '200m', memory: '256Mi' },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const map = await fetchBindingInfoByEnv({
+      ...base,
+      fetchApi: makeFetchApi(fetch),
+    });
+    // Keyed by the lowercased environment name.
+    expect(map.get('dev')).toEqual({
+      cpuRequest: '100m',
+      cpuLimit: '200m',
+      memoryRequest: '128Mi',
+      memoryLimit: '256Mi',
+      lastSpecUpdateTime: '2026-08-01T00:00:00.000Z',
+    });
+    expect(map.get('Dev')).toBeUndefined();
+  });
+
+  it('returns an empty map when the request is not ok', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, statusText: 'nope' } as Response);
+    const map = await fetchBindingInfoByEnv({
+      ...base,
+      fetchApi: makeFetchApi(fetch),
+    });
+    expect(map.size).toBe(0);
+  });
+
+  it('returns an empty map when the fetch throws', async () => {
+    const fetch = jest.fn().mockRejectedValue(new Error('network'));
+    const map = await fetchBindingInfoByEnv({
+      ...base,
+      fetchApi: makeFetchApi(fetch),
+    });
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('normalizeEnv', () => {
+  it('lowercases the environment name', () => {
+    expect(normalizeEnv('Prod')).toBe('prod');
+    expect(normalizeEnv('dev')).toBe('dev');
+  });
+});
+
+describe('buildRecommendationChanges', () => {
+  it('emits modified and new diffs and omits unchanged/absent values', () => {
+    const changes = buildRecommendationChanges({
+      cpuRequest: '50m',
+      memoryRequest: '64Mi',
+      cpuCost: 1,
+      memoryCost: 1,
+      total: 2,
+      current: {
+        cpuRequest: '100m', // modified
+        memoryRequest: '64Mi', // unchanged -> omitted
+      },
+    });
+    expect(changes).toEqual([
+      {
+        path: 'resources.requests.cpu',
+        type: 'modified',
+        oldValue: '100m',
+        newValue: '50m',
+      },
+    ]);
+  });
+
+  it('marks a value with no current as new', () => {
+    const changes = buildRecommendationChanges({
+      cpuRequest: '50m',
+      cpuCost: 1,
+      memoryCost: 1,
+      total: 2,
+    });
+    expect(changes).toEqual([
+      {
+        path: 'resources.requests.cpu',
+        type: 'new',
+        oldValue: undefined,
+        newValue: '50m',
+      },
+    ]);
+  });
+});
+
+describe('hasApplyableRecommendation', () => {
+  it('is false when undefined or has no resource values', () => {
+    expect(hasApplyableRecommendation(undefined)).toBe(false);
+    expect(
+      hasApplyableRecommendation({ cpuCost: 1, memoryCost: 1, total: 2 }),
+    ).toBe(false);
+  });
+
+  it('is true when at least one resource value is present', () => {
+    expect(
+      hasApplyableRecommendation({
+        cpuRequest: '50m',
+        cpuCost: 1,
+        memoryCost: 1,
+        total: 2,
+      }),
+    ).toBe(true);
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/optimizeChange.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/optimizeChange.ts
@@ -1,0 +1,233 @@
+import type { FetchApi } from '@backstage/core-plugin-api';
+import type { Change } from '@openchoreo/backstage-plugin-react';
+import type {
+  FieldChangeDef,
+  ResourceChangeDef,
+} from '../../utils/applyResourceChange';
+import type { CostRowRecommendation } from './types';
+
+/**
+ * Resource limits/requests on a ReleaseBinding live under
+ * `spec.componentTypeEnvironmentConfigs.resources.{requests,limits}.{cpu,memory}`
+ * (the ComponentType env-config schema). These are the JSON pointers the FinOps
+ * apply flow uses too - see `FinOpsApplyButton.test.tsx` fixtures.
+ */
+const POINTER = {
+  cpuRequest: '/spec/componentTypeEnvironmentConfigs/resources/requests/cpu',
+  cpuLimit: '/spec/componentTypeEnvironmentConfigs/resources/limits/cpu',
+  memoryRequest:
+    '/spec/componentTypeEnvironmentConfigs/resources/requests/memory',
+  memoryLimit: '/spec/componentTypeEnvironmentConfigs/resources/limits/memory',
+} as const;
+
+/** One release binding as returned by `GET /api/openchoreo/release-bindings`. */
+interface ReleaseBindingListItem {
+  name: string;
+  environment: string;
+  lastSpecUpdateTime?: string;
+  componentTypeEnvironmentConfigs?: {
+    resources?: {
+      requests?: { cpu?: string; memory?: string };
+      limits?: { cpu?: string; memory?: string };
+    };
+  };
+}
+
+/** Normalize an environment name so lookups tolerate casing differences. */
+export const normalizeEnv = (env: string): string => env.toLowerCase();
+
+/** Live spec state for one environment's ReleaseBinding. */
+export interface ReleaseBindingInfo {
+  cpuRequest?: string;
+  cpuLimit?: string;
+  memoryRequest?: string;
+  memoryLimit?: string;
+  /** When the binding's spec was last changed (ISO). */
+  lastSpecUpdateTime?: string;
+}
+
+/**
+ * Fetch the live spec state (resource requests/limits + last spec-update time)
+ * for every environment of a component, keyed by environment name.
+ *
+ * Needed because the observer's recommendation API derives its "current" usage —
+ * and hence the recommendation itself from samples over the selected time
+ * window. If the window predates a spec change, those samples reflect the old
+ * spec, producing wrong recommendations (e.g. suggesting an *increase* with a
+ * phantom saving). We use `lastSpecUpdateTime` to detect that case and the live
+ * requests as the source of truth for the displayed `current` value.
+ *
+ * Best-effort: returns an empty map on any failure.
+ */
+export async function fetchBindingInfoByEnv(opts: {
+  openchoreoBaseUrl: string;
+  fetchApi: FetchApi;
+  namespaceName: string;
+  projectName: string;
+  componentName: string;
+}): Promise<Map<string, ReleaseBindingInfo>> {
+  const {
+    openchoreoBaseUrl,
+    fetchApi,
+    namespaceName,
+    projectName,
+    componentName,
+  } = opts;
+
+  const url = `${openchoreoBaseUrl}/release-bindings?componentName=${encodeURIComponent(
+    componentName,
+  )}&projectName=${encodeURIComponent(
+    projectName,
+  )}&namespaceName=${encodeURIComponent(namespaceName)}`;
+
+  const map = new Map<string, ReleaseBindingInfo>();
+  try {
+    const response = await fetchApi.fetch(url);
+    if (!response.ok) return map;
+    const body = await response.json();
+    const items: ReleaseBindingListItem[] = body?.data?.items ?? [];
+    for (const item of items) {
+      const resources = item.componentTypeEnvironmentConfigs?.resources;
+      map.set(normalizeEnv(item.environment), {
+        cpuRequest: resources?.requests?.cpu,
+        cpuLimit: resources?.limits?.cpu,
+        memoryRequest: resources?.requests?.memory,
+        memoryLimit: resources?.limits?.memory,
+        lastSpecUpdateTime: item.lastSpecUpdateTime,
+      });
+    }
+  } catch {
+    // Best-effort; keep the observer-derived values on failure.
+  }
+  return map;
+}
+
+/**
+ * Resolve the ReleaseBinding `metadata.name` for a component in a given
+ * environment by listing the component's bindings and matching the environment.
+ *
+ * The observability recommendation API does not carry a binding name, so we
+ * look it up via the existing openchoreo backend route (no new backend needed).
+ */
+export async function resolveReleaseBindingName(opts: {
+  openchoreoBaseUrl: string;
+  fetchApi: FetchApi;
+  namespaceName: string;
+  projectName: string;
+  componentName: string;
+  environment: string;
+}): Promise<string> {
+  const {
+    openchoreoBaseUrl,
+    fetchApi,
+    namespaceName,
+    projectName,
+    componentName,
+    environment,
+  } = opts;
+
+  const url = `${openchoreoBaseUrl}/release-bindings?componentName=${encodeURIComponent(
+    componentName,
+  )}&projectName=${encodeURIComponent(
+    projectName,
+  )}&namespaceName=${encodeURIComponent(namespaceName)}`;
+
+  const response = await fetchApi.fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to look up release bindings: ${response.statusText}`,
+    );
+  }
+
+  const body = await response.json();
+  const items: ReleaseBindingListItem[] = body?.data?.items ?? [];
+
+  // Match the recommendation's environment against the binding's environment.
+  // Fall back to a case-insensitive match to tolerate display-name vs
+  // resource-name differences.
+  const match =
+    items.find(item => item.environment === environment) ??
+    items.find(
+      item => item.environment?.toLowerCase() === environment.toLowerCase(),
+    );
+
+  if (!match?.name) {
+    throw new Error(
+      `No release binding found for component '${componentName}' in environment '${environment}'`,
+    );
+  }
+  return match.name;
+}
+
+/**
+ * Build the resource change that applies a right-sizing recommendation. Only
+ * the values present on the recommendation are patched (the observer may omit
+ * some request/limit strings).
+ */
+export function buildOptimizeChange(
+  releaseBinding: string,
+  recommendation: CostRowRecommendation,
+): ResourceChangeDef {
+  const fields: FieldChangeDef[] = [];
+  const add = (pointer: string, value?: string) => {
+    if (typeof value === 'string' && value.length > 0) {
+      fields.push({ json_pointer: pointer, value });
+    }
+  };
+  add(POINTER.cpuRequest, recommendation.cpuRequest);
+  add(POINTER.cpuLimit, recommendation.cpuLimit);
+  add(POINTER.memoryRequest, recommendation.memoryRequest);
+  add(POINTER.memoryLimit, recommendation.memoryLimit);
+
+  return { release_binding: releaseBinding, fields };
+}
+
+/**
+ * Build a human-readable list of the resource changes a recommendation applies,
+ * as `current → recommended` diffs (or `[New]` when there is no current value),
+ * for the confirmation dialog. No-op fields (unchanged or absent) are omitted.
+ */
+export function buildRecommendationChanges(
+  recommendation: CostRowRecommendation,
+): Change[] {
+  const current = recommendation.current ?? {};
+  const specs: Array<[string, string | undefined, string | undefined]> = [
+    ['resources.requests.cpu', current.cpuRequest, recommendation.cpuRequest],
+    ['resources.limits.cpu', current.cpuLimit, recommendation.cpuLimit],
+    [
+      'resources.requests.memory',
+      current.memoryRequest,
+      recommendation.memoryRequest,
+    ],
+    [
+      'resources.limits.memory',
+      current.memoryLimit,
+      recommendation.memoryLimit,
+    ],
+  ];
+
+  const changes: Change[] = [];
+  for (const [path, oldValue, newValue] of specs) {
+    if (!newValue || oldValue === newValue) continue;
+    changes.push({
+      path,
+      type: oldValue ? 'modified' : 'new',
+      oldValue,
+      newValue,
+    });
+  }
+  return changes;
+}
+
+/** Whether a recommendation carries at least one applyable resource value. */
+export function hasApplyableRecommendation(
+  recommendation: CostRowRecommendation | undefined,
+): recommendation is CostRowRecommendation {
+  if (!recommendation) return false;
+  return Boolean(
+    recommendation.cpuRequest ||
+      recommendation.cpuLimit ||
+      recommendation.memoryRequest ||
+      recommendation.memoryLimit,
+  );
+}

--- a/plugins/openchoreo-observability/src/components/CostInsights/types.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/types.ts
@@ -16,9 +16,17 @@ export interface CostScope {
   component?: string;
 }
 
+/** The four resource quantity strings (K8s notation) for a workload. */
+export type CostResourceQuantities = Pick<
+  CostResourceProfile,
+  'cpuRequest' | 'cpuLimit' | 'memoryRequest' | 'memoryLimit'
+>;
+
 /** Recommendation ("Cost After Optimizing") shown only at the component level. */
 export interface CostRowRecommendation extends CostResourceProfile {
   total: number;
+  /** Current (pre-optimization) resource values, for the confirm-diff dialog. */
+  current?: CostResourceQuantities;
 }
 
 export interface CostRow {
@@ -33,6 +41,14 @@ export interface CostRow {
   /** Percent change vs the previous equal-length window (null if unknown). */
   deltaPct: number | null;
   recommendation?: CostRowRecommendation;
+  /**
+   * True when the environment's ReleaseBinding was updated after the selected
+   * window's start, so recommendations derived from that window's usage would be
+   * based on the pre-change spec and are therefore withheld.
+   */
+  recommendationStale?: boolean;
+  /** ISO spec update time of the binding, shown in the withheld-recommendation notice. */
+  recommendationStaleSince?: string;
 }
 
 export interface CostSummary {

--- a/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.test.ts
@@ -9,6 +9,18 @@ jest.mock('@backstage/core-plugin-api', () => {
   return { ...actual, useApi: jest.fn() };
 });
 
+// The component-level path fetches release-binding info to detect stale
+// recommendations; stub it to no bindings so it's a no-op here.
+jest.mock('./optimizeChange', () => ({
+  ...jest.requireActual('./optimizeChange'),
+  fetchBindingInfoByEnv: jest.fn().mockResolvedValue(new Map()),
+}));
+import { fetchBindingInfoByEnv } from './optimizeChange';
+
+const mockFetchBindingInfo = fetchBindingInfoByEnv as jest.MockedFunction<
+  typeof fetchBindingInfoByEnv
+>;
+
 // Keep the real caching wrapper; only pin the window so previous-window maths
 // and the per-env call args are deterministic.
 jest.mock('@openchoreo/backstage-plugin-react', () => ({
@@ -49,7 +61,12 @@ describe('useCostInsights', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useApi as jest.Mock).mockReturnValue({ getCosts, getCostRecommendations });
+    (useApi as jest.Mock).mockReturnValue({
+      getCosts,
+      getCostRecommendations,
+      getBaseUrl: jest.fn().mockResolvedValue('http://openchoreo'),
+      fetch: jest.fn(),
+    });
     getCosts.mockResolvedValue({ items: [costItem()] });
     getCostRecommendations.mockResolvedValue({ items: [] });
   });
@@ -101,6 +118,85 @@ describe('useCostInsights', () => {
     expect(getCostRecommendations).toHaveBeenCalledTimes(1);
     const devRow = result.current.data?.rows.find(r => r.key === 'dev');
     expect(devRow?.recommendation?.total).toBe(8);
+  });
+
+  it('withholds a recommendation when the binding changed after the window started', async () => {
+    getCostRecommendations.mockResolvedValue({
+      items: [
+        {
+          component: 'comp',
+          environment: 'dev',
+          project: 'gcp',
+          namespace: 'default',
+          current: { cpuCost: 22, memoryCost: 0, cpuRequest: '100m' },
+          recommendation: { cpuCost: 5, memoryCost: 3, cpuRequest: '50m' },
+        },
+      ],
+    });
+    // Spec updated at the window start -> within the settling buffer -> stale.
+    mockFetchBindingInfo.mockResolvedValueOnce(
+      new Map([['dev', { lastSpecUpdateTime: '2026-07-02T00:00:00.000Z' }]]),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCostInsights(
+          baseParams({
+            scope: { namespace: 'default', project: 'gcp', component: 'comp' },
+            environments: ['dev'],
+          }),
+        ),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const devRow = result.current.data?.rows.find(r => r.key === 'dev');
+    expect(devRow?.recommendationStale).toBe(true);
+    expect(devRow?.recommendationStaleSince).toBe('2026-07-02T00:00:00.000Z');
+    expect(devRow?.recommendation).toBeUndefined();
+  });
+
+  it('overrides the recommendation current request with live spec values', async () => {
+    getCostRecommendations.mockResolvedValue({
+      items: [
+        {
+          component: 'comp',
+          environment: 'dev',
+          project: 'gcp',
+          namespace: 'default',
+          current: { cpuCost: 22, memoryCost: 0, cpuRequest: '100m' },
+          recommendation: { cpuCost: 5, memoryCost: 3, cpuRequest: '50m' },
+        },
+      ],
+    });
+    // Spec updated well before the window -> not stale; live request wins.
+    mockFetchBindingInfo.mockResolvedValueOnce(
+      new Map([
+        [
+          'dev',
+          {
+            cpuRequest: '250m',
+            lastSpecUpdateTime: '2026-06-01T00:00:00.000Z',
+          },
+        ],
+      ]),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCostInsights(
+          baseParams({
+            scope: { namespace: 'default', project: 'gcp', component: 'comp' },
+            environments: ['dev'],
+          }),
+        ),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const devRow = result.current.data?.rows.find(r => r.key === 'dev');
+    expect(devRow?.recommendationStale).toBe(false);
+    expect(devRow?.recommendation?.current?.cpuRequest).toBe('250m');
   });
 
   it('passes the granularity only in graph view', async () => {

--- a/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.ts
@@ -1,4 +1,8 @@
-import { useApi } from '@backstage/core-plugin-api';
+import {
+  useApi,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
 import {
   useOpenChoreoQuery,
   calculateTimeRange,
@@ -6,6 +10,7 @@ import {
 import { observabilityApiRef } from '../../api/ObservabilityApi';
 import type { CostItem, CostRecommendationItem } from '../../types';
 import { buildCostInsightsData, deriveLevel } from './costAggregation';
+import { fetchBindingInfoByEnv, normalizeEnv } from './optimizeChange';
 import type { CostInsightsData, CostScope, CostViewMode } from './types';
 
 export interface UseCostInsightsParams {
@@ -38,6 +43,8 @@ export function useCostInsights(
   params: UseCostInsightsParams,
 ): UseCostInsightsResult {
   const api = useApi(observabilityApiRef);
+  const discovery = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const { scope, environments, timeRange, view, granularity } = params;
   const namespace = scope.namespace;
   const level = deriveLevel(scope);
@@ -133,17 +140,66 @@ export function useCostInsights(
         const previousItems = fulfilled.flatMap(r => r.value.previous);
         const recommendations = fulfilled.flatMap(r => r.value.recommendations);
 
+        // A recommendation is only trustworthy when its window's usage reflects
+        // the current spec. If the ReleaseBinding was updated after the window
+        // started, the samples include the pre-change spec, so we withhold those
+        // (keyed by env -> spec update time) and flag the row. For valid rows we
+        // override the window-derived "current" request strings with live spec
+        // values (display + diff only; costs stay window-based).
+        const staleRecommendationEnvs = new Map<string, string>();
+        if (level === 'component' && recommendations.length > 0) {
+          const openchoreoBaseUrl = await discovery.getBaseUrl('openchoreo');
+          const infoByEnv = await fetchBindingInfoByEnv({
+            openchoreoBaseUrl,
+            fetchApi,
+            namespaceName: namespace!,
+            projectName: scope.project!,
+            componentName: scope.component!,
+          });
+          const windowStartMs = new Date(startTime).getTime();
+          // Buffer so the settling period right after a spec change (pods rolling
+          // out) doesn't skew the recommendation.
+          const SETTLING_BUFFER_MS = 5 * 60 * 1000;
+          for (const rec of recommendations) {
+            const info = infoByEnv.get(normalizeEnv(rec.environment));
+            if (!info) continue;
+            const updatedMs = info.lastSpecUpdateTime
+              ? new Date(info.lastSpecUpdateTime).getTime()
+              : NaN;
+            if (
+              Number.isFinite(updatedMs) &&
+              updatedMs + SETTLING_BUFFER_MS > windowStartMs
+            ) {
+              staleRecommendationEnvs.set(
+                rec.environment,
+                info.lastSpecUpdateTime!,
+              );
+              continue;
+            }
+            rec.current = {
+              ...rec.current,
+              cpuRequest: info.cpuRequest ?? rec.current.cpuRequest,
+              cpuLimit: info.cpuLimit ?? rec.current.cpuLimit,
+              memoryRequest: info.memoryRequest ?? rec.current.memoryRequest,
+              memoryLimit: info.memoryLimit ?? rec.current.memoryLimit,
+            };
+          }
+        }
+
         return buildCostInsightsData({
           level,
           currentItems,
           previousItems,
           recommendations,
+          staleRecommendationEnvs,
           windowStart: startTime,
           windowEnd: endTime,
           now: new Date(),
         });
       },
-      { enabled, keepPreviousData: true },
+      // No keepPreviousData: a window/view/scope change shows the centered loader
+      // rather than stale data. Manual refresh keeps its key and uses the overlay.
+      { enabled },
     );
 
   return {

--- a/plugins/openchoreo-react/src/index.ts
+++ b/plugins/openchoreo-react/src/index.ts
@@ -425,6 +425,7 @@ export {
   useReleaseBindingUpdatePermission,
   type UseReleaseBindingUpdatePermissionResult,
 } from './hooks/useReleaseBindingUpdatePermission';
+export { useEnvScopedPermission } from './hooks/useEnvScopedPermission';
 export {
   useResourceReleaseBindingUpdatePermission,
   type UseResourceReleaseBindingUpdatePermissionResult,


### PR DESCRIPTION
## Purpose

Extends the cost insights view to show CPU and memory recommendations that lets users save costs. Furthermore, this change provides a single button which when pressed, updates the releaseBinding and applies the recommended CPU and memory values
https://github.com/openchoreo/openchoreo/issues/4381

## Goals

Provide cost saving information to users

## Approach
- Extended the cost insights table view at component level to show recommendations for cost savings
- Apply action: Resolves the ReleaseBinding, shows a confirm-diff dialog (similar to what exists in the deploy page now), and applies the recommended CPU/memory value. This is environment-scoped and releasebinding:update permission is required to apply this
- Withholds recommendations when the ReleaseBinding's `lastSpecUpdateTime` is after the window start (+5 min buffer) and shows a notice with the update time. 

## Screenshots
Please note that the costs shown here are inflated costs and does not reflect the cost of actually running these components. These costs were manually inflated for testing purposes only

Per environment recommendations
<img width="1725" height="1028" alt="Screenshot 2026-08-05 at 14 15 21" src="https://github.com/user-attachments/assets/159d6737-623b-4042-8dbc-d43fb02d3999" />

Dialog box that appears when the apply button is clicked. This is similar to the dialog box in the 
<img width="1724" height="1027" alt="Screenshot 2026-08-05 at 14 16 05" src="https://github.com/user-attachments/assets/d5b4df8e-7eaf-447c-9f20-81eb23fe9bb7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added component-level cost recommendations with savings, efficiency visualizations, and suggested CPU/memory changes.
  - Added permission-aware Optimize actions with confirmation dialogs, progress feedback, success messages, and retryable errors.
  - Refreshes cost insights after successful optimization.
  - Displays stale-recommendation messaging and suppresses recommendations when resources have recently changed.

- **Improvements**
  - Cost values now consistently display two decimal places.
  - Loading states now appear when changing insight selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->