### PR TITLE
fix: allow selecting/copying text from expanded log and event rows

### DIFF
--- a/.changeset/selection-safe-row-toggle.md
+++ b/.changeset/selection-safe-row-toggle.md
@@ -1,0 +1,12 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+---
+
+Let the expanded panel of a log or event row be selected and copied. The
+expand/collapse handler covered the whole row, expanded panel included, so the
+`click` completing a drag-select collapsed the row and discarded the selection
+— the full message and every metadata value were impossible to copy.
+
+The handler now sits on the summary row only, leaving the expanded panel
+outside the click target. Clicking the summary row expands and collapses
+exactly as before.

--- a/plugins/openchoreo-observability/src/components/RuntimeEvents/EventEntry.test.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeEvents/EventEntry.test.tsx
@@ -129,6 +129,18 @@ describe('EventEntry', () => {
     expect(screen.queryByText('Event Message')).not.toBeInTheDocument();
   });
 
+  it('stays expanded when clicking inside the expanded panel', async () => {
+    const user = userEvent.setup();
+    renderEventEntry();
+
+    await user.click(screen.getByText('Scaled up replica set to 3'));
+    expect(screen.getByText('Event Message')).toBeInTheDocument();
+
+    await user.click(screen.getByText('comp-uid-1'));
+
+    expect(screen.getByText('Event Message')).toBeInTheDocument();
+  });
+
   it('falls back to prop values when metadata is missing', async () => {
     const user = userEvent.setup();
     renderEventEntry({

--- a/plugins/openchoreo-observability/src/components/RuntimeEvents/EventEntry.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeEvents/EventEntry.tsx
@@ -23,7 +23,9 @@ interface EventEntryProps {
    * expansion survives the virtualizer unmounting the row off-screen.
    */
   expanded: boolean;
-  /** Called when the user clicks the row to expand or collapse it. */
+  /**
+   * Called when the user clicks the summary row to expand or collapse it.
+   */
   onToggleExpand: () => void;
 }
 
@@ -69,10 +71,9 @@ export const EventEntry: FC<EventEntryProps> = ({
   return (
     <Box
       className={`${classes.eventRow} ${expanded ? classes.expandedRow : ''}`}
-      onClick={onToggleExpand}
       role="row"
     >
-      <Box className={classes.eventRowMain}>
+      <Box className={classes.eventRowMain} onClick={onToggleExpand}>
         {selectedFields.map(field => {
           if (field === EventEntryField.Timestamp) {
             return (

--- a/plugins/openchoreo-observability/src/components/RuntimeEvents/styles.ts
+++ b/plugins/openchoreo-observability/src/components/RuntimeEvents/styles.ts
@@ -71,7 +71,6 @@ export const useEventsTableStyles = makeStyles(theme => ({
 
 export const useEventEntryStyles = makeStyles(theme => ({
   eventRow: {
-    cursor: 'pointer',
     borderBottom: `1px solid ${theme.palette.grey[100]}`,
     '&:hover': {
       backgroundColor: theme.palette.action.hover,
@@ -84,7 +83,9 @@ export const useEventEntryStyles = makeStyles(theme => ({
   },
   // Flex container replacing the former <TableRow>. `alignItems: 'center'`
   // mirrors the default `vertical-align: middle` of MUI table cells.
+  // `cursor` toggles row expansion. Expanded panel below it is selectable text.
   eventRowMain: {
+    cursor: 'pointer',
     display: 'flex',
     alignItems: 'center',
     width: '100%',

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.test.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.test.tsx
@@ -127,6 +127,18 @@ describe('LogEntry', () => {
     expect(screen.queryByText('Full Log Message')).not.toBeInTheDocument();
   });
 
+  it('stays expanded when clicking inside the expanded panel', async () => {
+    const user = userEvent.setup();
+    renderLogEntry();
+
+    await user.click(screen.getByText('Server started on port 8080'));
+    expect(screen.getByText('Full Log Message')).toBeInTheDocument();
+
+    await user.click(screen.getByText('api-service-abc123'));
+
+    expect(screen.getByText('Full Log Message')).toBeInTheDocument();
+  });
+
   it('renders ERROR level chip', () => {
     renderLogEntry({
       log: { ...sampleLog, level: 'ERROR' },

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.tsx
@@ -34,7 +34,9 @@ interface LogEntryProps {
    * expansion survives the virtualizer unmounting the row off-screen.
    */
   expanded: boolean;
-  /** Called when the user clicks the row to expand or collapse it. */
+  /**
+   * Called when the user clicks the summary row to expand or collapse it.
+   */
   onToggleExpand: () => void;
   /**
    * Stable callback (typically backed by a ref) returning the table's
@@ -104,10 +106,9 @@ export const LogEntry: FC<LogEntryProps> = ({
   return (
     <Box
       className={`${classes.logRow} ${expanded ? classes.expandedRow : ''}`}
-      onClick={onToggleExpand}
       role="row"
     >
-      <Box className={classes.logRowMain}>
+      <Box className={classes.logRowMain} onClick={onToggleExpand}>
         {selectedFields.map(field => {
           if (field === LogEntryField.Timestamp) {
             return (

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/styles.ts
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/styles.ts
@@ -100,7 +100,6 @@ export const useLogsTableStyles = makeStyles(theme => ({
 
 export const useLogEntryStyles = makeStyles(theme => ({
   logRow: {
-    cursor: 'pointer',
     // Match MUI `<TableCell>`'s hardcoded light grey rather than
     // `palette.divider`, which is alpha-based and blends darker against
     // Backstage's Paper background.
@@ -119,7 +118,9 @@ export const useLogEntryStyles = makeStyles(theme => ({
   // 'center'` mirrors the default `vertical-align: middle` of MUI table cells,
   // so the LogLevel chip and timestamp stay centered when the Log column wraps
   // to multiple lines.
+  // `cursor` toggles row expansion. Expanded panel below it is selectable text.
   logRowMain: {
+    cursor: 'pointer',
     display: 'flex',
     alignItems: 'center',
     width: '100%',


### PR DESCRIPTION
## Purpose
The expand/collapse handler covered the whole row, expanded panel included, so the click completing a drag-select collapsed the row and discarded the selection — the full message and metadata values could not be copied.

- Move the handler from the row wrapper to the summary row, leaving the expanded panel outside the click target
- Move `cursor: pointer` onto the summary row to match

Fixes openchoreo/openchoreo#4429


## Goals

> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
- Before

https://github.com/user-attachments/assets/2058d74d-3c40-40dc-8262-6aa4fb66979c


- After

https://github.com/user-attachments/assets/abcffd91-9cce-4cbf-92f3-ca1b29326316



## User stories

> Summary of user stories addressed by this change>

## Release note

> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification

> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests

- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature

## Related PRs

> List any other related PRs

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested

## Test environment

> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning

> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Expanded runtime log and event panels no longer collapse when users click, drag-select, or copy their contents.
  - Row expansion is now triggered only from the summary row, with clearer visual indication of the clickable area.
  - Improved accessibility semantics for expanded log and event rows.

- **Tests**
  - Added coverage confirming expanded log and event content remains open when interacted with.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->