### PR TITLE
backport-v1.2: fix: allow selecting/copying text from expanded log and event rows (#746)

### DIFF
--- a/.changeset/selection-safe-row-toggle.md
+++ b/.changeset/selection-safe-row-toggle.md
@@ -1,0 +1,12 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+---
+
+Let the expanded panel of a log or event row be selected and copied. The
+expand/collapse handler covered the whole row, expanded panel included, so the
+`click` completing a drag-select collapsed the row and discarded the selection
+— the full message and every metadata value were impossible to copy.
+
+The handler now sits on the summary row only, leaving the expanded panel
+outside the click target. Clicking the summary row expands and collapses
+exactly as before.

--- a/plugins/openchoreo-observability/src/components/RuntimeEvents/EventEntry.test.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeEvents/EventEntry.test.tsx
@@ -129,6 +129,18 @@ describe('EventEntry', () => {
     expect(screen.queryByText('Event Message')).not.toBeInTheDocument();
   });
 
+  it('stays expanded when clicking inside the expanded panel', async () => {
+    const user = userEvent.setup();
+    renderEventEntry();
+
+    await user.click(screen.getByText('Scaled up replica set to 3'));
+    expect(screen.getByText('Event Message')).toBeInTheDocument();
+
+    await user.click(screen.getByText('comp-uid-1'));
+
+    expect(screen.getByText('Event Message')).toBeInTheDocument();
+  });
+
   it('falls back to prop values when metadata is missing', async () => {
     const user = userEvent.setup();
     renderEventEntry({

--- a/plugins/openchoreo-observability/src/components/RuntimeEvents/EventEntry.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeEvents/EventEntry.tsx
@@ -23,7 +23,9 @@ interface EventEntryProps {
    * expansion survives the virtualizer unmounting the row off-screen.
    */
   expanded: boolean;
-  /** Called when the user clicks the row to expand or collapse it. */
+  /**
+   * Called when the user clicks the summary row to expand or collapse it.
+   */
   onToggleExpand: () => void;
 }
 
@@ -69,10 +71,9 @@ export const EventEntry: FC<EventEntryProps> = ({
   return (
     <Box
       className={`${classes.eventRow} ${expanded ? classes.expandedRow : ''}`}
-      onClick={onToggleExpand}
       role="row"
     >
-      <Box className={classes.eventRowMain}>
+      <Box className={classes.eventRowMain} onClick={onToggleExpand}>
         {selectedFields.map(field => {
           if (field === EventEntryField.Timestamp) {
             return (

--- a/plugins/openchoreo-observability/src/components/RuntimeEvents/styles.ts
+++ b/plugins/openchoreo-observability/src/components/RuntimeEvents/styles.ts
@@ -71,7 +71,6 @@ export const useEventsTableStyles = makeStyles(theme => ({
 
 export const useEventEntryStyles = makeStyles(theme => ({
   eventRow: {
-    cursor: 'pointer',
     borderBottom: `1px solid ${theme.palette.grey[100]}`,
     '&:hover': {
       backgroundColor: theme.palette.action.hover,
@@ -84,7 +83,9 @@ export const useEventEntryStyles = makeStyles(theme => ({
   },
   // Flex container replacing the former <TableRow>. `alignItems: 'center'`
   // mirrors the default `vertical-align: middle` of MUI table cells.
+  // `cursor` toggles row expansion. Expanded panel below it is selectable text.
   eventRowMain: {
+    cursor: 'pointer',
     display: 'flex',
     alignItems: 'center',
     width: '100%',

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.test.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.test.tsx
@@ -127,6 +127,18 @@ describe('LogEntry', () => {
     expect(screen.queryByText('Full Log Message')).not.toBeInTheDocument();
   });
 
+  it('stays expanded when clicking inside the expanded panel', async () => {
+    const user = userEvent.setup();
+    renderLogEntry();
+
+    await user.click(screen.getByText('Server started on port 8080'));
+    expect(screen.getByText('Full Log Message')).toBeInTheDocument();
+
+    await user.click(screen.getByText('api-service-abc123'));
+
+    expect(screen.getByText('Full Log Message')).toBeInTheDocument();
+  });
+
   it('renders ERROR level chip', () => {
     renderLogEntry({
       log: { ...sampleLog, level: 'ERROR' },

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.tsx
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/LogEntry.tsx
@@ -34,7 +34,9 @@ interface LogEntryProps {
    * expansion survives the virtualizer unmounting the row off-screen.
    */
   expanded: boolean;
-  /** Called when the user clicks the row to expand or collapse it. */
+  /**
+   * Called when the user clicks the summary row to expand or collapse it.
+   */
   onToggleExpand: () => void;
   /**
    * Stable callback (typically backed by a ref) returning the table's
@@ -104,10 +106,9 @@ export const LogEntry: FC<LogEntryProps> = ({
   return (
     <Box
       className={`${classes.logRow} ${expanded ? classes.expandedRow : ''}`}
-      onClick={onToggleExpand}
       role="row"
     >
-      <Box className={classes.logRowMain}>
+      <Box className={classes.logRowMain} onClick={onToggleExpand}>
         {selectedFields.map(field => {
           if (field === LogEntryField.Timestamp) {
             return (

--- a/plugins/openchoreo-observability/src/components/RuntimeLogs/styles.ts
+++ b/plugins/openchoreo-observability/src/components/RuntimeLogs/styles.ts
@@ -100,7 +100,6 @@ export const useLogsTableStyles = makeStyles(theme => ({
 
 export const useLogEntryStyles = makeStyles(theme => ({
   logRow: {
-    cursor: 'pointer',
     // Match MUI `<TableCell>`'s hardcoded light grey rather than
     // `palette.divider`, which is alpha-based and blends darker against
     // Backstage's Paper background.
@@ -119,7 +118,9 @@ export const useLogEntryStyles = makeStyles(theme => ({
   // 'center'` mirrors the default `vertical-align: middle` of MUI table cells,
   // so the LogLevel chip and timestamp stay centered when the Log column wraps
   // to multiple lines.
+  // `cursor` toggles row expansion. Expanded panel below it is selectable text.
   logRowMain: {
+    cursor: 'pointer',
     display: 'flex',
     alignItems: 'center',
     width: '100%',


### PR DESCRIPTION
## Purpose

Backport of #746 to the `release-v1.2` line. Resolves openchoreo/openchoreo#4429 for 1.2.

The expand/collapse handler covered the whole log/event row, expanded panel included, so the `click` completing a drag-select collapsed the row and discarded the selection — the full message and every metadata value were impossible to copy.

## Goals

Let users select and copy the full message and metadata values from an expanded log or event row, without the row collapsing out from under them.

## Approach

Clean cherry-pick of `6729dc3b` — the patch content is byte-identical to what merged on `main`, with no conflicts (all six source files were identical between the two branches).

- Move the expand/collapse handler from the row wrapper onto the summary row, leaving the expanded panel outside the click target
- Move `cursor: pointer` onto the summary row to match, so the expanded panel reads as selectable text rather than as a button

Before/after recordings are on the original PR: #746

## User stories

As a developer debugging a component, I can copy a pod name, container name, or the full log/event message out of the expanded row to paste into a search or a chat.

## Release note

Fixed log and event rows in the Runtime Logs and Events views collapsing when text in the expanded panel was selected, which made the full message and metadata values impossible to copy.

## Documentation

N/A — behavioural bug fix with no user-facing documentation impact.

## Training

N/A

## Certification

N/A — no certification impact for a UI interaction fix.

## Automation tests

- Unit tests
  > One regression test added per component (`LogEntry`, `EventEntry`) asserting a click inside the expanded panel does not collapse the row. 25 tests pass across the two suites on this branch. Codecov reported all modified lines covered on #746.
- Integration tests
  > N/A — covered by the unit tests above plus manual verification.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript/React change, no Java sources
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- #746 — original fix on `main`

## Migrations (if applicable)

N/A

## Test environment

macOS, Chrome. Verified manually on the Runtime Logs and component Events views.

## Learning

The root cause was structural rather than behavioural: the click target enclosed the content it was meant to reveal. Moving the target removed the need for any drag-detection heuristic. A sweep of the other 15 `Collapse` users in the repo confirmed they all already render the panel as a sibling of the click target, so no other surface needed the change.
