### PR TITLE
Fix Deploy UI showing Failed for ProjectReleaseBinding during namespace provisioning

### DIFF
--- a/.changeset/upset-clowns-worry.md
+++ b/.changeset/upset-clowns-worry.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-backend': patch
+---
+
+Fix Deploy UI showing Failed for ProjectReleaseBinding during namespace provisioning

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.test.ts
@@ -56,6 +56,17 @@ describe('deriveBindingStatus', () => {
     expect(deriveBindingStatus(binding)).toBe('NotReady');
   });
 
+  it('returns NotReady for NamespaceProgressing reason', () => {
+    const binding = makeBinding([
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'NamespaceProgressing',
+        message: 'Namespace is still being provisioned',
+      },
+    ]);
+    expect(deriveBindingStatus(binding)).toBe('NotReady');
+  });
   it('returns NotReady for JobRunning reason', () => {
     const binding = makeBinding([
       { type: 'Ready', status: 'False', reason: 'JobRunning' },

--- a/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
+++ b/plugins/openchoreo-backend/src/services/transformers/release-binding.ts
@@ -19,6 +19,9 @@ const PROGRESSING_REASONS = [
   // plane seeds it with the project's latest release once one exists, so a
   // just-created binding sits here briefly. Pending, not an error.
   'ProjectReleaseNotSet',
+  // ProjectReleaseBinding's DataPlane Namespace is still being created or has
+  // not yet been observed as ready. Pending, not an error.
+  'NamespaceProgressing',
 ] as const;
 
 /** Reasons that represent an intentional non-deployed state, not an error. */


### PR DESCRIPTION
## Purpose
Resolves openchoreo/openchoreo#4440

## Goals
Fix the Deploy UI incorrectly showing "Failed" for a ProjectReleaseBinding while its DataPlane Namespace is still being provisioned (normal `NamespaceProgressing` state).

## Approach
Added `NamespaceProgressing` to the `PROGRESSING_REASONS` list in `deriveBindingStatusDetailed` (release-binding.ts). This reason is set by the core controller when the Project's DataPlane Namespace is still being created or has not yet been observed as ready — it was previously falling through to the default "Failed" status branch since it wasn't recognized as a progressing state.

## User stories
As a developer deploying a Project for the first time, I want the Deploy UI to show a "Pending" or in-progress status while the namespace is provisioning, instead of a misleading "Failed" status that later flips to "Active" without any retry.

## Release note
Fixed an issue where the Deploy UI showed "Failed" for a ProjectReleaseBinding during normal namespace-provisioning, before it became "Active".

## Documentation
N/A - Bug fix, no doc impact.

## Training
N/A

## Certification
N/A - No impact on certification exams.

## Marketing
N/A

## Automation tests
Added a unit test for the NamespaceProgressing reason in release-binding.test.ts to verify it derives a NotReady status instead of Failed.

## Security checks
- Followed secure coding standards? Yes
- Ran FindSecurityBugs plugin? N/A
- No keys, passwords, or secrets committed? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
Verified the logic change against the reported reproduction steps in openchoreo/openchoreo#4440.

## Learning
Traced the status derivation logic from the reported UI symptom back to `deriveBindingStatusDetailed` in `release-binding.ts`, where `NamespaceProgressing` was missing from the `PROGRESSING_REASONS` allow-list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bindings now remain in a pending state while their namespace is progressing, instead of being incorrectly marked as failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->