### PR TITLE
feat: nest HelmRelease inventory children in resource tree

### DIFF
--- a/.changeset/resource-tree-helm-children.md
+++ b/.changeset/resource-tree-helm-children.md
@@ -1,0 +1,7 @@
+---
+'@openchoreo/backstage-plugin': minor
+---
+
+Nest HelmRelease Flux inventory workloads (Deployment/PVC/…) under the
+HelmRelease in the runtime resource tree so each child is a separate node
+with its own Events tab, instead of hanging flat under RenderedRelease.

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceEventsTable.tsx
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/ResourceEventsTable.tsx
@@ -113,11 +113,11 @@ export const ResourceEventsTable: FC<ResourceEventsTableProps> = ({
           const responseData = (response as any)?.data ?? response;
           const fetched = responseData?.events ?? [];
           // Sort by lastTimestamp descending (newest first)
-          fetched.sort(
-            (a: ResourceEvent, b: ResourceEvent) =>
-              new Date(b.lastTimestamp).getTime() -
-              new Date(a.lastTimestamp).getTime(),
-          );
+          fetched.sort((a: ResourceEvent, b: ResourceEvent) => {
+            const tb = new Date(b.lastTimestamp).getTime();
+            const ta = new Date(a.lastTimestamp).getTime();
+            return (Number.isNaN(tb) ? 0 : tb) - (Number.isNaN(ta) ? 0 : ta);
+          });
           setEvents(fetched);
         }
       } catch (err: any) {

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/helmInventoryNesting.test.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/helmInventoryNesting.test.ts
@@ -1,0 +1,61 @@
+import {
+  nestHelmReleaseChildren,
+  parseFluxHelmInventoryEntryId,
+} from './helmInventoryNesting';
+
+describe('helmInventoryNesting', () => {
+  it('parses Deployment and PVC inventory ids', () => {
+    expect(parseFluxHelmInventoryEntryId('obt-dev_smollm2_apps_Deployment')).toEqual({
+      namespace: 'obt-dev',
+      name: 'smollm2',
+      kind: 'Deployment',
+      group: 'apps',
+    });
+    expect(
+      parseFluxHelmInventoryEntryId(
+        'obt-dev_smollm2-model-storage__PersistentVolumeClaim',
+      ),
+    ).toEqual({
+      namespace: 'obt-dev',
+      name: 'smollm2-model-storage',
+      kind: 'PersistentVolumeClaim',
+    });
+  });
+
+  it('reparents inventory Deployment under HelmRelease', () => {
+    const nodes = [
+      {
+        id: 'hr-1',
+        kind: 'HelmRelease',
+        name: 'smollm2',
+        namespace: 'obt-dev',
+        parentIds: ['__release__rel'],
+        specObject: {
+          status: {
+            inventory: {
+              entries: [{ id: 'obt-dev_smollm2_apps_Deployment' }],
+            },
+          },
+        },
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      },
+      {
+        id: 'dep-1',
+        kind: 'Deployment',
+        name: 'smollm2',
+        namespace: 'obt-dev',
+        parentIds: ['__release__rel'],
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      },
+    ];
+
+    nestHelmReleaseChildren(nodes as any, '__release__rel');
+    expect(nodes[1].parentIds).toEqual(['hr-1']);
+  });
+});

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/helmInventoryNesting.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/helmInventoryNesting.ts
@@ -1,0 +1,140 @@
+import type { TreeNode } from './treeTypes';
+
+const INVENTORY_KINDS = [
+  'Deployment',
+  'StatefulSet',
+  'DaemonSet',
+  'ReplicaSet',
+  'Job',
+  'Pod',
+  'PersistentVolumeClaim',
+] as const;
+
+export interface FluxInventoryRef {
+  namespace: string;
+  name: string;
+  kind: string;
+  group?: string;
+}
+
+/**
+ * Parse Flux helm-controller inventory entry IDs.
+ *
+ * Examples:
+ *   obt-dev_smollm2_apps_Deployment
+ *   obt-dev_smollm2-model-storage__PersistentVolumeClaim
+ */
+export function parseFluxHelmInventoryEntryId(
+  id: string,
+): FluxInventoryRef | undefined {
+  const trimmed = id.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  for (const kind of INVENTORY_KINDS) {
+    const suffix = kind === 'PersistentVolumeClaim' ? `__${kind}` : `_${kind}`;
+    if (!trimmed.endsWith(suffix)) {
+      continue;
+    }
+    const prefix = trimmed.slice(0, -suffix.length);
+    if (kind === 'PersistentVolumeClaim') {
+      const splitAt = prefix.indexOf('_');
+      if (splitAt <= 0) {
+        return undefined;
+      }
+      return {
+        namespace: prefix.slice(0, splitAt),
+        name: prefix.slice(splitAt + 1),
+        kind,
+      };
+    }
+
+    const groupSplit = prefix.lastIndexOf('_');
+    if (groupSplit <= 0) {
+      return undefined;
+    }
+    const group = prefix.slice(groupSplit + 1);
+    const nsName = prefix.slice(0, groupSplit);
+    const nsSplit = nsName.indexOf('_');
+    if (nsSplit <= 0) {
+      return undefined;
+    }
+    return {
+      namespace: nsName.slice(0, nsSplit),
+      name: nsName.slice(nsSplit + 1),
+      kind,
+      group: group || undefined,
+    };
+  }
+
+  return undefined;
+}
+
+function resourceKey(kind: string, name: string, namespace?: string): string {
+  return `${namespace ?? ''}/${kind}/${name}`;
+}
+
+/**
+ * Nest workload nodes under their HelmRelease using Flux inventory entries.
+ * Fixes flat trees where Deployments hang under RenderedRelease because
+ * openchoreo-api omitted parentRefs on inventory workloads.
+ */
+export function nestHelmReleaseChildren(
+  nodes: TreeNode[],
+  releaseNodeId: string,
+): void {
+  const helmReleases = nodes.filter(n => n.kind === 'HelmRelease');
+  if (helmReleases.length === 0) {
+    return;
+  }
+
+  for (const hr of helmReleases) {
+    const inventoryKeys = new Set<string>();
+    const entries =
+      (
+        hr.specObject as
+          | { status?: { inventory?: { entries?: Array<{ id?: string }> } } }
+          | undefined
+      )?.status?.inventory?.entries ?? [];
+
+    for (const entry of entries) {
+      const parsed = parseFluxHelmInventoryEntryId(String(entry?.id || ''));
+      if (!parsed?.kind || !parsed?.name) {
+        continue;
+      }
+      inventoryKeys.add(
+        resourceKey(parsed.kind, parsed.name, parsed.namespace),
+      );
+    }
+
+    for (const node of nodes) {
+      if (node.id === hr.id || node.isRoot || node.kind === 'RenderedRelease') {
+        continue;
+      }
+
+      const key = resourceKey(node.kind, node.name, node.namespace);
+      const listedInInventory = inventoryKeys.has(key);
+      const onlyUnderRelease =
+        node.parentIds.length === 1 && node.parentIds[0] === releaseNodeId;
+      const alreadyUnderHr = node.parentIds.includes(hr.id);
+
+      if (listedInInventory && !alreadyUnderHr) {
+        node.parentIds = [hr.id];
+        continue;
+      }
+
+      if (
+        onlyUnderRelease &&
+        helmReleases.length === 1 &&
+        (node.kind === 'Deployment' ||
+          node.kind === 'StatefulSet' ||
+          node.kind === 'DaemonSet' ||
+          node.kind === 'PersistentVolumeClaim') &&
+        !alreadyUnderHr
+      ) {
+        node.parentIds = [hr.id];
+      }
+    }
+  }
+}

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.test.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.test.ts
@@ -157,6 +157,64 @@ describe('buildTreeNodes', () => {
     expect(svcNode.parentIds).toEqual(['dep-1']);
   });
 
+  it('nests HelmRelease inventory Deployments under the HelmRelease', () => {
+    const data: ResourceTreeData = {
+      renderedReleases: [
+        {
+          name: 'smollm2-obt-dev',
+          targetPlane: 'dp',
+          nodes: [
+            makeNode({
+              uid: 'hr-1',
+              kind: 'HelmRelease',
+              name: 'smollm2',
+              group: 'helm.toolkit.fluxcd.io',
+              version: 'v2',
+              namespace: 'obt-dev',
+              object: {
+                status: {
+                  inventory: {
+                    entries: [{ id: 'obt-dev_smollm2_apps_Deployment' }],
+                  },
+                },
+              },
+            }),
+            makeNode({
+              uid: 'dep-1',
+              kind: 'Deployment',
+              name: 'smollm2',
+              group: 'apps',
+              version: 'v1',
+              namespace: 'obt-dev',
+            }),
+            makeNode({
+              uid: 'pod-1',
+              kind: 'Pod',
+              name: 'smollm2-abc',
+              namespace: 'obt-dev',
+              parentRefs: [
+                {
+                  uid: 'dep-1',
+                  kind: 'Deployment',
+                  name: 'smollm2',
+                  version: 'v1',
+                  namespace: 'obt-dev',
+                },
+              ],
+            }),
+          ],
+        },
+      ],
+    };
+
+    const nodes = buildTreeNodes(data);
+    const dep = nodes.find(n => n.kind === 'Deployment')!;
+    const pod = nodes.find(n => n.kind === 'Pod')!;
+
+    expect(dep.parentIds).toEqual(['hr-1']);
+    expect(pod.parentIds).toEqual(['dep-1']);
+  });
+
   it('preserves resource node metadata', () => {
     const nodes = buildTreeNodes(singleReleaseData);
     const depNode = nodes.find(n => n.kind === 'Deployment')!;

--- a/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.ts
+++ b/plugins/openchoreo/src/components/Environments/ReleaseDataRenderer/ResourceTreeView/treeLayoutUtils.ts
@@ -11,6 +11,7 @@ import type {
   EdgeLine,
   TreeLayout,
 } from './treeTypes';
+import { nestHelmReleaseChildren } from './helmInventoryNesting';
 
 export const NODE_WIDTH = 320;
 export const NODE_HEIGHT = 64;
@@ -142,6 +143,8 @@ export function buildTreeNodes(
         parentIds,
       });
     }
+
+    nestHelmReleaseChildren(nodes, releaseNodeId);
   }
 
   return nodes;


### PR DESCRIPTION
## Summary

Nest Flux HelmRelease inventory workloads (Deployment / PVC / …) **under the HelmRelease** in the runtime resource tree.

Previously those children often hung as flat siblings under `RenderedRelease` (missing `parentRefs`), so the HelmRelease looked like a leaf and there was no place to open per-child Events.

### Behavior
- Parse `HelmRelease.status.inventory.entries` and re-parent matching tree nodes under that HelmRelease
- Fallback: if there is a single HelmRelease and a Deployment/StatefulSet/PVC still only under `RenderedRelease`, nest it under the HelmRelease
- **Events stay per-node** — click Deployment/Pod to see that object's Events (no aggregation into the parent)

### Out of scope / companion
- Discovering workloads that are **absent** from `k8sresources/tree` (empty inventory and no live objects) needs openchoreo-api expansion (parentRefs + optional Flux label LIST). This PR only fixes nesting for nodes already returned by the tree API.

## Test plan
- [ ] Unit: `helmInventoryNesting.test.ts`, `treeLayoutUtils` inventory nesting case
- [ ] Runtime tree with HelmRelease that has inventory Deployment → Deployment appears **under** HelmRelease
- [ ] Click Deployment / Pod → EVENTS shows that resource's events only
- [ ] Click HelmRelease → EVENTS does **not** list child Pod/RS events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HelmRelease-managed workloads now appear nested beneath their HelmRelease in the runtime resource tree.
  * Each nested workload is displayed as a separate resource node with its own Events tab.

* **Bug Fixes**
  * Improved event sorting when resources have invalid or missing timestamps.

* **Tests**
  * Added coverage for HelmRelease inventory relationships and resource tree nesting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->