### PR TITLE
feat: add additional graphs in the cost insights view

### DIFF
--- a/.changeset/cost-insights-graphs-dashboard.md
+++ b/.changeset/cost-insights-graphs-dashboard.md
@@ -1,0 +1,20 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': minor
+---
+
+Expand the Cost Insights **Graphs** tab into a
+multi-chart dashboard rendered at every scope level:
+
+- **Spend forecast** – cumulative actual spend this month plus two month-end
+  projections ("at current rate" and "if recommendations applied"), with a
+  clickable legend to toggle each line. Independent of the chart granularity.
+- **Cost vs efficiency** – a scatter of each dimension (x: efficiency, y: cost,
+  bubble size: potential saving) with a low-efficiency band, numbered bubbles,
+  and a clickable numbered legend.
+- **Cost over time** – a per-dimension line chart and the existing stacked-bar
+  chart; at the component level the bar chart overlays a dashed
+  "if recommendations applied" line.
+
+The per-dimension saving and aggregate `totalSaving` are now computed at all
+levels (previously component-only), recommendations are fetched for the graphs
+view, and each chart carries an info tooltip describing what it shows.

--- a/plugins/openchoreo-observability/src/components/CostInsights/ChartTitle.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/ChartTitle.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChartTitle } from './ChartTitle';
+
+describe('ChartTitle', () => {
+  it('renders the title and reveals the info on hover', async () => {
+    const { container } = render(
+      <ChartTitle title="Cost over time" info="what this shows" />,
+    );
+    expect(screen.getByText('Cost over time')).toBeInTheDocument();
+    const icon = container.querySelector('svg')!;
+    fireEvent.mouseOver(icon);
+    expect(await screen.findByText('what this shows')).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/ChartTitle.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/ChartTitle.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react';
+import { Tooltip, Typography, makeStyles } from '@material-ui/core';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    marginBottom: theme.spacing(1),
+  },
+  icon: {
+    fontSize: 16,
+    color: theme.palette.text.secondary,
+    cursor: 'help',
+  },
+}));
+
+export interface ChartTitleProps {
+  title: string;
+  info: string;
+  className?: string;
+}
+
+export const ChartTitle: FC<ChartTitleProps> = ({ title, info, className }) => {
+  const classes = useStyles();
+  return (
+    <div className={`${classes.root} ${className ?? ''}`.trim()}>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Tooltip title={info} arrow>
+        <InfoOutlinedIcon className={classes.icon} />
+      </Tooltip>
+    </div>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostEfficiencyScatter.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostEfficiencyScatter.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CostEfficiencyScatter } from './CostEfficiencyScatter';
+import type { CostRow } from './types';
+
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  ScatterChart: ({ children }: any) => (
+    <div data-testid="scatter-chart">{children}</div>
+  ),
+  Scatter: ({ data, children }: any) => (
+    <div data-testid="scatter" data-count={data?.length}>
+      {children}
+    </div>
+  ),
+  Cell: () => null,
+  LabelList: () => null,
+  ReferenceArea: () => null,
+  ZAxis: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  // Invoke the tooltip render prop with a bubble's data point.
+  Tooltip: ({ content }: any) =>
+    content?.({
+      active: true,
+      payload: [
+        { payload: { rank: 1, label: 'gcp', x: 30, y: 22, saving: 5 } },
+      ],
+    }) ?? null,
+}));
+
+const rows: CostRow[] = [
+  {
+    key: 'gcp',
+    label: 'gcp',
+    cpuCost: 10,
+    memoryCost: 12,
+    total: 22,
+    efficiency: 0.3,
+    saving: 5,
+    deltaPct: null,
+  },
+  {
+    key: 'shop',
+    label: 'shop',
+    cpuCost: 1,
+    memoryCost: 1,
+    total: 2,
+    efficiency: 0.8,
+    saving: 0,
+    deltaPct: null,
+  },
+];
+
+describe('CostEfficiencyScatter', () => {
+  it('plots a bubble per row and lists them in the numbered legend', () => {
+    render(<CostEfficiencyScatter rows={rows} />);
+    expect(screen.getByTestId('scatter').getAttribute('data-count')).toBe('2');
+    expect(screen.getByText('gcp')).toBeInTheDocument();
+    expect(screen.getByText('shop')).toBeInTheDocument();
+  });
+
+  it('renders the tooltip with cost, efficiency and potential saving', () => {
+    render(<CostEfficiencyScatter rows={rows} />);
+    expect(screen.getByText(/cost \$/)).toBeInTheDocument();
+    expect(screen.getByText(/efficiency /)).toBeInTheDocument();
+    expect(screen.getByText(/potential saving \$/)).toBeInTheDocument();
+  });
+
+  it('hides a bubble when its legend item is toggled off', () => {
+    render(<CostEfficiencyScatter rows={rows} />);
+    expect(screen.getByTestId('scatter').getAttribute('data-count')).toBe('2');
+    fireEvent.click(screen.getByRole('button', { name: /gcp/ }));
+    expect(screen.getByTestId('scatter').getAttribute('data-count')).toBe('1');
+  });
+
+  it('renders an empty state without rows', () => {
+    render(<CostEfficiencyScatter rows={[]} />);
+    expect(screen.queryByTestId('scatter-chart')).not.toBeInTheDocument();
+    expect(screen.getByText(/No cost data/i)).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostEfficiencyScatter.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostEfficiencyScatter.tsx
@@ -1,0 +1,269 @@
+import { FC, useMemo, useState } from 'react';
+import { Paper, Typography, makeStyles, useTheme } from '@material-ui/core';
+import {
+  Cell,
+  LabelList,
+  ReferenceArea,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from 'recharts';
+import type { CostRow } from './types';
+import { ChartTitle } from './ChartTitle';
+import { formatAxisCost } from './chartUtils';
+import { formatCost, formatEfficiency } from './format';
+
+const LOW_EFFICIENCY_THRESHOLD = 0.4;
+const LEGEND_LIMIT = 10;
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    padding: theme.spacing(2),
+    height: 360,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  header: { marginBottom: theme.spacing(1) },
+  body: { flex: 1, minHeight: 0, display: 'flex', gap: theme.spacing(1) },
+  chart: { flex: 1, minWidth: 0 },
+  legend: {
+    width: 180,
+    overflowY: 'auto',
+    fontSize: 12,
+    color: theme.palette.text.primary,
+  },
+  legendRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.25, 0),
+  },
+  badge: {
+    width: 20,
+    height: 20,
+    borderRadius: '50%',
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: 600,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  legendLabel: {
+    flex: 1,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  legendValue: { fontWeight: 500 },
+  empty: {
+    height: 360,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+}));
+
+interface Point {
+  x: number;
+  y: number;
+  z: number;
+  rank: number;
+  label: string;
+  saving: number;
+  color: string;
+}
+
+export interface CostEfficiencyScatterProps {
+  rows: CostRow[];
+  title?: string;
+}
+
+export const CostEfficiencyScatter: FC<CostEfficiencyScatterProps> = ({
+  rows,
+  title = 'Cost vs efficiency',
+}) => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const dark = theme.palette.type === 'dark';
+
+  // Legend-toggled points; hidden labels are dimmed in the legend and not drawn.
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const toggle = (label: string) =>
+    setHidden(prev => {
+      const next = new Set(prev);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      return next;
+    });
+
+  const effColor = (eff: number): string => {
+    if (eff < LOW_EFFICIENCY_THRESHOLD) return dark ? '#d98c74' : '#b06636';
+    if (eff < 0.7) return dark ? '#d8c85f' : '#b6952f';
+    return dark ? '#4fc0a4' : '#2f8f7a';
+  };
+
+  const anySaving = rows.some(r => (r.saving ?? 0) > 0);
+
+  const points: Point[] = useMemo(
+    () =>
+      rows
+        .slice()
+        .sort((a, b) => b.total - a.total)
+        .map((row, i) => ({
+          x: Math.round((row.efficiency ?? 0) * 100),
+          y: row.total,
+          z: anySaving ? row.saving ?? 0 : row.total,
+          rank: i + 1,
+          label: row.label,
+          saving: row.saving ?? 0,
+          color: effColor(row.efficiency ?? 0),
+        })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [rows, anySaving, dark],
+  );
+
+  if (points.length === 0) {
+    return (
+      <Paper variant="outlined" className={classes.empty}>
+        <Typography color="textSecondary">
+          No cost data for the selected scope, environments and time range.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper variant="outlined" className={classes.container}>
+      <ChartTitle
+        title={title}
+        className={classes.header}
+        info="Each bubble is one dimension: x is resource efficiency, y is spend, and bubble size is the estimated saving. Bubbles in the shaded band are low-efficiency spend worth reviewing first."
+      />
+      <div className={classes.body}>
+        <div className={classes.chart}>
+          <ResponsiveContainer width="100%" height="100%">
+            <ScatterChart margin={{ top: 8, right: 16, bottom: 24, left: 0 }}>
+              <ReferenceArea
+                x1={0}
+                x2={LOW_EFFICIENCY_THRESHOLD * 100}
+                fill={dark ? '#b06636' : '#a53f63'}
+                fillOpacity={0.08}
+                label={{
+                  value: 'LOW EFFICIENCY',
+                  position: 'insideBottomLeft',
+                  fontSize: 10,
+                  fill: theme.palette.text.secondary,
+                }}
+              />
+              <XAxis
+                type="number"
+                dataKey="x"
+                name="Efficiency"
+                unit="%"
+                domain={[0, 100]}
+                tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+                label={{
+                  value: 'Efficiency →',
+                  position: 'insideBottom',
+                  offset: -12,
+                  fontSize: 12,
+                  fill: theme.palette.text.secondary,
+                }}
+              />
+              <YAxis
+                type="number"
+                dataKey="y"
+                name="Spend"
+                width={64}
+                tickFormatter={formatAxisCost}
+                tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+              />
+              <ZAxis type="number" dataKey="z" range={[120, 900]} />
+              <Tooltip
+                cursor={{ strokeDasharray: '3 3' }}
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const p = payload[0].payload as Point;
+                  return (
+                    <div
+                      style={{
+                        backgroundColor: theme.palette.background.paper,
+                        border: `1px solid ${theme.palette.divider}`,
+                        borderRadius: 4,
+                        padding: theme.spacing(1, 1.5),
+                        color: theme.palette.text.primary,
+                        fontSize: 12,
+                      }}
+                    >
+                      <div style={{ fontWeight: 600, marginBottom: 2 }}>
+                        {p.rank}. {p.label}
+                      </div>
+                      <div>cost ${formatCost(p.y)}</div>
+                      <div>efficiency {formatEfficiency(p.x / 100)}</div>
+                      <div>potential saving ${formatCost(p.saving)}</div>
+                    </div>
+                  );
+                }}
+              />
+              <Scatter
+                data={points.filter(p => !hidden.has(p.label))}
+                fillOpacity={0.85}
+              >
+                {points
+                  .filter(p => !hidden.has(p.label))
+                  .map(p => (
+                    <Cell key={p.label} fill={p.color} />
+                  ))}
+                <LabelList
+                  dataKey="rank"
+                  position="center"
+                  fill="#fff"
+                  fontSize={11}
+                  fontWeight={600}
+                />
+              </Scatter>
+            </ScatterChart>
+          </ResponsiveContainer>
+        </div>
+        <div className={classes.legend}>
+          {points.slice(0, LEGEND_LIMIT).map(p => (
+            <div
+              key={p.label}
+              role="button"
+              tabIndex={0}
+              onClick={() => toggle(p.label)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') toggle(p.label);
+              }}
+              className={classes.legendRow}
+              style={{
+                cursor: 'pointer',
+                opacity: hidden.has(p.label) ? 0.4 : 1,
+                textDecoration: hidden.has(p.label) ? 'line-through' : 'none',
+              }}
+            >
+              <span
+                className={classes.badge}
+                style={{ backgroundColor: p.color }}
+              >
+                {p.rank}
+              </span>
+              <span className={classes.legendLabel} title={p.label}>
+                {p.label}
+              </span>
+              <span className={classes.legendValue}>
+                {formatCost(anySaving ? p.saving : p.y)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Paper>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.test.tsx
@@ -17,8 +17,6 @@ function renderFilters(
     onViewChange: jest.fn(),
     timeRange: '1h',
     onTimeRangeChange: jest.fn(),
-    granularity: '1d',
-    onGranularityChange: jest.fn(),
     ...overrides,
   };
   return { props, ...render(<CostInsightsFilters {...props} />) };
@@ -28,7 +26,7 @@ describe('CostInsightsFilters', () => {
   it('renders the view toggle, environments and time range', () => {
     renderFilters();
     expect(screen.getByRole('button', { name: 'Table' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Graph' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Graphs' })).toBeInTheDocument();
     expect(
       screen.getByRole('textbox', { name: 'Environments' }),
     ).toBeInTheDocument();
@@ -37,25 +35,15 @@ describe('CostInsightsFilters', () => {
     ).toBeInTheDocument();
   });
 
-  it('hides the granularity selector in table view and shows it in graph view', () => {
-    const { rerender, props } = renderFilters({ view: 'table' });
-    expect(screen.queryByText('Time Granularity')).not.toBeInTheDocument();
-
-    rerender(<CostInsightsFilters {...props} view="graph" />);
-    expect(
-      screen.getAllByText('Time Granularity').length,
-    ).toBeGreaterThanOrEqual(1);
-  });
-
   it('emits the selected view when a toggle is clicked', () => {
     const { props } = renderFilters({ view: 'table' });
-    fireEvent.click(screen.getByRole('button', { name: 'Graph' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Graphs' }));
     expect(props.onViewChange).toHaveBeenCalledWith('graph');
   });
 
   it('disables the view toggles when disabled', () => {
     renderFilters({ disabled: true });
     expect(screen.getByRole('button', { name: 'Table' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Graph' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Graphs' })).toBeDisabled();
   });
 });

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.tsx
@@ -1,12 +1,5 @@
 import { FC } from 'react';
-import {
-  FormControl,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
-  makeStyles,
-} from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import {
@@ -41,8 +34,6 @@ export interface CostInsightsFiltersProps {
     customStartTime?: string;
     customEndTime?: string;
   }) => void;
-  granularity: string;
-  onGranularityChange: (granularity: string) => void;
   disabled?: boolean;
 }
 
@@ -64,12 +55,9 @@ export const CostInsightsFilters: FC<CostInsightsFiltersProps> = ({
   customStartTime,
   customEndTime,
   onTimeRangeChange,
-  granularity,
-  onGranularityChange,
   disabled = false,
 }) => {
   const classes = useStyles();
-  const isGraph = view === 'graph';
 
   return (
     <Grid container spacing={2} alignItems="center" wrap="nowrap">
@@ -94,7 +82,7 @@ export const CostInsightsFilters: FC<CostInsightsFiltersProps> = ({
             className={classes.toggleButton}
             disabled={disabled}
           >
-            Graph
+            Graphs
           </ToggleButton>
         </ToggleButtonGroup>
       </Grid>
@@ -120,28 +108,6 @@ export const CostInsightsFilters: FC<CostInsightsFiltersProps> = ({
           disabled={disabled}
         />
       </Grid>
-
-      {isGraph && (
-        <Grid item className={classes.control}>
-          <FormControl fullWidth variant="outlined" disabled={disabled}>
-            <InputLabel id="cost-granularity-label">
-              Time Granularity
-            </InputLabel>
-            <Select
-              labelId="cost-granularity-label"
-              label="Time Granularity"
-              value={granularity}
-              onChange={e => onGranularityChange(e.target.value as string)}
-            >
-              {GRANULARITY_OPTIONS.map(o => (
-                <MenuItem key={o.value} value={o.value}>
-                  {o.label}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Grid>
-      )}
     </Grid>
   );
 };

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraph.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraph.test.tsx
@@ -1,21 +1,30 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { CostInsightsGraph } from './CostInsightsGraph';
 import type { CostSeriesPoint } from './types';
 
-// recharts' ResponsiveContainer measures its parent, which is 0×0 in jsdom, so
-// the real chart renders nothing. Mock the primitives to expose the props we
-// care about (one <Bar> per stack key) as inspectable DOM.
+// recharts measures 0×0 in jsdom; mock the primitives, invoking the custom
+// tooltip/legend render props so their code is exercised.
 jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
-  BarChart: ({ children }: any) => (
+  ComposedChart: ({ children }: any) => (
     <div data-testid="bar-chart">{children}</div>
   ),
   Bar: ({ dataKey }: any) => <div data-testid="bar" data-key={dataKey} />,
+  Line: ({ dataKey }: any) => <div data-testid="line" data-key={dataKey} />,
   CartesianGrid: () => null,
   XAxis: () => null,
   YAxis: () => null,
-  Tooltip: () => null,
-  Legend: () => null,
+  Tooltip: ({ content }: any) =>
+    content?.({
+      active: true,
+      label: '2026-07-01T00:00:00.000Z',
+      payload: [
+        { dataKey: 'gcp', name: 'gcp', value: 10 },
+        { dataKey: 'shop', name: 'shop', value: 2 },
+        { dataKey: '__afterRec', name: 'after', value: 8 },
+      ],
+    }) ?? null,
+  Legend: ({ content }: any) => content?.() ?? null,
 }));
 
 const series: CostSeriesPoint[] = [
@@ -42,5 +51,69 @@ describe('CostInsightsGraph', () => {
     render(<CostInsightsGraph series={series} seriesKeys={[]} />);
     expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
     expect(screen.getByText(/No cost data to plot/i)).toBeInTheDocument();
+  });
+
+  it('adds the post-recommendation overlay line when an overlay is given', () => {
+    render(
+      <CostInsightsGraph
+        series={series}
+        seriesKeys={['gcp', 'shop']}
+        recommendationOverlay={{ savingFraction: 0.2 }}
+      />,
+    );
+    const line = screen.getByTestId('line');
+    expect(line.getAttribute('data-key')).toBe('__afterRec');
+  });
+
+  it('draws no overlay line without a recommendation overlay', () => {
+    render(<CostInsightsGraph series={series} seriesKeys={['gcp', 'shop']} />);
+    expect(screen.queryByTestId('line')).not.toBeInTheDocument();
+  });
+
+  it('renders the tooltip rows and the overlay entry when an overlay is set', () => {
+    render(
+      <CostInsightsGraph
+        series={series}
+        seriesKeys={['gcp', 'shop']}
+        title="Cost over time"
+        recommendationOverlay={{ savingFraction: 0.2 }}
+      />,
+    );
+    // Tooltip rows for each series plus the "If recommendations applied" entry
+    // (which also appears in the legend, hence getAllByText).
+    expect(screen.getByText('$10.00')).toBeInTheDocument();
+    expect(screen.getByText('$8.00')).toBeInTheDocument();
+    expect(
+      screen.getAllByText('If recommendations applied').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('toggles a series off via its legend item', () => {
+    render(<CostInsightsGraph series={series} seriesKeys={['gcp', 'shop']} />);
+    const legendItem = screen.getByRole('button', { name: 'gcp' });
+    fireEvent.click(legendItem);
+    expect(legendItem).toHaveStyle('text-decoration: line-through');
+  });
+
+  it('toggles a series off via the keyboard', () => {
+    render(<CostInsightsGraph series={series} seriesKeys={['gcp', 'shop']} />);
+    const legendItem = screen.getByRole('button', { name: 'shop' });
+    fireEvent.keyDown(legendItem, { key: 'Enter' });
+    expect(legendItem).toHaveStyle('text-decoration: line-through');
+  });
+
+  it('toggles the overlay line via its legend item', () => {
+    render(
+      <CostInsightsGraph
+        series={series}
+        seriesKeys={['gcp', 'shop']}
+        recommendationOverlay={{ savingFraction: 0.2 }}
+      />,
+    );
+    const overlayItem = screen.getByRole('button', {
+      name: 'If recommendations applied',
+    });
+    fireEvent.click(overlayItem);
+    expect(overlayItem).toHaveStyle('text-decoration: line-through');
   });
 });

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraph.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraph.tsx
@@ -1,30 +1,44 @@
-import { FC, useMemo } from 'react';
+import { FC, useMemo, useState } from 'react';
 import { Paper, Typography, makeStyles, useTheme } from '@material-ui/core';
 import {
   Bar,
-  BarChart,
   CartesianGrid,
+  ComposedChart,
   Legend,
+  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from 'recharts';
 import type { CostSeriesPoint } from './types';
+import { ChartTitle } from './ChartTitle';
+import {
+  FILL_OPACITY,
+  MAX_BAR_SIZE,
+  MIN_BUCKET_WIDTH,
+  PALETTE_DARK,
+  PALETTE_LIGHT,
+  buildColorMap,
+  formatAxisCost,
+  formatBucket,
+  savingColor,
+} from './chartUtils';
 
 const useStyles = makeStyles(theme => ({
   container: {
     padding: theme.spacing(2),
     height: 420,
+    display: 'flex',
+    flexDirection: 'column',
   },
+  chart: { flex: 1, minHeight: 0 },
   empty: {
     height: 420,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  // Horizontal scroll kicks in only when the chart's min width exceeds the
-  // container (many buckets); otherwise it just fills the available space.
   scroll: {
     height: '100%',
     overflowX: 'auto',
@@ -32,89 +46,64 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-// Curated categorical palettes for the stacked series. The colours are muted
-// mid-tones (calm rather than neon), yet each meets WCAG 2.2 AA / BITV 2.0
-const PALETTE_LIGHT = [
-  '#3f6cb0', // blue
-  '#2f8f7a', // teal
-  '#b06636', // rust
-  '#845bb0', // violet
-  '#a53f63', // rose
-  '#6f7a2f', // olive
-  '#2f8fae', // cyan
-  '#8a6a34', // brown
-  '#6f727a', // grey
-  '#993f8f', // magenta
-];
-const PALETTE_DARK = [
-  '#8fa8e0', // blue
-  '#4fc0a4', // teal
-  '#e0a074', // rust
-  '#bb9fe0', // violet
-  '#e07f9f', // rose
-  '#b6c470', // olive
-  '#5fc0e0', // cyan
-  '#a7adb8', // grey
-  '#d8c85f', // yellow
-  '#d98fd0', // magenta
-];
+const AFTER_REC_KEY = '__afterRec';
+const AFTER_REC_LABEL = 'If recommendations applied';
 
-const FILL_OPACITY = 0.9;
-
-// Cap each bar's width so a lone bucket doesn't stretch across the whole chart;
-// it stays this wide and centred regardless of how few bars there are.
-const MAX_BAR_SIZE = 64;
-// Minimum horizontal room per bucket. Once there are enough buckets to exceed
-// the container, the chart grows to this width per bucket and scrolls sideways
-const MIN_BUCKET_WIDTH = 48;
-
-// Costs are often sub-dollar; scale the decimal precision to the axis range so
-// small values don't all collapse to "$0".
-const formatAxisCost = (value: number): string => {
-  if (value === 0) return '$0';
-  const abs = Math.abs(value);
-  let digits = 0;
-  if (abs < 0.01) digits = 4;
-  else if (abs < 0.1) digits = 3;
-  else if (abs < 1) digits = 2;
-  else if (abs < 10) digits = 1;
-  return `$${value.toFixed(digits)}`;
-};
-
-const formatBucket = (iso: string): string => {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-};
+export interface RecommendationOverlay {
+  savingFraction: number;
+}
 
 export interface CostInsightsGraphProps {
   series: CostSeriesPoint[];
   seriesKeys: string[];
+  title?: string;
+  /** When set (component level), overlays the post-recommendation cost. */
+  recommendationOverlay?: RecommendationOverlay;
 }
 
 export const CostInsightsGraph: FC<CostInsightsGraphProps> = ({
   series,
   seriesKeys,
+  title,
+  recommendationOverlay,
 }) => {
   const classes = useStyles();
   const theme = useTheme();
   const dark = theme.palette.type === 'dark';
-
-  // Theme-aware categorical palette; flips with light/dark.
   const palette = dark ? PALETTE_DARK : PALETTE_LIGHT;
+  const green = savingColor(dark);
 
-  // Deterministic per-key colour assignment so a series keeps its colour across
-  // re-renders. With more series than palette entries the colours wrap.
-  const colorFor = useMemo(() => {
-    const map = new Map<string, string>();
-    seriesKeys.forEach((key, i) => map.set(key, palette[i % palette.length]));
-    return map;
-  }, [seriesKeys, palette]);
+  const colorFor = useMemo(
+    () => buildColorMap(seriesKeys, palette),
+    [seriesKeys, palette],
+  );
+  // Legend-toggled series; hidden keys are dimmed in the legend and not drawn.
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const toggle = (key: string) =>
+    setHidden(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  // Augment each bucket with the post-recommendation total, used only when
+  // overlaying the "cost after recommendations" line.
+  const data = useMemo(() => {
+    if (!recommendationOverlay) return series;
+    const factor = 1 - recommendationOverlay.savingFraction;
+    return series.map(point => {
+      // Sum only the visible stacks so the overlay tracks what's drawn.
+      const total = seriesKeys.reduce(
+        (sum, key) =>
+          hidden.has(key) || typeof point[key] !== 'number'
+            ? sum
+            : sum + (point[key] as number),
+        0,
+      );
+      return { ...point, [AFTER_REC_KEY]: total * factor };
+    });
+  }, [series, seriesKeys, recommendationOverlay, hidden]);
 
   if (series.length === 0 || seriesKeys.length === 0) {
     return (
@@ -129,55 +118,69 @@ export const CostInsightsGraph: FC<CostInsightsGraphProps> = ({
 
   return (
     <Paper variant="outlined" className={classes.container}>
-      <div className={classes.scroll}>
-        <div
-          style={{
-            height: '100%',
-            width: `max(100%, ${series.length * MIN_BUCKET_WIDTH}px)`,
-          }}
-        >
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={series}
-              margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
-            >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke={theme.palette.divider}
-              />
-              <XAxis
-                dataKey="timestamp"
-                tickFormatter={formatBucket}
-                tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
-              />
-              <YAxis
-                tickFormatter={formatAxisCost}
-                width={64}
-                tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
-              />
-              <Tooltip
-                cursor={{ fill: theme.palette.action.hover }}
-                content={({ active, payload, label }) => {
-                  if (!active || !payload?.length) return null;
-                  return (
-                    <div
-                      style={{
-                        backgroundColor: theme.palette.background.paper,
-                        border: `1px solid ${theme.palette.divider}`,
-                        borderRadius: 4,
-                        padding: theme.spacing(1, 1.5),
-                        color: theme.palette.text.primary,
-                        fontSize: 12,
-                      }}
-                    >
-                      <div style={{ marginBottom: 4, fontWeight: 500 }}>
-                        {formatBucket(String(label))}
-                      </div>
-                      {/* List top-to-bottom to mirror the stacked bar: the last
-                      series is drawn on top, so it appears first here. */}
-                      {[...payload].reverse().map(entry => {
-                        const colour = colorFor.get(String(entry.dataKey));
-                        return (
+      {title && (
+        <ChartTitle
+          title={title}
+          info={`Cost per dimension across time buckets, stacked to show the total.${
+            recommendationOverlay
+              ? ' The dashed line shows the total cost if the recommendations were applied.'
+              : ''
+          }`}
+        />
+      )}
+      <div className={classes.chart}>
+        <div className={classes.scroll}>
+          <div
+            style={{
+              height: '100%',
+              width: `max(100%, ${series.length * MIN_BUCKET_WIDTH}px)`,
+            }}
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart
+                data={data}
+                margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke={theme.palette.divider}
+                />
+                <XAxis
+                  dataKey="timestamp"
+                  tickFormatter={formatBucket}
+                  tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+                />
+                <YAxis
+                  tickFormatter={formatAxisCost}
+                  width={64}
+                  tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+                />
+                <Tooltip
+                  cursor={{ fill: theme.palette.action.hover }}
+                  content={({ active, payload, label }) => {
+                    if (!active || !payload?.length) return null;
+                    const rows = payload.filter(e =>
+                      seriesKeys.includes(String(e.dataKey)),
+                    );
+                    const afterRec = payload.find(
+                      e => e.dataKey === AFTER_REC_KEY,
+                    );
+                    return (
+                      <div
+                        style={{
+                          backgroundColor: theme.palette.background.paper,
+                          border: `1px solid ${theme.palette.divider}`,
+                          borderRadius: 4,
+                          padding: theme.spacing(1, 1.5),
+                          color: theme.palette.text.primary,
+                          fontSize: 12,
+                        }}
+                      >
+                        <div style={{ marginBottom: 4, fontWeight: 500 }}>
+                          {formatBucket(String(label))}
+                        </div>
+                        {/* Top-to-bottom mirrors the stacked bar (top series first). */}
+                        {[...rows].reverse().map(entry => (
                           <div
                             key={String(entry.dataKey)}
                             style={{
@@ -187,13 +190,14 @@ export const CostInsightsGraph: FC<CostInsightsGraphProps> = ({
                               lineHeight: 1.6,
                             }}
                           >
-                            {/* Colour swatch tying the row back to its stacked bar. */}
                             <span
                               style={{
                                 width: 10,
                                 height: 10,
                                 borderRadius: 2,
-                                backgroundColor: colour,
+                                backgroundColor: colorFor.get(
+                                  String(entry.dataKey),
+                                ),
                                 opacity: FILL_OPACITY,
                                 flexShrink: 0,
                               }}
@@ -205,37 +209,62 @@ export const CostInsightsGraph: FC<CostInsightsGraphProps> = ({
                               ${Number(entry.value).toFixed(2)}
                             </span>
                           </div>
-                        );
-                      })}
-                    </div>
-                  );
-                }}
-              />
-              <Legend
-                content={({ payload }) => (
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                      justifyContent: 'center',
-                      gap: theme.spacing(0.5, 1.5),
-                      paddingTop: theme.spacing(1),
-                      color: theme.palette.text.primary,
-                      fontSize: 12,
-                    }}
-                  >
-                    {payload?.map(entry => {
-                      const key = String(entry.dataKey ?? entry.value);
-                      return (
+                        ))}
+                        {afterRec && (
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 6,
+                              lineHeight: 1.6,
+                              marginTop: 4,
+                              color: green,
+                              fontWeight: 500,
+                            }}
+                          >
+                            <span>{AFTER_REC_LABEL}</span>
+                            <span style={{ marginLeft: 'auto' }}>
+                              ${Number(afterRec.value).toFixed(2)}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  }}
+                />
+                <Legend
+                  content={() => (
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        justifyContent: 'center',
+                        gap: theme.spacing(0.5, 1.5),
+                        paddingTop: theme.spacing(1),
+                        color: theme.palette.text.primary,
+                        fontSize: 12,
+                      }}
+                    >
+                      {seriesKeys.map(key => (
                         <span
                           key={key}
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => toggle(key)}
+                          onKeyDown={e => {
+                            if (e.key === 'Enter' || e.key === ' ') toggle(key);
+                          }}
                           style={{
                             display: 'inline-flex',
                             alignItems: 'center',
                             gap: 6,
+                            cursor: 'pointer',
+                            opacity: hidden.has(key) ? 0.4 : 1,
+                            textDecoration: hidden.has(key)
+                              ? 'line-through'
+                              : 'none',
                           }}
                         >
-                          {/* Swatch at the same opacity as the bars. */}
                           <span
                             style={{
                               width: 10,
@@ -246,26 +275,72 @@ export const CostInsightsGraph: FC<CostInsightsGraphProps> = ({
                               flexShrink: 0,
                             }}
                           />
-                          {String(entry.value)}
+                          {key}
                         </span>
-                      );
-                    })}
-                  </div>
-                )}
-              />
-              {seriesKeys.map(key => (
-                <Bar
-                  key={key}
-                  dataKey={key}
-                  stackId="cost"
-                  fill={colorFor.get(key)}
-                  fillOpacity={FILL_OPACITY}
-                  name={key}
-                  maxBarSize={MAX_BAR_SIZE}
+                      ))}
+                      {recommendationOverlay && (
+                        <span
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => toggle(AFTER_REC_KEY)}
+                          onKeyDown={e => {
+                            if (e.key === 'Enter' || e.key === ' ')
+                              toggle(AFTER_REC_KEY);
+                          }}
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 6,
+                            cursor: 'pointer',
+                            color: green,
+                            opacity: hidden.has(AFTER_REC_KEY) ? 0.4 : 1,
+                            textDecoration: hidden.has(AFTER_REC_KEY)
+                              ? 'line-through'
+                              : 'none',
+                          }}
+                        >
+                          <span
+                            style={{
+                              width: 14,
+                              height: 0,
+                              borderTop: `2px dashed ${green}`,
+                              flexShrink: 0,
+                            }}
+                          />
+                          {AFTER_REC_LABEL}
+                        </span>
+                      )}
+                    </div>
+                  )}
                 />
-              ))}
-            </BarChart>
-          </ResponsiveContainer>
+                {seriesKeys.map(key => (
+                  <Bar
+                    key={key}
+                    dataKey={key}
+                    stackId="cost"
+                    fill={colorFor.get(key)}
+                    fillOpacity={FILL_OPACITY}
+                    name={key}
+                    maxBarSize={MAX_BAR_SIZE}
+                    hide={hidden.has(key)}
+                  />
+                ))}
+                {recommendationOverlay && (
+                  <Line
+                    dataKey={AFTER_REC_KEY}
+                    stroke={green}
+                    strokeWidth={2}
+                    strokeDasharray="5 4"
+                    dot={false}
+                    name={AFTER_REC_LABEL}
+                    isAnimationActive={false}
+                    legendType="none"
+                    hide={hidden.has(AFTER_REC_KEY)}
+                  />
+                )}
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       </div>
     </Paper>

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraphs.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraphs.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CostInsightsGraphs } from './CostInsightsGraphs';
+import type { CostInsightsData } from './types';
+
+// The individual charts are covered by their own suites; stub them so this
+// suite focuses on the container's layout and the granularity control.
+jest.mock('./ForecastDivergenceChart', () => ({
+  ForecastDivergenceChart: () => <div data-testid="forecast" />,
+}));
+jest.mock('./CostEfficiencyScatter', () => ({
+  CostEfficiencyScatter: () => <div data-testid="scatter" />,
+}));
+jest.mock('./CostLineChart', () => ({
+  CostLineChart: () => <div data-testid="line" />,
+}));
+jest.mock('./CostInsightsGraph', () => ({
+  CostInsightsGraph: ({ recommendationOverlay }: any) => (
+    <div
+      data-testid="bar"
+      data-overlay={recommendationOverlay ? 'yes' : 'no'}
+    />
+  ),
+}));
+
+const data = (over: Partial<CostInsightsData> = {}): CostInsightsData => ({
+  level: 'namespace',
+  summary: {
+    totalCost: 100,
+    deltaPct: null,
+    forecastThisMonth: 200,
+    efficiency: 0.5,
+    totalSaving: 0,
+  },
+  rows: [],
+  series: [{ timestamp: '2026-07-01T00:00:00.000Z', gcp: 10 }],
+  seriesKeys: ['gcp'],
+  forecast: null,
+  ...over,
+});
+
+describe('CostInsightsGraphs', () => {
+  it('renders all four charts and the granularity selector', () => {
+    render(
+      <CostInsightsGraphs
+        data={data()}
+        granularity="1d"
+        onGranularityChange={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId('forecast')).toBeInTheDocument();
+    expect(screen.getByTestId('scatter')).toBeInTheDocument();
+    expect(screen.getByTestId('line')).toBeInTheDocument();
+    expect(screen.getByTestId('bar')).toBeInTheDocument();
+    expect(screen.getByLabelText('Time Granularity')).toBeInTheDocument();
+  });
+
+  it('emits granularity changes', () => {
+    const onGranularityChange = jest.fn();
+    render(
+      <CostInsightsGraphs
+        data={data()}
+        granularity="1d"
+        onGranularityChange={onGranularityChange}
+      />,
+    );
+    fireEvent.mouseDown(screen.getByLabelText('Time Granularity'));
+    const option = screen.getAllByRole('option')[0];
+    fireEvent.click(option);
+    expect(onGranularityChange).toHaveBeenCalled();
+  });
+
+  it('passes a recommendation overlay only at the component level with saving', () => {
+    const { rerender } = render(
+      <CostInsightsGraphs
+        data={data()}
+        granularity="1d"
+        onGranularityChange={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId('bar').getAttribute('data-overlay')).toBe('no');
+
+    rerender(
+      <CostInsightsGraphs
+        data={data({
+          level: 'component',
+          summary: {
+            totalCost: 100,
+            deltaPct: null,
+            forecastThisMonth: 200,
+            efficiency: 0.5,
+            totalSaving: 40,
+          },
+        })}
+        granularity="1d"
+        onGranularityChange={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId('bar').getAttribute('data-overlay')).toBe('yes');
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraphs.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraphs.tsx
@@ -1,0 +1,106 @@
+import { FC } from 'react';
+import {
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  makeStyles,
+} from '@material-ui/core';
+import type { CostInsightsData } from './types';
+import { ForecastDivergenceChart } from './ForecastDivergenceChart';
+import { CostEfficiencyScatter } from './CostEfficiencyScatter';
+import { CostLineChart } from './CostLineChart';
+import { CostInsightsGraph } from './CostInsightsGraph';
+import { GRANULARITY_OPTIONS } from './CostInsightsFilters';
+
+const useStyles = makeStyles(theme => ({
+  timeSeriesGroup: {
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(2),
+  },
+  groupHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  },
+  granularityControl: { minWidth: 220 },
+}));
+
+export interface CostInsightsGraphsProps {
+  data: CostInsightsData;
+  granularity: string;
+  onGranularityChange: (granularity: string) => void;
+}
+
+export const CostInsightsGraphs: FC<CostInsightsGraphsProps> = ({
+  data,
+  granularity,
+  onGranularityChange,
+}) => {
+  const classes = useStyles();
+  const { summary } = data;
+  const overlay =
+    data.level === 'component' &&
+    summary.totalSaving > 0 &&
+    summary.totalCost > 0
+      ? { savingFraction: summary.totalSaving / summary.totalCost }
+      : undefined;
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12} md={6}>
+        <ForecastDivergenceChart forecast={data.forecast} />
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <CostEfficiencyScatter rows={data.rows} />
+      </Grid>
+      <Grid item xs={12}>
+        {/* Grouped so it's clear the granularity applies only to these two. */}
+        <div className={classes.timeSeriesGroup}>
+          <div className={classes.groupHeader}>
+            <FormControl
+              variant="outlined"
+              className={classes.granularityControl}
+            >
+              <InputLabel id="cost-granularity-label">
+                Time Granularity
+              </InputLabel>
+              <Select
+                labelId="cost-granularity-label"
+                label="Time Granularity"
+                value={granularity}
+                onChange={e => onGranularityChange(e.target.value as string)}
+              >
+                {GRANULARITY_OPTIONS.map(o => (
+                  <MenuItem key={o.value} value={o.value}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </div>
+          <Grid container spacing={2}>
+            <Grid item xs={12}>
+              <CostLineChart
+                series={data.series}
+                seriesKeys={data.seriesKeys}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <CostInsightsGraph
+                series={data.series}
+                seriesKeys={data.seriesKeys}
+                title="Cost over time"
+                recommendationOverlay={overlay}
+              />
+            </Grid>
+          </Grid>
+        </div>
+      </Grid>
+    </Grid>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.test.tsx
@@ -17,8 +17,8 @@ jest.mock('./CostSummaryCards', () => ({
 jest.mock('./CostInsightsTable', () => ({
   CostInsightsTable: () => <div data-testid="cost-table" />,
 }));
-jest.mock('./CostInsightsGraph', () => ({
-  CostInsightsGraph: () => <div data-testid="cost-graph" />,
+jest.mock('./CostInsightsGraphs', () => ({
+  CostInsightsGraphs: () => <div data-testid="cost-graph" />,
 }));
 
 const mockUseNamespaceEnvironments = jest.fn();
@@ -43,6 +43,7 @@ const data = {
     deltaPct: 10,
     forecastThisMonth: 500,
     efficiency: 0.3,
+    totalSaving: 0,
   },
   rows: [
     {

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.tsx
@@ -17,7 +17,7 @@ import {
 } from './CostInsightsFilters';
 import { CostSummaryCards } from './CostSummaryCards';
 import { CostInsightsTable } from './CostInsightsTable';
-import { CostInsightsGraph } from './CostInsightsGraph';
+import { CostInsightsGraphs } from './CostInsightsGraphs';
 import { useNamespaceEnvironments } from './useNamespaceEnvironments';
 import { useDimensionTitles } from './useDimensionTitles';
 import { useCostInsights } from './useCostInsights';
@@ -238,8 +238,6 @@ export const CostInsightsPage = () => {
             customStartTime={customStartTime}
             customEndTime={customEndTime}
             onTimeRangeChange={onTimeRangeChange}
-            granularity={granularity}
-            onGranularityChange={onGranularityChange}
           />
         </Box>
 
@@ -252,8 +250,7 @@ export const CostInsightsPage = () => {
         {noEnvironments && (
           <Box className={classes.section}>
             <Alert severity="info">
-              No environments found for namespace “{namespace}”. Select another
-              namespace from the breadcrumb.
+              No environments found for namespace “{namespace}”.
             </Alert>
           </Box>
         )}
@@ -282,14 +279,17 @@ export const CostInsightsPage = () => {
               active={isRefetching}
               label="Refreshing cost data"
             />
-            <Box className={classes.section}>
-              <CostSummaryCards summary={data.summary} />
-            </Box>
+            {view !== 'graph' && (
+              <Box className={classes.section}>
+                <CostSummaryCards summary={data.summary} />
+              </Box>
+            )}
             <Box className={classes.section}>
               {view === 'graph' ? (
-                <CostInsightsGraph
-                  series={data.series}
-                  seriesKeys={data.seriesKeys}
+                <CostInsightsGraphs
+                  data={data}
+                  granularity={granularity}
+                  onGranularityChange={onGranularityChange}
                 />
               ) : (
                 <CostInsightsTable

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostLineChart.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostLineChart.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CostLineChart } from './CostLineChart';
+import type { CostSeriesPoint } from './types';
+
+// recharts measures 0×0 in jsdom; mock the primitives and invoke the custom
+// tooltip/legend render props so their code is exercised.
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  LineChart: ({ children }: any) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  Line: ({ dataKey }: any) => <div data-testid="line" data-key={dataKey} />,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: ({ content }: any) =>
+    content?.({
+      active: true,
+      label: '2026-07-01T00:00:00.000Z',
+      payload: [
+        { dataKey: 'gcp', name: 'gcp', value: 10 },
+        { dataKey: 'shop', name: 'shop', value: 2 },
+      ],
+    }) ?? null,
+  Legend: ({ content }: any) => <div>{content?.()}</div>,
+}));
+
+const series: CostSeriesPoint[] = [
+  { timestamp: '2026-07-01T00:00:00.000Z', gcp: 10, shop: 2 },
+  { timestamp: '2026-07-02T00:00:00.000Z', gcp: 6 },
+];
+
+describe('CostLineChart', () => {
+  it('renders one line per series key', () => {
+    render(<CostLineChart series={series} seriesKeys={['gcp', 'shop']} />);
+    expect(
+      screen.getAllByTestId('line').map(l => l.getAttribute('data-key')),
+    ).toEqual(['gcp', 'shop']);
+  });
+
+  it('renders an empty state when there is no data', () => {
+    render(<CostLineChart series={[]} seriesKeys={[]} />);
+    expect(screen.queryByTestId('line-chart')).not.toBeInTheDocument();
+    expect(screen.getByText(/No cost data to plot/i)).toBeInTheDocument();
+  });
+
+  it('renders tooltip rows sorted by value', () => {
+    render(<CostLineChart series={series} seriesKeys={['gcp', 'shop']} />);
+    expect(screen.getByText('$10.00')).toBeInTheDocument();
+    expect(screen.getByText('$2.00')).toBeInTheDocument();
+  });
+
+  it('toggles a series off via its legend item', () => {
+    render(<CostLineChart series={series} seriesKeys={['gcp', 'shop']} />);
+    const legendItem = screen.getByRole('button', { name: 'gcp' });
+    fireEvent.click(legendItem);
+    expect(legendItem).toHaveStyle('text-decoration: line-through');
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostLineChart.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostLineChart.tsx
@@ -1,0 +1,222 @@
+import { FC, useMemo, useState } from 'react';
+import { Paper, Typography, makeStyles, useTheme } from '@material-ui/core';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { CostSeriesPoint } from './types';
+import { ChartTitle } from './ChartTitle';
+import {
+  PALETTE_DARK,
+  PALETTE_LIGHT,
+  buildColorMap,
+  formatAxisCost,
+  formatBucket,
+} from './chartUtils';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    padding: theme.spacing(2),
+    height: 360,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  chart: { flex: 1, minHeight: 0 },
+  empty: {
+    height: 360,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+}));
+
+export interface CostLineChartProps {
+  series: CostSeriesPoint[];
+  seriesKeys: string[];
+  title?: string;
+}
+
+export const CostLineChart: FC<CostLineChartProps> = ({
+  series,
+  seriesKeys,
+  title = 'Cost over time',
+}) => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const dark = theme.palette.type === 'dark';
+  const palette = dark ? PALETTE_DARK : PALETTE_LIGHT;
+
+  const colorFor = useMemo(
+    () => buildColorMap(seriesKeys, palette),
+    [seriesKeys, palette],
+  );
+  // Legend-toggled series; hidden keys are dimmed in the legend and not drawn.
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const toggle = (key: string) =>
+    setHidden(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  if (series.length === 0 || seriesKeys.length === 0) {
+    return (
+      <Paper variant="outlined" className={classes.empty}>
+        <Typography color="textSecondary">
+          No cost data to plot for the selected scope, environments and time
+          range.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper variant="outlined" className={classes.container}>
+      <ChartTitle
+        title={title}
+        info="Cost over time for each dimension, one line per dimension."
+      />
+      <div className={classes.chart}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={series}
+            margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={theme.palette.divider}
+            />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatBucket}
+              tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+            />
+            <YAxis
+              tickFormatter={formatAxisCost}
+              width={64}
+              tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+            />
+            <Tooltip
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null;
+                return (
+                  <div
+                    style={{
+                      backgroundColor: theme.palette.background.paper,
+                      border: `1px solid ${theme.palette.divider}`,
+                      borderRadius: 4,
+                      padding: theme.spacing(1, 1.5),
+                      color: theme.palette.text.primary,
+                      fontSize: 12,
+                    }}
+                  >
+                    <div style={{ marginBottom: 4, fontWeight: 500 }}>
+                      {formatBucket(String(label))}
+                    </div>
+                    {/* Highest line first, so the order matches the chart. */}
+                    {[...payload]
+                      .sort((a, b) => Number(b.value) - Number(a.value))
+                      .map(entry => (
+                        <div
+                          key={String(entry.dataKey)}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 6,
+                            lineHeight: 1.6,
+                          }}
+                        >
+                          <span
+                            style={{
+                              width: 10,
+                              height: 10,
+                              borderRadius: 2,
+                              backgroundColor: colorFor.get(
+                                String(entry.dataKey),
+                              ),
+                              flexShrink: 0,
+                            }}
+                          />
+                          <span>{entry.name}</span>
+                          <span style={{ marginLeft: 'auto', fontWeight: 500 }}>
+                            ${Number(entry.value).toFixed(2)}
+                          </span>
+                        </div>
+                      ))}
+                  </div>
+                );
+              }}
+            />
+            <Legend
+              content={() => (
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    justifyContent: 'center',
+                    gap: theme.spacing(0.5, 1.5),
+                    paddingTop: theme.spacing(1),
+                    color: theme.palette.text.primary,
+                    fontSize: 12,
+                  }}
+                >
+                  {seriesKeys.map(key => (
+                    <span
+                      key={key}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => toggle(key)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' || e.key === ' ') toggle(key);
+                      }}
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        cursor: 'pointer',
+                        opacity: hidden.has(key) ? 0.4 : 1,
+                        textDecoration: hidden.has(key)
+                          ? 'line-through'
+                          : 'none',
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 14,
+                          height: 0,
+                          borderTop: `2px solid ${colorFor.get(key)}`,
+                          flexShrink: 0,
+                        }}
+                      />
+                      {key}
+                    </span>
+                  ))}
+                </div>
+              )}
+            />
+            {seriesKeys.map(key => (
+              <Line
+                key={key}
+                dataKey={key}
+                name={key}
+                stroke={colorFor.get(key)}
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+                hide={hidden.has(key)}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </Paper>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.test.tsx
@@ -7,6 +7,7 @@ const summary = (over: Partial<CostSummary> = {}): CostSummary => ({
   deltaPct: 10,
   forecastThisMonth: 500,
   efficiency: 0.3,
+  totalSaving: 0,
   ...over,
 });
 

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
-import { Grid, Typography, makeStyles } from '@material-ui/core';
+import { Grid, Tooltip, Typography, makeStyles } from '@material-ui/core';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import { Card } from '@openchoreo/backstage-design-system';
 import type { CostSummary } from './types';
 import { formatUsd, formatEfficiency } from './format';
@@ -31,6 +32,12 @@ const useStyles = makeStyles(theme => ({
   down: { color: theme.palette.success.main },
   deltaIcon: { fontSize: 16 },
   muted: { color: theme.palette.text.secondary },
+  labelRow: { display: 'flex', alignItems: 'center', gap: theme.spacing(0.5) },
+  infoIcon: {
+    fontSize: 15,
+    color: theme.palette.text.secondary,
+    cursor: 'help',
+  },
 }));
 
 export interface CostSummaryCardsProps {
@@ -90,7 +97,15 @@ export const CostSummaryCards: FC<CostSummaryCardsProps> = ({ summary }) => {
       </Grid>
       <Grid item xs={12} sm={4}>
         <Card padding={16} className={classes.card}>
-          <Typography className={classes.label}>Efficiency</Typography>
+          <div className={classes.labelRow}>
+            <Typography className={classes.label}>Efficiency</Typography>
+            <Tooltip
+              title="Share of provisioned resources actually used (usage/requested) as a percentage, weighted by cost. Low efficiency means you are paying for capacity that sits idle."
+              arrow
+            >
+              <InfoOutlinedIcon className={classes.infoIcon} />
+            </Tooltip>
+          </div>
           <Typography component="div" className={classes.value}>
             {formatEfficiency(summary.efficiency)}
           </Typography>

--- a/plugins/openchoreo-observability/src/components/CostInsights/ForecastDivergenceChart.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/ForecastDivergenceChart.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ForecastDivergenceChart } from './ForecastDivergenceChart';
+import type { ForecastData } from './types';
+
+const JUL9 = new Date('2026-07-09T00:00:00.000Z').getTime();
+const AUG1 = new Date('2026-08-01T00:00:00.000Z').getTime();
+
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  ComposedChart: ({ children }: any) => (
+    <div data-testid="forecast-chart">{children}</div>
+  ),
+  Line: ({ dataKey, children }: any) => (
+    <div data-testid="line" data-key={dataKey}>
+      {children}
+    </div>
+  ),
+  // Invoke the end-label render prop for both the last point (renders) and an
+  // earlier point (returns null).
+  LabelList: ({ content }: any) => (
+    <>
+      {content?.({ index: 2, x: 100, y: 50 })}
+      {content?.({ index: 0, x: 10, y: 10 })}
+    </>
+  ),
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  // Render both tooltip branches: the pre-fork "actual" point and the two
+  // post-fork projections.
+  Tooltip: ({ content }: any) => (
+    <>
+      {content?.({
+        active: true,
+        label: JUL9,
+        payload: [{ dataKey: 'actual', name: 'so far', value: 24 }],
+      })}
+      {content?.({
+        active: true,
+        label: AUG1,
+        payload: [
+          { dataKey: 'atCurrent', name: 'at current rate', value: 90 },
+          {
+            dataKey: 'ifApplied',
+            name: 'if recommendations applied',
+            value: 70,
+          },
+        ],
+      })}
+    </>
+  ),
+}));
+
+const forecast: ForecastData = {
+  points: [
+    { timestamp: '2026-07-01T00:00:00.000Z', actual: 0 },
+    {
+      timestamp: '2026-07-09T00:00:00.000Z',
+      actual: 24,
+      atCurrent: 24,
+      ifApplied: 24,
+    },
+    { timestamp: '2026-08-01T00:00:00.000Z', atCurrent: 90, ifApplied: 70 },
+  ],
+  atCurrentTotal: 90,
+  ifAppliedTotal: 70,
+  leftOnTable: 20,
+};
+
+describe('ForecastDivergenceChart', () => {
+  it('renders the three projection lines with a clickable legend', () => {
+    render(<ForecastDivergenceChart forecast={forecast} />);
+    expect(
+      screen.getAllByTestId('line').map(l => l.getAttribute('data-key')),
+    ).toEqual(['actual', 'atCurrent', 'ifApplied']);
+    // Appears in both the legend and the (mock-invoked) tooltip.
+    expect(screen.getAllByText('so far').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('at current rate').length).toBeGreaterThan(0);
+  });
+
+  it('renders both tooltip branches and the end labels', () => {
+    render(<ForecastDivergenceChart forecast={forecast} />);
+    // Pre-fork tooltip shows only "so far"; post-fork shows both projections.
+    expect(screen.getByText('$24.00')).toBeInTheDocument();
+    expect(screen.getByText('$90.00')).toBeInTheDocument();
+    expect(screen.getByText('$70.00')).toBeInTheDocument();
+    // End labels drawn at the last point.
+    expect(screen.getAllByText('at current rate').length).toBeGreaterThan(1);
+  });
+
+  it('toggles a line off via its legend item', () => {
+    render(<ForecastDivergenceChart forecast={forecast} />);
+    const legendItem = screen.getByRole('button', { name: 'so far' });
+    fireEvent.click(legendItem);
+    expect(legendItem).toHaveStyle('text-decoration: line-through');
+  });
+
+  it('renders an empty state when there is no forecast', () => {
+    render(<ForecastDivergenceChart forecast={null} />);
+    expect(screen.queryByTestId('forecast-chart')).not.toBeInTheDocument();
+    expect(screen.getByText(/Not enough data to project/i)).toBeInTheDocument();
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/ForecastDivergenceChart.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/ForecastDivergenceChart.tsx
@@ -1,0 +1,272 @@
+import { FC, useMemo, useState } from 'react';
+import { Paper, Typography, makeStyles, useTheme } from '@material-ui/core';
+import {
+  CartesianGrid,
+  ComposedChart,
+  LabelList,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ForecastData } from './types';
+import { ChartTitle } from './ChartTitle';
+import {
+  PALETTE_DARK,
+  PALETTE_LIGHT,
+  formatAxisCost,
+  formatBucket,
+  savingColor,
+} from './chartUtils';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    padding: theme.spacing(2),
+    height: 360,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  header: { marginBottom: theme.spacing(1) },
+  chart: { flex: 1, minHeight: 0 },
+  legend: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: theme.spacing(0.5, 1.5),
+    paddingTop: theme.spacing(1),
+    color: theme.palette.text.primary,
+    fontSize: 12,
+  },
+  legendItem: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    cursor: 'pointer',
+  },
+  empty: {
+    height: 360,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+}));
+
+export interface ForecastDivergenceChartProps {
+  forecast: ForecastData | null;
+  title?: string;
+}
+
+export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
+  forecast,
+  title = 'Spend forecast',
+}) => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const dark = theme.palette.type === 'dark';
+  const blue = (dark ? PALETTE_DARK : PALETTE_LIGHT)[0];
+  const green = savingColor(dark);
+
+  // Legend-toggled lines; hidden keys are dimmed in the legend and not drawn.
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const toggle = (key: string) =>
+    setHidden(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  const legendItems = [
+    { key: 'actual', name: 'so far', color: blue, dashed: false },
+    { key: 'atCurrent', name: 'at current rate', color: blue, dashed: true },
+    { key: 'ifApplied', name: 'if applied', color: green, dashed: true },
+  ];
+
+  const data = useMemo(
+    () =>
+      (forecast?.points ?? []).map(p => ({
+        ...p,
+        t: new Date(p.timestamp).getTime(),
+      })),
+    [forecast],
+  );
+
+  if (!forecast || data.length === 0) {
+    return (
+      <Paper variant="outlined" className={classes.empty}>
+        <Typography color="textSecondary">
+          Not enough data to project a forecast for this window.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  const lastIndex = data.length - 1;
+  const endLabel =
+    (text: string, color: string, dy: number) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (props: any) => {
+      if (props.index !== lastIndex) return null;
+      const { x = 0, y = 0 } = props;
+      return (
+        <text
+          x={x - 6}
+          y={y + dy}
+          textAnchor="end"
+          dominantBaseline="central"
+          fill={color}
+          fontSize={12}
+          fontWeight={600}
+        >
+          {text}
+        </text>
+      );
+    };
+
+  return (
+    <Paper variant="outlined" className={classes.container}>
+      <ChartTitle
+        title={title}
+        className={classes.header}
+        info="Cumulative spend so far this month (solid), then two projections to month end: at the current rate, and if the cost recommendations are applied. The gap is the potential saving."
+      />
+      <div className={classes.chart}>
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart
+            data={data}
+            margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={theme.palette.divider}
+            />
+            <XAxis
+              dataKey="t"
+              type="number"
+              scale="time"
+              domain={['dataMin', 'dataMax']}
+              tickFormatter={ms => formatBucket(new Date(ms).toISOString())}
+              tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+            />
+            <YAxis
+              tickFormatter={formatAxisCost}
+              width={64}
+              tick={{ fontSize: 12, fill: theme.palette.text.secondary }}
+            />
+            <Tooltip
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null;
+                // Up to now the point is on the single actual line, so show only
+                // "so far"; past now show the two projections.
+                const actual = payload.find(e => e.dataKey === 'actual');
+                const shown = actual
+                  ? [actual]
+                  : payload.filter(e => e.dataKey !== 'actual');
+                if (!shown.length) return null;
+                return (
+                  <div
+                    style={{
+                      backgroundColor: theme.palette.background.paper,
+                      border: `1px solid ${theme.palette.divider}`,
+                      borderRadius: 4,
+                      padding: theme.spacing(1, 1.5),
+                      color: theme.palette.text.primary,
+                      fontSize: 12,
+                    }}
+                  >
+                    <div style={{ marginBottom: 4, fontWeight: 500 }}>
+                      {formatBucket(new Date(Number(label)).toISOString())}
+                    </div>
+                    {shown.map(entry => (
+                      <div
+                        key={String(entry.dataKey)}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 12,
+                          lineHeight: 1.6,
+                          color: entry.color,
+                        }}
+                      >
+                        <span>{entry.name}</span>
+                        <span style={{ marginLeft: 'auto', fontWeight: 500 }}>
+                          ${Number(entry.value).toFixed(2)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                );
+              }}
+            />
+            <Line
+              dataKey="actual"
+              name="so far"
+              stroke={blue}
+              strokeWidth={2}
+              dot={false}
+              connectNulls
+              hide={hidden.has('actual')}
+              isAnimationActive={false}
+            />
+            <Line
+              dataKey="atCurrent"
+              name="at current rate"
+              stroke={blue}
+              strokeWidth={2}
+              strokeDasharray="5 4"
+              dot={false}
+              connectNulls
+              hide={hidden.has('atCurrent')}
+              isAnimationActive={false}
+            >
+              <LabelList content={endLabel('at current rate', blue, -12)} />
+            </Line>
+            <Line
+              dataKey="ifApplied"
+              name="if recommendations applied"
+              stroke={green}
+              strokeWidth={2}
+              strokeDasharray="5 4"
+              dot={false}
+              connectNulls
+              hide={hidden.has('ifApplied')}
+              isAnimationActive={false}
+            >
+              <LabelList content={endLabel('if applied', green, 14)} />
+            </Line>
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+      <div className={classes.legend}>
+        {legendItems.map(item => (
+          <span
+            key={item.key}
+            role="button"
+            tabIndex={0}
+            onClick={() => toggle(item.key)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') toggle(item.key);
+            }}
+            className={classes.legendItem}
+            style={{
+              opacity: hidden.has(item.key) ? 0.4 : 1,
+              textDecoration: hidden.has(item.key) ? 'line-through' : 'none',
+            }}
+          >
+            <span
+              style={{
+                width: 14,
+                height: 0,
+                borderTop: `2px ${item.dashed ? 'dashed' : 'solid'} ${
+                  item.color
+                }`,
+                flexShrink: 0,
+              }}
+            />
+            {item.name}
+          </span>
+        ))}
+      </div>
+    </Paper>
+  );
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/chartUtils.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/chartUtils.test.ts
@@ -1,0 +1,56 @@
+import {
+  PALETTE_DARK,
+  PALETTE_LIGHT,
+  buildColorMap,
+  formatAxisCost,
+  formatBucket,
+  savingColor,
+} from './chartUtils';
+
+describe('savingColor', () => {
+  it('picks a theme-aware green', () => {
+    expect(savingColor(true)).not.toBe(savingColor(false));
+  });
+});
+
+describe('buildColorMap', () => {
+  it('assigns a palette colour per key and wraps past the palette length', () => {
+    const keys = Array.from(
+      { length: PALETTE_LIGHT.length + 1 },
+      (_, i) => `k${i}`,
+    );
+    const map = buildColorMap(keys, PALETTE_LIGHT);
+    expect(map.get('k0')).toBe(PALETTE_LIGHT[0]);
+    // Wraps: the (n+1)th key reuses the first colour.
+    expect(map.get(`k${PALETTE_LIGHT.length}`)).toBe(PALETTE_LIGHT[0]);
+  });
+
+  it('works with the dark palette', () => {
+    expect(buildColorMap(['a'], PALETTE_DARK).get('a')).toBe(PALETTE_DARK[0]);
+  });
+});
+
+describe('formatAxisCost', () => {
+  it('scales decimal precision to the magnitude', () => {
+    expect(formatAxisCost(0)).toBe('$0');
+    expect(formatAxisCost(0.005)).toBe('$0.0050');
+    expect(formatAxisCost(0.05)).toBe('$0.050');
+    expect(formatAxisCost(0.5)).toBe('$0.50');
+    expect(formatAxisCost(5)).toBe('$5.0');
+    expect(formatAxisCost(50)).toBe('$50');
+  });
+
+  it('scales negative values by magnitude', () => {
+    expect(formatAxisCost(-0.005)).toBe('$-0.0050');
+  });
+});
+
+describe('formatBucket', () => {
+  it('formats a valid ISO timestamp', () => {
+    expect(formatBucket('2026-07-01T00:00:00.000Z')).toMatch(/\d/);
+  });
+
+  it('returns the input unchanged when it is not a date', () => {
+    expect(formatBucket('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/plugins/openchoreo-observability/src/components/CostInsights/chartUtils.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/chartUtils.ts
@@ -1,0 +1,70 @@
+// Shared chart helpers so the stacked-bar and line charts render identically.
+
+// Muted mid-tone categorical palettes; each meets WCAG 2.2 AA / BITV 2.0.
+export const PALETTE_LIGHT = [
+  '#3f6cb0',
+  '#2f8f7a',
+  '#b06636',
+  '#845bb0',
+  '#a53f63',
+  '#6f7a2f',
+  '#2f8fae',
+  '#8a6a34',
+  '#6f727a',
+  '#993f8f',
+];
+export const PALETTE_DARK = [
+  '#8fa8e0',
+  '#4fc0a4',
+  '#e0a074',
+  '#bb9fe0',
+  '#e07f9f',
+  '#b6c470',
+  '#5fc0e0',
+  '#a7adb8',
+  '#d8c85f',
+  '#d98fd0',
+];
+
+export const FILL_OPACITY = 0.9;
+
+export const MAX_BAR_SIZE = 64;
+export const MIN_BUCKET_WIDTH = 48;
+
+/** Green used for savings/recommendation overlays, theme-aware. */
+export const savingColor = (dark: boolean): string =>
+  dark ? '#4fc0a4' : '#2f8f7a';
+
+/** Deterministic per-key colour map that wraps when keys exceed the palette. */
+export function buildColorMap(
+  keys: string[],
+  palette: string[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  keys.forEach((key, i) => map.set(key, palette[i % palette.length]));
+  return map;
+}
+
+// Costs are often sub-dollar; scale decimal precision to the axis range so
+// small values don't all collapse to "$0".
+export const formatAxisCost = (value: number): string => {
+  if (value === 0) return '$0';
+  const abs = Math.abs(value);
+  let digits = 0;
+  if (abs < 0.01) digits = 4;
+  else if (abs < 0.1) digits = 3;
+  else if (abs < 1) digits = 2;
+  else if (abs < 10) digits = 1;
+  return `$${value.toFixed(digits)}`;
+};
+
+export const formatBucket = (iso: string): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};

--- a/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.test.ts
@@ -9,6 +9,7 @@ import {
   aggregateRows,
   computeSummary,
   buildSeries,
+  buildForecast,
   buildCostInsightsData,
 } from './costAggregation';
 
@@ -174,11 +175,192 @@ describe('computeSummary', () => {
       '2026-07-01T00:00:00.000Z',
       '2026-07-01T01:00:00.000Z',
       now,
+      [],
+      'namespace',
+      new Map(),
     );
     expect(summary.totalCost).toBe(22);
     expect(summary.deltaPct).toBeCloseTo(((22 - 20) / 20) * 100);
     expect(summary.efficiency).toBeCloseTo(0.3);
     expect(summary.forecastThisMonth).toBeGreaterThan(0);
+    expect(summary.totalSaving).toBe(0);
+  });
+
+  it('counts saving only for dimensions that have a recommendation', () => {
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const current = [
+      costItem({ project: 'gcp', cpuCost: 10, memoryCost: 12 }), // total 22
+      costItem({ project: 'shop', cpuCost: 4, memoryCost: 4 }), // no rec
+    ];
+    const recommendations: CostRecommendationItem[] = [
+      {
+        component: 'comp',
+        environment: 'dev',
+        project: 'gcp',
+        namespace: 'default',
+        current: { cpuCost: 22, memoryCost: 0 },
+        recommendation: { cpuCost: 6, memoryCost: 6 }, // gcp rec total 12
+      },
+    ];
+    const summary = computeSummary(
+      current,
+      [],
+      '2026-07-01T00:00:00.000Z',
+      '2026-07-01T01:00:00.000Z',
+      now,
+      recommendations,
+      'namespace',
+      new Map(),
+    );
+    // Only gcp's own cost is reclaimable (22 - 12); shop's spend is untouched.
+    expect(summary.totalSaving).toBeCloseTo(22 - 12);
+  });
+
+  it('credits saving from a zero-cost recommendation', () => {
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const current = [costItem({ project: 'gcp', cpuCost: 5, memoryCost: 0 })];
+    const recommendations: CostRecommendationItem[] = [
+      {
+        component: 'comp',
+        environment: 'dev',
+        project: 'gcp',
+        namespace: 'default',
+        current: { cpuCost: 5, memoryCost: 0 },
+        recommendation: { cpuCost: 0, memoryCost: 0 }, // reclaim everything
+      },
+    ];
+    const summary = computeSummary(
+      current,
+      [],
+      '2026-07-01T00:00:00.000Z',
+      '2026-07-01T01:00:00.000Z',
+      now,
+      recommendations,
+      'namespace',
+      new Map(),
+    );
+    expect(summary.totalSaving).toBeCloseTo(5);
+  });
+
+  it('excludes stale environments from claimed saving', () => {
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const current = [
+      costItem({ environment: 'dev', cpuCost: 8, memoryCost: 0 }),
+    ];
+    const recommendations: CostRecommendationItem[] = [
+      {
+        component: 'comp',
+        environment: 'dev',
+        project: 'proj',
+        namespace: 'default',
+        current: { cpuCost: 8, memoryCost: 0 },
+        recommendation: { cpuCost: 2, memoryCost: 0 },
+      },
+    ];
+    const summary = computeSummary(
+      current,
+      [],
+      '2026-07-01T00:00:00.000Z',
+      '2026-07-01T01:00:00.000Z',
+      now,
+      recommendations,
+      'component',
+      new Map([['dev', '2026-07-01T00:00:00.000Z']]),
+    );
+    expect(summary.totalSaving).toBe(0);
+  });
+});
+
+describe('aggregateRows saving', () => {
+  it('sets a per-row saving from the recommended dimension total', () => {
+    const current = [costItem({ project: 'gcp', cpuCost: 10, memoryCost: 12 })];
+    const recommendations: CostRecommendationItem[] = [
+      {
+        component: 'comp',
+        environment: 'dev',
+        project: 'gcp',
+        namespace: 'default',
+        current: { cpuCost: 22, memoryCost: 0 },
+        recommendation: { cpuCost: 5, memoryCost: 5 }, // rec total 10
+      },
+    ];
+    const rows = aggregateRows(current, [], 'namespace', recommendations);
+    const gcp = rows.find(r => r.key === 'gcp')!;
+    expect(gcp.saving).toBe(22 - 10);
+  });
+
+  it('leaves saving undefined when no recommendation covers the row', () => {
+    const rows = aggregateRows(
+      [costItem({ project: 'gcp', cpuCost: 1, memoryCost: 1 })],
+      [],
+      'namespace',
+    );
+    expect(rows[0].saving).toBeUndefined();
+  });
+});
+
+describe('buildForecast', () => {
+  const now = new Date('2026-07-15T00:00:00.000Z');
+
+  it('forks the actual line into the two month-end projections', () => {
+    const forecast = buildForecast({
+      totalActual: 24,
+      totalSaving: 6,
+      windowStart: '2026-07-08T00:00:00.000Z',
+      windowEnd: '2026-07-09T00:00:00.000Z', // 1-day window, $24 -> $1/hour
+      now,
+    })!;
+    expect(forecast).not.toBeNull();
+    // $1/h over the 31-day month.
+    expect(forecast.atCurrentTotal).toBeCloseTo(24 * 31);
+    expect(forecast.ifAppliedTotal).toBeLessThan(forecast.atCurrentTotal);
+    expect(forecast.leftOnTable).toBeCloseTo(
+      forecast.atCurrentTotal - forecast.ifAppliedTotal,
+    );
+    const fork = forecast.points.find(p => p.actual !== undefined);
+    expect(fork?.atCurrent).toBe(fork?.ifApplied);
+  });
+
+  it('returns null for a non-positive window', () => {
+    expect(
+      buildForecast({
+        totalActual: 10,
+        totalSaving: 0,
+        windowStart: '2026-07-09T00:00:00.000Z',
+        windowEnd: '2026-07-09T00:00:00.000Z',
+        now,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when the window ends past the month end', () => {
+    expect(
+      buildForecast({
+        totalActual: 10,
+        totalSaving: 0,
+        windowStart: '2026-07-30T00:00:00.000Z',
+        windowEnd: '2026-08-05T00:00:00.000Z',
+        now,
+      }),
+    ).toBeNull();
+  });
+
+  it('excludes prior-month spend when the window crosses the month boundary', () => {
+    // 3-day window (72h) spanning Jun 29 -> Jul 2 at $1/hour; only the 24h in
+    // July should count toward this month's cumulative fork.
+    const forecast = buildForecast({
+      totalActual: 72,
+      totalSaving: 0,
+      windowStart: '2026-06-29T00:00:00.000Z',
+      windowEnd: '2026-07-02T00:00:00.000Z',
+      now,
+    })!;
+    expect(forecast).not.toBeNull();
+    const fork = forecast.points.find(
+      p => p.actual !== undefined && p.atCurrent !== undefined,
+    );
+    expect(fork?.actual).toBeCloseTo(24); // not 72
+    expect(forecast.atCurrentTotal).toBeCloseTo(31 * 24); // $1/h * 31 days
   });
 });
 

--- a/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.ts
@@ -6,6 +6,8 @@ import type {
   CostSummary,
   CostSeriesPoint,
   CostInsightsData,
+  ForecastData,
+  ForecastPoint,
 } from './types';
 
 /** Derive the scope level from the breadcrumb selection depth. */
@@ -95,15 +97,53 @@ function groupBy<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]> {
   return map;
 }
 
-/** Previous-window totals keyed by dimension value, for delta computation. */
-function previousTotalsByDimension(
-  previousItems: CostItem[],
+/** Cost totals keyed by dimension value (used for deltas and per-dim saving). */
+function totalsByDimension(
+  items: CostItem[],
   level: CostScopeLevel,
 ): Map<string, number> {
   const totals = new Map<string, number>();
-  for (const item of previousItems) {
+  for (const item of items) {
     const dim = dimensionOf(item, level);
     totals.set(dim, (totals.get(dim) ?? 0) + itemTotal(item));
+  }
+  return totals;
+}
+
+/** The dimension value a recommendation is grouped by at the given level. */
+function recDimensionOf(
+  rec: CostRecommendationItem,
+  level: CostScopeLevel,
+): string {
+  switch (level) {
+    case 'namespace':
+      return rec.project;
+    case 'project':
+      return rec.component;
+    case 'component':
+    default:
+      return rec.environment;
+  }
+}
+
+const recTotal = (rec: CostRecommendationItem): number =>
+  (rec.recommendation.cpuCost ?? 0) + (rec.recommendation.memoryCost ?? 0);
+
+/**
+ * Recommended (post-optimization) totals keyed by dimension value. At the
+ * component level, environments in `staleEnvs` are skipped (their recommendation
+ * is withheld).
+ */
+function recommendedTotalsByDimension(
+  recommendations: CostRecommendationItem[],
+  level: CostScopeLevel,
+  staleEnvs: Map<string, string>,
+): Map<string, number> {
+  const totals = new Map<string, number>();
+  for (const rec of recommendations) {
+    if (level === 'component' && staleEnvs.has(rec.environment)) continue;
+    const dim = recDimensionOf(rec, level);
+    totals.set(dim, (totals.get(dim) ?? 0) + recTotal(rec));
   }
   return totals;
 }
@@ -120,7 +160,12 @@ export function aggregateRows(
   recommendations: CostRecommendationItem[] = [],
   staleRecommendationEnvs: Map<string, string> = new Map(),
 ): CostRow[] {
-  const prevTotals = previousTotalsByDimension(previousItems, level);
+  const prevTotals = totalsByDimension(previousItems, level);
+  const recTotals = recommendedTotalsByDimension(
+    recommendations,
+    level,
+    staleRecommendationEnvs,
+  );
   const grouped = groupBy(currentItems, item => dimensionOf(item, level));
 
   // Recommendations are only meaningful at the component level, where rows are
@@ -181,6 +226,10 @@ export function aggregateRows(
       }
     }
 
+    const recDimTotal = recTotals.get(key);
+    const saving =
+      recDimTotal !== undefined ? Math.max(0, total - recDimTotal) : undefined;
+
     rows.push({
       key,
       label: key,
@@ -188,6 +237,7 @@ export function aggregateRows(
       memoryCost,
       total,
       efficiency: weightedEfficiency(items),
+      saving,
       deltaPct: percentChange(total, prevTotals.get(key)),
       recommendation,
       recommendationStale,
@@ -198,21 +248,37 @@ export function aggregateRows(
   return rows.sort((a, b) => b.total - a.total);
 }
 
-/** Overall summary cards (total + delta + forecast + efficiency). */
+/** Overall summary cards (total + delta + forecast + efficiency + saving). */
 export function computeSummary(
   currentItems: CostItem[],
   previousItems: CostItem[],
   windowStart: string,
   windowEnd: string,
   now: Date,
+  recommendations: CostRecommendationItem[],
+  level: CostScopeLevel,
+  staleRecommendationEnvs: Map<string, string>,
 ): CostSummary {
   const total = totalCost(currentItems);
   const prevTotal = totalCost(previousItems);
+  // Only dimensions with a (non-stale) recommendation contribute saving, each
+  // clamped at its own cost so unrelated spend isn't counted as reclaimable.
+  const currentTotals = totalsByDimension(currentItems, level);
+  const recTotals = recommendedTotalsByDimension(
+    recommendations,
+    level,
+    staleRecommendationEnvs,
+  );
+  let totalSaving = 0;
+  for (const [dim, recDimTotal] of recTotals) {
+    totalSaving += Math.max(0, (currentTotals.get(dim) ?? 0) - recDimTotal);
+  }
   return {
     totalCost: total,
     deltaPct: percentChange(total, prevTotal || undefined),
     forecastThisMonth: forecastThisMonth(total, windowStart, windowEnd, now),
     efficiency: weightedEfficiency(currentItems),
+    totalSaving,
   };
 }
 
@@ -288,10 +354,77 @@ function fillMissingBuckets(series: CostSeriesPoint[]): CostSeriesPoint[] {
   return filled;
 }
 
+/**
+ * Forecast divergence: "at current rate" projects the window rate across the
+ * whole month; "if applied" forks at the window end and reduces the rate only
+ * going forward. Independent of chart granularity.
+ */
+export function buildForecast(params: {
+  totalActual: number;
+  totalSaving: number;
+  windowStart: string;
+  windowEnd: string;
+  now: Date;
+}): ForecastData | null {
+  const { totalActual, totalSaving, windowStart, windowEnd, now } = params;
+  const startMs = new Date(windowStart).getTime();
+  const endMs = new Date(windowEnd).getTime();
+  const windowMs = endMs - startMs;
+  if (!Number.isFinite(windowMs) || windowMs <= 0) return null;
+
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  const monthMs = monthEnd.getTime() - monthStart.getTime();
+  const remainingMs = monthEnd.getTime() - endMs;
+  if (!(remainingMs > 0)) return null;
+
+  const rate = totalActual / windowMs;
+  const savingFraction = totalActual > 0 ? totalSaving / totalActual : 0;
+  const atCurrentTotal = rate * monthMs;
+
+  // Current-month spend so far at the window rate. Deriving it from elapsed
+  // month-time (rather than totalActual) excludes any prior-month spend when the
+  // window crosses a month boundary.
+  const elapsedThisMonthMs = Math.max(0, endMs - monthStart.getTime());
+  const forkTotal = rate * elapsedThisMonthMs;
+  const ifAppliedTotal = forkTotal + rate * (1 - savingFraction) * remainingMs;
+
+  // One actual-cost line from the month start to now, drawn at the window rate
+  // so its shape is independent of the chart's time granularity. It forks at
+  // the current point (window end) into the two projections.
+  const points: ForecastPoint[] = [
+    { timestamp: monthStart.toISOString(), actual: 0 },
+  ];
+  points.push({
+    timestamp: windowEnd,
+    actual: forkTotal,
+    atCurrent: forkTotal,
+    ifApplied: forkTotal,
+  });
+  points.push({
+    timestamp: monthEnd.toISOString(),
+    atCurrent: atCurrentTotal,
+    ifApplied: ifAppliedTotal,
+  });
+
+  points.sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  );
+
+  return {
+    points,
+    atCurrentTotal,
+    ifAppliedTotal,
+    leftOnTable: Math.max(0, atCurrentTotal - ifAppliedTotal),
+  };
+}
+
 /** Assemble everything the view needs from the raw multi-env responses. */
 export function buildCostInsightsData(params: {
   level: CostScopeLevel;
   currentItems: CostItem[];
+  /** Time-bucketed items for the graph's time-series; defaults to currentItems. */
+  seriesItems?: CostItem[];
   previousItems: CostItem[];
   recommendations?: CostRecommendationItem[];
   /** Withheld-recommendation envs mapped to the binding's spec update time. */
@@ -303,6 +436,7 @@ export function buildCostInsightsData(params: {
   const {
     level,
     currentItems,
+    seriesItems,
     previousItems,
     recommendations = [],
     staleRecommendationEnvs = new Map<string, string>(),
@@ -311,16 +445,23 @@ export function buildCostInsightsData(params: {
     now,
   } = params;
 
-  const { series, seriesKeys } = buildSeries(currentItems, level);
+  const { series, seriesKeys } = buildSeries(
+    seriesItems ?? currentItems,
+    level,
+  );
+  const summary = computeSummary(
+    currentItems,
+    previousItems,
+    windowStart,
+    windowEnd,
+    now,
+    recommendations,
+    level,
+    staleRecommendationEnvs,
+  );
   return {
     level,
-    summary: computeSummary(
-      currentItems,
-      previousItems,
-      windowStart,
-      windowEnd,
-      now,
-    ),
+    summary,
     rows: aggregateRows(
       currentItems,
       previousItems,
@@ -330,5 +471,12 @@ export function buildCostInsightsData(params: {
     ),
     series,
     seriesKeys,
+    forecast: buildForecast({
+      totalActual: summary.totalCost,
+      totalSaving: summary.totalSaving,
+      windowStart,
+      windowEnd,
+      now,
+    }),
   };
 }

--- a/plugins/openchoreo-observability/src/components/CostInsights/types.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/types.ts
@@ -38,6 +38,8 @@ export interface CostRow {
   total: number;
   /** Cost-weighted average efficiency in 0..1. */
   efficiency: number;
+  /** Reclaimable spend (current total − recommended total), clamped ≥ 0. */
+  saving?: number;
   /** Percent change vs the previous equal-length window (null if unknown). */
   deltaPct: number | null;
   recommendation?: CostRowRecommendation;
@@ -57,12 +59,35 @@ export interface CostSummary {
   /** Linear extrapolation of the window's spend to the current calendar month. */
   forecastThisMonth: number;
   efficiency: number;
+  /** Aggregate reclaimable spend across the scope. */
+  totalSaving: number;
 }
 
 /** One stacked-bar time bucket: `{ timestamp, [dimensionValue]: cost }`. */
 export type CostSeriesPoint = {
   timestamp: string;
 } & Record<string, number | string>;
+
+/**
+ * One point on the forecast-divergence chart. `actual` covers the measured
+ * window; `atCurrent`/`ifApplied` are the two projections.
+ */
+export interface ForecastPoint {
+  timestamp: string;
+  actual?: number;
+  atCurrent?: number;
+  ifApplied?: number;
+}
+
+export interface ForecastData {
+  points: ForecastPoint[];
+  /** Projected month-end spend at the current rate. */
+  atCurrentTotal: number;
+  /** Projected month-end spend with recommendations applied. */
+  ifAppliedTotal: number;
+  /** Gap between the projections (the cost of doing nothing). */
+  leftOnTable: number;
+}
 
 export interface CostInsightsData {
   level: CostScopeLevel;
@@ -71,4 +96,6 @@ export interface CostInsightsData {
   series: CostSeriesPoint[];
   /** Distinct dimension values used as stack keys in the graph. */
   seriesKeys: string[];
+  /** Forecast-divergence chart data; null when the window can't be projected. */
+  forecast: ForecastData | null;
 }

--- a/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.test.ts
@@ -207,10 +207,37 @@ describe('useCostInsights', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // The first call is the current window and carries the granularity.
-    expect(getCosts.mock.calls[0][2]).toEqual(
-      expect.objectContaining({ granularity: '6h' }),
+    // Graph view fetches an accumulated window (no granularity) plus a bucketed
+    // time-series window that carries the granularity.
+    const opts = getCosts.mock.calls.map(c => c[2]);
+    expect(opts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ granularity: '6h' })]),
     );
+    expect(
+      opts.some(o => o && !('granularity' in o) && o.startTime && o.endTime),
+    ).toBe(true);
+  });
+
+  it('keeps summary and rows when only the granular series call fails', async () => {
+    // Fail only the bucketed (granularity-carrying) request; the accumulated and
+    // previous windows still resolve.
+    getCosts.mockImplementation((_ns: string, _env: string, opts: any) =>
+      opts?.granularity
+        ? Promise.reject(new Error('series unavailable'))
+        : Promise.resolve({ items: [costItem()] }),
+    );
+
+    const { result } = renderHook(
+      () => useCostInsights(baseParams({ view: 'graph', granularity: '6h' })),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.data?.summary.totalCost).toBeGreaterThan(0);
+    expect(result.current.data?.rows.length).toBeGreaterThan(0);
+    // The time-series chart just has no data.
+    expect(result.current.data?.series).toEqual([]);
   });
 
   it('is disabled without a namespace or environments', async () => {

--- a/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.ts
@@ -84,29 +84,51 @@ export function useCostInsights(
           component: scope.component,
         };
 
+        // Charts (all levels) and the component table both need recommendations.
+        const needsRecs = view === 'graph' || level === 'component';
+        const isGraph = view === 'graph';
+
         const perEnv = await Promise.allSettled(
           sortedEnvs.map(async env => {
+            // Accumulated cost drives rows/summary/scatter/saving in both views
+            // and shares the recommendation's (non-bucketed) pricing basis.
             const current = await api.getCosts(namespace!, env, {
               ...scopeOpts,
               startTime,
               endTime,
-              granularity: view === 'graph' ? granularity : undefined,
             });
+            // Time-bucketed cost drives the graph's time-series charts only; its
+            // per-bucket totals need not sum to the accumulated total. Degrade
+            // gracefully: a series failure shouldn't drop the env's other data.
+            const series = isGraph
+              ? await api
+                  .getCosts(namespace!, env, {
+                    ...scopeOpts,
+                    startTime,
+                    endTime,
+                    granularity,
+                  })
+                  .catch(() => ({ items: [] as CostItem[] }))
+              : { items: [] as CostItem[] };
             const previous = await api.getCosts(namespace!, env, {
               ...scopeOpts,
               startTime: prevStart,
               endTime: prevEnd,
             });
-            const recommendations =
-              level === 'component'
-                ? await api.getCostRecommendations(namespace!, env, {
+            // Degrade gracefully: a recommendation failure shouldn't drop the
+            // env's cost data with it.
+            const recommendations = needsRecs
+              ? await api
+                  .getCostRecommendations(namespace!, env, {
                     ...scopeOpts,
                     startTime,
                     endTime,
                   })
-                : { items: [] as CostRecommendationItem[] };
+                  .catch(() => ({ items: [] as CostRecommendationItem[] }))
+              : { items: [] as CostRecommendationItem[] };
             return {
               current: current.items,
+              series: series.items,
               previous: previous.items,
               recommendations: recommendations.items,
             };
@@ -118,6 +140,7 @@ export function useCostInsights(
             r,
           ): r is PromiseFulfilledResult<{
             current: CostItem[];
+            series: CostItem[];
             previous: CostItem[];
             recommendations: CostRecommendationItem[];
           }> => r.status === 'fulfilled',
@@ -137,6 +160,7 @@ export function useCostInsights(
         }
 
         const currentItems = fulfilled.flatMap(r => r.value.current);
+        const seriesItems = fulfilled.flatMap(r => r.value.series);
         const previousItems = fulfilled.flatMap(r => r.value.previous);
         const recommendations = fulfilled.flatMap(r => r.value.recommendations);
 
@@ -189,6 +213,7 @@ export function useCostInsights(
         return buildCostInsightsData({
           level,
           currentItems,
+          seriesItems,
           previousItems,
           recommendations,
           staleRecommendationEnvs,


### PR DESCRIPTION
## Purpose

This PR extends the graphs tab in the cost insights view. So far there was only a stacked bar chart in it. This PR adds more graphs to display additional information to users at namespace, project and component levels
https://github.com/openchoreo/openchoreo/issues/4381

## Goals

Show more insights to users through additional graphs

## Approach

- Added the following graphs to the cost insights view
  - Spend forecast: Shows the spend up until now for a calendar month and the forecast at the current rate and if cost recommendations are applied
  - Cost vs efficiency: A scatter-plot  which shows the cost vs efficiency. This helps users identify at a glance, the items which would provide the greatest savings
  - Line chart of cost over time
- Added a curve to the stacked barchart as an overlay to show the cost after applying recommendations
- Made legend items clickable in all charts so users can enable/disable items from charts
- Added tooltips for the charts to explain what they show
- Added unit tests

## Screenshots
Please note that the cost values shown in these screenshots do not reflect the actual cost of running these components at the given CPU and memory requests in OpenChoreo. The costs have been manually inflated for testing purposes

Light theme
<img width="1724" height="607" alt="Screenshot 2026-08-07 at 14 17 00" src="https://github.com/user-attachments/assets/402eb973-f093-48d5-bd87-eb9735323dd1" />

<img width="1711" height="995" alt="Screenshot 2026-08-07 at 14 10 13" src="https://github.com/user-attachments/assets/78a25be1-785c-4f57-bcce-b95c00df42ea" /> <br>        

Dark theme
<img width="1723" height="605" alt="Screenshot 2026-08-07 at 14 17 18" src="https://github.com/user-attachments/assets/202396a1-1573-472d-a619-7bcfe4f60c0f" />

<img width="1702" height="992" alt="Screenshot 2026-08-07 at 14 11 53" src="https://github.com/user-attachments/assets/c8573605-338a-486c-92fc-1c25856a1a09" /> <br>     

   

Overlay curve at the component level showing the cost after applying recommendations
<img width="1442" height="442" alt="Screenshot 2026-08-07 at 14 13 03" src="https://github.com/user-attachments/assets/117aac2f-4122-4a78-b7e8-a816ef736b47" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost-efficiency, forecast divergence, and cost-over-time visualizations.
  * Added interactive chart legends, tooltips, projected savings overlays, and empty states.
  * Added chart titles with informational tooltips.
  * Added savings details to cost summaries and efficiency explanations.
  * Added separate Graphs view controls and time-series granularity selection.
* **Bug Fixes**
  * Improved handling of missing forecast or cost data with clear empty-state messages.
* **Tests**
  * Added coverage for chart rendering, legends, tooltips, forecasts, savings calculations, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->