### PR TITLE
fix(auth): support OAuth audience configuration

### DIFF
--- a/.changeset/openchoreo-auth-audience.md
+++ b/.changeset/openchoreo-auth-audience.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth': patch
+---
+
+Add optional audience configuration to the OpenChoreo auth provider and normalize issued Backstage ownership entity refs.

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -92,6 +92,7 @@ auth:
         # Explicit OAuth2 endpoints
         authorizationUrl: ${OPENCHOREO_AUTH_AUTHORIZATION_URL}
         tokenUrl: ${OPENCHOREO_AUTH_TOKEN_URL}
+        audience: ${OPENCHOREO_AUTH_AUDIENCE}
         scope: ${OPENCHOREO_AUTH_OIDC_SCOPE} # Defaults to 'openid profile email' if unset
 
     # Guest provider - used when openchoreo.features.auth.enabled is false

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -141,6 +141,7 @@ auth:
         # Explicit OAuth2 endpoints (used if metadataUrl not set, or as override)
         authorizationUrl: ${OPENCHOREO_AUTH_AUTHORIZATION_URL}
         tokenUrl: ${OPENCHOREO_AUTH_TOKEN_URL}
+        audience: ${OPENCHOREO_AUTH_AUDIENCE}
         scope: 'openid profile email' # Override via OPENCHOREO_AUTH_OIDC_SCOPE in production
 
     # Guest provider - used when openchoreo.features.auth.enabled is false

--- a/plugins/auth-backend-module-openchoreo-auth/config.d.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/config.d.ts
@@ -8,6 +8,11 @@ export interface Config {
            * Space-separated list, e.g. 'openid profile email groups offline_access'.
            */
           scope?: string;
+          /**
+           * OAuth2/OIDC audience to request from the identity provider.
+           * For Auth0 this must match the API identifier to receive JWT access tokens.
+           */
+          audience?: string;
         };
       };
     };

--- a/plugins/auth-backend-module-openchoreo-auth/src/auth.test.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/auth.test.ts
@@ -1,0 +1,46 @@
+import { extractGroups, toBackstageEntityName } from './auth';
+
+function unsignedJwt(payload: object): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+    'base64url',
+  );
+
+  return `header.${encodedPayload}.signature`;
+}
+
+describe('OpenChoreo auth resolver helpers', () => {
+  it('extracts the plain groups claim from access tokens', () => {
+    const accessToken = unsignedJwt({
+      sub: 'auth0|user',
+      groups: ['developers', 'platform-engineers'],
+    });
+
+    expect(extractGroups(accessToken)).toEqual([
+      'developers',
+      'platform-engineers',
+    ]);
+  });
+
+  it('merges token groups with userinfo groups', () => {
+    const accessToken = unsignedJwt({
+      sub: 'auth0|user',
+      groups: ['developers'],
+    });
+
+    expect(
+      extractGroups(accessToken, { groups: ['developers', 'admins'] }),
+    ).toEqual(['developers', 'admins']);
+  });
+
+  it('normalizes emails into valid Backstage entity names', () => {
+    expect(toBackstageEntityName('Leandro.User+ops@Example.COM')).toBe(
+      'leandro.user-ops-example.com',
+    );
+  });
+
+  it('rejects values without a usable entity name', () => {
+    expect(() => toBackstageEntityName('@@@')).toThrow(
+      'Backstage entity name is empty after normalization',
+    );
+  });
+});

--- a/plugins/auth-backend-module-openchoreo-auth/src/auth.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/auth.ts
@@ -1,6 +1,7 @@
 import {
   createBackendModule,
   coreServices,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 import {
   authProvidersExtensionPoint,
@@ -12,6 +13,52 @@ import {
 } from '@backstage/catalog-model';
 import { openChoreoAuthenticator } from './oidcAuthenticator';
 import { decodeJwtUnsafe } from './jwtUtils';
+
+type Logger = Pick<LoggerService, 'warn'>;
+
+const MAX_ENTITY_NAME_LENGTH = 63;
+
+export function toBackstageEntityName(value: string): string {
+  const normalized = value
+    .trim()
+    .toLocaleLowerCase('en-US')
+    .replace(/[^a-z0-9_.-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '')
+    .slice(0, MAX_ENTITY_NAME_LENGTH)
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
+
+  if (!normalized) {
+    throw new Error('Backstage entity name is empty after normalization');
+  }
+
+  return normalized;
+}
+
+export function extractGroups(
+  accessToken?: string,
+  userinfo?: { groups?: unknown; group?: unknown },
+  logger?: Logger,
+): string[] {
+  let groups: string[] = [];
+
+  if (accessToken) {
+    const payload = decodeJwtUnsafe(accessToken);
+    if (payload?.groups && Array.isArray(payload.groups)) {
+      groups = payload.groups;
+    } else if (!payload) {
+      logger?.warn('Failed to decode access token for group extraction');
+    }
+  }
+
+  if (userinfo?.groups && Array.isArray(userinfo.groups)) {
+    groups = [...new Set([...groups, ...userinfo.groups])];
+  } else if (userinfo?.group && typeof userinfo.group === 'string') {
+    groups = [...new Set([...groups, userinfo.group])];
+  }
+
+  return groups;
+}
 
 /**
  * OpenChoreo authentication backend module for Backstage.
@@ -35,6 +82,7 @@ import { decodeJwtUnsafe } from './jwtUtils';
  *         clientSecret: ${OPENCHOREO_AUTH_CLIENT_SECRET}
  *         authorizationUrl: ${OPENCHOREO_AUTH_AUTHORIZATION_URL}
  *         tokenUrl: ${OPENCHOREO_AUTH_TOKEN_URL}
+ *         audience: ${OPENCHOREO_AUTH_AUDIENCE}
  *         scope: 'openid profile email'
  * ```
  *
@@ -85,34 +133,15 @@ export const OpenChoreoAuthModule = createBackendModule({
               // Extract groups from access token (where the group claim is located)
               const accessToken = (info.result as any).session?.accessToken;
 
-              let groups: string[] = [];
-              if (accessToken) {
-                const payload = decodeJwtUnsafe(accessToken);
-                if (payload?.groups && Array.isArray(payload.groups)) {
-                  groups = payload.groups;
-                } else if (!payload) {
-                  logger.warn(
-                    'Failed to decode access token for group extraction',
-                  );
-                }
-              }
-
               // Also check userinfo for groups (OIDC standard)
               const userinfo = (info.result as any).fullProfile?.userinfo;
-              if (userinfo?.groups && Array.isArray(userinfo.groups)) {
-                groups = [...new Set([...groups, ...userinfo.groups])];
-              } else if (
-                userinfo?.group &&
-                typeof userinfo.group === 'string'
-              ) {
-                groups = [...new Set([...groups, userinfo.group])];
-              }
+              const groups = extractGroups(accessToken, userinfo, logger);
 
               // Build entity references
               const userEntityRef = stringifyEntityRef({
                 kind: 'User',
                 namespace: DEFAULT_NAMESPACE,
-                name: profile.email,
+                name: toBackstageEntityName(profile.email),
               });
 
               const ownershipEntityRefs = [
@@ -121,7 +150,7 @@ export const OpenChoreoAuthModule = createBackendModule({
                   stringifyEntityRef({
                     kind: 'Group',
                     namespace: DEFAULT_NAMESPACE,
-                    name: group.toLowerCase(),
+                    name: toBackstageEntityName(group),
                   }),
                 ),
               ];

--- a/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.test.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.test.ts
@@ -1,0 +1,62 @@
+import { Strategy as OAuth2Strategy } from 'passport-oauth2';
+import {
+  applyOAuth2StrategyParameterOverrides,
+  buildOAuth2StrategyOptions,
+  buildOAuthRequestOptions,
+} from './oidcAuthenticator';
+
+describe('openChoreoAuthenticator OAuth options', () => {
+  const baseOptions = {
+    clientID: 'client-id',
+    clientSecret: 'client-secret',
+    callbackURL: 'https://portal.example.com/callback',
+    authorizationURL: 'https://idp.example.com/authorize',
+    tokenURL: 'https://idp.example.com/oauth/token',
+    scope: 'openid profile email',
+  };
+
+  it('omits audience when unset', () => {
+    expect(buildOAuth2StrategyOptions(baseOptions)).toEqual(baseOptions);
+    expect(buildOAuthRequestOptions(baseOptions.scope)).toEqual({
+      scope: baseOptions.scope,
+    });
+  });
+
+  it('includes audience when configured', () => {
+    const audience = 'https://api.example.com/';
+
+    expect(buildOAuth2StrategyOptions({ ...baseOptions, audience })).toEqual({
+      ...baseOptions,
+      audience,
+    });
+    expect(buildOAuthRequestOptions(baseOptions.scope, audience)).toEqual({
+      scope: baseOptions.scope,
+      audience,
+    });
+  });
+
+  it('adds scope and audience to authorization and token params', () => {
+    const strategy = {
+      authorizationParams: jest.fn(() => ({ prompt: 'login' })),
+      tokenParams: jest.fn(() => ({ resource: 'existing-resource' })),
+    } as unknown as OAuth2Strategy;
+    const audience = 'https://api.example.com/';
+
+    applyOAuth2StrategyParameterOverrides(
+      strategy,
+      baseOptions.scope,
+      audience,
+    );
+
+    expect(strategy.authorizationParams({})).toEqual({
+      prompt: 'login',
+      scope: baseOptions.scope,
+      audience,
+    });
+    expect(strategy.tokenParams({})).toEqual({
+      resource: 'existing-resource',
+      scope: baseOptions.scope,
+      audience,
+    });
+  });
+});

--- a/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.ts
+++ b/plugins/auth-backend-module-openchoreo-auth/src/oidcAuthenticator.ts
@@ -36,6 +36,72 @@ let discoveryCache: OIDCDiscoveryConfig | null = null;
 // Trusted JWKS URL resolved during initialize() from config/discovery
 let trustedJwksUrl: string | null = null;
 
+type OpenChoreoOAuthOptions = {
+  clientID: string;
+  clientSecret: string;
+  callbackURL: string;
+  authorizationURL: string;
+  tokenURL: string;
+  scope: string;
+  audience?: string;
+};
+
+export function buildOAuth2StrategyOptions({
+  audience,
+  ...options
+}: OpenChoreoOAuthOptions): OpenChoreoOAuthOptions {
+  return audience ? { ...options, audience } : options;
+}
+
+export function buildOAuthRequestOptions(
+  scope: string,
+  audience?: string,
+): Record<string, string> {
+  const options: Record<string, string> = { scope };
+  if (audience) {
+    options.audience = audience;
+  }
+  return options;
+}
+
+function addOAuthRequestParams(
+  params: Record<string, unknown>,
+  scope: string,
+  audience?: string,
+) {
+  params.scope = scope;
+  if (audience) {
+    params.audience = audience;
+  }
+  return params;
+}
+
+export function applyOAuth2StrategyParameterOverrides(
+  strategy: OAuth2Strategy,
+  scope: string,
+  audience?: string,
+) {
+  const originalAuthorizationParams =
+    strategy.authorizationParams?.bind(strategy);
+  strategy.authorizationParams = options =>
+    addOAuthRequestParams(
+      (originalAuthorizationParams?.(options) ?? {}) as Record<
+        string,
+        unknown
+      >,
+      scope,
+      audience,
+    );
+
+  const originalTokenParams = strategy.tokenParams?.bind(strategy);
+  strategy.tokenParams = options =>
+    addOAuthRequestParams(
+      (originalTokenParams?.(options) ?? {}) as Record<string, unknown>,
+      scope,
+      audience,
+    );
+}
+
 /**
  * Fetches OIDC discovery configuration from a metadata URL (synchronous with caching).
  * Returns null if discovery fails.
@@ -163,6 +229,7 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
     const clientSecret = config.getString('clientSecret');
     const scope =
       config.getOptionalString('scope')?.trim() || 'openid profile email';
+    const audience = config.getOptionalString('audience')?.trim();
 
     // Support both OIDC discovery and explicit URLs
     const metadataUrl = config.getOptionalString('metadataUrl');
@@ -202,14 +269,15 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
     trustedJwksUrl = discoveryCache?.jwks_uri ?? null;
 
     const strategy = new OAuth2Strategy(
-      {
+      buildOAuth2StrategyOptions({
         clientID,
         clientSecret,
         callbackURL: callbackUrl,
         authorizationURL,
         tokenURL,
         scope,
-      },
+        audience,
+      }),
       (
         accessToken: string,
         refreshToken: string,
@@ -236,9 +304,11 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
       },
     );
 
-    // passport-oauth2 omits scope from the authorization-code token exchange by default.
-    // Some IdPs require it; without it they return a token scoped to the client defaults
-    // rather than what was requested in /authorize.
+    applyOAuth2StrategyParameterOverrides(strategy, scope, audience);
+
+    // passport-oauth2 omits provider-specific parameters from the authorization-code token
+    // exchange by default. Some IdPs require them; without them they return a token scoped
+    // to the client defaults rather than what was requested in /authorize.
     const oauth2 = (strategy as any)._oauth2;
     const origGetOAuthAccessToken = oauth2.getOAuthAccessToken.bind(oauth2);
     oauth2.getOAuthAccessToken = function getOAuthAccessToken(
@@ -247,16 +317,20 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
       callback: any,
     ) {
       if (params?.grant_type === 'authorization_code') {
-        params.scope = scope;
+        addOAuthRequestParams(params, scope, audience);
       }
       return origGetOAuthAccessToken(code, params, callback);
     };
 
-    return { helper: PassportOAuthAuthenticatorHelper.from(strategy), scope };
+    return {
+      helper: PassportOAuthAuthenticatorHelper.from(strategy),
+      scope,
+      audience,
+    };
   },
 
-  async start(input, { helper, scope }) {
-    return helper.start(input, { scope });
+  async start(input, { helper, scope, audience }) {
+    return helper.start(input, buildOAuthRequestOptions(scope, audience));
   },
 
   async authenticate(input, { helper }) {
@@ -271,7 +345,7 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
     return { fullProfile, session };
   },
 
-  async refresh(input, { helper, scope }) {
+  async refresh(input, { helper, scope, audience }) {
     const { refreshToken } = input;
 
     // Check if this is our pseudo-refresh token
@@ -332,6 +406,9 @@ export const openChoreoAuthenticator = createOAuthAuthenticator({
     // Use config scope directly, same as start() does.
     // The frontend always sends hardcoded 'openid profile email' which doesn't
     // reflect the full scope configured for this provider.
-    return helper.refresh({ ...input, scope });
+    return helper.refresh({
+      ...input,
+      ...buildOAuthRequestOptions(scope, audience),
+    });
   },
 });


### PR DESCRIPTION
## Summary
- add optional `audience` config to the OpenChoreo auth provider
- pass `audience` through OAuth authorize, token exchange, start, and refresh requests
- keep the resolver reading the plain `groups` claim and normalize Backstage ownership entity names so emails do not produce invalid entity refs

## Why
Providers such as Auth0 require an API audience to issue JWT access tokens. Without it they may issue opaque access tokens, while this module decodes access tokens as JWTs for profile/group extraction.

## Validation
- `yarn workspace @openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth test --watch=false`
- `yarn workspace @openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth lint`
- `yarn tsc`
- `yarn workspace @openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional OAuth audience configuration for OpenChoreo authentication across development and production environments.
  - OAuth authorization, token exchange, sign-in, and refresh flows now support the configured audience.
  - Group memberships can be combined from token and user information, with duplicates removed.

- **Bug Fixes**
  - Standardized user and group ownership references for consistent Backstage entity naming.
  - Invalid or empty ownership names are now rejected safely.

- **Tests**
  - Added coverage for OAuth audience handling, group extraction, and entity-name normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->