### PR TITLE
fix(catalog): reconcile namespaced provider entities

### DIFF
--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.test.ts
@@ -731,12 +731,38 @@ describe('OpenChoreoEntityProvider', () => {
     it('applies full mutation with correct locationKey', async () => {
       await runProvider();
 
-      expect(mockConnection.applyMutation).toHaveBeenCalledTimes(1);
+      expect(mockConnection.applyMutation).toHaveBeenCalledTimes(2);
       const mutation = mockConnection.applyMutation.mock.calls[0][0];
       expect(mutation.type).toBe('full');
       expect(mutation.entities[0].locationKey).toBe(
         'provider:OpenChoreoEntityProvider',
       );
+    });
+
+    it('reconciles namespaced OpenChoreo entities with a post-full delta', async () => {
+      await runProvider();
+
+      expect(mockConnection.applyMutation).toHaveBeenCalledTimes(2);
+      const mutation = mockConnection.applyMutation.mock.calls[1][0];
+      expect(mutation.type).toBe('delta');
+      expect(mutation.removed).toEqual([]);
+
+      const refs = mutation.added.map((item: any) => {
+        const entity = item.entity;
+        return `${entity.kind}:${entity.metadata.namespace ?? 'default'}/${
+          entity.metadata.name
+        }`;
+      });
+
+      expect(refs).toContain('Domain:default/test-ns');
+      expect(refs).toContain('System:test-ns/my-project');
+      expect(refs).toContain('Component:test-ns/api-service');
+      expect(refs).not.toContain(
+        'Template:openchoreo-cluster/template-idp-service',
+      );
+      expect(
+        refs.some((ref: string) => ref.startsWith('ClusterComponentType:')),
+      ).toBe(false);
     });
   });
 
@@ -1000,7 +1026,7 @@ describe('OpenChoreoEntityProvider', () => {
       // Environment from ns-ok should be present
       expect(findEntities(entities, 'Environment')).toHaveLength(1);
       // applyMutation should still be called
-      expect(mockConnection.applyMutation).toHaveBeenCalledTimes(1);
+      expect(mockConnection.applyMutation).toHaveBeenCalledTimes(2);
     });
 
     it('processes other namespaces when one fails for notification channels', async () => {
@@ -1032,7 +1058,7 @@ describe('OpenChoreoEntityProvider', () => {
       expect(
         findEntities(entities, 'ObservabilityAlertsNotificationChannel'),
       ).toHaveLength(1);
-      expect(mockConnection.applyMutation).toHaveBeenCalledTimes(1);
+      expect(mockConnection.applyMutation).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
+++ b/plugins/catalog-backend-module-openchoreo/src/provider/OpenChoreoEntityProvider.ts
@@ -3,7 +3,7 @@ import {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import {
   AuthService,
   LoggerService,
@@ -260,6 +260,18 @@ export class OpenChoreoEntityProvider implements EntityProvider {
     ] = `provider:${this.getProviderName()}`;
   }
 
+  private shouldReconcileNamespacedEntity(entity: Entity): boolean {
+    const kind = entity.kind.toLocaleLowerCase('en-US');
+    if (kind === 'template' || kind.startsWith('cluster')) {
+      return false;
+    }
+
+    return Boolean(
+      entity.metadata.namespace ||
+        entity.metadata.annotations?.[CHOREO_ANNOTATIONS.NAMESPACE],
+    );
+  }
+
   async connect(connection: EntityProviderConnection): Promise<void> {
     this.connection = connection;
 
@@ -423,10 +435,32 @@ export class OpenChoreoEntityProvider implements EntityProvider {
         `Found ${namespaces.length} namespaces from OpenChoreo`,
       );
 
+      const effectiveNamespaces =
+        namespaces.length > 0
+          ? namespaces
+          : ([
+              {
+                metadata: {
+                  name: 'default',
+                  annotations: {
+                    'openchoreo.io/display-name': 'Default',
+                    'openchoreo.io/description':
+                      'Default OpenChoreo namespace synthesized by the catalog provider',
+                  },
+                },
+              },
+            ] as NewNamespace[]);
+
+      if (namespaces.length === 0) {
+        this.logger.warn(
+          'OpenChoreo API returned no namespaces; falling back to namespace default because namespaced resources are still available',
+        );
+      }
+
       const allEntities: Entity[] = [];
 
       // Create Domain entities for each namespace
-      const domainEntities: Entity[] = namespaces.map(ns =>
+      const domainEntities: Entity[] = effectiveNamespaces.map(ns =>
         translateNewNamespaceToDomainEntity(
           ns as NewNamespace,
           this.translatorContext,
@@ -435,7 +469,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       allEntities.push(...domainEntities);
 
       // Get environments for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const environments = await fetchAllPages<NewEnvironment>(cursor =>
@@ -469,7 +503,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get notification channels for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const notificationChannels =
@@ -510,7 +544,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get dataplanes for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const dataplanes = await fetchAllPages<NewDataPlane>(cursor =>
@@ -544,7 +578,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get workflowplanes for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const workflowplanes = await fetchAllPages<NewWorkflowPlane>(() =>
@@ -583,7 +617,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get observabilityplanes for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const observabilityplanes =
@@ -624,7 +658,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get projects for each namespace and create System entities
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const projects = await fetchAllPages<NewProject>(cursor =>
@@ -891,7 +925,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Fetch Component Type Definitions and generate Template entities
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           this.logger.info(
@@ -1046,7 +1080,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get traits for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const traits = await fetchAllPages<NewTrait>(cursor =>
@@ -1080,7 +1114,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get resource types for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const resourceTypes = await fetchAllPages<NewResourceType>(cursor =>
@@ -1210,7 +1244,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get project types for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const projectTypes = await fetchAllPages<NewProjectType>(cursor =>
@@ -1287,7 +1321,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get resources for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const resources = await fetchAllPages<NewResource>(cursor =>
@@ -1334,7 +1368,7 @@ export class OpenChoreoEntityProvider implements EntityProvider {
       }
 
       // Get workflows for each namespace
-      for (const ns of namespaces) {
+      for (const ns of effectiveNamespaces) {
         const nsName = getName(ns)!;
         try {
           const workflows = await fetchAllPages<NewWorkflow>(cursor =>
@@ -1906,6 +1940,29 @@ export class OpenChoreoEntityProvider implements EntityProvider {
           locationKey: `provider:${this.getProviderName()}`,
         })),
       });
+
+      const namespacedEntities = allEntities.filter(entity =>
+        this.shouldReconcileNamespacedEntity(entity),
+      );
+
+      if (namespacedEntities.length > 0) {
+        await this.connection!.applyMutation({
+          type: 'delta',
+          added: namespacedEntities.map(entity => ({
+            entity,
+            locationKey: `provider:${this.getProviderName()}`,
+          })),
+          removed: [],
+        });
+
+        this.logger.info(
+          `Reconciled ${
+            namespacedEntities.length
+          } namespaced OpenChoreo entities via delta (${namespacedEntities
+            .map(entity => stringifyEntityRef(entity))
+            .join(', ')})`,
+        );
+      }
 
       this.logEntityCounts(allEntities, domainEntities.length);
     } catch (error) {


### PR DESCRIPTION
## Summary\n\nFixes a catalog provider failure mode where the OpenChoreo full sync fetches and translates namespaced resources, including Components, but those entities can disappear before they are materialized in Backstage final_entities.\n\nThe provider now:\n- falls back to the default namespace if the namespace list endpoint is empty while namespaced resources are still available\n- re-emits namespaced OpenChoreo entities as a post-full delta mutation\n- excludes Templates and cluster-scoped entities from that delta\n\n## Reproduction\n\nIn a production Kira/OpenChoreo deployment, provider logs showed four Components processed from the idp-platform namespace, but the Backstage catalog had no real Component rows in final_entities. Only a temporary static catalog workaround was visible. Re-emitting the namespaced entities through a delta caused the real Components to materialize and remain visible after reconciliation.\n\n## Tests\n\n- yarn workspace @openchoreo/backstage-plugin-catalog-backend-module test OpenChoreoEntityProvider.test.ts\n  - 29 tests passed; local Jest process printed PASS and then stayed open, so it was interrupted after completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog synchronization for namespaced entities.
  * Added fallback support for environments without explicitly defined namespaces by using a default namespace.
  * Prevented cluster-derived templates and component types from being included in namespaced updates.
  * Improved error isolation so successful namespace updates can proceed independently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->