### PR TITLE
backport-v1.2: refactor: use POST method based API to fetch span details from Observer 

### DIFF
--- a/.changeset/span-details-post-search-scope.md
+++ b/.changeset/span-details-post-search-scope.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+---
+
+Fetch span details via the new `POST /traces/{traceId}/spans/{spanId}` endpoint with `searchScope` in the body, and read span `status` from its `code` field so expanding a trace no longer crashes.

--- a/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
@@ -382,12 +382,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   /api/v1alpha1/traces/{traceId}/spans/{spanId}:
-    get:
+    post:
       tags:
         - Traces
       summary: Get details of a span for a trace
       description: Get details of a span for a trace from the observer service
-      operationId: getSpanDetailsForTrace
+      operationId: querySpanDetailsForTrace
       parameters:
         - name: traceId
           in: path
@@ -401,6 +401,12 @@ paths:
           description: The ID of the span
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TraceSpanDetailsRequest'
       responses:
         '200':
           description: Span details queried successfully
@@ -1458,6 +1464,14 @@ components:
         tookMs:
           type: integer
           description: The time taken to query the spans in milliseconds
+
+    # Request schema for span details
+    TraceSpanDetailsRequest:
+      type: object
+      properties:
+        searchScope:
+          $ref: '#/components/schemas/ComponentSearchScope'
+      required: [searchScope]
 
     TraceSpanDetailsResponse:
       type: object

--- a/packages/openchoreo-client-node/src/generated/observability/types.ts
+++ b/packages/openchoreo-client-node/src/generated/observability/types.ts
@@ -155,13 +155,13 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    get?: never;
+    put?: never;
     /**
      * Get details of a span for a trace
      * @description Get details of a span for a trace from the observer service
      */
-    get: operations['getSpanDetailsForTrace'];
-    put?: never;
-    post?: never;
+    post: operations['querySpanDetailsForTrace'];
     delete?: never;
     options?: never;
     head?: never;
@@ -808,6 +808,9 @@ export interface components {
       total?: number;
       /** @description The time taken to query the spans in milliseconds */
       tookMs?: number;
+    };
+    TraceSpanDetailsRequest: {
+      searchScope: components['schemas']['ComponentSearchScope'];
     };
     TraceSpanDetailsResponse: {
       /** @description The span ID */
@@ -1753,7 +1756,7 @@ export interface operations {
       };
     };
   };
-  getSpanDetailsForTrace: {
+  querySpanDetailsForTrace: {
     parameters: {
       query?: never;
       header?: never;
@@ -1765,7 +1768,11 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TraceSpanDetailsRequest'];
+      };
+    };
     responses: {
       /** @description Span details queried successfully */
       200: {

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.test.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.test.ts
@@ -435,10 +435,7 @@ describe('ObservabilityClient.getTraceSpans', () => {
 
     const [url] = mockFetchApi.fetch.mock.calls[0];
     expect(url).toBe('http://observer/api/v1alpha1/traces/trace-1/spans/query');
-    expect(result.spans[0].status).toEqual({
-      code: 'error',
-      message: 'boom',
-    });
+    expect(result.spans[0].status).toBe('error');
   });
 });
 
@@ -448,7 +445,7 @@ describe('ObservabilityClient.getSpanDetails', () => {
     resolveUrls.mockResolvedValue({ observerUrl: 'http://observer' });
   });
 
-  it('maps the status object into the span details', async () => {
+  it('maps the status code and posts the search scope', async () => {
     mockFetchApi.fetch.mockResolvedValueOnce(
       mockOkResponse({
         spanId: 'span-1',
@@ -466,13 +463,24 @@ describe('ObservabilityClient.getSpanDetails', () => {
       'trace-1',
       'span-1',
       'ns1',
+      'proj1',
       'dev',
+      'comp1',
     );
 
-    const [url] = mockFetchApi.fetch.mock.calls[0];
+    const [url, init] = mockFetchApi.fetch.mock.calls[0];
     expect(url).toBe(
       'http://observer/api/v1alpha1/traces/trace-1/spans/span-1',
     );
-    expect(result.status).toEqual({ code: 'ok' });
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      searchScope: {
+        namespace: 'ns1',
+        project: 'proj1',
+        component: 'comp1',
+        environment: 'dev',
+      },
+    });
+    expect(result.status).toBe('ok');
   });
 });

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
@@ -100,7 +100,9 @@ export interface ObservabilityApi {
     traceId: string,
     spanId: string,
     namespaceName: string,
+    projectName: string,
     environmentName: string,
+    componentName?: string,
   ): Promise<SpanDetails>;
 
   getRCAReports(
@@ -425,7 +427,7 @@ export class ObservabilityClient implements ObservabilityApi {
         endTime: s.endTime ?? '',
         durationNs: s.durationNs ?? 0,
         parentSpanId: s.parentSpanId,
-        status: s.status,
+        status: s.status?.code,
       })),
       total: data.total ?? 0,
       tookMs: data.tookMs ?? 0,
@@ -436,7 +438,9 @@ export class ObservabilityClient implements ObservabilityApi {
     traceId: string,
     spanId: string,
     namespaceName: string,
+    projectName: string,
     environmentName: string,
+    componentName?: string,
   ): Promise<SpanDetails> {
     const { observerUrl } = await this.urlCache.resolveUrls(
       namespaceName,
@@ -448,7 +452,16 @@ export class ObservabilityClient implements ObservabilityApi {
         traceId,
       )}/spans/${encodeURIComponent(spanId)}`,
       {
-        headers: { ...DIRECT_HEADER },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...DIRECT_HEADER },
+        body: JSON.stringify({
+          searchScope: {
+            namespace: namespaceName,
+            project: projectName,
+            ...(componentName ? { component: componentName } : {}),
+            environment: environmentName,
+          },
+        }),
       },
     );
 
@@ -469,7 +482,7 @@ export class ObservabilityClient implements ObservabilityApi {
       endTime: data.endTime ?? '',
       durationNs: data.durationNs ?? 0,
       parentSpanId: data.parentSpanId,
-      status: data.status,
+      status: data.status?.code,
       attributes: data.attributes,
       resourceAttributes: data.resourceAttributes,
     };

--- a/plugins/openchoreo-observability/src/components/Traces/ObservabilityTracesPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/ObservabilityTracesPage.tsx
@@ -96,7 +96,9 @@ const ObservabilityTracesContent = () => {
 
   const spanDetails = useSpanDetails({
     namespaceName: namespace,
+    projectName,
     environmentName: filters.environment?.name ?? '',
+    componentName,
   });
 
   const handleFiltersChange = useCallback(

--- a/plugins/openchoreo-observability/src/hooks/useSpanDetails.test.ts
+++ b/plugins/openchoreo-observability/src/hooks/useSpanDetails.test.ts
@@ -16,7 +16,9 @@ describe('useSpanDetails', () => {
 
   const options = {
     namespaceName: 'dev',
+    projectName: 'proj',
     environmentName: 'development',
+    componentName: 'comp',
   };
 
   const details = {
@@ -85,7 +87,9 @@ describe('useSpanDetails', () => {
       'trace-1',
       'span-1',
       'dev',
+      'proj',
       'development',
+      'comp',
     );
     await waitFor(() =>
       expect(result.current.getDetails('trace-1', 'span-1')).toEqual(details),

--- a/plugins/openchoreo-observability/src/hooks/useSpanDetails.ts
+++ b/plugins/openchoreo-observability/src/hooks/useSpanDetails.ts
@@ -6,7 +6,9 @@ import { SpanDetails } from '../types';
 
 interface UseSpanDetailsOptions {
   namespaceName: string;
+  projectName: string;
   environmentName: string;
+  componentName?: string;
 }
 
 /**
@@ -23,18 +25,42 @@ export function useSpanDetails(options: UseSpanDetailsOptions) {
   // Bumped whenever a fetch resolves so cache-backed reads re-render.
   const [, setVersion] = useState(0);
 
-  // Composite key for the local loading/error maps.
-  const makeKey = (traceId: string, spanId: string) => `${traceId}::${spanId}`;
+  // Composite key for the local loading/error maps. Scoped to match detailsKey
+  // so switching components can't reuse another scope's pending/error state.
+  const makeKey = useCallback(
+    (traceId: string, spanId: string) =>
+      [
+        options.namespaceName,
+        options.projectName,
+        options.environmentName,
+        options.componentName ?? '',
+        traceId,
+        spanId,
+      ].join('::'),
+    [
+      options.namespaceName,
+      options.projectName,
+      options.environmentName,
+      options.componentName,
+    ],
+  );
 
   const detailsKey = useCallback(
     (traceId: string, spanId: string) => [
       'span-details',
       options.namespaceName,
+      options.projectName,
       options.environmentName,
+      options.componentName ?? '',
       traceId,
       spanId,
     ],
-    [options.namespaceName, options.environmentName],
+    [
+      options.namespaceName,
+      options.projectName,
+      options.environmentName,
+      options.componentName,
+    ],
   );
 
   const fetchSpanDetails = useCallback(
@@ -61,7 +87,9 @@ export function useSpanDetails(options: UseSpanDetailsOptions) {
             traceId,
             spanId,
             options.namespaceName,
+            options.projectName,
             options.environmentName,
+            options.componentName,
           ),
         );
         setVersion(v => v + 1);
@@ -80,7 +108,7 @@ export function useSpanDetails(options: UseSpanDetailsOptions) {
         });
       }
     },
-    [observabilityApi, options, loadingMap, cache, detailsKey],
+    [observabilityApi, options, loadingMap, cache, detailsKey, makeKey],
   );
 
   const getDetails = useCallback(
@@ -92,13 +120,13 @@ export function useSpanDetails(options: UseSpanDetailsOptions) {
   const isLoading = useCallback(
     (traceId: string, spanId: string): boolean =>
       loadingMap.get(makeKey(traceId, spanId)) ?? false,
-    [loadingMap],
+    [loadingMap, makeKey],
   );
 
   const getError = useCallback(
     (traceId: string, spanId: string): string | undefined =>
       errorMap.get(makeKey(traceId, spanId)),
-    [errorMap],
+    [errorMap, makeKey],
   );
 
   return {


### PR DESCRIPTION
## Purpose

Backport the changes in https://github.com/openchoreo/backstage-plugins/pull/762 to release-v1.2 

## Approach
Cherry picked commit 2be6137ad43c45fc25fadd826fc5309ce1326069 
For the approach used for the implementation, please refer the original PR

