### PR TITLE
revert: "refactor: use POST method based API to fetch span details from Observer (#762)"

### DIFF
--- a/.changeset/span-details-post-search-scope.md
+++ b/.changeset/span-details-post-search-scope.md
@@ -1,5 +1,0 @@
----
-'@openchoreo/backstage-plugin-openchoreo-observability': patch
----
-
-Fetch span details via the new `POST /traces/{traceId}/spans/{spanId}` endpoint with `searchScope` in the body, and read span `status` from its `code` field so expanding a trace no longer crashes.

--- a/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
+++ b/packages/openchoreo-client-node/openapi/openchoreo-observability-api.yaml
@@ -382,12 +382,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   /api/v1alpha1/traces/{traceId}/spans/{spanId}:
-    post:
+    get:
       tags:
         - Traces
       summary: Get details of a span for a trace
       description: Get details of a span for a trace from the observer service
-      operationId: querySpanDetailsForTrace
+      operationId: getSpanDetailsForTrace
       parameters:
         - name: traceId
           in: path
@@ -401,12 +401,6 @@ paths:
           description: The ID of the span
           schema:
             type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TraceSpanDetailsRequest'
       responses:
         '200':
           description: Span details queried successfully
@@ -1464,14 +1458,6 @@ components:
         tookMs:
           type: integer
           description: The time taken to query the spans in milliseconds
-
-    # Request schema for span details
-    TraceSpanDetailsRequest:
-      type: object
-      properties:
-        searchScope:
-          $ref: '#/components/schemas/ComponentSearchScope'
-      required: [searchScope]
 
     TraceSpanDetailsResponse:
       type: object

--- a/packages/openchoreo-client-node/src/generated/observability/types.ts
+++ b/packages/openchoreo-client-node/src/generated/observability/types.ts
@@ -155,13 +155,13 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
-    put?: never;
     /**
      * Get details of a span for a trace
      * @description Get details of a span for a trace from the observer service
      */
-    post: operations['querySpanDetailsForTrace'];
+    get: operations['getSpanDetailsForTrace'];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -808,9 +808,6 @@ export interface components {
       total?: number;
       /** @description The time taken to query the spans in milliseconds */
       tookMs?: number;
-    };
-    TraceSpanDetailsRequest: {
-      searchScope: components['schemas']['ComponentSearchScope'];
     };
     TraceSpanDetailsResponse: {
       /** @description The span ID */
@@ -1756,7 +1753,7 @@ export interface operations {
       };
     };
   };
-  querySpanDetailsForTrace: {
+  getSpanDetailsForTrace: {
     parameters: {
       query?: never;
       header?: never;
@@ -1768,11 +1765,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['TraceSpanDetailsRequest'];
-      };
-    };
+    requestBody?: never;
     responses: {
       /** @description Span details queried successfully */
       200: {

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.test.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.test.ts
@@ -435,7 +435,10 @@ describe('ObservabilityClient.getTraceSpans', () => {
 
     const [url] = mockFetchApi.fetch.mock.calls[0];
     expect(url).toBe('http://observer/api/v1alpha1/traces/trace-1/spans/query');
-    expect(result.spans[0].status).toBe('error');
+    expect(result.spans[0].status).toEqual({
+      code: 'error',
+      message: 'boom',
+    });
   });
 });
 
@@ -445,7 +448,7 @@ describe('ObservabilityClient.getSpanDetails', () => {
     resolveUrls.mockResolvedValue({ observerUrl: 'http://observer' });
   });
 
-  it('maps the status code and posts the search scope', async () => {
+  it('maps the status object into the span details', async () => {
     mockFetchApi.fetch.mockResolvedValueOnce(
       mockOkResponse({
         spanId: 'span-1',
@@ -463,24 +466,13 @@ describe('ObservabilityClient.getSpanDetails', () => {
       'trace-1',
       'span-1',
       'ns1',
-      'proj1',
       'dev',
-      'comp1',
     );
 
-    const [url, init] = mockFetchApi.fetch.mock.calls[0];
+    const [url] = mockFetchApi.fetch.mock.calls[0];
     expect(url).toBe(
       'http://observer/api/v1alpha1/traces/trace-1/spans/span-1',
     );
-    expect(init.method).toBe('POST');
-    expect(JSON.parse(init.body)).toEqual({
-      searchScope: {
-        namespace: 'ns1',
-        project: 'proj1',
-        component: 'comp1',
-        environment: 'dev',
-      },
-    });
-    expect(result.status).toBe('ok');
+    expect(result.status).toEqual({ code: 'ok' });
   });
 });

--- a/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
+++ b/plugins/openchoreo-observability/src/api/ObservabilityApi.ts
@@ -102,9 +102,7 @@ export interface ObservabilityApi {
     traceId: string,
     spanId: string,
     namespaceName: string,
-    projectName: string,
     environmentName: string,
-    componentName?: string,
   ): Promise<SpanDetails>;
 
   getRCAReports(
@@ -452,7 +450,7 @@ export class ObservabilityClient implements ObservabilityApi {
         endTime: s.endTime ?? '',
         durationNs: s.durationNs ?? 0,
         parentSpanId: s.parentSpanId,
-        status: s.status?.code,
+        status: s.status,
       })),
       total: data.total ?? 0,
       tookMs: data.tookMs ?? 0,
@@ -463,9 +461,7 @@ export class ObservabilityClient implements ObservabilityApi {
     traceId: string,
     spanId: string,
     namespaceName: string,
-    projectName: string,
     environmentName: string,
-    componentName?: string,
   ): Promise<SpanDetails> {
     const { observerUrl } = await this.urlCache.resolveUrls(
       namespaceName,
@@ -477,16 +473,7 @@ export class ObservabilityClient implements ObservabilityApi {
         traceId,
       )}/spans/${encodeURIComponent(spanId)}`,
       {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...DIRECT_HEADER },
-        body: JSON.stringify({
-          searchScope: {
-            namespace: namespaceName,
-            project: projectName,
-            ...(componentName ? { component: componentName } : {}),
-            environment: environmentName,
-          },
-        }),
+        headers: { ...DIRECT_HEADER },
       },
     );
 
@@ -507,7 +494,7 @@ export class ObservabilityClient implements ObservabilityApi {
       endTime: data.endTime ?? '',
       durationNs: data.durationNs ?? 0,
       parentSpanId: data.parentSpanId,
-      status: data.status?.code,
+      status: data.status,
       attributes: data.attributes,
       resourceAttributes: data.resourceAttributes,
     };

--- a/plugins/openchoreo-observability/src/components/Traces/ObservabilityTracesPage.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/ObservabilityTracesPage.tsx
@@ -96,9 +96,7 @@ const ObservabilityTracesContent = () => {
 
   const spanDetails = useSpanDetails({
     namespaceName: namespace,
-    projectName,
     environmentName: filters.environment?.name ?? '',
-    componentName,
   });
 
   const handleFiltersChange = useCallback(

--- a/plugins/openchoreo-observability/src/hooks/useSpanDetails.test.ts
+++ b/plugins/openchoreo-observability/src/hooks/useSpanDetails.test.ts
@@ -16,9 +16,7 @@ describe('useSpanDetails', () => {
 
   const options = {
     namespaceName: 'dev',
-    projectName: 'proj',
     environmentName: 'development',
-    componentName: 'comp',
   };
 
   const details = {
@@ -87,9 +85,7 @@ describe('useSpanDetails', () => {
       'trace-1',
       'span-1',
       'dev',
-      'proj',
       'development',
-      'comp',
     );
     await waitFor(() =>
       expect(result.current.getDetails('trace-1', 'span-1')).toEqual(details),

--- a/plugins/openchoreo-observability/src/hooks/useSpanDetails.ts
+++ b/plugins/openchoreo-observability/src/hooks/useSpanDetails.ts
@@ -6,9 +6,7 @@ import { SpanDetails } from '../types';
 
 interface UseSpanDetailsOptions {
   namespaceName: string;
-  projectName: string;
   environmentName: string;
-  componentName?: string;
 }
 
 /**
@@ -25,42 +23,18 @@ export function useSpanDetails(options: UseSpanDetailsOptions) {
   // Bumped whenever a fetch resolves so cache-backed reads re-render.
   const [, setVersion] = useState(0);
 
-  // Composite key for the local loading/error maps. Scoped to match detailsKey
-  // so switching components can't reuse another scope's pending/error state.
-  const makeKey = useCallback(
-    (traceId: string, spanId: string) =>
-      [
-        options.namespaceName,
-        options.projectName,
-        options.environmentName,
-        options.componentName ?? '',
-        traceId,
-        spanId,
-      ].join('::'),
-    [
-      options.namespaceName,
-      options.projectName,
-      options.environmentName,
-      options.componentName,
-    ],
-  );
+  // Composite key for the local loading/error maps.
+  const makeKey = (traceId: string, spanId: string) => `${traceId}::${spanId}`;
 
   const detailsKey = useCallback(
     (traceId: string, spanId: string) => [
       'span-details',
       options.namespaceName,
-      options.projectName,
       options.environmentName,
-      options.componentName ?? '',
       traceId,
       spanId,
     ],
-    [
-      options.namespaceName,
-      options.projectName,
-      options.environmentName,
-      options.componentName,
-    ],
+    [options.namespaceName, options.environmentName],
   );
 
   const fetchSpanDetails = useCallback(
@@ -87,9 +61,7 @@ export function useSpanDetails(options: UseSpanDetailsOptions) {
             traceId,
             spanId,
             options.namespaceName,
-            options.projectName,
             options.environmentName,
-            options.componentName,
           ),
         );
         setVersion(v => v + 1);
@@ -108,7 +80,7 @@ export function useSpanDetails(options: UseSpanDetailsOptions) {
         });
       }
     },
-    [observabilityApi, options, loadingMap, cache, detailsKey, makeKey],
+    [observabilityApi, options, loadingMap, cache, detailsKey],
   );
 
   const getDetails = useCallback(
@@ -120,13 +92,13 @@ export function useSpanDetails(options: UseSpanDetailsOptions) {
   const isLoading = useCallback(
     (traceId: string, spanId: string): boolean =>
       loadingMap.get(makeKey(traceId, spanId)) ?? false,
-    [loadingMap, makeKey],
+    [loadingMap],
   );
 
   const getError = useCallback(
     (traceId: string, spanId: string): string | undefined =>
       errorMap.get(makeKey(traceId, spanId)),
-    [errorMap, makeKey],
+    [errorMap],
   );
 
   return {


### PR DESCRIPTION
## Purpose

Revert https://github.com/openchoreo/backstage-plugins/pull/762

## Approach

Reverts commit 898dbaf44305228c72bcf5a407ca0386be5a59d4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed trace expansion so span details load reliably without project or component filters.
  - Preserved complete span status information, preventing errors when viewing trace details.

- **Changes**
  - Updated span-detail requests to use the simplified retrieval flow without a request body or search scope.
  - Simplified span-detail loading and caching to use namespace and environment context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->