### PR TITLE
feat: remove end time column from traces table

### DIFF
--- a/.changeset/fiery-sloths-shout.md
+++ b/.changeset/fiery-sloths-shout.md
@@ -1,0 +1,5 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': patch
+---
+
+Remove the End Time column from the traces table and widen the Trace Name column.

--- a/plugins/openchoreo-observability/src/components/Traces/TracesTable.test.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/TracesTable.test.tsx
@@ -78,7 +78,6 @@ describe('TracesTable', () => {
 
     expect(screen.getByText('Trace Name')).toBeInTheDocument();
     expect(screen.getByText('Start Time')).toBeInTheDocument();
-    expect(screen.getByText('End Time')).toBeInTheDocument();
     expect(screen.getByText('Duration')).toBeInTheDocument();
     expect(screen.getByText('Number of Spans')).toBeInTheDocument();
     expect(screen.getByText('Details')).toBeInTheDocument();
@@ -156,5 +155,13 @@ describe('TracesTable', () => {
     const { container } = renderTable();
 
     expect(container.querySelector('[class*="errorStripe"]')).toBeNull();
+  });
+
+  // Start time and duration provide enough timing information without cluttering the table.
+  it('does not display end time in the traces table', () => {
+    renderTable();
+
+    expect(screen.queryByText('End Time')).not.toBeInTheDocument();
+    expect(screen.queryByText(sampleTrace.endTime)).not.toBeInTheDocument();
   });
 });

--- a/plugins/openchoreo-observability/src/components/Traces/TracesTable.tsx
+++ b/plugins/openchoreo-observability/src/components/Traces/TracesTable.tsx
@@ -50,7 +50,6 @@ const HEADER_COLUMNS: {
 }[] = [
   { key: 'traceName', label: 'Trace Name' },
   { key: 'startTime', label: 'Start Time' },
-  { key: 'endTime', label: 'End Time' },
   { key: 'duration', label: 'Duration' },
   { key: 'spanCount', label: 'Number of Spans' },
   { key: 'details', label: 'Details', align: 'right' },
@@ -151,12 +150,6 @@ export const TracesTable: FC<TracesTableProps> = ({
             className={`${classes.cell} ${classes.traceCell}`}
           >
             {trace.startTime}
-          </Box>
-          <Box
-            style={getColumnStyle('endTime')}
-            className={`${classes.cell} ${classes.traceCell}`}
-          >
-            {trace.endTime}
           </Box>
           <Box
             style={getColumnStyle('duration')}

--- a/plugins/openchoreo-observability/src/components/Traces/columns.ts
+++ b/plugins/openchoreo-observability/src/components/Traces/columns.ts
@@ -7,7 +7,6 @@ import { makeColumnStyle } from '@openchoreo/backstage-plugin-react';
 export type TracesColumn =
   | 'traceName'
   | 'startTime'
-  | 'endTime'
   | 'duration'
   | 'spanCount'
   | 'details';
@@ -19,9 +18,8 @@ export type TracesColumn =
  * total (88%) leaves the same trailing whitespace MUI's table did.
  */
 export const getColumnStyle = makeColumnStyle<TracesColumn>({
-  traceName: '0 0 12%',
+  traceName: '0 0 32%',
   startTime: '0 0 20%',
-  endTime: '0 0 20%',
   duration: '0 0 12%',
   spanCount: '0 0 12%',
   details: '0 0 12%',


### PR DESCRIPTION
## Purpose

The traces table shows start time, end time, and duration, making rows
cluttered. Start time and duration provide sufficient timing information.

Resolves https://github.com/openchoreo/openchoreo/issues/4704

## Goals

Remove the redundant End Time column and make trace names easier to read.


## Approach

- Remove the End Time header, row cell, and column sizing entry.
- Increase the Trace Name column width from 12% to 32%.
- Preserve end-time data and the span detail view.
- Add a patch changeset for the observability plugin.

<img width="1728" height="960" alt="스크린샷 2026-09-10 오후 8 25 05" src="https://github.com/user-attachments/assets/03bd9078-3d0f-4fe3-bc53-d235b8736878" />
Verified in the Portal's Catalog → Traces page using two mock traces.
The temporary mock setup is not included in this PR.

## User stories

Users can read longer trace names without redundant timestamps cluttering the traces table.


## Release note

Removed the End Time column from the traces table and widened the Trace Name column.

## Documentation

N/A — no configuration or workflow changes.

## Training

N/A

## Certification

N/A — presentation-only change.

## Marketing

N/A

## Automation tests

- All 10 TracesTable tests passed, including a regression test verifying that the End Time header and value are not displayed.
- Manually verified the Catalog → Traces page with two mock traces.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

https://github.com/openchoreo/openchoreo/issues/4704

## Migrations (if applicable)

N/A

## Test environment

macOS, local Chrome browser

## Learning

The table header and rows share column sizing through getColumnStyle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Removed the **End Time** column from the traces table for a simpler view.
  * Widened the **Trace Name** column to improve readability.
* **Bug Fixes**
  * Updated trace table behavior to ensure end-time headers and values are no longer displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->