### PR TITLE
feat: improve cost insights UI and UX

### DIFF
--- a/.changeset/cost-insights-single-page-and-forecast.md
+++ b/.changeset/cost-insights-single-page-and-forecast.md
@@ -1,0 +1,33 @@
+---
+'@openchoreo/backstage-plugin-openchoreo-observability': minor
+'@openchoreo/backstage-design-system': minor
+'@openchoreo/backstage-portal-app': minor
+---
+
+Improve the Cost Insights view UX.
+
+- **Single page**: removed the Table/Graphs toggle - the graphs and the cost
+  table now render on one page (table after the graphs), and the Total Cost /
+  Forecast this month / Efficiency tiles were removed.
+- **Accumulated cost & forecast chart**: the former "Spend forecast" chart is
+  renamed to **"Accumulated cost and forecast"** and reworked. It always covers the
+  current calendar month (no longer affected by the time-range filter): it shows
+  the actual cost accumulated from the 1st to today, then projects month-end
+  spend at the current rate and if the recommendations are applied. The two
+  forecast lines are now visually distinct (dashed vs dotted), and the axis ends on
+  the month's last day. The time-range selector moved below this chart since it
+  only drives the views under it.
+- **Cost vs efficiency**: added a "Potential savings" legend heading and removed
+  the red low-efficiency shaded region.
+- **Refresh**: added a Refresh button to re-fetch cost data without a page
+  reload.
+- **Scope filters**: the Project and Component filters now show "All" (not
+  "None") when nothing is explicitly selected, since an empty selection
+  aggregates everything. `MultiSelectFilter` gained an optional `emptyLabel`
+  prop for this.
+- **Fixes**: the platform-level "not enabled" message now reads "Cost Insights
+  have not been enabled" instead of the component-scoped observability message,
+  and the numeric cost-table column headers are right-aligned with their values.
+- **Sidebar**: moved "Platform" and "Cost Insights" into their own
+  divider-bounded section after "API", separating platform concerns from the
+  main menu.

--- a/packages/design-system/src/components/MultiSelectFilter/MultiSelectFilter.tsx
+++ b/packages/design-system/src/components/MultiSelectFilter/MultiSelectFilter.tsx
@@ -34,19 +34,21 @@ export interface MultiSelectFilterProps {
   allValues: string[];
   selected: Set<string>;
   onChange: (selected: Set<string>) => void;
+  emptyLabel?: string;
 }
 
 /**
- * Builds the trigger value: "All" / "None" / the single selected value /
- * "<first value> +N" for a multi-selection. `selectedOptions` must be in menu
+ * Builds the trigger value: "All" / the empty label / the single selected value
+ * / "<first value> +N" for a multi-selection. `selectedOptions` must be in menu
  * order so the shown value is stable.
  */
 function triggerValue(
   selectedOptions: MultiSelectOption[],
   total: number,
+  emptyLabel: string,
 ): string {
   if (total === 0 || selectedOptions.length === total) return 'All';
-  if (selectedOptions.length === 0) return 'None';
+  if (selectedOptions.length === 0) return emptyLabel;
   const [first, ...rest] = selectedOptions;
   return rest.length === 0 ? first.label : `${first.label} +${rest.length}`;
 }
@@ -63,6 +65,7 @@ export const MultiSelectFilter = ({
   allValues,
   selected,
   onChange,
+  emptyLabel = 'None',
 }: MultiSelectFilterProps) => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -114,7 +117,8 @@ export const MultiSelectFilter = ({
             disabled={allValues.length === 0}
           >
             <span className={classes.buttonLabel}>
-              {label}: {triggerValue(selectedOptions, allValues.length)}
+              {label}:{' '}
+              {triggerValue(selectedOptions, allValues.length, emptyLabel)}
             </span>
           </Button>
         </span>

--- a/packages/portal-app/src/components/Root/PortalNavContent.tsx
+++ b/packages/portal-app/src/components/Root/PortalNavContent.tsx
@@ -185,8 +185,6 @@ export function PortalNavContent({ navItems }: NavContentComponentProps) {
       <SidebarGroup label="Menu" icon={<MenuIcon />}>
         {home && <NavItemLink item={home} />}
         {catalog && <NavItemLink item={catalog} />}
-        {platform && <NavItemLink item={platform} />}
-        {costInsights && <NavItemLink item={costInsights} />}
         <MyGroupsSidebarItem
           singularTitle="My Group"
           pluralTitle="My Groups"
@@ -196,6 +194,10 @@ export function PortalNavContent({ navItems }: NavContentComponentProps) {
         {create && <NavItemLink item={create} />}
         <SidebarScrollWrapper />
       </SidebarGroup>
+      <SidebarDivider />
+      {platform && <NavItemLink item={platform} />}
+      {costInsights && <NavItemLink item={costInsights} />}
+      <SidebarDivider />
       <SidebarSpace />
       <SidebarDivider />
       <SidebarGroup

--- a/plugins/openchoreo-observability/src/components/CostInsights/ChartTitle.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/ChartTitle.tsx
@@ -14,15 +14,26 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.text.secondary,
     cursor: 'help',
   },
+  subtitle: {
+    marginLeft: theme.spacing(0.5),
+    color: theme.palette.text.secondary,
+  },
 }));
 
 export interface ChartTitleProps {
   title: string;
   info: string;
+  /** Optional muted text shown after the title */
+  subtitle?: string;
   className?: string;
 }
 
-export const ChartTitle: FC<ChartTitleProps> = ({ title, info, className }) => {
+export const ChartTitle: FC<ChartTitleProps> = ({
+  title,
+  info,
+  subtitle,
+  className,
+}) => {
   const classes = useStyles();
   return (
     <div className={`${classes.root} ${className ?? ''}`.trim()}>
@@ -30,6 +41,11 @@ export const ChartTitle: FC<ChartTitleProps> = ({ title, info, className }) => {
       <Tooltip title={info} arrow>
         <InfoOutlinedIcon className={classes.icon} />
       </Tooltip>
+      {subtitle && (
+        <Typography variant="caption" className={classes.subtitle}>
+          {subtitle}
+        </Typography>
+      )}
     </div>
   );
 };

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostEfficiencyScatter.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostEfficiencyScatter.tsx
@@ -3,7 +3,6 @@ import { Paper, Typography, makeStyles, useTheme } from '@material-ui/core';
 import {
   Cell,
   LabelList,
-  ReferenceArea,
   ResponsiveContainer,
   Scatter,
   ScatterChart,
@@ -35,6 +34,14 @@ const useStyles = makeStyles(theme => ({
     overflowY: 'auto',
     fontSize: 12,
     color: theme.palette.text.primary,
+  },
+  legendHeading: {
+    fontWeight: 600,
+    fontSize: '0.7rem',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: theme.palette.text.secondary,
+    padding: theme.spacing(0, 0, 0.5, 0),
   },
   legendRow: {
     display: 'flex',
@@ -143,24 +150,12 @@ export const CostEfficiencyScatter: FC<CostEfficiencyScatterProps> = ({
       <ChartTitle
         title={title}
         className={classes.header}
-        info="Each bubble is one dimension: x is resource efficiency, y is spend, and bubble size is the estimated saving. Bubbles in the shaded band are low-efficiency spend worth reviewing first."
+        info="Each bubble is one dimension: x is resource efficiency, y is spend, and bubble size is the estimated saving. Low-efficiency, high-spend bubbles are worth reviewing first."
       />
       <div className={classes.body}>
         <div className={classes.chart}>
           <ResponsiveContainer width="100%" height="100%">
             <ScatterChart margin={{ top: 8, right: 16, bottom: 24, left: 0 }}>
-              <ReferenceArea
-                x1={0}
-                x2={LOW_EFFICIENCY_THRESHOLD * 100}
-                fill={dark ? '#b06636' : '#a53f63'}
-                fillOpacity={0.08}
-                label={{
-                  value: 'LOW EFFICIENCY',
-                  position: 'insideBottomLeft',
-                  fontSize: 10,
-                  fill: theme.palette.text.secondary,
-                }}
-              />
               <XAxis
                 type="number"
                 dataKey="x"
@@ -232,6 +227,9 @@ export const CostEfficiencyScatter: FC<CostEfficiencyScatterProps> = ({
           </ResponsiveContainer>
         </div>
         <div className={classes.legend}>
+          <div className={classes.legendHeading}>
+            {anySaving ? 'Potential savings' : 'Spend'}
+          </div>
           {points.slice(0, LEGEND_LIMIT).map(p => (
             <div
               key={p.label}

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.test.tsx
@@ -13,37 +13,35 @@ function renderFilters(
     environments,
     selectedEnvironments: ['dev'],
     onEnvironmentsChange: jest.fn(),
-    view: 'table' as const,
-    onViewChange: jest.fn(),
-    timeRange: '1h',
-    onTimeRangeChange: jest.fn(),
     ...overrides,
   };
   return { props, ...render(<CostInsightsFilters {...props} />) };
 }
 
 describe('CostInsightsFilters', () => {
-  it('renders the view toggle, environments and time range', () => {
+  it('renders the environments select', () => {
     renderFilters();
-    expect(screen.getByRole('button', { name: 'Table' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Graphs' })).toBeInTheDocument();
     expect(
       screen.getByRole('textbox', { name: 'Environments' }),
     ).toBeInTheDocument();
+  });
+
+  it('renders a refresh button and invokes onRefresh when clicked', () => {
+    const onRefresh = jest.fn();
+    renderFilters({ onRefresh });
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('disables the refresh button while refreshing', () => {
+    renderFilters({ onRefresh: jest.fn(), refreshing: true });
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeDisabled();
+  });
+
+  it('omits the refresh button when no handler is given', () => {
+    renderFilters();
     expect(
-      screen.getByRole('textbox', { name: 'Time Range' }),
-    ).toBeInTheDocument();
-  });
-
-  it('emits the selected view when a toggle is clicked', () => {
-    const { props } = renderFilters({ view: 'table' });
-    fireEvent.click(screen.getByRole('button', { name: 'Graphs' }));
-    expect(props.onViewChange).toHaveBeenCalledWith('graph');
-  });
-
-  it('disables the view toggles when disabled', () => {
-    renderFilters({ disabled: true });
-    expect(screen.getByRole('button', { name: 'Table' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Graphs' })).toBeDisabled();
+      screen.queryByRole('button', { name: 'Refresh' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsFilters.tsx
@@ -1,13 +1,8 @@
 import { FC } from 'react';
-import { Grid, makeStyles } from '@material-ui/core';
-import ToggleButton from '@material-ui/lab/ToggleButton';
-import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
-import {
-  TimeRangeFilter,
-  type Environment,
-} from '@openchoreo/backstage-plugin-react';
+import { Button, Grid, Tooltip, makeStyles } from '@material-ui/core';
+import Refresh from '@material-ui/icons/Refresh';
+import { type Environment } from '@openchoreo/backstage-plugin-react';
 import { EnvironmentMultiSelect } from './EnvironmentMultiSelect';
-import type { CostViewMode } from './types';
 
 export const GRANULARITY_OPTIONS: Array<{ value: string; label: string }> = [
   { value: '1h', label: '1 hour' },
@@ -24,22 +19,14 @@ export interface CostInsightsFiltersProps {
   environmentsLoading?: boolean;
   selectedEnvironments: string[];
   onEnvironmentsChange: (names: string[]) => void;
-  view: CostViewMode;
-  onViewChange: (view: CostViewMode) => void;
-  timeRange: string;
-  customStartTime?: string;
-  customEndTime?: string;
-  onTimeRangeChange: (next: {
-    timeRange: string;
-    customStartTime?: string;
-    customEndTime?: string;
-  }) => void;
+  /** Refetch the cost data. */
+  onRefresh?: () => void;
+  /** Disables the refresh button while a fetch is in flight. */
+  refreshing?: boolean;
   disabled?: boolean;
 }
 
-const useStyles = makeStyles(theme => ({
-  toggleGroup: { height: '100%' },
-  toggleButton: { textTransform: 'none', padding: theme.spacing(0, 2) },
+const useStyles = makeStyles(() => ({
   spacer: { flexGrow: 1 },
   control: { minWidth: 220 },
 }));
@@ -49,44 +36,14 @@ export const CostInsightsFilters: FC<CostInsightsFiltersProps> = ({
   environmentsLoading = false,
   selectedEnvironments,
   onEnvironmentsChange,
-  view,
-  onViewChange,
-  timeRange,
-  customStartTime,
-  customEndTime,
-  onTimeRangeChange,
+  onRefresh,
+  refreshing = false,
   disabled = false,
 }) => {
   const classes = useStyles();
 
   return (
     <Grid container spacing={2} alignItems="center" wrap="nowrap">
-      <Grid item>
-        <ToggleButtonGroup
-          exclusive
-          size="medium"
-          value={view}
-          onChange={(_e, next) => next && onViewChange(next as CostViewMode)}
-          className={classes.toggleGroup}
-          aria-label="View mode"
-        >
-          <ToggleButton
-            value="table"
-            className={classes.toggleButton}
-            disabled={disabled}
-          >
-            Table
-          </ToggleButton>
-          <ToggleButton
-            value="graph"
-            className={classes.toggleButton}
-            disabled={disabled}
-          >
-            Graphs
-          </ToggleButton>
-        </ToggleButtonGroup>
-      </Grid>
-
       <Grid item className={classes.spacer} />
 
       <Grid item className={classes.control}>
@@ -99,15 +56,20 @@ export const CostInsightsFilters: FC<CostInsightsFiltersProps> = ({
         />
       </Grid>
 
-      <Grid item className={classes.control}>
-        <TimeRangeFilter
-          value={timeRange}
-          customStartTime={customStartTime}
-          customEndTime={customEndTime}
-          onChange={onTimeRangeChange}
-          disabled={disabled}
-        />
-      </Grid>
+      {onRefresh && (
+        <Grid item>
+          <Tooltip title="Refresh">
+            <Button
+              variant="outlined"
+              startIcon={<Refresh />}
+              onClick={onRefresh}
+              disabled={disabled || refreshing}
+            >
+              Refresh
+            </Button>
+          </Tooltip>
+        </Grid>
+      )}
     </Grid>
   );
 };

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraphs.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraphs.test.tsx
@@ -4,9 +4,6 @@ import type { CostInsightsData } from './types';
 
 // The individual charts are covered by their own suites; stub them so this
 // suite focuses on the container's layout and the granularity control.
-jest.mock('./ForecastDivergenceChart', () => ({
-  ForecastDivergenceChart: () => <div data-testid="forecast" />,
-}));
 jest.mock('./CostEfficiencyScatter', () => ({
   CostEfficiencyScatter: () => <div data-testid="scatter" />,
 }));
@@ -27,7 +24,6 @@ const data = (over: Partial<CostInsightsData> = {}): CostInsightsData => ({
   summary: {
     totalCost: 100,
     deltaPct: null,
-    forecastThisMonth: 200,
     efficiency: 0.5,
     totalSaving: 0,
   },
@@ -39,7 +35,7 @@ const data = (over: Partial<CostInsightsData> = {}): CostInsightsData => ({
 });
 
 describe('CostInsightsGraphs', () => {
-  it('renders all four charts and the granularity selector', () => {
+  it('renders the scatter and time-series charts with the granularity selector', () => {
     render(
       <CostInsightsGraphs
         data={data()}
@@ -47,7 +43,6 @@ describe('CostInsightsGraphs', () => {
         onGranularityChange={jest.fn()}
       />,
     );
-    expect(screen.getByTestId('forecast')).toBeInTheDocument();
     expect(screen.getByTestId('scatter')).toBeInTheDocument();
     expect(screen.getByTestId('line')).toBeInTheDocument();
     expect(screen.getByTestId('bar')).toBeInTheDocument();
@@ -86,7 +81,6 @@ describe('CostInsightsGraphs', () => {
           summary: {
             totalCost: 100,
             deltaPct: null,
-            forecastThisMonth: 200,
             efficiency: 0.5,
             totalSaving: 40,
           },

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraphs.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsGraphs.tsx
@@ -8,7 +8,6 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import type { CostInsightsData } from './types';
-import { ForecastDivergenceChart } from './ForecastDivergenceChart';
 import { CostEfficiencyScatter } from './CostEfficiencyScatter';
 import { CostLineChart } from './CostLineChart';
 import { CostInsightsGraph } from './CostInsightsGraph';
@@ -23,7 +22,7 @@ const useStyles = makeStyles(theme => ({
   groupHeader: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-end',
     gap: theme.spacing(2),
     marginBottom: theme.spacing(2),
   },
@@ -52,10 +51,7 @@ export const CostInsightsGraphs: FC<CostInsightsGraphsProps> = ({
 
   return (
     <Grid container spacing={2}>
-      <Grid item xs={12} md={6}>
-        <ForecastDivergenceChart forecast={data.forecast} />
-      </Grid>
-      <Grid item xs={12} md={6}>
+      <Grid item xs={12}>
         <CostEfficiencyScatter rows={data.rows} />
       </Grid>
       <Grid item xs={12}>

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.test.tsx
@@ -11,14 +11,18 @@ jest.mock('./CostInsightsFilters', () => ({
   CostInsightsFilters: () => <div data-testid="filters" />,
   DEFAULT_GRANULARITY: '1d',
 }));
-jest.mock('./CostSummaryCards', () => ({
-  CostSummaryCards: () => <div data-testid="summary-cards" />,
-}));
 jest.mock('./CostInsightsTable', () => ({
   CostInsightsTable: () => <div data-testid="cost-table" />,
 }));
 jest.mock('./CostInsightsGraphs', () => ({
   CostInsightsGraphs: () => <div data-testid="cost-graph" />,
+}));
+jest.mock('./ForecastDivergenceChart', () => ({
+  ForecastDivergenceChart: () => <div data-testid="forecast" />,
+}));
+jest.mock('@openchoreo/backstage-plugin-react', () => ({
+  ...jest.requireActual('@openchoreo/backstage-plugin-react'),
+  TimeRangeFilter: () => <div data-testid="time-range" />,
 }));
 // The Cost Analysis tab lazy-loads this; stub it so the tab can be exercised
 // without its catalog/permission dependencies.
@@ -46,10 +50,10 @@ const data = {
   summary: {
     totalCost: 22,
     deltaPct: 10,
-    forecastThisMonth: 500,
     efficiency: 0.3,
     totalSaving: 0,
   },
+  forecast: null,
   rows: [
     {
       key: 'gcp',
@@ -90,18 +94,13 @@ describe('CostInsightsPage', () => {
     setupDefaults();
   });
 
-  it('renders the filters, summary cards and table in table view', async () => {
+  it('renders the filters, forecast, graphs and table on one page', async () => {
     await renderPage();
     expect(screen.getByTestId('filters')).toBeInTheDocument();
-    expect(screen.getByTestId('summary-cards')).toBeInTheDocument();
-    expect(screen.getByTestId('cost-table')).toBeInTheDocument();
-    expect(screen.queryByTestId('cost-graph')).not.toBeInTheDocument();
-  });
-
-  it('renders the graph instead of the table in graph view', async () => {
-    await renderPage('/?namespace=default&view=graph');
+    expect(screen.getByTestId('forecast')).toBeInTheDocument();
+    expect(screen.getByTestId('time-range')).toBeInTheDocument();
     expect(screen.getByTestId('cost-graph')).toBeInTheDocument();
-    expect(screen.queryByTestId('cost-table')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cost-table')).toBeInTheDocument();
   });
 
   it('shows a loader while cost data loads', async () => {
@@ -115,7 +114,7 @@ describe('CostInsightsPage', () => {
     await renderPage();
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.queryByTestId('cost-table')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('summary-cards')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cost-graph')).not.toBeInTheDocument();
   });
 
   it('shows an error alert when the cost query fails', async () => {
@@ -128,6 +127,20 @@ describe('CostInsightsPage', () => {
     });
     await renderPage();
     expect(screen.getByText('Failed to load cost data')).toBeInTheDocument();
+  });
+
+  it('rewrites the "observability not enabled" error for the platform view', async () => {
+    mockUseCostInsights.mockReturnValue({
+      data: undefined,
+      loading: false,
+      isRefetching: false,
+      error: 'Observability is not enabled for this component',
+      refresh: jest.fn(),
+    });
+    await renderPage();
+    expect(
+      screen.getByText('Cost Insights have not been enabled'),
+    ).toBeInTheDocument();
   });
 
   it('prompts to pick another namespace when it has no environments', async () => {

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsPage.tsx
@@ -17,6 +17,7 @@ import {
   RefreshOverlay,
 } from '@openchoreo/backstage-design-system';
 import { CHOREO_ANNOTATIONS } from '@openchoreo/backstage-plugin-common';
+import { TimeRangeFilter } from '@openchoreo/backstage-plugin-react';
 import { parseUrlTimeRange, writeUrlTimeRange } from '../../utils/urlTimeRange';
 import { CostInsightsScopeFilters } from './CostInsightsScopeFilters';
 import { expandSelection } from './costAggregation';
@@ -24,9 +25,9 @@ import {
   CostInsightsFilters,
   DEFAULT_GRANULARITY,
 } from './CostInsightsFilters';
-import { CostSummaryCards } from './CostSummaryCards';
 import { CostInsightsTable } from './CostInsightsTable';
 import { CostInsightsGraphs } from './CostInsightsGraphs';
+import { ForecastDivergenceChart } from './ForecastDivergenceChart';
 import { useNamespaceEnvironments } from './useNamespaceEnvironments';
 import { useDimensionTitles } from './useDimensionTitles';
 import { useCostInsights } from './useCostInsights';
@@ -34,7 +35,6 @@ import type {
   CostComponentRef,
   CostProjectRef,
   CostScopeSelection,
-  CostViewMode,
 } from './types';
 
 // Cost Analysis is a heavier feature (report views, FinOps chat). Load it lazily
@@ -57,6 +57,12 @@ const LEVEL_KIND: Record<string, string> = {
 
 const useStyles = makeStyles(theme => ({
   section: { marginTop: theme.spacing(2) },
+  timeRangeRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(1),
+  },
   analysisContent: { marginTop: theme.spacing(3) },
   tabBar: {
     display: 'flex',
@@ -84,6 +90,14 @@ const useStyles = makeStyles(theme => ({
 const projectValue = (p: CostProjectRef) => `${p.namespace}/${p.name}`;
 const componentValue = (c: CostComponentRef) =>
   `${c.namespace}/${c.project}/${c.name}`;
+
+// The API's component-scoped "not enabled" message is wrong for this
+// platform-level feature.
+function friendlyCostError(message: string): string {
+  return /observability is not enabled/i.test(message)
+    ? 'Cost Insights have not been enabled'
+    : message;
+}
 
 /**
  * Parse the multi-select scope from the URL. Reads the plural params
@@ -204,8 +218,6 @@ const CostInsightsInsightsTab = () => {
   // Raw dimension name to catalog title, so rows read "GCP Microservice Demo".
   const titles = useDimensionTitles(level, scopes);
 
-  const view: CostViewMode =
-    searchParams.get('view') === 'graph' ? 'graph' : 'table';
   const granularity = searchParams.get('granularity') || DEFAULT_GRANULARITY;
   const { timeRange, customStartTime, customEndTime } = parseUrlTimeRange(
     searchParams,
@@ -251,15 +263,6 @@ const CostInsightsInsightsTab = () => {
     [update, allEnvNames.length],
   );
 
-  const onViewChange = useCallback(
-    (nextView: CostViewMode) =>
-      update(params => {
-        if (nextView === 'table') params.delete('view');
-        else params.set('view', nextView);
-      }),
-    [update],
-  );
-
   const onTimeRangeChange = useCallback(
     (next: {
       timeRange: string;
@@ -289,7 +292,6 @@ const CostInsightsInsightsTab = () => {
     timeRange,
     customStartTime,
     customEndTime,
-    view,
     granularity,
   });
 
@@ -310,12 +312,9 @@ const CostInsightsInsightsTab = () => {
           environmentsLoading={envsLoading}
           selectedEnvironments={selectedEnvironments}
           onEnvironmentsChange={onEnvironmentsChange}
-          view={view}
-          onViewChange={onViewChange}
-          timeRange={timeRange}
-          customStartTime={customStartTime}
-          customEndTime={customEndTime}
-          onTimeRangeChange={onTimeRangeChange}
+          onRefresh={refresh}
+          refreshing={loading || isRefetching}
+          disabled={noScope}
         />
       </Box>
 
@@ -329,7 +328,7 @@ const CostInsightsInsightsTab = () => {
 
       {envsError && (
         <Box className={classes.section}>
-          <Alert severity="error">{envsError}</Alert>
+          <Alert severity="error">{friendlyCostError(envsError)}</Alert>
         </Box>
       )}
 
@@ -354,7 +353,7 @@ const CostInsightsInsightsTab = () => {
 
       {error && (
         <Box className={classes.section}>
-          <Alert severity="error">{error}</Alert>
+          <Alert severity="error">{friendlyCostError(error)}</Alert>
         </Box>
       )}
 
@@ -363,31 +362,40 @@ const CostInsightsInsightsTab = () => {
       {!loading && data && (
         <Box position="relative">
           <RefreshOverlay active={isRefetching} label="Refreshing cost data" />
-          {view !== 'graph' && (
-            <Box className={classes.section}>
-              <CostSummaryCards summary={data.summary} />
-            </Box>
-          )}
+          {/* Forecast covers the whole month, so it sits above the time range. */}
           <Box className={classes.section}>
-            {view === 'graph' ? (
-              <CostInsightsGraphs
-                data={data}
-                granularity={granularity}
-                onGranularityChange={onGranularityChange}
-              />
-            ) : (
-              <CostInsightsTable
-                level={data.level}
-                rows={data.rows}
-                icon={app.getSystemIcon(`kind:${LEVEL_KIND[data.level]}`)}
-                titles={titles}
-                scope={optimizeScope}
-                onOptimized={refresh}
-                singleComponent={
-                  data.level === 'component' && scopes.length === 1
-                }
-              />
-            )}
+            <ForecastDivergenceChart forecast={data.forecast} />
+          </Box>
+          <Box className={`${classes.section} ${classes.timeRangeRow}`}>
+            <Typography variant="body2" color="textSecondary">
+              Time range for everything below
+            </Typography>
+            <TimeRangeFilter
+              value={timeRange}
+              customStartTime={customStartTime}
+              customEndTime={customEndTime}
+              onChange={onTimeRangeChange}
+            />
+          </Box>
+          <Box className={classes.section}>
+            <CostInsightsGraphs
+              data={data}
+              granularity={granularity}
+              onGranularityChange={onGranularityChange}
+            />
+          </Box>
+          <Box className={classes.section}>
+            <CostInsightsTable
+              level={data.level}
+              rows={data.rows}
+              icon={app.getSystemIcon(`kind:${LEVEL_KIND[data.level]}`)}
+              titles={titles}
+              scope={optimizeScope}
+              onOptimized={refresh}
+              singleComponent={
+                data.level === 'component' && scopes.length === 1
+              }
+            />
           </Box>
         </Box>
       )}

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsScopeFilters.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsScopeFilters.tsx
@@ -195,6 +195,8 @@ export const CostInsightsScopeFilters: FC<CostInsightsScopeFiltersProps> = ({
         allValues={projectOptions.map(o => o.value)}
         selected={selectedProjects}
         onChange={onProjectsChange}
+        // Empty selection means all projects.
+        emptyLabel="All"
       />
       <MultiSelectFilter
         label="Components"
@@ -202,6 +204,8 @@ export const CostInsightsScopeFilters: FC<CostInsightsScopeFiltersProps> = ({
         allValues={componentOptions.map(o => o.value)}
         selected={selectedComponents}
         onChange={onComponentsChange}
+        // Empty selection means all components.
+        emptyLabel="All"
       />
     </Box>
   );

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsSummaryCard.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsSummaryCard.tsx
@@ -109,9 +109,9 @@ export const CostInsightsSummaryCard = () => {
     level: deriveLevel(scope),
     environments: ready ? envNames : [],
     timeRange: COST_SUMMARY_TIME_RANGE,
-    view: 'table',
-    // Table view ignores granularity; a valid value keeps the hook's key stable.
+    // This card only reads the summary; a valid granularity keeps the key stable.
     granularity: '1h',
+    summaryOnly: true,
   });
 
   const busy = envsLoading || loading;

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostInsightsTable.tsx
@@ -39,6 +39,7 @@ function formatSpecUpdateTime(iso: string): string {
 
 const useStyles = makeStyles(theme => ({
   numeric: { textAlign: 'right', whiteSpace: 'nowrap' },
+  numericSort: { flexDirection: 'row-reverse' },
   up: { color: theme.palette.error.main },
   down: { color: theme.palette.success.main },
   savings: { color: theme.palette.success.main, fontWeight: 600 },
@@ -299,8 +300,9 @@ const RecommendationCostTable: FC<CostInsightsTableProps> = ({
     });
   }, [rows, titles, order, orderBy]);
 
-  const sortLabel = (id: typeof orderBy, label: string) => (
+  const sortLabel = (id: typeof orderBy, label: string, numeric = false) => (
     <TableSortLabel
+      className={numeric ? classes.numericSort : undefined}
       active={orderBy === id}
       direction={orderBy === id ? order : 'asc'}
       onClick={() => onSort(id)}
@@ -316,12 +318,12 @@ const RecommendationCostTable: FC<CostInsightsTableProps> = ({
           <TableRow>
             <TableCell>{sortLabel('name', 'Environment')}</TableCell>
             <TableCell className={classes.numeric}>
-              {sortLabel('total', 'Current cost (USD)')}
+              {sortLabel('total', 'Current cost (USD)', true)}
             </TableCell>
             <TableCell>{sortLabel('efficiency', 'Efficiency')}</TableCell>
             <TableCell>Recommended change</TableCell>
             <TableCell className={classes.numeric}>
-              {sortLabel('saving', 'Saving (USD)')}
+              {sortLabel('saving', 'Saving (USD)', true)}
             </TableCell>
             <TableCell className={classes.actionCell} />
           </TableRow>
@@ -480,8 +482,9 @@ const StandardCostTable: FC<CostInsightsTableProps> = ({
     });
   }, [rows, titles, order, orderBy]);
 
-  const sortLabel = (id: SortId, label: string) => (
+  const sortLabel = (id: SortId, label: string, numeric = false) => (
     <TableSortLabel
+      className={numeric ? classes.numericSort : undefined}
       active={orderBy === id}
       direction={orderBy === id ? order : 'asc'}
       onClick={() => onSort(id)}
@@ -502,31 +505,31 @@ const StandardCostTable: FC<CostInsightsTableProps> = ({
               className={classes.numeric}
               sortDirection={orderBy === 'cpuCost' ? order : false}
             >
-              {sortLabel('cpuCost', 'CPU (USD)')}
+              {sortLabel('cpuCost', 'CPU (USD)', true)}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'memoryCost' ? order : false}
             >
-              {sortLabel('memoryCost', 'Memory (USD)')}
+              {sortLabel('memoryCost', 'Memory (USD)', true)}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'efficiency' ? order : false}
             >
-              {sortLabel('efficiency', 'Efficiency')}
+              {sortLabel('efficiency', 'Efficiency', true)}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'total' ? order : false}
             >
-              {sortLabel('total', 'Total (USD)')}
+              {sortLabel('total', 'Total (USD)', true)}
             </TableCell>
             <TableCell
               className={classes.numeric}
               sortDirection={orderBy === 'deltaPct' ? order : false}
             >
-              {sortLabel('deltaPct', 'Inc/dec vs prev window')}
+              {sortLabel('deltaPct', 'Inc/dec vs prev window', true)}
             </TableCell>
           </TableRow>
         </TableHead>

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.test.tsx
@@ -1,39 +1,34 @@
 import { render, screen } from '@testing-library/react';
-import { CostSummaryCards } from './CostSummaryCards';
+import { TotalCostContent } from './CostSummaryCards';
 import type { CostSummary } from './types';
 
 const summary = (over: Partial<CostSummary> = {}): CostSummary => ({
   totalCost: 22,
   deltaPct: 10,
-  forecastThisMonth: 500,
   efficiency: 0.3,
   totalSaving: 0,
   ...over,
 });
 
-describe('CostSummaryCards', () => {
-  it('renders the total, forecast and efficiency headlines', () => {
-    render(<CostSummaryCards summary={summary()} />);
+describe('TotalCostContent', () => {
+  it('renders the total cost headline', () => {
+    render(<TotalCostContent summary={summary()} />);
     expect(screen.getByText('Total Cost')).toBeInTheDocument();
     expect(screen.getByText('USD 22.00')).toBeInTheDocument();
-    expect(screen.getByText('Forecast this month')).toBeInTheDocument();
-    expect(screen.getByText('USD 500.00')).toBeInTheDocument();
-    expect(screen.getByText('Efficiency')).toBeInTheDocument();
-    expect(screen.getByText('30%')).toBeInTheDocument();
   });
 
   it('shows an upward delta chip against the previous window', () => {
-    render(<CostSummaryCards summary={summary({ deltaPct: 10 })} />);
+    render(<TotalCostContent summary={summary({ deltaPct: 10 })} />);
     expect(screen.getByText('10% vs prev window')).toBeInTheDocument();
   });
 
   it('shows a downward delta with its magnitude only', () => {
-    render(<CostSummaryCards summary={summary({ deltaPct: -8 })} />);
+    render(<TotalCostContent summary={summary({ deltaPct: -8 })} />);
     expect(screen.getByText('8% vs prev window')).toBeInTheDocument();
   });
 
   it('falls back to a "No previous window" note when the delta is unknown', () => {
-    render(<CostSummaryCards summary={summary({ deltaPct: null })} />);
+    render(<TotalCostContent summary={summary({ deltaPct: null })} />);
     expect(screen.getByText('No previous window')).toBeInTheDocument();
   });
 });

--- a/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/CostSummaryCards.tsx
@@ -1,19 +1,11 @@
 import { FC } from 'react';
-import { Grid, Tooltip, Typography, makeStyles } from '@material-ui/core';
+import { Typography, makeStyles } from '@material-ui/core';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
-import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
-import { Card } from '@openchoreo/backstage-design-system';
 import type { CostSummary } from './types';
-import { formatUsd, formatEfficiency } from './format';
+import { formatUsd } from './format';
 
 const useStyles = makeStyles(theme => ({
-  card: {
-    height: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(0.5),
-  },
   label: {
     fontWeight: 600,
     fontSize: '0.75rem',
@@ -33,17 +25,7 @@ const useStyles = makeStyles(theme => ({
   down: { color: theme.palette.success.main },
   deltaIcon: { fontSize: 16 },
   muted: { color: theme.palette.text.secondary },
-  labelRow: { display: 'flex', alignItems: 'center', gap: theme.spacing(0.5) },
-  infoIcon: {
-    fontSize: 15,
-    color: theme.palette.text.secondary,
-    cursor: 'help',
-  },
 }));
-
-export interface CostSummaryCardsProps {
-  summary: CostSummary;
-}
 
 const DeltaChip: FC<{ deltaPct: number | null }> = ({ deltaPct }) => {
   const classes = useStyles();
@@ -74,8 +56,8 @@ const DeltaChip: FC<{ deltaPct: number | null }> = ({ deltaPct }) => {
 
 /**
  * The Total Cost card's inner content (label, headline value, delta), without a
- * `Card` wrapper — so it can be reused both here and in the catalog overview's
- * cost summary card without nesting one `Card` inside another.
+ * `Card` wrapper — so the catalog overview's cost summary card can render it
+ * without nesting one `Card` inside another.
  */
 export const TotalCostContent: FC<{
   summary: CostSummary;
@@ -93,55 +75,5 @@ export const TotalCostContent: FC<{
       </Typography>
       <DeltaChip deltaPct={summary.deltaPct} />
     </>
-  );
-};
-
-export const CostSummaryCards: FC<CostSummaryCardsProps> = ({ summary }) => {
-  const classes = useStyles();
-  return (
-    <Grid container spacing={2}>
-      <Grid item xs={12} sm={4}>
-        <Card padding={16} className={classes.card}>
-          <TotalCostContent summary={summary} />
-        </Card>
-      </Grid>
-      <Grid item xs={12} sm={4}>
-        <Card padding={16} className={classes.card}>
-          <div className={classes.labelRow}>
-            <Typography className={classes.label}>
-              Forecast this month
-            </Typography>
-            <Tooltip
-              title="Extrapolates the selected time window's spend rate across the whole month. Hence the forecast can change with the time range you pick, especially when only part of that range has cost data."
-              arrow
-            >
-              <InfoOutlinedIcon className={classes.infoIcon} />
-            </Tooltip>
-          </div>
-          <Typography component="div" className={classes.value}>
-            {formatUsd(summary.forecastThisMonth)}
-          </Typography>
-          <Typography variant="body2" className={classes.muted}>
-            at current rate
-          </Typography>
-        </Card>
-      </Grid>
-      <Grid item xs={12} sm={4}>
-        <Card padding={16} className={classes.card}>
-          <div className={classes.labelRow}>
-            <Typography className={classes.label}>Efficiency</Typography>
-            <Tooltip
-              title="Share of provisioned resources actually used (usage/requested) as a percentage, weighted by cost. Low efficiency means you are paying for capacity that sits idle."
-              arrow
-            >
-              <InfoOutlinedIcon className={classes.infoIcon} />
-            </Tooltip>
-          </div>
-          <Typography component="div" className={classes.value}>
-            {formatEfficiency(summary.efficiency)}
-          </Typography>
-        </Card>
-      </Grid>
-    </Grid>
   );
 };

--- a/plugins/openchoreo-observability/src/components/CostInsights/ForecastDivergenceChart.test.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/ForecastDivergenceChart.test.tsx
@@ -10,8 +10,14 @@ jest.mock('recharts', () => ({
   ComposedChart: ({ children }: any) => (
     <div data-testid="forecast-chart">{children}</div>
   ),
+  // Both the areas (actual, forecast) and the if-applied line are "series".
+  Area: ({ dataKey, children }: any) => (
+    <div data-testid="series" data-key={dataKey}>
+      {children}
+    </div>
+  ),
   Line: ({ dataKey, children }: any) => (
-    <div data-testid="line" data-key={dataKey}>
+    <div data-testid="series" data-key={dataKey}>
       {children}
     </div>
   ),
@@ -26,23 +32,23 @@ jest.mock('recharts', () => ({
   CartesianGrid: () => null,
   XAxis: () => null,
   YAxis: () => null,
-  // Render both tooltip branches: the pre-fork "actual" point and the two
-  // post-fork projections.
+  // Render both tooltip branches: the pre-fork "accumulated cost" point and the
+  // two post-fork projections.
   Tooltip: ({ content }: any) => (
     <>
       {content?.({
         active: true,
         label: JUL9,
-        payload: [{ dataKey: 'actual', name: 'so far', value: 24 }],
+        payload: [{ dataKey: 'actual', name: 'accumulated cost', value: 24 }],
       })}
       {content?.({
         active: true,
         label: AUG1,
         payload: [
-          { dataKey: 'atCurrent', name: 'at current rate', value: 90 },
+          { dataKey: 'forecast', name: 'forecast at current rate', value: 90 },
           {
             dataKey: 'ifApplied',
-            name: 'if recommendations applied',
+            name: 'forecast if recommendations applied',
             value: 70,
           },
         ],
@@ -57,10 +63,10 @@ const forecast: ForecastData = {
     {
       timestamp: '2026-07-09T00:00:00.000Z',
       actual: 24,
-      atCurrent: 24,
+      forecast: 24,
       ifApplied: 24,
     },
-    { timestamp: '2026-08-01T00:00:00.000Z', atCurrent: 90, ifApplied: 70 },
+    { timestamp: '2026-08-01T00:00:00.000Z', forecast: 90, ifApplied: 70 },
   ],
   atCurrentTotal: 90,
   ifAppliedTotal: 70,
@@ -68,29 +74,34 @@ const forecast: ForecastData = {
 };
 
 describe('ForecastDivergenceChart', () => {
-  it('renders the three projection lines with a clickable legend', () => {
+  it('renders the accumulated area plus the two forecast series with a legend', () => {
     render(<ForecastDivergenceChart forecast={forecast} />);
     expect(
-      screen.getAllByTestId('line').map(l => l.getAttribute('data-key')),
-    ).toEqual(['actual', 'atCurrent', 'ifApplied']);
+      screen.getAllByTestId('series').map(l => l.getAttribute('data-key')),
+    ).toEqual(['actual', 'forecast', 'ifApplied']);
     // Appears in both the legend and the (mock-invoked) tooltip.
-    expect(screen.getAllByText('so far').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('at current rate').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('accumulated cost').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('forecast at current rate').length,
+    ).toBeGreaterThan(0);
   });
 
   it('renders both tooltip branches and the end labels', () => {
     render(<ForecastDivergenceChart forecast={forecast} />);
-    // Pre-fork tooltip shows only "so far"; post-fork shows both projections.
+    // Pre-fork tooltip shows only the accumulated cost; post-fork shows both
+    // projections.
     expect(screen.getByText('$24.00')).toBeInTheDocument();
     expect(screen.getByText('$90.00')).toBeInTheDocument();
     expect(screen.getByText('$70.00')).toBeInTheDocument();
-    // End labels drawn at the last point.
-    expect(screen.getAllByText('at current rate').length).toBeGreaterThan(1);
+    // End labels drawn at the last point (legend + tooltip + end label).
+    expect(
+      screen.getAllByText('forecast at current rate').length,
+    ).toBeGreaterThan(1);
   });
 
-  it('toggles a line off via its legend item', () => {
+  it('toggles a series off via its legend item', () => {
     render(<ForecastDivergenceChart forecast={forecast} />);
-    const legendItem = screen.getByRole('button', { name: 'so far' });
+    const legendItem = screen.getByRole('button', { name: 'accumulated cost' });
     fireEvent.click(legendItem);
     expect(legendItem).toHaveStyle('text-decoration: line-through');
   });
@@ -98,6 +109,8 @@ describe('ForecastDivergenceChart', () => {
   it('renders an empty state when there is no forecast', () => {
     render(<ForecastDivergenceChart forecast={null} />);
     expect(screen.queryByTestId('forecast-chart')).not.toBeInTheDocument();
-    expect(screen.getByText(/Not enough data to project/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Not enough data yet to forecast/i),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/openchoreo-observability/src/components/CostInsights/ForecastDivergenceChart.tsx
+++ b/plugins/openchoreo-observability/src/components/CostInsights/ForecastDivergenceChart.tsx
@@ -1,6 +1,7 @@
 import { FC, useMemo, useState } from 'react';
 import { Paper, Typography, makeStyles, useTheme } from '@material-ui/core';
 import {
+  Area,
   CartesianGrid,
   ComposedChart,
   LabelList,
@@ -59,7 +60,7 @@ export interface ForecastDivergenceChartProps {
 
 export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
   forecast,
-  title = 'Spend forecast',
+  title = 'Accumulated cost and forecast',
 }) => {
   const classes = useStyles();
   const theme = useTheme();
@@ -67,7 +68,7 @@ export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
   const blue = (dark ? PALETTE_DARK : PALETTE_LIGHT)[0];
   const green = savingColor(dark);
 
-  // Legend-toggled lines; hidden keys are dimmed in the legend and not drawn.
+  // Legend-toggled series; hidden keys are dimmed in the legend and not drawn.
   const [hidden, setHidden] = useState<Set<string>>(new Set());
   const toggle = (key: string) =>
     setHidden(prev => {
@@ -76,10 +77,23 @@ export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
       else next.add(key);
       return next;
     });
+  // strokeDasharray per series: solid for actual cost, dashes for the current-rate
+  // forecast, round dots for the if-applied forecast.
+  const DASH = { actual: undefined, forecast: '8 6', ifApplied: '1 9' };
   const legendItems = [
-    { key: 'actual', name: 'so far', color: blue, dashed: false },
-    { key: 'atCurrent', name: 'at current rate', color: blue, dashed: true },
-    { key: 'ifApplied', name: 'if applied', color: green, dashed: true },
+    { key: 'actual', name: 'accumulated cost', color: blue, dash: DASH.actual },
+    {
+      key: 'forecast',
+      name: 'forecast at current rate',
+      color: blue,
+      dash: DASH.forecast,
+    },
+    {
+      key: 'ifApplied',
+      name: 'forecast if recommendations applied',
+      color: green,
+      dash: DASH.ifApplied,
+    },
   ];
 
   const data = useMemo(
@@ -91,11 +105,20 @@ export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
     [forecast],
   );
 
+  // Month label from the first (month-start) point.
+  const monthLabel =
+    data.length > 0
+      ? new Date(data[0].t).toLocaleDateString(undefined, {
+          month: 'long',
+          year: 'numeric',
+        })
+      : '';
+
   if (!forecast || data.length === 0) {
     return (
       <Paper variant="outlined" className={classes.empty}>
         <Typography color="textSecondary">
-          Not enough data to project a forecast for this window.
+          Not enough data yet to forecast this month's cost.
         </Typography>
       </Paper>
     );
@@ -127,14 +150,15 @@ export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
     <Paper variant="outlined" className={classes.container}>
       <ChartTitle
         title={title}
+        subtitle={monthLabel}
         className={classes.header}
-        info="Cumulative spend so far this month (solid), then two projections to month end: at the current rate, and if the cost recommendations are applied. The gap is the potential saving. Extrapolates the selected time window's spend rate across the whole month. Hence the forecast can change with the time range you pick, especially when only part of that range has cost data."
+        info="The solid part shows the accumulated cost so far this calendar month. Each point is the running total from the 1st to that date. Then two forecast projections to month end; the forecast cost at the current rate, and the forecast cost if recommendations are applied. The gap between them is the potential saving."
       />
       <div className={classes.chart}>
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart
             data={data}
-            margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+            margin={{ top: 24, right: 16, bottom: 8, left: 0 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -156,12 +180,18 @@ export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
             <Tooltip
               content={({ active, payload, label }) => {
                 if (!active || !payload?.length) return null;
-                // Up to now the point is on the single actual line, so show only
-                // "so far"; past now show the two projections.
-                const actual = payload.find(e => e.dataKey === 'actual');
+                // Up to today the point is on the actual-cost curve, so show only
+                // "actual cost"; past today show the two projections.
+                const defined = payload.filter(
+                  e =>
+                    e.value !== null &&
+                    e.value !== undefined &&
+                    Number.isFinite(Number(e.value)),
+                );
+                const actual = defined.find(e => e.dataKey === 'actual');
                 const shown = actual
                   ? [actual]
-                  : payload.filter(e => e.dataKey !== 'actual');
+                  : defined.filter(e => e.dataKey !== 'actual');
                 if (!shown.length) return null;
                 return (
                   <div
@@ -198,41 +228,54 @@ export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
                 );
               }}
             />
-            <Line
+            <Area
               dataKey="actual"
-              name="so far"
+              name="accumulated cost"
               stroke={blue}
               strokeWidth={2}
+              fill={blue}
+              fillOpacity={0.28}
               dot={false}
               connectNulls
               hide={hidden.has('actual')}
               isAnimationActive={false}
             />
-            <Line
-              dataKey="atCurrent"
-              name="at current rate"
+            <Area
+              dataKey="forecast"
+              name="forecast at current rate"
               stroke={blue}
               strokeWidth={2}
-              strokeDasharray="5 4"
+              strokeDasharray={DASH.forecast}
+              fill={blue}
+              fillOpacity={0.08}
               dot={false}
               connectNulls
-              hide={hidden.has('atCurrent')}
+              hide={hidden.has('forecast')}
               isAnimationActive={false}
             >
-              <LabelList content={endLabel('at current rate', blue, -12)} />
-            </Line>
+              <LabelList
+                content={endLabel('forecast at current rate', blue, -12)}
+              />
+            </Area>
             <Line
               dataKey="ifApplied"
-              name="if recommendations applied"
+              name="forecast if recommendations applied"
               stroke={green}
-              strokeWidth={2}
-              strokeDasharray="5 4"
+              strokeWidth={3}
+              strokeDasharray={DASH.ifApplied}
+              strokeLinecap="round"
               dot={false}
               connectNulls
               hide={hidden.has('ifApplied')}
               isAnimationActive={false}
             >
-              <LabelList content={endLabel('if applied', green, 14)} />
+              <LabelList
+                content={endLabel(
+                  'forecast if recommendations are applied',
+                  green,
+                  14,
+                )}
+              />
             </Line>
           </ComposedChart>
         </ResponsiveContainer>
@@ -253,16 +296,23 @@ export const ForecastDivergenceChart: FC<ForecastDivergenceChartProps> = ({
               textDecoration: hidden.has(item.key) ? 'line-through' : 'none',
             }}
           >
-            <span
-              style={{
-                width: 14,
-                height: 0,
-                borderTop: `2px ${item.dashed ? 'dashed' : 'solid'} ${
-                  item.color
-                }`,
-                flexShrink: 0,
-              }}
-            />
+            <svg
+              width={26}
+              height={8}
+              style={{ flexShrink: 0, overflow: 'visible' }}
+              aria-hidden
+            >
+              <line
+                x1={0}
+                y1={4}
+                x2={26}
+                y2={4}
+                stroke={item.color}
+                strokeWidth={item.dash === DASH.ifApplied ? 3 : 2}
+                strokeDasharray={item.dash}
+                strokeLinecap="round"
+              />
+            </svg>
             {item.name}
           </span>
         ))}

--- a/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.test.ts
@@ -5,8 +5,6 @@ import {
   dimensionOf,
   totalCost,
   percentChange,
-  monthDurationMs,
-  forecastThisMonth,
   aggregateRows,
   computeSummary,
   buildSeries,
@@ -111,33 +109,6 @@ describe('totalCost & percentChange', () => {
   });
 });
 
-describe('forecastThisMonth', () => {
-  it('extrapolates the window rate to the calendar month', () => {
-    const now = new Date('2026-07-15T00:00:00.000Z');
-    const monthMs = monthDurationMs(now); // July = 31 days
-    // 1-hour window costing $1 means rate $1/hour.
-    const forecast = forecastThisMonth(
-      1,
-      '2026-07-01T00:00:00.000Z',
-      '2026-07-01T01:00:00.000Z',
-      now,
-    );
-    expect(forecast).toBeCloseTo(monthMs / (60 * 60 * 1000));
-  });
-
-  it('falls back to the raw total for a non-positive window', () => {
-    const now = new Date('2026-07-15T00:00:00.000Z');
-    expect(
-      forecastThisMonth(
-        42,
-        '2026-07-01T00:00:00Z',
-        '2026-07-01T00:00:00Z',
-        now,
-      ),
-    ).toBe(42);
-  });
-});
-
 describe('aggregateRows', () => {
   it('aggregates across environments and cost-weights efficiency', () => {
     // Same project "gcp" seen in two environments; efficiency should be
@@ -212,7 +183,6 @@ describe('aggregateRows', () => {
 
 describe('computeSummary', () => {
   it('produces total, delta and efficiency', () => {
-    const now = new Date('2026-07-15T00:00:00.000Z');
     const current = [
       costItem({ cpuCost: 10, memoryCost: 12, efficiency: 0.3 }),
     ];
@@ -220,9 +190,6 @@ describe('computeSummary', () => {
     const summary = computeSummary(
       current,
       previous,
-      '2026-07-01T00:00:00.000Z',
-      '2026-07-01T01:00:00.000Z',
-      now,
       [],
       'namespace',
       new Map(),
@@ -230,12 +197,10 @@ describe('computeSummary', () => {
     expect(summary.totalCost).toBe(22);
     expect(summary.deltaPct).toBeCloseTo(((22 - 20) / 20) * 100);
     expect(summary.efficiency).toBeCloseTo(0.3);
-    expect(summary.forecastThisMonth).toBeGreaterThan(0);
     expect(summary.totalSaving).toBe(0);
   });
 
   it('counts saving only for dimensions that have a recommendation', () => {
-    const now = new Date('2026-07-15T00:00:00.000Z');
     const current = [
       costItem({ project: 'gcp', cpuCost: 10, memoryCost: 12 }), // total 22
       costItem({ project: 'shop', cpuCost: 4, memoryCost: 4 }), // no rec
@@ -253,9 +218,6 @@ describe('computeSummary', () => {
     const summary = computeSummary(
       current,
       [],
-      '2026-07-01T00:00:00.000Z',
-      '2026-07-01T01:00:00.000Z',
-      now,
       recommendations,
       'namespace',
       new Map(),
@@ -265,7 +227,6 @@ describe('computeSummary', () => {
   });
 
   it('credits saving from a zero-cost recommendation', () => {
-    const now = new Date('2026-07-15T00:00:00.000Z');
     const current = [costItem({ project: 'gcp', cpuCost: 5, memoryCost: 0 })];
     const recommendations: CostRecommendationItem[] = [
       {
@@ -280,9 +241,6 @@ describe('computeSummary', () => {
     const summary = computeSummary(
       current,
       [],
-      '2026-07-01T00:00:00.000Z',
-      '2026-07-01T01:00:00.000Z',
-      now,
       recommendations,
       'namespace',
       new Map(),
@@ -291,7 +249,6 @@ describe('computeSummary', () => {
   });
 
   it('excludes stale environments from claimed saving', () => {
-    const now = new Date('2026-07-15T00:00:00.000Z');
     const current = [
       costItem({ environment: 'dev', cpuCost: 8, memoryCost: 0 }),
     ];
@@ -308,9 +265,6 @@ describe('computeSummary', () => {
     const summary = computeSummary(
       current,
       [],
-      '2026-07-01T00:00:00.000Z',
-      '2026-07-01T01:00:00.000Z',
-      now,
       recommendations,
       'component',
       new Map([['dev', '2026-07-01T00:00:00.000Z']]),
@@ -348,67 +302,56 @@ describe('aggregateRows saving', () => {
 });
 
 describe('buildForecast', () => {
-  const now = new Date('2026-07-15T00:00:00.000Z');
+  // Use local Date constructors so the internally-computed month boundaries line
+  // up with the inputs regardless of the test runner's timezone.
+  const now = new Date(2026, 6, 15); // Jul 15
+  const monthStart = new Date(2026, 6, 1); // Jul 1
+  // Daily buckets Jul 1..Jul 14, $24 each -> $336 month-to-date.
+  const mtdItems = Array.from({ length: 14 }, (_, i) =>
+    costItem({
+      startTime: new Date(2026, 6, i + 1).toISOString(),
+      cpuCost: 12,
+      memoryCost: 12,
+    }),
+  );
 
-  it('forks the actual line into the two month-end projections', () => {
+  it('accumulates the actual curve and forks into two month-end projections', () => {
     const forecast = buildForecast({
-      totalActual: 24,
-      totalSaving: 6,
-      windowStart: '2026-07-08T00:00:00.000Z',
-      windowEnd: '2026-07-09T00:00:00.000Z', // 1-day window, $24 -> $1/hour
+      mtdItems,
+      savingFraction: 0.25,
+      monthStart,
       now,
     })!;
     expect(forecast).not.toBeNull();
-    // $1/h over the 31-day month.
-    expect(forecast.atCurrentTotal).toBeCloseTo(24 * 31);
+    // The actual curve starts at zero on the month start.
+    expect(forecast.points[0]).toMatchObject({ actual: 0 });
+    // Fork at "now" carries the month-to-date total on all three series.
+    const fork = forecast.points.find(
+      p => p.actual !== undefined && p.forecast !== undefined,
+    );
+    expect(fork?.actual).toBeCloseTo(336);
+    expect(fork?.forecast).toBe(fork?.actual);
+    expect(fork?.ifApplied).toBe(fork?.actual);
+    // Extrapolated to the full ~31-day month at the same $24/day rate.
+    expect(forecast.atCurrentTotal).toBeCloseTo(744, 0);
+    // Recommendations cut only the remaining spend, so it lands between the
+    // month-to-date total and the at-current projection.
     expect(forecast.ifAppliedTotal).toBeLessThan(forecast.atCurrentTotal);
+    expect(forecast.ifAppliedTotal).toBeGreaterThan(336);
     expect(forecast.leftOnTable).toBeCloseTo(
       forecast.atCurrentTotal - forecast.ifAppliedTotal,
     );
-    const fork = forecast.points.find(p => p.actual !== undefined);
-    expect(fork?.atCurrent).toBe(fork?.ifApplied);
   });
 
-  it('returns null for a non-positive window', () => {
+  it('returns null before any time has elapsed this month', () => {
     expect(
       buildForecast({
-        totalActual: 10,
-        totalSaving: 0,
-        windowStart: '2026-07-09T00:00:00.000Z',
-        windowEnd: '2026-07-09T00:00:00.000Z',
-        now,
+        mtdItems: [],
+        savingFraction: 0,
+        monthStart,
+        now: monthStart,
       }),
     ).toBeNull();
-  });
-
-  it('returns null when the window ends past the month end', () => {
-    expect(
-      buildForecast({
-        totalActual: 10,
-        totalSaving: 0,
-        windowStart: '2026-07-30T00:00:00.000Z',
-        windowEnd: '2026-08-05T00:00:00.000Z',
-        now,
-      }),
-    ).toBeNull();
-  });
-
-  it('excludes prior-month spend when the window crosses the month boundary', () => {
-    // 3-day window (72h) spanning Jun 29 -> Jul 2 at $1/hour; only the 24h in
-    // July should count toward this month's cumulative fork.
-    const forecast = buildForecast({
-      totalActual: 72,
-      totalSaving: 0,
-      windowStart: '2026-06-29T00:00:00.000Z',
-      windowEnd: '2026-07-02T00:00:00.000Z',
-      now,
-    })!;
-    expect(forecast).not.toBeNull();
-    const fork = forecast.points.find(
-      p => p.actual !== undefined && p.atCurrent !== undefined,
-    );
-    expect(fork?.actual).toBeCloseTo(24); // not 72
-    expect(forecast.atCurrentTotal).toBeCloseTo(31 * 24); // $1/h * 31 days
   });
 });
 
@@ -451,7 +394,7 @@ describe('buildSeries', () => {
 
 describe('buildCostInsightsData', () => {
   it('assembles the level, summary, rows and series into one payload', () => {
-    const now = new Date('2026-07-15T00:00:00.000Z');
+    const now = new Date(2026, 6, 15);
     const data = buildCostInsightsData({
       level: 'namespace',
       currentItems: [
@@ -471,8 +414,7 @@ describe('buildCostInsightsData', () => {
       previousItems: [
         costItem({ project: 'gcp', cpuCost: 10, memoryCost: 10 }),
       ],
-      windowStart: '2026-07-01T00:00:00.000Z',
-      windowEnd: '2026-07-01T01:00:00.000Z',
+      monthStart: new Date(2026, 6, 1),
       now,
     });
 

--- a/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/costAggregation.ts
@@ -98,30 +98,6 @@ export function percentChange(
   return ((current - previous) / previous) * 100;
 }
 
-/** Milliseconds in the calendar month that contains `now`. */
-export function monthDurationMs(now: Date): number {
-  const start = new Date(now.getFullYear(), now.getMonth(), 1);
-  const end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-  return end.getTime() - start.getTime();
-}
-
-/**
- * Forecast the current calendar month's spend by extrapolating the window's
- * spend rate. `windowStart`/`windowEnd` bound the measured window.
- */
-export function forecastThisMonth(
-  total: number,
-  windowStart: string,
-  windowEnd: string,
-  now: Date,
-): number {
-  const windowMs =
-    new Date(windowEnd).getTime() - new Date(windowStart).getTime();
-  if (!Number.isFinite(windowMs) || windowMs <= 0) return total;
-  const ratePerMs = total / windowMs;
-  return ratePerMs * monthDurationMs(now);
-}
-
 function groupBy<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]> {
   const map = new Map<string, T[]>();
   for (const item of items) {
@@ -284,13 +260,10 @@ export function aggregateRows(
   return rows.sort((a, b) => b.total - a.total);
 }
 
-/** Overall summary cards (total + delta + forecast + efficiency + saving). */
+/** Overall summary (total + delta + efficiency + saving). */
 export function computeSummary(
   currentItems: CostItem[],
   previousItems: CostItem[],
-  windowStart: string,
-  windowEnd: string,
-  now: Date,
   recommendations: CostRecommendationItem[],
   level: CostScopeLevel,
   staleRecommendationEnvs: Map<string, string>,
@@ -312,7 +285,6 @@ export function computeSummary(
   return {
     totalCost: total,
     deltaPct: percentChange(total, prevTotal || undefined),
-    forecastThisMonth: forecastThisMonth(total, windowStart, windowEnd, now),
     efficiency: weightedEfficiency(currentItems),
     totalSaving,
   };
@@ -391,55 +363,66 @@ function fillMissingBuckets(series: CostSeriesPoint[]): CostSeriesPoint[] {
 }
 
 /**
- * Forecast divergence: "at current rate" projects the window rate across the
- * whole month; "if applied" forks at the window end and reduces the rate only
- * going forward. Independent of chart granularity.
+ * Accumulates the month-to-date costs into the actual-cost curve, then projects
+ * month-end spend from the average rate so far — at the current rate and if the
+ * recommendations are applied (`savingFraction` cuts only the remaining spend).
  */
 export function buildForecast(params: {
-  totalActual: number;
-  totalSaving: number;
-  windowStart: string;
-  windowEnd: string;
+  mtdItems: CostItem[];
+  savingFraction: number;
+  monthStart: Date;
   now: Date;
 }): ForecastData | null {
-  const { totalActual, totalSaving, windowStart, windowEnd, now } = params;
-  const startMs = new Date(windowStart).getTime();
-  const endMs = new Date(windowEnd).getTime();
-  const windowMs = endMs - startMs;
-  if (!Number.isFinite(windowMs) || windowMs <= 0) return null;
+  const { mtdItems, savingFraction, monthStart, now } = params;
+  const monthStartMs = monthStart.getTime();
+  const nowMs = now.getTime();
+  // Last minute of the month, so the chart ends on its final day at 23:59
+  const monthEnd = new Date(
+    new Date(now.getFullYear(), now.getMonth() + 1, 1).getTime() - 60 * 1000,
+  );
+  const elapsedMs = nowMs - monthStartMs;
+  const remainingMs = monthEnd.getTime() - nowMs;
+  if (!(elapsedMs > 0) || !(remainingMs > 0)) return null;
 
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-  const monthMs = monthEnd.getTime() - monthStart.getTime();
-  const remainingMs = monthEnd.getTime() - endMs;
-  if (!(remainingMs > 0)) return null;
+  const byBucket = groupBy(mtdItems, item => {
+    const t = new Date(item.startTime).getTime();
+    return Number.isNaN(t) ? item.startTime : new Date(t).toISOString();
+  });
+  const buckets = [...byBucket.entries()]
+    .map(([ts, items]) => ({
+      ms: new Date(ts).getTime(),
+      total: totalCost(items),
+    }))
+    .filter(b => Number.isFinite(b.ms) && b.ms >= monthStartMs && b.ms <= nowMs)
+    .sort((a, b) => a.ms - b.ms);
 
-  const rate = totalActual / windowMs;
-  const savingFraction = totalActual > 0 ? totalSaving / totalActual : 0;
-  const atCurrentTotal = rate * monthMs;
-
-  // Current-month spend so far at the window rate. Deriving it from elapsed
-  // month-time (rather than totalActual) excludes any prior-month spend when the
-  // window crosses a month boundary.
-  const elapsedThisMonthMs = Math.max(0, endMs - monthStart.getTime());
-  const forkTotal = rate * elapsedThisMonthMs;
-  const ifAppliedTotal = forkTotal + rate * (1 - savingFraction) * remainingMs;
-
-  // One actual-cost line from the month start to now, drawn at the window rate
-  // so its shape is independent of the chart's time granularity. It forks at
-  // the current point (window end) into the two projections.
   const points: ForecastPoint[] = [
     { timestamp: monthStart.toISOString(), actual: 0 },
   ];
+  let cumulative = 0;
+  for (const b of buckets) {
+    cumulative += b.total;
+    points.push({
+      timestamp: new Date(b.ms).toISOString(),
+      actual: cumulative,
+    });
+  }
+  const actualMTD = cumulative;
+
+  const rate = actualMTD / elapsedMs;
+  const atCurrentTotal = actualMTD + rate * remainingMs;
+  const ifAppliedTotal = actualMTD + rate * (1 - savingFraction) * remainingMs;
+
+  // Fork at "now" so the actual curve and both projections join.
   points.push({
-    timestamp: windowEnd,
-    actual: forkTotal,
-    atCurrent: forkTotal,
-    ifApplied: forkTotal,
+    timestamp: now.toISOString(),
+    actual: actualMTD,
+    forecast: actualMTD,
+    ifApplied: actualMTD,
   });
   points.push({
     timestamp: monthEnd.toISOString(),
-    atCurrent: atCurrentTotal,
+    forecast: atCurrentTotal,
     ifApplied: ifAppliedTotal,
   });
 
@@ -465,8 +448,12 @@ export function buildCostInsightsData(params: {
   recommendations?: CostRecommendationItem[];
   /** Withheld-recommendation envs mapped to the binding's spec update time. */
   staleRecommendationEnvs?: Map<string, string>;
-  windowStart: string;
-  windowEnd: string;
+  /** Month-to-date time-bucketed costs (month start → now) for the forecast. */
+  monthToDateItems?: CostItem[];
+  /** Month-to-date recommendations (month start until now) for the "if applied" curve. */
+  monthToDateRecommendations?: CostRecommendationItem[];
+  /** Start of the current calendar month, for the forecast window. */
+  monthStart: Date;
   now: Date;
 }): CostInsightsData {
   const {
@@ -476,8 +463,9 @@ export function buildCostInsightsData(params: {
     previousItems,
     recommendations = [],
     staleRecommendationEnvs = new Map<string, string>(),
-    windowStart,
-    windowEnd,
+    monthToDateItems = [],
+    monthToDateRecommendations = [],
+    monthStart,
     now,
   } = params;
 
@@ -488,13 +476,24 @@ export function buildCostInsightsData(params: {
   const summary = computeSummary(
     currentItems,
     previousItems,
-    windowStart,
-    windowEnd,
-    now,
     recommendations,
     level,
     staleRecommendationEnvs,
   );
+  // The "if applied" forecast uses a month-to-date saving fraction: recommendations
+  // measured over month start to now vs the month-to-date cost, so the curve is
+  // independent of the selected time range (which only drives the breakdown below).
+  const mtdSummary = computeSummary(
+    monthToDateItems,
+    [],
+    monthToDateRecommendations,
+    level,
+    staleRecommendationEnvs,
+  );
+  const savingFraction =
+    mtdSummary.totalCost > 0
+      ? mtdSummary.totalSaving / mtdSummary.totalCost
+      : 0;
   return {
     level,
     summary,
@@ -508,10 +507,9 @@ export function buildCostInsightsData(params: {
     series,
     seriesKeys,
     forecast: buildForecast({
-      totalActual: summary.totalCost,
-      totalSaving: summary.totalSaving,
-      windowStart,
-      windowEnd,
+      mtdItems: monthToDateItems,
+      savingFraction,
+      monthStart,
       now,
     }),
   };

--- a/plugins/openchoreo-observability/src/components/CostInsights/types.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/types.ts
@@ -1,7 +1,5 @@
 import type { CostResourceProfile } from '../../types';
 
-export type CostViewMode = 'table' | 'graph';
-
 /**
  * The scope level is derived from how deep the breadcrumb selection goes:
  * - `namespace`: rows are projects
@@ -80,8 +78,6 @@ export interface CostRow {
 export interface CostSummary {
   totalCost: number;
   deltaPct: number | null;
-  /** Linear extrapolation of the window's spend to the current calendar month. */
-  forecastThisMonth: number;
   efficiency: number;
   /** Aggregate reclaimable spend across the scope. */
   totalSaving: number;
@@ -93,13 +89,15 @@ export type CostSeriesPoint = {
 } & Record<string, number | string>;
 
 /**
- * One point on the forecast-divergence chart. `actual` covers the measured
- * window; `atCurrent`/`ifApplied` are the two projections.
+ * One point on the current-cost-and-forecast chart. `actual` is the accumulated
+ * spend so far this calendar month (month start till today); `forecast`/`ifApplied`
+ * are the two projections from today to month end (they share today's value with
+ * `actual` so the areas/lines join).
  */
 export interface ForecastPoint {
   timestamp: string;
   actual?: number;
-  atCurrent?: number;
+  forecast?: number;
   ifApplied?: number;
 }
 

--- a/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.test.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.test.ts
@@ -51,7 +51,6 @@ const baseParams = (
   level: 'namespace',
   environments: ['dev'],
   timeRange: '1h',
-  view: 'table',
   granularity: '1d',
   ...over,
 });
@@ -80,10 +79,11 @@ describe('useCostInsights', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // 2 envs × (current + previous) = 4 cost calls; recommendations only at the
-    // component level, so none here.
-    expect(getCosts).toHaveBeenCalledTimes(4);
-    expect(getCostRecommendations).not.toHaveBeenCalled();
+    // 2 envs × (current + series + month-to-date + previous) = 8 cost calls;
+    // recommendations are fetched twice per env (selected window + month-to-date
+    // for the forecast's "if applied" curve) = 4.
+    expect(getCosts).toHaveBeenCalledTimes(8);
+    expect(getCostRecommendations).toHaveBeenCalledTimes(4);
     expect(result.current.data?.level).toBe('namespace');
     expect(result.current.data?.rows.map(r => r.key)).toContain('gcp');
     expect(result.current.error).toBeNull();
@@ -110,8 +110,8 @@ describe('useCostInsights', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // 2 scopes × 1 env × (current + previous) = 4 cost calls.
-    expect(getCosts).toHaveBeenCalledTimes(4);
+    // 2 scopes × 1 env × (current + series + month-to-date + previous) = 8 calls.
+    expect(getCosts).toHaveBeenCalledTimes(8);
     const keys = result.current.data?.rows.map(r => r.key) ?? [];
     expect(keys).toEqual(expect.arrayContaining(['p1', 'p2']));
   });
@@ -124,8 +124,9 @@ describe('useCostInsights', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // The duplicate env collapses to one: 1 env × (current + previous) = 2 calls.
-    expect(getCosts).toHaveBeenCalledTimes(2);
+    // The duplicate env collapses to one: 1 env ×
+    // (current + series + month-to-date + previous) = 4 calls.
+    expect(getCosts).toHaveBeenCalledTimes(4);
     // A single dev item (cpu 10 + mem 12), not double-counted.
     expect(result.current.data?.summary.totalCost).toBe(22);
   });
@@ -160,9 +161,25 @@ describe('useCostInsights', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(getCostRecommendations).toHaveBeenCalledTimes(1);
+    // Selected window + month-to-date recommendations = 2 calls.
+    expect(getCostRecommendations).toHaveBeenCalledTimes(2);
     const devRow = result.current.data?.rows.find(r => r.key === 'dev');
     expect(devRow?.recommendation?.total).toBe(8);
+  });
+
+  it('fetches only current + previous cost in summary-only mode', async () => {
+    const { result } = renderHook(
+      () => useCostInsights(baseParams({ summaryOnly: true })),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 1 env × (current + previous); series, month-to-date and recommendations
+    // are skipped.
+    expect(getCosts).toHaveBeenCalledTimes(2);
+    expect(getCostRecommendations).not.toHaveBeenCalled();
+    expect(result.current.data?.summary.totalCost).toBe(22);
   });
 
   it('withholds a recommendation when the binding changed after the window started', async () => {
@@ -250,16 +267,16 @@ describe('useCostInsights', () => {
     expect(devRow?.recommendation?.current?.cpuRequest).toBe('250m');
   });
 
-  it('passes the granularity only in graph view', async () => {
+  it('passes the granularity on the bucketed time-series request', async () => {
     const { result } = renderHook(
-      () => useCostInsights(baseParams({ view: 'graph', granularity: '6h' })),
+      () => useCostInsights(baseParams({ granularity: '6h' })),
       { wrapper: createQueryWrapper() },
     );
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // Graph view fetches an accumulated window (no granularity) plus a bucketed
-    // time-series window that carries the granularity.
+    // Fetches an accumulated window (no granularity) plus a bucketed time-series
+    // window that carries the granularity.
     const opts = getCosts.mock.calls.map(c => c[2]);
     expect(opts).toEqual(
       expect.arrayContaining([expect.objectContaining({ granularity: '6h' })]),
@@ -279,7 +296,7 @@ describe('useCostInsights', () => {
     );
 
     const { result } = renderHook(
-      () => useCostInsights(baseParams({ view: 'graph', granularity: '6h' })),
+      () => useCostInsights(baseParams({ granularity: '6h' })),
       { wrapper: createQueryWrapper() },
     );
 

--- a/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.ts
+++ b/plugins/openchoreo-observability/src/components/CostInsights/useCostInsights.ts
@@ -11,12 +11,7 @@ import { observabilityApiRef } from '../../api/ObservabilityApi';
 import type { CostItem, CostRecommendationItem } from '../../types';
 import { buildCostInsightsData } from './costAggregation';
 import { fetchBindingInfoByEnv, normalizeEnv } from './optimizeChange';
-import type {
-  CostInsightsData,
-  CostScope,
-  CostScopeLevel,
-  CostViewMode,
-} from './types';
+import type { CostInsightsData, CostScope, CostScopeLevel } from './types';
 
 export interface UseCostInsightsParams {
   /** Atomic scopes to query (one per selected item at `level`). */
@@ -28,9 +23,13 @@ export interface UseCostInsightsParams {
   timeRange: string;
   customStartTime?: string;
   customEndTime?: string;
-  view: CostViewMode;
-  /** Cost-API granularity (e.g. `1h`, `1d`), only used in graph view. */
+  /** Cost-API granularity (e.g. `1h`, `1d`) for the time-series charts. */
   granularity: string;
+  /**
+   * Fetch only current + previous cost for the catalog overview
+   * card, which renders just the total.
+   */
+  summaryOnly?: boolean;
 }
 
 /** Stable key for a scope, so the query cache and fan-out stay deterministic. */
@@ -57,7 +56,8 @@ export function useCostInsights(
   const api = useApi(observabilityApiRef);
   const discovery = useApi(discoveryApiRef);
   const fetchApi = useApi(fetchApiRef);
-  const { scopes, level, environments, timeRange, view, granularity } = params;
+  const { scopes, level, environments, timeRange, granularity } = params;
+  const summaryOnly = params.summaryOnly ?? false;
   // Dedupe so a repeated env or scope can't fan out duplicate requests and
   // double-count the aggregated totals.
   const sortedEnvs = [...new Set(environments)].sort();
@@ -76,8 +76,8 @@ export function useCostInsights(
         timeRange,
         params.customStartTime ?? '',
         params.customEndTime ?? '',
-        view,
         granularity,
+        summaryOnly ? 'summary' : 'full',
       ],
       async () => {
         const { startTime, endTime } = calculateTimeRange(timeRange, {
@@ -92,9 +92,11 @@ export function useCostInsights(
         ).toISOString();
         const prevEnd = startTime;
 
-        // Charts (all levels) and the component table both need recommendations.
-        const needsRecs = view === 'graph' || level === 'component';
-        const isGraph = view === 'graph';
+        // Current calendar month, for the forecast chart (ignores the time range).
+        const now = new Date();
+        const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+        const monthStartIso = monthStart.toISOString();
+        const nowIso = now.toISOString();
 
         // The cost API is per (namespace, environment) with an optional
         // project/component filter, so fan out across every selected scope and
@@ -117,19 +119,43 @@ export function useCostInsights(
               startTime,
               endTime,
             });
-            // Time-bucketed cost drives the graph's time-series charts only; its
+            // Time-bucketed cost drives the graph's time-series charts; its
             // per-bucket totals need not sum to the accumulated total. Degrade
             // gracefully: a series failure shouldn't drop the request's data.
-            const series = isGraph
-              ? await api
+            // The summary-only card skips all of these.
+            const series = summaryOnly
+              ? { items: [] as CostItem[] }
+              : await api
                   .getCosts(ns, env, {
                     ...scopeOpts,
                     startTime,
                     endTime,
                     granularity,
                   })
-                  .catch(() => ({ items: [] as CostItem[] }))
-              : { items: [] as CostItem[] };
+                  .catch(() => ({ items: [] as CostItem[] }));
+            // Month-to-date daily cost for the forecast chart
+            const monthToDate = summaryOnly
+              ? { items: [] as CostItem[] }
+              : await api
+                  .getCosts(ns, env, {
+                    ...scopeOpts,
+                    startTime: monthStartIso,
+                    endTime: nowIso,
+                    granularity: '1d',
+                  })
+                  .catch(() => ({ items: [] as CostItem[] }));
+            // Month-to-date recommendations drive the forecast's "if applied"
+            // curve: the saving rate is measured over month start to now, then
+            // extrapolated to month end (same window as the actual curve).
+            const monthToDateRecommendations = summaryOnly
+              ? { items: [] as CostRecommendationItem[] }
+              : await api
+                  .getCostRecommendations(ns, env, {
+                    ...scopeOpts,
+                    startTime: monthStartIso,
+                    endTime: nowIso,
+                  })
+                  .catch(() => ({ items: [] as CostRecommendationItem[] }));
             const previous = await api.getCosts(ns, env, {
               ...scopeOpts,
               startTime: prevStart,
@@ -137,18 +163,20 @@ export function useCostInsights(
             });
             // Degrade gracefully: a recommendation failure shouldn't drop the
             // request's cost data with it.
-            const recommendations = needsRecs
-              ? await api
+            const recommendations = summaryOnly
+              ? { items: [] as CostRecommendationItem[] }
+              : await api
                   .getCostRecommendations(ns, env, {
                     ...scopeOpts,
                     startTime,
                     endTime,
                   })
-                  .catch(() => ({ items: [] as CostRecommendationItem[] }))
-              : { items: [] as CostRecommendationItem[] };
+                  .catch(() => ({ items: [] as CostRecommendationItem[] }));
             return {
               current: current.items,
               series: series.items,
+              monthToDate: monthToDate.items,
+              monthToDateRecommendations: monthToDateRecommendations.items,
               previous: previous.items,
               recommendations: recommendations.items,
             };
@@ -161,6 +189,8 @@ export function useCostInsights(
           ): r is PromiseFulfilledResult<{
             current: CostItem[];
             series: CostItem[];
+            monthToDate: CostItem[];
+            monthToDateRecommendations: CostRecommendationItem[];
             previous: CostItem[];
             recommendations: CostRecommendationItem[];
           }> => r.status === 'fulfilled',
@@ -181,6 +211,10 @@ export function useCostInsights(
 
         const currentItems = fulfilled.flatMap(r => r.value.current);
         const seriesItems = fulfilled.flatMap(r => r.value.series);
+        const monthToDateItems = fulfilled.flatMap(r => r.value.monthToDate);
+        const mtdRecommendations = fulfilled.flatMap(
+          r => r.value.monthToDateRecommendations,
+        );
         const previousItems = fulfilled.flatMap(r => r.value.previous);
         const recommendations = fulfilled.flatMap(r => r.value.recommendations);
 
@@ -240,12 +274,13 @@ export function useCostInsights(
           level,
           currentItems,
           seriesItems,
+          monthToDateItems,
+          monthToDateRecommendations: mtdRecommendations,
           previousItems,
           recommendations,
           staleRecommendationEnvs,
-          windowStart: startTime,
-          windowEnd: endTime,
-          now: new Date(),
+          monthStart,
+          now,
         });
       },
       // No keepPreviousData: a window/view/scope change shows the centered loader


### PR DESCRIPTION
## Purpose

Makes several improvements to the cost insights UI and the User experience
https://github.com/openchoreo/openchoreo/issues/4381

## Goals

Make the cost insights feature more intuitive and user friendly

## Approach

1. Consolidated the table and graph views into a single page and removed the tabs. Now the table is shown at the bottom of the cost insights view after all the graphs
<img width="1722" height="1026" alt="Screenshot 2026-09-11 at 13 54 37" src="https://github.com/user-attachments/assets/f0b32b43-a983-47a0-9c46-c89c9e896717" />

2. Added a sidebar divider and moved "Cost insights" and "Platform" items into a new section so that developer and platform concerns are shown separately
<img width="222" height="605" alt="Screenshot 2026-09-11 at 13 53 45" src="https://github.com/user-attachments/assets/0ac06606-090b-49bf-8dce-751fe4e7b2ef" />

3. Reworked the cost forecast graph
- Renamed it to "Accumulated cost and forecast" and updated the tooltip & legend labels; made the two forecast lines visually distinct (dashed for current rate and dotted for if recommendations applied)
- It now shows actual accumulated cost from the start of the calendar month to today, then extrapolates that to forecast month-end cost, instead of extrapolating the selected time range's cost both ways. The graph is now always the current calendar month and is not affected by the time-range filter, so the time-range selector was moved below it.
<img width="1728" height="1011" alt="Screenshot 2026-09-11 at 14 19 01" src="https://github.com/user-attachments/assets/a2a2c97e-db1f-4b41-b564-d67bc3f97bc5" />

4. Cost vs efficiency graph: added a "Potential savings" legend heading and removed the red "low efficiency" shaded area
5. Fixed the "Observability is not enabled for this component" message on this platform-level page to read "Cost Insights have not been enabled"
6. Component/Project dropdown filters now show "All" (instead of "None") when nothing is explicitly selected. 
7. Added a Refresh button to re-fetch cost data without a full page reload
8. Right-aligned the table column headers to line up with their values
9. Updated the unit tests to suit the changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cost Insights now displays graphs and tables together, with time-range filtering and a refresh control.
  - Forecast charts show month-to-date spending, month-end projections, and potential savings.
  - Multi-select filters support custom empty-selection labels, including “All.”
  - Chart titles support optional subtitles.

- **Updates**
  - Platform and Cost Insights links appear in a dedicated sidebar section.
  - Cost-efficiency charts have improved legends and full-width presentation.
  - Numeric table headers are clearer, and Cost Insights errors use improved messaging.
  - Removed the graph/table toggle and forecast and efficiency summary cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->